### PR TITLE
feat(auth): harden credential and registry handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,8 @@ clodex-claude [args...]     # second bin: launch claude bridged to a running clo
 
 **Provider registry** (`src/registry/`): only two providers exist — templates in `src/provider-templates.ts` (`openai` API-key template with `https://api.openai.com/v1`, and `openai-oauth`). `provider-auth.ts` implements the OpenAI device-code OAuth flow; `refresh-models.ts` fetches the model list (3-tier fetch for OAuth). `io.ts::loadRegistry` and `config.ts::readConfig` both trigger the one-time legacy migration. Materialization (`materialize.ts`) turns registry providers into `LocalProvider`s with per-model `npm`/`baseUrl`/`upstreamModelId`.
 
+Registry writes use atomic hard-link lock publication, so the filesystem containing `CLODEX_HOME` must support hard links. A parseable lock owned by a live PID is never reclaimed based on age; contenders wait for a bounded interval and fail with the owner PID. Malformed locks and locks owned by dead PIDs remain reclaimable. This live-owner rule is what makes the final ownership check before `providers.json` publication meaningful because a concurrent process cannot invalidate a live writer between its check and rename.
+
 **Config & migration** (`src/paths.ts`, `src/config.ts`, `src/env.ts`):
 
 - Config home `~/.clodex`, override `CLODEX_HOME`. `ensureLegacyAppHomeMigrated()` silently copies a legacy `~/.relay-ai` (skipping `logs/`) on first read — **never mutates the legacy directory**.

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ clodex --version    # version
 ## Configuration
 
 - Config home: `~/.clodex` (override with `CLODEX_HOME`). On first run, config is migrated automatically from a legacy `~/.relay-ai` directory if present; the legacy directory is never modified.
-- Credentials live in the OS credential store (Keychain / Windows Credential Manager / Secret Service) under the `clodex` service.
+- Credentials live in the OS credential store (Keychain / Windows Credential Manager / Secret Service) under the `clodex` service. Set `CLODEX_CREDENTIAL_HELPER` to an absolute executable path to use an external secure store instead; see [credential helpers](docs/credential-helpers.md).
 - `CLODEX_CLAUDE_PATH` overrides Claude Code binary discovery.
 - **Outbound proxy:** when `HTTP_PROXY`/`HTTPS_PROXY` (and optionally `NO_PROXY`) are set in clodex's environment, all clodex-originated network calls honor them — OAuth sign-in and token refresh, model-list and models.dev refreshes, upstream OpenAI API calls, and the ChatGPT/Codex OAuth WebSocket transport (tunneled via HTTP CONNECT).
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,12 @@ clodex --version    # version
 ## Configuration
 
 - Config home: `~/.clodex` (override with `CLODEX_HOME`). On first run, config is migrated automatically from a legacy `~/.relay-ai` directory if present; the legacy directory is never modified.
+- The config-home filesystem must support hard links because registry locks are
+  published atomically. Keep `CLODEX_HOME` on a local filesystem rather than
+  FAT, exFAT, or a network mount that rejects hard links. An abrupt process kill
+  during lock publication can leave a `providers.json.lock.*.tmp` file; it does
+  not block later lock acquisition and can be removed when no Clodex process is
+  running.
 - Credentials live in the OS credential store (Keychain / Windows Credential Manager / Secret Service) under the `clodex` service. Set `CLODEX_CREDENTIAL_HELPER` to an absolute executable path to use an external secure store instead; see [credential helpers](docs/credential-helpers.md).
 - `CLODEX_CLAUDE_PATH` overrides Claude Code binary discovery.
 - **Outbound proxy:** when `HTTP_PROXY`/`HTTPS_PROXY` (and optionally `NO_PROXY`) are set in clodex's environment, all clodex-originated network calls honor them — OAuth sign-in and token refresh, model-list and models.dev refreshes, upstream OpenAI API calls, and the ChatGPT/Codex OAuth WebSocket transport (tunneled via HTTP CONNECT).

--- a/docs/credential-helpers.md
+++ b/docs/credential-helpers.md
@@ -1,0 +1,69 @@
+# Credential helpers
+
+Clodex uses the operating system credential store by default. Headless Linux,
+containers, and WSL installations can instead delegate opaque credential
+storage to an external helper:
+
+```bash
+export CLODEX_CREDENTIAL_HELPER=/absolute/path/to/clodex-credential-helper
+clodex providers auth openai
+```
+
+The value must be an absolute path to an executable file. Clodex invokes the
+helper directly without a shell. Provider configuration records a versioned
+`helper:v1:<helper-id>:<account>` reference. The helper ID is a SHA-256 digest
+of the normalized executable path, so the path and username are not written to
+`providers.json`. A helper-backed credential never silently falls back to the
+OS keyring or an environment variable.
+
+Changing `CLODEX_CREDENTIAL_HELPER` to a different path does not redirect old
+references. Clodex refuses the operation before starting the new helper. Restore
+the prior path to read or delete the old credential, or reauthenticate to create
+a reference owned by the new helper.
+
+Clodex verifies the selected store with a disposable write, read, and delete
+before starting device authorization. It also reads back real credential
+writes.
+
+## Protocol
+
+The helper receives one of these invocations:
+
+```text
+helper get clodex <account>
+helper set clodex <account>
+helper delete clodex <account>
+```
+
+- `set` reads the complete opaque credential from standard input and produces
+  no output.
+- `get` writes the exact credential to standard output without adding a
+  newline.
+- `delete` removes the credential.
+- Exit code `0` means success.
+- Exit code `2` means not found for `get` or `delete`.
+- Any other exit code means the credential operation failed.
+
+The service and account arguments are identifiers, not secrets. Credential
+contents are never passed in arguments or environment variables. Helper
+standard error is not copied into Clodex diagnostics, and output and runtime
+are bounded.
+
+## Security responsibilities
+
+The helper owns storage and its security properties. A helper should:
+
+- encrypt credentials at rest using a system or user trust root;
+- serialize concurrent updates when its backend requires it;
+- avoid logging standard input or standard output;
+- make `set` replace the prior value atomically;
+- treat `delete` of a missing entry as success or exit code `2`;
+- return the stored bytes exactly from `get`.
+
+Users who need helper arguments can point `CLODEX_CREDENTIAL_HELPER` at a small
+executable wrapper. Clodex intentionally does not evaluate a shell command from
+this setting.
+
+Existing `keyring:` and `env:` provider references retain their original
+behavior. Enabling a helper affects newly saved credentials; reauthenticate a
+provider to move it to the helper-backed store.

--- a/docs/credential-helpers.md
+++ b/docs/credential-helpers.md
@@ -25,6 +25,12 @@ Clodex verifies the selected store with a disposable write, read, and delete
 before starting device authorization. It also reads back real credential
 writes.
 
+Credential storage is fail-closed. If the selected credential store fails its
+probe, Clodex stops before device authorization and includes the backend
+diagnostic in the error instead of continuing with tokens that cannot be
+durably stored. Set `CLODEX_CREDENTIAL_HELPER` to the absolute path of an
+external helper, then run the authorization command again.
+
 ## Protocol
 
 The helper receives one of these invocations:

--- a/src/credential-helper.ts
+++ b/src/credential-helper.ts
@@ -1,0 +1,152 @@
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { accessSync, constants, statSync } from 'node:fs';
+import { isAbsolute, normalize } from 'node:path';
+
+export const CREDENTIAL_HELPER_ENV = 'CLODEX_CREDENTIAL_HELPER';
+export const CREDENTIAL_HELPER_SERVICE = 'clodex';
+
+const HELPER_TIMEOUT_MS = 10_000;
+const HELPER_MAX_OUTPUT_BYTES = 1024 * 1024;
+
+type HelperOperation = 'get' | 'set' | 'delete';
+
+interface HelperResult {
+  code: number;
+  stdout: string;
+}
+
+export interface ConfiguredCredentialHelper {
+  path: string;
+  id: string;
+}
+
+export function credentialHelperIdForPath(path: string): string {
+  return createHash('sha256')
+    .update('clodex-credential-helper\0')
+    .update(normalize(path))
+    .digest('hex');
+}
+
+export function configuredCredentialHelperPath(): string | null {
+  const value = process.env[CREDENTIAL_HELPER_ENV]?.trim();
+  if (!value) return null;
+  if (!isAbsolute(value)) {
+    throw new Error(`${CREDENTIAL_HELPER_ENV} must be an absolute executable path`);
+  }
+  try {
+    const stat = statSync(value);
+    if (!stat.isFile()) {
+      throw new Error(`${CREDENTIAL_HELPER_ENV} must point to a file`);
+    }
+    accessSync(value, constants.X_OK);
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith(CREDENTIAL_HELPER_ENV)) throw err;
+    throw new Error(`${CREDENTIAL_HELPER_ENV} is not an executable file`);
+  }
+  return value;
+}
+
+export function configuredCredentialHelper(): ConfiguredCredentialHelper | null {
+  const path = configuredCredentialHelperPath();
+  return path ? { path, id: credentialHelperIdForPath(path) } : null;
+}
+
+export function credentialAuthRef(account: string): string {
+  const helper = configuredCredentialHelper();
+  return helper
+    ? `helper:v1:${helper.id}:${account}`
+    : `keyring:${account}`;
+}
+
+async function runCredentialHelper(
+  operation: HelperOperation,
+  account: string,
+  input?: string,
+  expectedHelperId?: string,
+): Promise<HelperResult> {
+  const helper = configuredCredentialHelper();
+  if (!helper) {
+    throw new Error(`${CREDENTIAL_HELPER_ENV} is required for helper credentials`);
+  }
+  if (expectedHelperId && helper.id !== expectedHelperId) {
+    throw new Error(
+      `${CREDENTIAL_HELPER_ENV} does not match the helper that owns this credential; restore the prior helper or reauthenticate`,
+    );
+  }
+
+  return new Promise<HelperResult>((resolve, reject) => {
+    const child = spawn(
+      helper.path,
+      [operation, CREDENTIAL_HELPER_SERVICE, account],
+      { shell: false, stdio: ['pipe', 'pipe', 'pipe'] },
+    );
+    const stdout: Buffer[] = [];
+    let stdoutBytes = 0;
+    let settled = false;
+
+    const finishReject = (message: string): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.stdin.destroy();
+      child.stdout.destroy();
+      child.stderr.destroy();
+      child.kill('SIGKILL');
+      reject(new Error(message));
+    };
+
+    const timer = setTimeout(() => {
+      finishReject(`credential helper ${operation} timed out`);
+    }, HELPER_TIMEOUT_MS);
+
+    child.stdout.on('data', (chunk: Buffer | string) => {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      stdoutBytes += buffer.length;
+      if (stdoutBytes > HELPER_MAX_OUTPUT_BYTES) {
+        finishReject(`credential helper ${operation} returned too much output`);
+        return;
+      }
+      stdout.push(buffer);
+    });
+    child.stderr.resume();
+    child.stdin.on('error', () => {
+      // The exit status remains authoritative when a helper closes stdin early.
+    });
+    child.on('error', () => {
+      finishReject(`credential helper ${operation} could not start`);
+    });
+    child.on('close', code => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ code: code ?? 1, stdout: Buffer.concat(stdout).toString('utf8') });
+    });
+
+    if (input !== undefined) child.stdin.end(input);
+    else child.stdin.end();
+  });
+}
+
+export async function readCredentialHelperAccount(account: string, helperId?: string): Promise<string | null> {
+  const result = await runCredentialHelper('get', account, undefined, helperId);
+  if (result.code === 2) return null;
+  if (result.code !== 0) {
+    throw new Error(`credential helper get failed with exit code ${result.code}`);
+  }
+  return result.stdout;
+}
+
+export async function writeCredentialHelperAccount(account: string, value: string, helperId?: string): Promise<void> {
+  const result = await runCredentialHelper('set', account, value, helperId);
+  if (result.code !== 0) {
+    throw new Error(`credential helper set failed with exit code ${result.code}`);
+  }
+}
+
+export async function deleteCredentialHelperAccount(account: string, helperId?: string): Promise<void> {
+  const result = await runCredentialHelper('delete', account, undefined, helperId);
+  if (result.code !== 0 && result.code !== 2) {
+    throw new Error(`credential helper delete failed with exit code ${result.code}`);
+  }
+}

--- a/src/env.ts
+++ b/src/env.ts
@@ -154,10 +154,12 @@ const oauthRefreshInflight = new Map<string, Promise<string | null>>();
 export type ParsedAuthRef =
   | { kind: 'keyring'; account: string }
   | { kind: 'helper'; helperId: string; account: string }
-  | { kind: 'env'; varName: string };
+  | { kind: 'env'; varName: string }
+  | { kind: 'none' };
 
 /** Parse registry credential references. */
 export function parseAuthRef(authRef: string): ParsedAuthRef | null {
+  if (authRef === 'none:anonymous') return { kind: 'none' };
   if (authRef.startsWith('keyring:')) {
     const account = authRef.slice('keyring:'.length);
     return account ? { kind: 'keyring', account } : null;
@@ -319,10 +321,12 @@ export async function resolveProviderCredential(
   authRef: string,
   diag?: (msg: string) => void,
 ): Promise<string | null> {
+  const parsed = parseAuthRef(authRef);
+  if (parsed?.kind === 'none') return null;
+
   const namespaced = readEnvCredential(clodexKeyEnvVar(providerId));
   if (namespaced) return namespaced;
 
-  const parsed = parseAuthRef(authRef);
   if (!parsed) return null;
 
   if (parsed.kind === 'env') {
@@ -338,7 +342,12 @@ export async function resolveProviderOAuthAccountId(
   diag?: (msg: string) => void,
 ): Promise<string | undefined> {
   const parsed = parseAuthRef(authRef);
-  if (!parsed || parsed.kind === 'env' || !oauthProviderIdFromAccount(parsed.account)) return undefined;
+  if (
+    !parsed
+    || parsed.kind === 'env'
+    || parsed.kind === 'none'
+    || !oauthProviderIdFromAccount(parsed.account)
+  ) return undefined;
   const raw = await readStoredCredential(parsed, diag);
   return parseStoredOAuthCredential(raw)?.accountId;
 }
@@ -348,7 +357,12 @@ export async function resolveProviderOAuthProviderData(
   diag?: (msg: string) => void,
 ): Promise<Record<string, unknown> | undefined> {
   const parsed = parseAuthRef(authRef);
-  if (!parsed || parsed.kind === 'env' || !oauthProviderIdFromAccount(parsed.account)) return undefined;
+  if (
+    !parsed
+    || parsed.kind === 'env'
+    || parsed.kind === 'none'
+    || !oauthProviderIdFromAccount(parsed.account)
+  ) return undefined;
   const raw = await readStoredCredential(parsed, diag);
   return parseStoredOAuthCredential(raw)?.providerData;
 }
@@ -422,7 +436,7 @@ export async function saveProviderCredential(
   diag?: (msg: string) => void,
 ): Promise<boolean> {
   const parsed = parseAuthRef(authRef);
-  if (!parsed || parsed.kind === 'env') return false;
+  if (!parsed || parsed.kind === 'env' || parsed.kind === 'none') return false;
   const written = await writeStoredCredential(parsed, key, diag);
   if (!written) return false;
   const readBack = await readStoredCredential(parsed, diag);
@@ -437,7 +451,7 @@ export async function probeProviderCredentialStore(
   diag?: (msg: string) => void,
 ): Promise<boolean> {
   const parsed = parseAuthRef(authRef);
-  if (!parsed || parsed.kind === 'env') return false;
+  if (!parsed || parsed.kind === 'env' || parsed.kind === 'none') return false;
   const probeAccount = `${parsed.account}::probe::${randomUUID()}`;
   const probeRef: StoredCredentialRef = parsed.kind === 'helper'
     ? { kind: 'helper', helperId: parsed.helperId, account: probeAccount }
@@ -469,7 +483,6 @@ export async function deleteProviderCredential(
   diag?: (msg: string) => void,
 ): Promise<boolean> {
   const parsed = parseAuthRef(authRef);
-  if (!parsed || parsed.kind === 'env') return false;
+  if (!parsed || parsed.kind === 'env' || parsed.kind === 'none') return false;
   return deleteStoredCredential(parsed, diag);
 }
-

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,5 +1,11 @@
 // src/env.ts
 import { CONFLICTING_ENV_VARS } from './constants.js';
+import { randomUUID } from 'node:crypto';
+import {
+  deleteCredentialHelperAccount,
+  readCredentialHelperAccount,
+  writeCredentialHelperAccount,
+} from './credential-helper.js';
 import { claudeCodeClientModelId, stripOneMContextSuffix } from './context-model-id.js';
 import { resolveContextWindow } from './context-window.js';
 import {
@@ -147,9 +153,10 @@ const oauthRefreshInflight = new Map<string, Promise<string | null>>();
 
 export type ParsedAuthRef =
   | { kind: 'keyring'; account: string }
+  | { kind: 'helper'; helperId: string; account: string }
   | { kind: 'env'; varName: string };
 
-/** Parse registry authRef strings like `keyring:provider:openai` or `env:OPENAI_API_KEY`. */
+/** Parse registry credential references. */
 export function parseAuthRef(authRef: string): ParsedAuthRef | null {
   if (authRef.startsWith('keyring:')) {
     const account = authRef.slice('keyring:'.length);
@@ -159,6 +166,8 @@ export function parseAuthRef(authRef: string): ParsedAuthRef | null {
     const varName = authRef.slice('env:'.length);
     return varName ? { kind: 'env', varName } : null;
   }
+  const helper = /^helper:v1:([0-9a-f]{64}):(.+)$/s.exec(authRef);
+  if (helper) return { kind: 'helper', helperId: helper[1]!, account: helper[2]! };
   return null;
 }
 
@@ -239,6 +248,7 @@ async function deleteKeyringAccount(account: string, diag?: (msg: string) => voi
   try {
     const { Entry } = await import('@napi-rs/keyring');
     const value = new Entry(KEYRING_SERVICE, account).getPassword();
+    if (value === null) return true;
     if (value?.startsWith(KEYRING_CHUNK_PREFIX)) {
       const chunkCount = Number(value.slice(KEYRING_CHUNK_PREFIX.length));
       for (let i = 0; i < chunkCount; i++) {
@@ -253,7 +263,57 @@ async function deleteKeyringAccount(account: string, diag?: (msg: string) => voi
   }
 }
 
-/** Resolve a provider secret from authRef (env → keyring). */
+type StoredCredentialRef = Extract<ParsedAuthRef, { kind: 'keyring' | 'helper' }>;
+
+function storedCredentialAuthRef(ref: StoredCredentialRef): string {
+  return ref.kind === 'helper'
+    ? `helper:v1:${ref.helperId}:${ref.account}`
+    : `keyring:${ref.account}`;
+}
+
+async function readStoredCredential(
+  ref: StoredCredentialRef,
+  diag?: (msg: string) => void,
+): Promise<string | null> {
+  if (ref.kind === 'keyring') return readKeyringAccount(ref.account, diag);
+  try {
+    return await readCredentialHelperAccount(ref.account, ref.helperId);
+  } catch (err) {
+    diag?.(err instanceof Error ? err.message : String(err));
+    return null;
+  }
+}
+
+async function writeStoredCredential(
+  ref: StoredCredentialRef,
+  value: string,
+  diag?: (msg: string) => void,
+): Promise<boolean> {
+  if (ref.kind === 'keyring') return writeKeyringAccount(ref.account, value, diag);
+  try {
+    await writeCredentialHelperAccount(ref.account, value, ref.helperId);
+    return true;
+  } catch (err) {
+    diag?.(err instanceof Error ? err.message : String(err));
+    return false;
+  }
+}
+
+async function deleteStoredCredential(
+  ref: StoredCredentialRef,
+  diag?: (msg: string) => void,
+): Promise<boolean> {
+  if (ref.kind === 'keyring') return deleteKeyringAccount(ref.account, diag);
+  try {
+    await deleteCredentialHelperAccount(ref.account, ref.helperId);
+    return true;
+  } catch (err) {
+    diag?.(err instanceof Error ? err.message : String(err));
+    return false;
+  }
+}
+
+/** Resolve a provider secret from a namespaced env var or its configured store. */
 export async function resolveProviderCredential(
   providerId: string,
   authRef: string,
@@ -269,7 +329,7 @@ export async function resolveProviderCredential(
     return readEnvCredential(parsed.varName);
   }
 
-  return readProviderSecret(parsed.account, diag);
+  return readProviderSecret(parsed, diag);
 }
 
 /** Read OAuth metadata retained alongside the access token. */
@@ -278,8 +338,8 @@ export async function resolveProviderOAuthAccountId(
   diag?: (msg: string) => void,
 ): Promise<string | undefined> {
   const parsed = parseAuthRef(authRef);
-  if (!parsed || parsed.kind !== 'keyring' || !oauthProviderIdFromAccount(parsed.account)) return undefined;
-  const raw = await readKeyringAccount(parsed.account, diag);
+  if (!parsed || parsed.kind === 'env' || !oauthProviderIdFromAccount(parsed.account)) return undefined;
+  const raw = await readStoredCredential(parsed, diag);
   return parseStoredOAuthCredential(raw)?.accountId;
 }
 
@@ -288,8 +348,8 @@ export async function resolveProviderOAuthProviderData(
   diag?: (msg: string) => void,
 ): Promise<Record<string, unknown> | undefined> {
   const parsed = parseAuthRef(authRef);
-  if (!parsed || parsed.kind !== 'keyring' || !oauthProviderIdFromAccount(parsed.account)) return undefined;
-  const raw = await readKeyringAccount(parsed.account, diag);
+  if (!parsed || parsed.kind === 'env' || !oauthProviderIdFromAccount(parsed.account)) return undefined;
+  const raw = await readStoredCredential(parsed, diag);
   return parseStoredOAuthCredential(raw)?.providerData;
 }
 
@@ -309,13 +369,14 @@ function decodeProviderSecret(raw: string | null): string | null {
   return trimmed;
 }
 
-async function refreshOAuthKeyringAccount(
-  account: string,
+async function refreshOAuthStoredCredential(
+  ref: StoredCredentialRef,
   providerId: string,
   raw: string,
   diag?: (msg: string) => void,
 ): Promise<string | null> {
-  const existing = oauthRefreshInflight.get(account);
+  const authRef = storedCredentialAuthRef(ref);
+  const existing = oauthRefreshInflight.get(authRef);
   if (existing) return existing;
 
   const work = (async (): Promise<string | null> => {
@@ -326,7 +387,8 @@ async function refreshOAuthKeyringAccount(
     try {
       const refreshed = await refreshStoredOAuthCredential(providerId, cred);
       const json = oauthCredentialToKeychainJson(refreshed);
-      await writeKeyringAccount(account, json, diag);
+      const saved = await saveProviderCredential(authRef, json, diag);
+      if (!saved) throw new Error('Could not persist refreshed OAuth credential');
       return refreshed.access;
     } catch (err) {
       diag?.(err instanceof Error ? err.message : String(err));
@@ -335,21 +397,21 @@ async function refreshOAuthKeyringAccount(
     }
   })();
 
-  oauthRefreshInflight.set(account, work);
+  oauthRefreshInflight.set(authRef, work);
   try {
     return await work;
   } finally {
-    oauthRefreshInflight.delete(account);
+    oauthRefreshInflight.delete(authRef);
   }
 }
 
-async function readProviderSecret(account: string, diag?: (msg: string) => void): Promise<string | null> {
-  const raw = await readKeyringAccount(account, diag);
+async function readProviderSecret(ref: StoredCredentialRef, diag?: (msg: string) => void): Promise<string | null> {
+  const raw = await readStoredCredential(ref, diag);
   if (!raw) return null;
 
-  const oauthProviderId = oauthProviderIdFromAccount(account);
+  const oauthProviderId = oauthProviderIdFromAccount(ref.account);
   if (oauthProviderId && raw.trim().startsWith('{')) {
-    return refreshOAuthKeyringAccount(account, oauthProviderId, raw, diag);
+    return refreshOAuthStoredCredential(ref, oauthProviderId, raw, diag);
   }
   return decodeProviderSecret(raw);
 }
@@ -360,18 +422,54 @@ export async function saveProviderCredential(
   diag?: (msg: string) => void,
 ): Promise<boolean> {
   const parsed = parseAuthRef(authRef);
-  if (!parsed || parsed.kind !== 'keyring') return false;
-  return writeKeyringAccount(parsed.account, key, diag);
+  if (!parsed || parsed.kind === 'env') return false;
+  const written = await writeStoredCredential(parsed, key, diag);
+  if (!written) return false;
+  const readBack = await readStoredCredential(parsed, diag);
+  if (readBack === key) return true;
+  diag?.('credential store read-back verification failed');
+  return false;
 }
 
-/** Delete a provider secret from keyring (no-op for env: refs). */
+/** Verify that a credential backend can durably round-trip a disposable secret. */
+export async function probeProviderCredentialStore(
+  authRef: string,
+  diag?: (msg: string) => void,
+): Promise<boolean> {
+  const parsed = parseAuthRef(authRef);
+  if (!parsed || parsed.kind === 'env') return false;
+  const probeAccount = `${parsed.account}::probe::${randomUUID()}`;
+  const probeRef: StoredCredentialRef = parsed.kind === 'helper'
+    ? { kind: 'helper', helperId: parsed.helperId, account: probeAccount }
+    : { kind: 'keyring', account: probeAccount };
+  const value = randomUUID();
+  let verified = false;
+  try {
+    const written = await writeStoredCredential(probeRef, value, diag);
+    if (!written) return false;
+    const readBack = await readStoredCredential(probeRef, diag);
+    if (readBack !== value) {
+      diag?.('credential store probe read-back verification failed');
+      return false;
+    }
+    verified = true;
+  } finally {
+    const deleted = await deleteStoredCredential(probeRef, diag);
+    if (!deleted) {
+      diag?.('credential store probe cleanup failed');
+      verified = false;
+    }
+  }
+  return verified;
+}
+
+/** Delete a provider secret from its credential store (no-op for env: refs). */
 export async function deleteProviderCredential(
   authRef: string,
   diag?: (msg: string) => void,
 ): Promise<boolean> {
   const parsed = parseAuthRef(authRef);
-  if (!parsed || parsed.kind !== 'keyring') return false;
-  return deleteKeyringAccount(parsed.account, diag);
+  if (!parsed || parsed.kind === 'env') return false;
+  return deleteStoredCredential(parsed, diag);
 }
-
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -13,6 +13,7 @@ import {
   parseStoredOAuthCredential,
 } from './oauth/types.js';
 import { refreshStoredOAuthCredential, oauthCredentialShouldRefresh } from './oauth/refresh.js';
+import { withCredentialMutationLock } from './registry/lock.js';
 import type { ConflictInfo } from './types.js';
 
 export function detectConflicts(): ConflictInfo[] {
@@ -386,17 +387,18 @@ function decodeProviderSecret(raw: string | null): string | null {
 async function refreshOAuthStoredCredential(
   ref: StoredCredentialRef,
   providerId: string,
-  raw: string,
   diag?: (msg: string) => void,
 ): Promise<string | null> {
   const authRef = storedCredentialAuthRef(ref);
   const existing = oauthRefreshInflight.get(authRef);
   if (existing) return existing;
 
-  const work = (async (): Promise<string | null> => {
-    const cred = parseStoredOAuthCredential(raw);
+  const work = withCredentialMutationLock(authRef, async (): Promise<string | null> => {
+    const currentRaw = await readStoredCredential(ref, diag);
+    if (!currentRaw) return null;
+    const cred = parseStoredOAuthCredential(currentRaw);
     if (!cred || !oauthCredentialShouldRefresh(cred, providerId)) {
-      return decodeProviderSecret(raw);
+      return decodeProviderSecret(currentRaw);
     }
     try {
       const refreshed = await refreshStoredOAuthCredential(providerId, cred);
@@ -409,7 +411,7 @@ async function refreshOAuthStoredCredential(
       if (cred.access && cred.expires > Date.now()) return cred.access;
       throw err;
     }
-  })();
+  });
 
   oauthRefreshInflight.set(authRef, work);
   try {
@@ -425,7 +427,7 @@ async function readProviderSecret(ref: StoredCredentialRef, diag?: (msg: string)
 
   const oauthProviderId = oauthProviderIdFromAccount(ref.account);
   if (oauthProviderId && raw.trim().startsWith('{')) {
-    return refreshOAuthStoredCredential(ref, oauthProviderId, raw, diag);
+    return refreshOAuthStoredCredential(ref, oauthProviderId, diag);
   }
   return decodeProviderSecret(raw);
 }
@@ -437,12 +439,14 @@ export async function saveProviderCredential(
 ): Promise<boolean> {
   const parsed = parseAuthRef(authRef);
   if (!parsed || parsed.kind === 'env' || parsed.kind === 'none') return false;
-  const written = await writeStoredCredential(parsed, key, diag);
-  if (!written) return false;
-  const readBack = await readStoredCredential(parsed, diag);
-  if (readBack === key) return true;
-  diag?.('credential store read-back verification failed');
-  return false;
+  return withCredentialMutationLock(authRef, async () => {
+    const written = await writeStoredCredential(parsed, key, diag);
+    if (!written) return false;
+    const readBack = await readStoredCredential(parsed, diag);
+    if (readBack === key) return true;
+    diag?.('credential store read-back verification failed');
+    return false;
+  });
 }
 
 /** Verify that a credential backend can durably round-trip a disposable secret. */
@@ -484,5 +488,6 @@ export async function deleteProviderCredential(
 ): Promise<boolean> {
   const parsed = parseAuthRef(authRef);
   if (!parsed || parsed.kind === 'env' || parsed.kind === 'none') return false;
-  return deleteStoredCredential(parsed, diag);
+  return withCredentialMutationLock(authRef, () =>
+    deleteStoredCredential(parsed, diag));
 }

--- a/src/provider-catalog.ts
+++ b/src/provider-catalog.ts
@@ -25,7 +25,7 @@ export function providersForPicker(providers: LocalProvider[]): LocalProvider[] 
   return providers.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base', numeric: true }));
 }
 
-/** Resolve API key when provider.apiKey is empty (registry authRef or OAuth keyring). */
+/** Resolve API key when provider.apiKey is empty (registry authRef or OAuth credential store). */
 export async function resolveLocalProviderApiKey(provider: LocalProvider): Promise<string | null> {
   const direct = provider.apiKey?.trim();
   if (direct) return direct;
@@ -38,7 +38,7 @@ export async function resolveLocalProviderApiKey(provider: LocalProvider): Promi
   }
 
   const reg = loadRegistry().providers.find(p => p.id === provider.id);
-  const authRef = reg?.authRef ?? oauthAuthRef(provider.id);
+  const authRef = provider.authRef ?? reg?.authRef ?? oauthAuthRef(provider.id);
   return resolveProviderCredential(provider.id, authRef);
 }
 
@@ -47,13 +47,16 @@ export function formatRegistryAuthLabel(
   provider: Pick<import('./registry/types.js').RegistryProvider, 'authRef' | 'authType'>,
 ): string {
   if (provider.authType === 'oauth' || provider.authRef.includes('oauth:provider:')) {
-    return 'keychain (OAuth)';
+    return provider.authRef.startsWith('helper:') ? 'helper (OAuth)' : 'keychain (OAuth)';
   }
   if (provider.authType === 'none') {
     return 'gcloud / manual credentials';
   }
   if (provider.authRef.startsWith('keyring:')) {
     return 'keychain (API key)';
+  }
+  if (provider.authRef.startsWith('helper:')) {
+    return 'helper (API key)';
   }
   if (provider.authRef.startsWith('env:')) {
     return provider.authRef;

--- a/src/provider-catalog.ts
+++ b/src/provider-catalog.ts
@@ -3,6 +3,7 @@ import type { CompatibilityAgent } from './model-compatibility.js';
 import { oauthAuthRef } from './registry/import-build.js';
 import { loadRegistry } from './registry/io.js';
 import { loadRegistryProviders } from './registry/load.js';
+import { isAnonymousProvider } from './registry/materialize.js';
 import { getTemplateById } from './provider-templates.js';
 import type { LocalProvider } from './types.js';
 import type { ServerModelInfo } from './server/models.js';
@@ -27,6 +28,8 @@ export function providersForPicker(providers: LocalProvider[]): LocalProvider[] 
 
 /** Resolve API key when provider.apiKey is empty (registry authRef or OAuth credential store). */
 export async function resolveLocalProviderApiKey(provider: LocalProvider): Promise<string | null> {
+  if (provider.authRef === 'none:anonymous') return 'anonymous';
+
   const direct = provider.apiKey?.trim();
   if (direct) return direct;
   
@@ -49,6 +52,7 @@ export function formatRegistryAuthLabel(
   if (provider.authType === 'oauth' || provider.authRef.includes('oauth:provider:')) {
     return provider.authRef.startsWith('helper:') ? 'helper (OAuth)' : 'keychain (OAuth)';
   }
+  if (isAnonymousProvider(provider)) return 'anonymous';
   if (provider.authType === 'none') {
     return 'gcloud / manual credentials';
   }

--- a/src/providers-command.ts
+++ b/src/providers-command.ts
@@ -312,6 +312,10 @@ export async function runProvidersRemove(id: string, interactive = false): Promi
     p.log.error(result.error ?? `Could not remove ${id}`);
     return 1;
   }
+  if (result.error) {
+    p.log.error(result.error);
+    return 1;
+  }
 
   p.log.success(`Removed ${result.name ?? id}.`);
   if (result.credentialDeleted) {

--- a/src/providers-command.ts
+++ b/src/providers-command.ts
@@ -114,7 +114,7 @@ function providerLabel(name: string, modelCount: number, enabled: boolean): stri
 export async function runProvidersAuth(providerId: string, method?: ProviderAuthMethod): Promise<number> {
   try {
     const result = await authenticateProvider(providerId, { method });
-    p.log.success(`Signed in to ${result.registryProvider.name} — credential saved to Keychain.`);
+    p.log.success(`Signed in to ${result.registryProvider.name} — credential saved to the credential store.`);
     return 0;
   } catch (err) {
     if (err instanceof Error && err.message === 'Cancelled') {
@@ -315,7 +315,7 @@ export async function runProvidersRemove(id: string, interactive = false): Promi
 
   p.log.success(`Removed ${result.name ?? id}.`);
   if (result.credentialDeleted) {
-    p.log.info('Provider API key removed from Keychain.');
+    p.log.info('Provider API key removed from the credential store.');
   }
   return 0;
 }
@@ -359,7 +359,7 @@ async function runProviderDetail(id: string): Promise<'back' | 'removed'> {
       label: provider.enabled ? 'Disable provider' : 'Enable provider',
       hint: provider.enabled ? 'Hide from clodex claude picker' : 'Show in clodex claude picker',
     },
-    { value: 'remove', label: 'Remove provider', hint: 'Delete from registry and Keychain when safe' },
+    { value: 'remove', label: 'Remove provider', hint: 'Delete from registry and credential store when safe' },
     { value: 'back', label: 'Back', hint: '' },
   );
 

--- a/src/registry/add-template.ts
+++ b/src/registry/add-template.ts
@@ -118,7 +118,9 @@ export async function addProviderFromTemplate(
       };
     }
 
-    const authRef = credentialAuthRef(`provider:${template.id}`);
+    const authRef = trimmedKey
+      ? credentialAuthRef(`provider:${template.id}`)
+      : 'none:anonymous';
     const saved = trimmedKey ? await saveProviderCredential(authRef, trimmedKey) : true;
     if (!saved) {
       return {
@@ -135,7 +137,10 @@ export async function addProviderFromTemplate(
       name: template.name,
       enabled: true,
       authRef,
-      authType: template.authType,
+      authType: trimmedKey ? template.authType : 'none',
+      ...(!trimmedKey && template.anonymousFreeModels
+        ? { subscriptionFilter: 'free' as const }
+        : {}),
       api: {
         npm: template.npm,
         url: fetched.baseUrl,

--- a/src/registry/add-template.ts
+++ b/src/registry/add-template.ts
@@ -7,7 +7,10 @@ import type { ProviderTemplate } from '../provider-templates.js';
 import { classifyFreeStatus, isFreeStatus } from '../free-models.js';
 import { fetchTemplateModels } from './fetch-template-models.js';
 import { loadRegistry, saveRegistry } from './io.js';
-import { withRegistryWriteLock } from './lock.js';
+import {
+  withCredentialMutationLock,
+  withRegistryWriteLock,
+} from './lock.js';
 import {
   buildPricingIndex,
   enrichModelsWithPricing,
@@ -107,7 +110,10 @@ export async function addProviderFromTemplate(
     buildPricingIndex(pricingCache),
     platform,
   );
-  const result = await withRegistryWriteLock(async () => {
+  const authRef = trimmedKey
+    ? credentialAuthRef(`provider:${template.id}`)
+    : 'none:anonymous';
+  const commitProvider = () => withRegistryWriteLock(() => {
     const registry = loadRegistry();
     const existing = registry.providers.find(p => p.id === template.id);
     if (existing && !opts?.replaceExisting) {
@@ -115,18 +121,6 @@ export async function addProviderFromTemplate(
         added: false,
         error: `${template.name} is already configured.`,
         hint: `Remove it first with: clodex providers remove ${template.id}`,
-      };
-    }
-
-    const authRef = trimmedKey
-      ? credentialAuthRef(`provider:${template.id}`)
-      : 'none:anonymous';
-    const saved = trimmedKey ? await saveProviderCredential(authRef, trimmedKey) : true;
-    if (!saved) {
-      return {
-        added: false,
-        error: 'Could not save API key to the credential store.',
-        hint: 'Check credential-store access and try again.',
       };
     }
 
@@ -162,6 +156,34 @@ export async function addProviderFromTemplate(
     saveRegistry(registry);
     return { added: true, provider: entry, modelCount: pricedModels.length };
   });
+
+  const result = trimmedKey
+    ? await withCredentialMutationLock(authRef, async () => {
+      const commitError = await withRegistryWriteLock(() => {
+        const registry = loadRegistry();
+        const existing = registry.providers.find(p => p.id === template.id);
+        if (existing && !opts?.replaceExisting) {
+          return {
+            added: false,
+            error: `${template.name} is already configured.`,
+            hint: `Remove it first with: clodex providers remove ${template.id}`,
+          };
+        }
+        return null;
+      });
+      if (commitError) return commitError;
+
+      const saved = await saveProviderCredential(authRef, trimmedKey);
+      if (!saved) {
+        return {
+          added: false,
+          error: 'Could not save API key to the credential store.',
+          hint: 'Check credential-store access and try again.',
+        };
+      }
+      return commitProvider();
+    })
+    : await commitProvider();
 
   if (result.added) enrichPricingAsync();
   return result;

--- a/src/registry/add-template.ts
+++ b/src/registry/add-template.ts
@@ -7,6 +7,7 @@ import type { ProviderTemplate } from '../provider-templates.js';
 import { classifyFreeStatus, isFreeStatus } from '../free-models.js';
 import { fetchTemplateModels } from './fetch-template-models.js';
 import { loadRegistry, saveRegistry } from './io.js';
+import { withRegistryWriteLock } from './lock.js';
 import {
   buildPricingIndex,
   enrichModelsWithPricing,
@@ -66,15 +67,19 @@ export async function addProviderFromTemplate(
     return { added: false, error: 'API key cannot be empty.' };
   }
 
-  const registry = loadRegistry();
-  const existing = registry.providers.find(p => p.id === template.id);
-  if (existing && !opts?.replaceExisting) {
-    return {
-      added: false,
-      error: `${template.name} is already configured.`,
-      hint: `Remove it first with: clodex providers remove ${template.id}`,
-    };
-  }
+  const existingError = await withRegistryWriteLock(() => {
+    const registry = loadRegistry();
+    const existing = registry.providers.find(p => p.id === template.id);
+    if (existing && !opts?.replaceExisting) {
+      return {
+        added: false,
+        error: `${template.name} is already configured.`,
+        hint: `Remove it first with: clodex providers remove ${template.id}`,
+      };
+    }
+    return null;
+  });
+  if (existingError) return existingError;
 
   const fetched = await fetchTemplateModels(template, trimmedKey, opts?.baseUrl);
   if (fetched.error || fetched.models.length === 0) {
@@ -95,17 +100,6 @@ export async function addProviderFromTemplate(
     };
   }
 
-  const authRef = credentialAuthRef(`provider:${template.id}`);
-  const saved = trimmedKey ? await saveProviderCredential(authRef, trimmedKey) : true;
-  if (!saved) {
-    return {
-      added: false,
-      error: 'Could not save API key to the credential store.',
-      hint: 'Check credential-store access and try again.',
-    };
-  }
-
-  const now = new Date().toISOString();
   const pricingCache = loadPricingCache();
   const platform = pricingPlatformForProvider(template.id, template.id);
   const pricedModels = enrichModelsWithPricing(
@@ -113,33 +107,57 @@ export async function addProviderFromTemplate(
     buildPricingIndex(pricingCache),
     platform,
   );
-  const entry: RegistryProvider = {
-    id: template.id,
-    templateId: template.id,
-    name: template.name,
-    enabled: true,
-    authRef,
-    authType: template.authType,
-    api: {
-      npm: template.npm,
-      url: fetched.baseUrl,
-    },
-    addedAt: existing?.addedAt ?? now,
-    refreshedAt: now,
-    modelsCache: {
-      fetchedAt: now,
-      models: pricedModels,
-    },
-  };
+  const result = await withRegistryWriteLock(async () => {
+    const registry = loadRegistry();
+    const existing = registry.providers.find(p => p.id === template.id);
+    if (existing && !opts?.replaceExisting) {
+      return {
+        added: false,
+        error: `${template.name} is already configured.`,
+        hint: `Remove it first with: clodex providers remove ${template.id}`,
+      };
+    }
 
-  if (existing) {
-    const idx = registry.providers.findIndex(p => p.id === template.id);
-    registry.providers[idx] = entry;
-  } else {
-    registry.providers.push(entry);
-  }
-  saveRegistry(registry);
-  enrichPricingAsync();
+    const authRef = credentialAuthRef(`provider:${template.id}`);
+    const saved = trimmedKey ? await saveProviderCredential(authRef, trimmedKey) : true;
+    if (!saved) {
+      return {
+        added: false,
+        error: 'Could not save API key to the credential store.',
+        hint: 'Check credential-store access and try again.',
+      };
+    }
 
-  return { added: true, provider: entry, modelCount: pricedModels.length };
+    const now = new Date().toISOString();
+    const entry: RegistryProvider = {
+      id: template.id,
+      templateId: template.id,
+      name: template.name,
+      enabled: true,
+      authRef,
+      authType: template.authType,
+      api: {
+        npm: template.npm,
+        url: fetched.baseUrl,
+      },
+      addedAt: existing?.addedAt ?? now,
+      refreshedAt: now,
+      modelsCache: {
+        fetchedAt: now,
+        models: pricedModels,
+      },
+    };
+
+    if (existing) {
+      const idx = registry.providers.findIndex(p => p.id === template.id);
+      registry.providers[idx] = entry;
+    } else {
+      registry.providers.push(entry);
+    }
+    saveRegistry(registry);
+    return { added: true, provider: entry, modelCount: pricedModels.length };
+  });
+
+  if (result.added) enrichPricingAsync();
+  return result;
 }

--- a/src/registry/add-template.ts
+++ b/src/registry/add-template.ts
@@ -1,6 +1,7 @@
 // src/registry/add-template.ts — add a provider from a builtin template
 
 import { saveProviderCredential } from '../env.js';
+import { credentialAuthRef } from '../credential-helper.js';
 import { isSdkMigratedNpm } from '../provider-factory.js';
 import type { ProviderTemplate } from '../provider-templates.js';
 import { classifyFreeStatus, isFreeStatus } from '../free-models.js';
@@ -94,13 +95,13 @@ export async function addProviderFromTemplate(
     };
   }
 
-  const authRef = `keyring:provider:${template.id}`;
+  const authRef = credentialAuthRef(`provider:${template.id}`);
   const saved = trimmedKey ? await saveProviderCredential(authRef, trimmedKey) : true;
   if (!saved) {
     return {
       added: false,
-      error: 'Could not save API key to Keychain.',
-      hint: 'Grant Keychain access or try again.',
+      error: 'Could not save API key to the credential store.',
+      hint: 'Check credential-store access and try again.',
     };
   }
 

--- a/src/registry/crud.ts
+++ b/src/registry/crud.ts
@@ -2,7 +2,11 @@
 
 import { deleteProviderCredential } from '../env.js';
 import { loadRegistry, saveRegistry } from './io.js';
-import { withRegistryWriteLock, withRegistryWriteLockSync } from './lock.js';
+import {
+  withCredentialMutationLock,
+  withRegistryWriteLock,
+  withRegistryWriteLockSync,
+} from './lock.js';
 import type { RegistryProvider } from './types.js';
 
 export interface RemoveProviderResult {
@@ -22,31 +26,54 @@ export async function removeProviderFromRegistry(
   id: string,
   opts?: { deleteCredential?: boolean },
 ): Promise<RemoveProviderResult> {
-  return withRegistryWriteLock(async () => {
+  const removal = await withRegistryWriteLock(() => {
     const registry = loadRegistry();
     const index = registry.providers.findIndex(p => p.id === id);
     if (index < 0) {
-      return { removed: false, id, credentialDeleted: false, error: `Provider not found: ${id}` };
+      return {
+        result: {
+          removed: false,
+          id,
+          credentialDeleted: false,
+          error: `Provider not found: ${id}`,
+        },
+        authRefToDelete: null,
+      };
     }
 
     const [removedProvider] = registry.providers.splice(index, 1);
     saveRegistry(registry);
 
-    let credentialDeleted = false;
-    if (opts?.deleteCredential !== false) {
-      const shouldDelete = !credentialStillReferenced(removedProvider.authRef, registry.providers);
-      if (shouldDelete) {
-        credentialDeleted = await deleteProviderCredential(removedProvider.authRef);
-      }
-    }
-
     return {
-      removed: true,
-      id,
-      name: removedProvider.name,
-      credentialDeleted,
+      result: {
+        removed: true,
+        id,
+        name: removedProvider.name,
+        credentialDeleted: false,
+      },
+      authRefToDelete:
+        opts?.deleteCredential !== false &&
+        !credentialStillReferenced(removedProvider.authRef, registry.providers)
+          ? removedProvider.authRef
+          : null,
     };
   });
+
+  const authRefToDelete = removal.authRefToDelete;
+  if (authRefToDelete) {
+    await withCredentialMutationLock(authRefToDelete, async () => {
+      const referencedAgain = await withRegistryWriteLock(() =>
+        credentialStillReferenced(
+          authRefToDelete,
+          loadRegistry().providers,
+        ));
+      if (referencedAgain) return;
+      removal.result.credentialDeleted = await deleteProviderCredential(
+        authRefToDelete,
+      );
+    });
+  }
+  return removal.result;
 }
 
 export function toggleProviderEnabled(id: string): { toggled: boolean; enabled?: boolean; error?: string } {

--- a/src/registry/crud.ts
+++ b/src/registry/crud.ts
@@ -2,6 +2,7 @@
 
 import { parseAuthRef, deleteProviderCredential } from '../env.js';
 import { loadRegistry, saveRegistry } from './io.js';
+import { withRegistryWriteLock, withRegistryWriteLockSync } from './lock.js';
 import type { RegistryProvider } from './types.js';
 
 export interface RemoveProviderResult {
@@ -21,37 +22,41 @@ export async function removeProviderFromRegistry(
   id: string,
   opts?: { deleteCredential?: boolean },
 ): Promise<RemoveProviderResult> {
-  const registry = loadRegistry();
-  const index = registry.providers.findIndex(p => p.id === id);
-  if (index < 0) {
-    return { removed: false, id, credentialDeleted: false, error: `Provider not found: ${id}` };
-  }
-
-  const [removedProvider] = registry.providers.splice(index, 1);
-  saveRegistry(registry);
-
-  let credentialDeleted = false;
-  if (opts?.deleteCredential !== false) {
-    const parsed = parseAuthRef(removedProvider.authRef);
-    const shouldDelete = !credentialStillReferenced(removedProvider.authRef, registry.providers);
-    if (shouldDelete && parsed?.kind === 'keyring') {
-      credentialDeleted = await deleteProviderCredential(removedProvider.authRef);
+  return withRegistryWriteLock(async () => {
+    const registry = loadRegistry();
+    const index = registry.providers.findIndex(p => p.id === id);
+    if (index < 0) {
+      return { removed: false, id, credentialDeleted: false, error: `Provider not found: ${id}` };
     }
-  }
 
-  return {
-    removed: true,
-    id,
-    name: removedProvider.name,
-    credentialDeleted,
-  };
+    const [removedProvider] = registry.providers.splice(index, 1);
+    saveRegistry(registry);
+
+    let credentialDeleted = false;
+    if (opts?.deleteCredential !== false) {
+      const parsed = parseAuthRef(removedProvider.authRef);
+      const shouldDelete = !credentialStillReferenced(removedProvider.authRef, registry.providers);
+      if (shouldDelete && parsed?.kind === 'keyring') {
+        credentialDeleted = await deleteProviderCredential(removedProvider.authRef);
+      }
+    }
+
+    return {
+      removed: true,
+      id,
+      name: removedProvider.name,
+      credentialDeleted,
+    };
+  });
 }
 
 export function toggleProviderEnabled(id: string): { toggled: boolean; enabled?: boolean; error?: string } {
-  const registry = loadRegistry();
-  const provider = registry.providers.find(p => p.id === id);
-  if (!provider) return { toggled: false, error: `Provider not found: ${id}` };
-  provider.enabled = !provider.enabled;
-  saveRegistry(registry);
-  return { toggled: true, enabled: provider.enabled };
+  return withRegistryWriteLockSync(() => {
+    const registry = loadRegistry();
+    const provider = registry.providers.find(p => p.id === id);
+    if (!provider) return { toggled: false, error: `Provider not found: ${id}` };
+    provider.enabled = !provider.enabled;
+    saveRegistry(registry);
+    return { toggled: true, enabled: provider.enabled };
+  });
 }

--- a/src/registry/crud.ts
+++ b/src/registry/crud.ts
@@ -1,6 +1,6 @@
 // src/registry/crud.ts — add/remove providers in the native registry
 
-import { parseAuthRef, deleteProviderCredential } from '../env.js';
+import { deleteProviderCredential } from '../env.js';
 import { loadRegistry, saveRegistry } from './io.js';
 import { withRegistryWriteLock, withRegistryWriteLockSync } from './lock.js';
 import type { RegistryProvider } from './types.js';
@@ -34,9 +34,8 @@ export async function removeProviderFromRegistry(
 
     let credentialDeleted = false;
     if (opts?.deleteCredential !== false) {
-      const parsed = parseAuthRef(removedProvider.authRef);
       const shouldDelete = !credentialStillReferenced(removedProvider.authRef, registry.providers);
-      if (shouldDelete && parsed?.kind === 'keyring') {
+      if (shouldDelete) {
         credentialDeleted = await deleteProviderCredential(removedProvider.authRef);
       }
     }

--- a/src/registry/crud.ts
+++ b/src/registry/crud.ts
@@ -17,6 +17,11 @@ export interface RemoveProviderResult {
   error?: string;
 }
 
+interface PendingProviderRemoval {
+  result: RemoveProviderResult;
+  authRefToDelete: string | null;
+}
+
 function credentialStillReferenced(authRef: string, remaining: RegistryProvider[]): boolean {
   return remaining.some(p => p.authRef === authRef);
 }
@@ -26,7 +31,7 @@ export async function removeProviderFromRegistry(
   id: string,
   opts?: { deleteCredential?: boolean },
 ): Promise<RemoveProviderResult> {
-  const removal = await withRegistryWriteLock(() => {
+  const removal = await withRegistryWriteLock<PendingProviderRemoval>(() => {
     const registry = loadRegistry();
     const index = registry.providers.findIndex(p => p.id === id);
     if (index < 0) {
@@ -71,6 +76,12 @@ export async function removeProviderFromRegistry(
       removal.result.credentialDeleted = await deleteProviderCredential(
         authRefToDelete,
       );
+      if (!removal.result.credentialDeleted) {
+        removal.result.error =
+          `Provider ${removal.result.name ?? id} was removed, but credential ` +
+          `cleanup failed for ${authRefToDelete}. The credential remains in ` +
+          'the configured store and must be removed manually.';
+      }
     });
   }
   return removal.result;

--- a/src/registry/custom-endpoint.ts
+++ b/src/registry/custom-endpoint.ts
@@ -6,6 +6,7 @@ import { deriveBrand } from '../models.js';
 import { resolveContextWindow } from '../context-window.js';
 import { fetchTemplateModels } from './fetch-template-models.js';
 import { loadRegistry, saveRegistry } from './io.js';
+import { withRegistryWriteLock } from './lock.js';
 import type { CachedModel, RegistryProvider } from './types.js';
 import { customProviderId, isValidProviderId, slugifyProviderId } from './validate.js';
 import { validateCustomEndpointUrl } from './url-security.js';
@@ -147,8 +148,9 @@ export async function addCustomEndpointProvider(input: AddCustomEndpointInput): 
     return { added: false, error: urlCheck.error, hint: urlCheck.hint };
   }
 
-  const registry = loadRegistry();
-  const providerId = uniqueProviderId(input.displayName.trim(), registry);
+  const normalizedUrl = urlCheck.normalizedUrl;
+  const displayName = input.displayName.trim();
+  const probeProviderId = uniqueProviderId(displayName, { providers: [] });
   const npm = npmForKind(input.kind);
   const apiKey = input.apiKey.trim() || 'local';
 
@@ -156,20 +158,20 @@ export async function addCustomEndpointProvider(input: AddCustomEndpointInput): 
 
   let fetched: { models: CachedModel[]; baseUrl: string; error?: string; hint?: string };
   if (input.kind === 'anthropic') {
-    fetched = await fetchAnthropicModels(urlCheck.normalizedUrl, apiKey, headers);
+    fetched = await fetchAnthropicModels(normalizedUrl, apiKey, headers);
   } else {
     fetched = await fetchTemplateModels(
       {
-        id: providerId,
-        name: input.displayName,
+        id: probeProviderId,
+        name: displayName,
         authType: apiKey === 'local' ? 'none' : 'api',
         npm,
-        defaultBaseUrl: urlCheck.normalizedUrl,
+        defaultBaseUrl: normalizedUrl,
         modelSource: 'api-list',
         supported: true,
       },
       apiKey,
-      urlCheck.normalizedUrl,
+      normalizedUrl,
       headers,
     );
   }
@@ -178,41 +180,45 @@ export async function addCustomEndpointProvider(input: AddCustomEndpointInput): 
     return { added: false, error: fetched.error ?? 'No models returned.', hint: fetched.hint };
   }
 
-  const authRef = credentialAuthRef(`provider:${providerId}`);
-  if (apiKey !== 'local') {
-    const saved = await saveProviderCredential(authRef, apiKey);
-    if (!saved) {
-      return { added: false, error: 'Could not save API key to the credential store.', hint: 'Check credential-store access and try again.' };
+  return withRegistryWriteLock(async () => {
+    const registry = loadRegistry();
+    const providerId = uniqueProviderId(displayName, registry);
+    const authRef = credentialAuthRef(`provider:${providerId}`);
+    if (apiKey !== 'local') {
+      const saved = await saveProviderCredential(authRef, apiKey);
+      if (!saved) {
+        return { added: false, error: 'Could not save API key to the credential store.', hint: 'Check credential-store access and try again.' };
+      }
     }
-  }
 
-  const now = new Date().toISOString();
-  const entry: RegistryProvider = {
-    id: providerId,
-    templateId: input.kind === 'anthropic' ? 'custom-anthropic' : 'custom-openai',
-    name: input.displayName.trim(),
-    enabled: true,
-    authRef,
-    api: { npm, url: fetched.baseUrl, ...(headers ? { headers } : {}) },
-    addedAt: now,
-    refreshedAt: now,
-    modelsCache: {
-      fetchedAt: now,
-      models: fetched.models.map(m => ({
-        ...m,
-        modelFormat: modelFormatForKind(input.kind),
-        npm,
-        apiUrl: fetched.baseUrl,
-      })),
-    },
-  };
+    const now = new Date().toISOString();
+    const entry: RegistryProvider = {
+      id: providerId,
+      templateId: input.kind === 'anthropic' ? 'custom-anthropic' : 'custom-openai',
+      name: displayName,
+      enabled: true,
+      authRef,
+      api: { npm, url: fetched.baseUrl, ...(headers ? { headers } : {}) },
+      addedAt: now,
+      refreshedAt: now,
+      modelsCache: {
+        fetchedAt: now,
+        models: fetched.models.map(m => ({
+          ...m,
+          modelFormat: modelFormatForKind(input.kind),
+          npm,
+          apiUrl: fetched.baseUrl,
+        })),
+      },
+    };
 
-  if (apiKey === 'local') {
-    await saveProviderCredential(entry.authRef, 'local');
-  }
+    if (apiKey === 'local') {
+      await saveProviderCredential(entry.authRef, 'local');
+    }
 
-  registry.providers.push(entry);
-  saveRegistry(registry);
+    registry.providers.push(entry);
+    saveRegistry(registry);
 
-  return { added: true, provider: entry, modelCount: fetched.models.length };
+    return { added: true, provider: entry, modelCount: fetched.models.length };
+  });
 }

--- a/src/registry/custom-endpoint.ts
+++ b/src/registry/custom-endpoint.ts
@@ -1,6 +1,7 @@
 // src/registry/custom-endpoint.ts — add custom OpenAI/Anthropic-compatible providers
 
 import { saveProviderCredential } from '../env.js';
+import { credentialAuthRef } from '../credential-helper.js';
 import { deriveBrand } from '../models.js';
 import { resolveContextWindow } from '../context-window.js';
 import { fetchTemplateModels } from './fetch-template-models.js';
@@ -177,10 +178,11 @@ export async function addCustomEndpointProvider(input: AddCustomEndpointInput): 
     return { added: false, error: fetched.error ?? 'No models returned.', hint: fetched.hint };
   }
 
+  const authRef = credentialAuthRef(`provider:${providerId}`);
   if (apiKey !== 'local') {
-    const saved = await saveProviderCredential(`keyring:provider:${providerId}`, apiKey);
+    const saved = await saveProviderCredential(authRef, apiKey);
     if (!saved) {
-      return { added: false, error: 'Could not save API key to Keychain.', hint: 'Grant Keychain access and try again.' };
+      return { added: false, error: 'Could not save API key to the credential store.', hint: 'Check credential-store access and try again.' };
     }
   }
 
@@ -190,7 +192,7 @@ export async function addCustomEndpointProvider(input: AddCustomEndpointInput): 
     templateId: input.kind === 'anthropic' ? 'custom-anthropic' : 'custom-openai',
     name: input.displayName.trim(),
     enabled: true,
-    authRef: apiKey === 'local' ? `keyring:provider:${providerId}` : `keyring:provider:${providerId}`,
+    authRef,
     api: { npm, url: fetched.baseUrl, ...(headers ? { headers } : {}) },
     addedAt: now,
     refreshedAt: now,

--- a/src/registry/custom-endpoint.ts
+++ b/src/registry/custom-endpoint.ts
@@ -1,12 +1,16 @@
 // src/registry/custom-endpoint.ts — add custom OpenAI/Anthropic-compatible providers
 
+import { randomUUID } from 'node:crypto';
 import { saveProviderCredential } from '../env.js';
 import { credentialAuthRef } from '../credential-helper.js';
 import { deriveBrand } from '../models.js';
 import { resolveContextWindow } from '../context-window.js';
 import { fetchTemplateModels } from './fetch-template-models.js';
 import { loadRegistry, saveRegistry } from './io.js';
-import { withRegistryWriteLock } from './lock.js';
+import {
+  withCredentialMutationLock,
+  withRegistryWriteLock,
+} from './lock.js';
 import type { CachedModel, RegistryProvider } from './types.js';
 import { customProviderId, isValidProviderId, slugifyProviderId } from './validate.js';
 import { validateCustomEndpointUrl } from './url-security.js';
@@ -181,18 +185,12 @@ export async function addCustomEndpointProvider(input: AddCustomEndpointInput): 
     return { added: false, error: fetched.error ?? 'No models returned.', hint: fetched.hint };
   }
 
-  return withRegistryWriteLock(async () => {
+  const authRef = anonymous
+    ? 'none:anonymous'
+    : credentialAuthRef(`provider:${probeProviderId}:${randomUUID()}`);
+  const commitProvider = () => withRegistryWriteLock(() => {
     const registry = loadRegistry();
     const providerId = uniqueProviderId(displayName, registry);
-    const authRef = anonymous
-      ? 'none:anonymous'
-      : credentialAuthRef(`provider:${providerId}`);
-    if (!anonymous) {
-      const saved = await saveProviderCredential(authRef, apiKey);
-      if (!saved) {
-        return { added: false, error: 'Could not save API key to the credential store.', hint: 'Check credential-store access and try again.' };
-      }
-    }
 
     const now = new Date().toISOString();
     const entry: RegistryProvider = {
@@ -220,5 +218,18 @@ export async function addCustomEndpointProvider(input: AddCustomEndpointInput): 
     saveRegistry(registry);
 
     return { added: true, provider: entry, modelCount: fetched.models.length };
+  });
+
+  if (anonymous) return commitProvider();
+  return withCredentialMutationLock(authRef, async () => {
+    const saved = await saveProviderCredential(authRef, apiKey);
+    if (!saved) {
+      return {
+        added: false,
+        error: 'Could not save API key to the credential store.',
+        hint: 'Check credential-store access and try again.',
+      };
+    }
+    return commitProvider();
   });
 }

--- a/src/registry/custom-endpoint.ts
+++ b/src/registry/custom-endpoint.ts
@@ -54,7 +54,7 @@ export async function fetchAnthropicModels(
     const response = await fetch(modelsUrl, {
       method: 'GET',
       headers: {
-        'x-api-key': apiKey,
+        ...(apiKey ? { 'x-api-key': apiKey } : {}),
         'anthropic-version': '2023-06-01',
         Accept: 'application/json',
         ...extraHeaders,
@@ -152,7 +152,8 @@ export async function addCustomEndpointProvider(input: AddCustomEndpointInput): 
   const displayName = input.displayName.trim();
   const probeProviderId = uniqueProviderId(displayName, { providers: [] });
   const npm = npmForKind(input.kind);
-  const apiKey = input.apiKey.trim() || 'local';
+  const apiKey = input.apiKey.trim();
+  const anonymous = apiKey.length === 0;
 
   const headers = input.headers && Object.keys(input.headers).length > 0 ? input.headers : undefined;
 
@@ -164,7 +165,7 @@ export async function addCustomEndpointProvider(input: AddCustomEndpointInput): 
       {
         id: probeProviderId,
         name: displayName,
-        authType: apiKey === 'local' ? 'none' : 'api',
+        authType: anonymous ? 'none' : 'api',
         npm,
         defaultBaseUrl: normalizedUrl,
         modelSource: 'api-list',
@@ -183,8 +184,10 @@ export async function addCustomEndpointProvider(input: AddCustomEndpointInput): 
   return withRegistryWriteLock(async () => {
     const registry = loadRegistry();
     const providerId = uniqueProviderId(displayName, registry);
-    const authRef = credentialAuthRef(`provider:${providerId}`);
-    if (apiKey !== 'local') {
+    const authRef = anonymous
+      ? 'none:anonymous'
+      : credentialAuthRef(`provider:${providerId}`);
+    if (!anonymous) {
       const saved = await saveProviderCredential(authRef, apiKey);
       if (!saved) {
         return { added: false, error: 'Could not save API key to the credential store.', hint: 'Check credential-store access and try again.' };
@@ -198,6 +201,7 @@ export async function addCustomEndpointProvider(input: AddCustomEndpointInput): 
       name: displayName,
       enabled: true,
       authRef,
+      authType: anonymous ? 'none' : 'api',
       api: { npm, url: fetched.baseUrl, ...(headers ? { headers } : {}) },
       addedAt: now,
       refreshedAt: now,
@@ -211,10 +215,6 @@ export async function addCustomEndpointProvider(input: AddCustomEndpointInput): 
         })),
       },
     };
-
-    if (apiKey === 'local') {
-      await saveProviderCredential(entry.authRef, 'local');
-    }
 
     registry.providers.push(entry);
     saveRegistry(registry);

--- a/src/registry/import-build.ts
+++ b/src/registry/import-build.ts
@@ -1,7 +1,9 @@
 // import-build.ts — registry auth-ref helpers for OAuth providers
 
+import { credentialAuthRef } from '../credential-helper.js';
+
 export function oauthAuthRef(providerId: string): string {
-  return `keyring:oauth:provider:${providerId}`;
+  return credentialAuthRef(`oauth:provider:${providerId}`);
 }
 
 /** Maps a canonical OAuth provider ID to its registry slot (openai → openai-oauth; others unchanged). */

--- a/src/registry/io.ts
+++ b/src/registry/io.ts
@@ -15,6 +15,7 @@ import { dirname } from 'node:path';
 import { ensureLegacyAppHomeMigrated, getAppHome, getProvidersPath } from '../paths.js';
 import type { ProviderRegistry, RegistryProvider } from './types.js';
 import { REGISTRY_SCHEMA_VERSION } from './types.js';
+import { withRegistryWriteLockSync } from './lock.js';
 import { migrateOAuthOpenAiProvider } from './migrate.js';
 import { isValidProviderId } from './validate.js';
 
@@ -122,7 +123,11 @@ export function loadRegistry(path = getProvidersPath()): ProviderRegistry {
     const migrated = migrateOAuthOpenAiProvider(registry);
     if (migrated) {
       try {
-        saveRegistry(registry, path);
+        withRegistryWriteLockSync(() => {
+          if (!existsSync(path)) return;
+          const current = parseRegistry(JSON.parse(readFileSync(path, 'utf8')));
+          if (migrateOAuthOpenAiProvider(current)) saveRegistry(current, path);
+        }, { lockPath: `${path}.lock` });
       } catch {
         // Parsed data remains usable even when migration persistence fails.
       }

--- a/src/registry/io.ts
+++ b/src/registry/io.ts
@@ -1,21 +1,26 @@
 // src/registry/io.ts — load/save providers.json with secure permissions
 
+import { randomUUID } from 'node:crypto';
 import {
   chmodSync,
+  closeSync,
   copyFileSync,
   existsSync,
   mkdirSync,
   openSync,
   readFileSync,
   renameSync,
+  unlinkSync,
   writeSync,
-  closeSync,
 } from 'node:fs';
 import { dirname } from 'node:path';
 import { ensureLegacyAppHomeMigrated, getAppHome, getProvidersPath } from '../paths.js';
 import type { ProviderRegistry, RegistryProvider } from './types.js';
 import { REGISTRY_SCHEMA_VERSION } from './types.js';
-import { withRegistryWriteLockSync } from './lock.js';
+import {
+  assertRegistryWriteOwnership,
+  withRegistryWriteLockSync,
+} from './lock.js';
 import { migrateOAuthOpenAiProvider } from './migrate.js';
 import { isValidProviderId } from './validate.js';
 
@@ -139,6 +144,7 @@ export function loadRegistry(path = getProvidersPath()): ProviderRegistry {
 }
 
 export function saveRegistry(registry: ProviderRegistry, path = getProvidersPath()): void {
+  assertRegistryWriteOwnership(path);
   const payload = `${JSON.stringify(registry, null, 2)}\n`;
   const backup = `${path}.bak`;
   if (existsSync(path)) {
@@ -148,9 +154,18 @@ export function saveRegistry(registry: ProviderRegistry, path = getProvidersPath
       // backup is best-effort
     }
   }
-  const tmp = `${path}.tmp`;
-  writeSecureFile(tmp, payload);
-  renameSync(tmp, path);
+  const tmp = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    writeSecureFile(tmp, payload);
+    assertRegistryWriteOwnership(path);
+    renameSync(tmp, path);
+  } finally {
+    try {
+      unlinkSync(tmp);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    }
+  }
 }
 
 export function emptyRegistry(): ProviderRegistry {

--- a/src/registry/load.ts
+++ b/src/registry/load.ts
@@ -3,7 +3,7 @@
 import { resolveProviderCredential, resolveProviderOAuthAccountId, resolveProviderOAuthProviderData } from '../env.js';
 import type { CompatibilityAgent } from '../model-compatibility.js';
 import type { LocalProvider } from '../types.js';
-import { materializeRegistry } from './materialize.js';
+import { isAnonymousProvider, materializeRegistry } from './materialize.js';
 import { loadRegistry } from './io.js';
 
 /** Load enabled providers from ~/.clodex/providers.json with resolved credentials. */
@@ -16,6 +16,7 @@ export async function loadRegistryProviders(
   const oauthAccountIds = new Map<string, string>();
   const oauthProviderData = new Map<string, Record<string, unknown>>();
   await Promise.all(registry.providers.map(async provider => {
+    if (isAnonymousProvider(provider)) return;
     try {
       const key = await resolveProviderCredential(provider.id, provider.authRef, diag);
       if (key) keys.set(provider.id, key);
@@ -47,5 +48,9 @@ export function loadRegistryProvidersSync(
   opts?: { agent?: CompatibilityAgent },
 ): LocalProvider[] {
   const registry = loadRegistry();
-  return materializeRegistry(registry, provider => resolveKey(provider.id, provider.authRef), opts);
+  return materializeRegistry(
+    registry,
+    provider => isAnonymousProvider(provider) ? null : resolveKey(provider.id, provider.authRef),
+    opts,
+  );
 }

--- a/src/registry/lock.ts
+++ b/src/registry/lock.ts
@@ -1,0 +1,335 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { randomUUID } from 'node:crypto';
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname } from 'node:path';
+import { getProvidersPath } from '../paths.js';
+
+const DEFAULT_WAIT_MS = 30_000;
+const DEFAULT_RETRY_MS = 25;
+const INVALID_LOCK_STALE_MS = 10 * 60 * 1000;
+
+interface RegistryLockOwner {
+  pid: number;
+  startedAt: number;
+  token: string;
+}
+
+interface RegistryLockSnapshot {
+  raw: string;
+  device: number;
+  inode: number;
+  modifiedAt: number;
+}
+
+interface RegistryLockOptions {
+  lockPath?: string;
+  waitMs?: number;
+  retryMs?: number;
+  now?: () => number;
+  isAlive?: (pid: number) => boolean;
+}
+
+interface RegistryLockContext {
+  leases: ReadonlyMap<string, RegistryLockLease>;
+}
+
+interface RegistryLockLease {
+  active: boolean;
+}
+
+const registryLockContext = new AsyncLocalStorage<RegistryLockContext>();
+
+export function getRegistryLockPath(): string {
+  return `${getProvidersPath()}.lock`;
+}
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+function parseLockOwner(raw: string): RegistryLockOwner | null {
+  try {
+    const parsed = JSON.parse(raw) as Partial<RegistryLockOwner>;
+    if (!Number.isInteger(parsed.pid) || (parsed.pid ?? 0) <= 0) return null;
+    if (
+      typeof parsed.startedAt !== 'number' ||
+      !Number.isFinite(parsed.startedAt)
+    )
+      return null;
+    if (typeof parsed.token !== 'string' || parsed.token.length === 0)
+      return null;
+    return parsed as RegistryLockOwner;
+  } catch {
+    return null;
+  }
+}
+
+function getStaleLockSnapshot(
+  lockPath: string,
+  now: number,
+  alive: (pid: number) => boolean,
+): RegistryLockSnapshot | null {
+  const raw = readFileSync(lockPath, 'utf8');
+  const stats = statSync(lockPath);
+  const snapshot: RegistryLockSnapshot = {
+    raw,
+    device: stats.dev,
+    inode: stats.ino,
+    modifiedAt: stats.mtimeMs,
+  };
+  const owner = parseLockOwner(raw);
+  if (owner) return alive(owner.pid) ? null : snapshot;
+
+  // A process can be between exclusive creation and writing its owner record.
+  // Only reap malformed locks after a long grace period.
+  return now - snapshot.modifiedAt >= INVALID_LOCK_STALE_MS ? snapshot : null;
+}
+
+function removeStaleLock(
+  lockPath: string,
+  expected?: RegistryLockSnapshot,
+): boolean {
+  try {
+    if (expected) {
+      const raw = readFileSync(lockPath, 'utf8');
+      const stats = statSync(lockPath);
+      if (
+        raw !== expected.raw ||
+        stats.dev !== expected.device ||
+        stats.ino !== expected.inode ||
+        stats.mtimeMs !== expected.modifiedAt
+      )
+        return false;
+    }
+    unlinkSync(lockPath);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    return false;
+  }
+}
+
+function tryAcquireReaperGuard(
+  lockPath: string,
+  now: number,
+  alive: (pid: number) => boolean,
+): (() => void) | null {
+  const guardPath = `${lockPath}.reap`;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const token = randomUUID();
+    let fd: number | undefined;
+    try {
+      fd = openSync(guardPath, 'wx', 0o600);
+      const owner: RegistryLockOwner = {
+        pid: process.pid,
+        startedAt: now,
+        token,
+      };
+      writeFileSync(fd, JSON.stringify(owner));
+      closeSync(fd);
+      fd = undefined;
+      return () => {
+        try {
+          const current = parseLockOwner(readFileSync(guardPath, 'utf8'));
+          if (current?.token === token) unlinkSync(guardPath);
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+        }
+      };
+    } catch (err) {
+      if (fd !== undefined) {
+        try {
+          closeSync(fd);
+        } catch {
+          // The original error remains authoritative.
+        }
+        removeStaleLock(guardPath);
+        throw err;
+      }
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+
+      let stale: RegistryLockSnapshot | null = null;
+      try {
+        stale = getStaleLockSnapshot(guardPath, now, alive);
+      } catch (readErr) {
+        if ((readErr as NodeJS.ErrnoException).code === 'ENOENT') continue;
+        throw readErr;
+      }
+      if (!stale) return null;
+      if (!removeStaleLock(guardPath, stale)) continue;
+    }
+  }
+  return null;
+}
+
+export function tryAcquireRegistryLock(
+  lockPath = getRegistryLockPath(),
+  options: Pick<RegistryLockOptions, 'now' | 'isAlive'> = {},
+): (() => void) | null {
+  const now = options.now?.() ?? Date.now();
+  const alive = options.isAlive ?? isPidAlive;
+  mkdirSync(dirname(lockPath), { recursive: true, mode: 0o700 });
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const token = randomUUID();
+    let fd: number | undefined;
+    try {
+      fd = openSync(lockPath, 'wx', 0o600);
+      const owner: RegistryLockOwner = {
+        pid: process.pid,
+        startedAt: now,
+        token,
+      };
+      writeFileSync(fd, JSON.stringify(owner));
+      closeSync(fd);
+      fd = undefined;
+      return () => {
+        try {
+          const current = parseLockOwner(readFileSync(lockPath, 'utf8'));
+          if (current?.token === token) unlinkSync(lockPath);
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+        }
+      };
+    } catch (err) {
+      if (fd !== undefined) {
+        try {
+          closeSync(fd);
+        } catch {
+          // The original error remains authoritative.
+        }
+        removeStaleLock(lockPath);
+        throw err;
+      }
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+
+      let stale: RegistryLockSnapshot | null = null;
+      try {
+        stale = getStaleLockSnapshot(lockPath, now, alive);
+      } catch (readErr) {
+        if ((readErr as NodeJS.ErrnoException).code === 'ENOENT') continue;
+        throw readErr;
+      }
+      if (!stale) return null;
+      const releaseReaper = tryAcquireReaperGuard(lockPath, now, alive);
+      if (!releaseReaper) return null;
+      try {
+        let currentStale: RegistryLockSnapshot | null = null;
+        try {
+          currentStale = getStaleLockSnapshot(lockPath, now, alive);
+        } catch (readErr) {
+          if ((readErr as NodeJS.ErrnoException).code === 'ENOENT') continue;
+          throw readErr;
+        }
+        if (!currentStale) return null;
+        if (!removeStaleLock(lockPath, currentStale)) continue;
+      } finally {
+        releaseReaper();
+      }
+    }
+  }
+  return null;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function lockTimeoutError(lockPath: string, waitMs: number): Error {
+  return new Error(
+    `Timed out after ${waitMs}ms waiting for provider registry lock: ${lockPath}`,
+  );
+}
+
+export async function withRegistryWriteLock<T>(
+  operation: () => Promise<T> | T,
+  options: RegistryLockOptions = {},
+): Promise<T> {
+  const lockPath = options.lockPath ?? getRegistryLockPath();
+  const inheritedLeases = registryLockContext.getStore()?.leases;
+  if (inheritedLeases?.get(lockPath)?.active) return operation();
+
+  const waitMs = options.waitMs ?? DEFAULT_WAIT_MS;
+  const retryMs = options.retryMs ?? DEFAULT_RETRY_MS;
+  const now = options.now ?? Date.now;
+  const deadline = now() + waitMs;
+  let release: (() => void) | null = null;
+
+  while (!release) {
+    release = tryAcquireRegistryLock(lockPath, {
+      now,
+      isAlive: options.isAlive,
+    });
+    if (release) break;
+    if (now() >= deadline) throw lockTimeoutError(lockPath, waitMs);
+    await sleep(retryMs);
+  }
+
+  const lease: RegistryLockLease = { active: true };
+  const leases = new Map(inheritedLeases);
+  leases.set(lockPath, lease);
+  const context: RegistryLockContext = { leases };
+  return registryLockContext.run(context, async () => {
+    try {
+      return await operation();
+    } finally {
+      lease.active = false;
+      release?.();
+    }
+  });
+}
+
+export function withRegistryWriteLockSync<T>(
+  operation: () => T,
+  options: RegistryLockOptions = {},
+): T {
+  const lockPath = options.lockPath ?? getRegistryLockPath();
+  const inheritedLeases = registryLockContext.getStore()?.leases;
+  if (inheritedLeases?.get(lockPath)?.active) return operation();
+
+  const waitMs = options.waitMs ?? DEFAULT_WAIT_MS;
+  const retryMs = options.retryMs ?? DEFAULT_RETRY_MS;
+  const now = options.now ?? Date.now;
+  const deadline = now() + waitMs;
+  let release: (() => void) | null = null;
+
+  while (!release) {
+    release = tryAcquireRegistryLock(lockPath, {
+      now,
+      isAlive: options.isAlive,
+    });
+    if (release) break;
+    if (now() >= deadline) throw lockTimeoutError(lockPath, waitMs);
+    sleepSync(retryMs);
+  }
+
+  const lease: RegistryLockLease = { active: true };
+  const leases = new Map(inheritedLeases);
+  leases.set(lockPath, lease);
+  const context: RegistryLockContext = { leases };
+  return registryLockContext.run(context, () => {
+    try {
+      return operation();
+    } finally {
+      lease.active = false;
+      release?.();
+    }
+  });
+}

--- a/src/registry/lock.ts
+++ b/src/registry/lock.ts
@@ -17,7 +17,6 @@ import { getProvidersPath } from '../paths.js';
 
 const DEFAULT_WAIT_MS = 30_000;
 const DEFAULT_RETRY_MS = 25;
-const LOCK_MAX_HOLD_MS = 10 * 60 * 1000;
 
 interface RegistryLockOwner {
   pid: number;
@@ -38,7 +37,6 @@ interface RegistryLockOptions {
   retryMs?: number;
   now?: () => number;
   isAlive?: (pid: number) => boolean;
-  reclaimExpiredLiveOwner?: boolean;
 }
 
 interface RegistryLockContext {
@@ -187,9 +185,7 @@ export function assertRegistryWriteOwnership(
 
 function getStaleLockSnapshot(
   lockPath: string,
-  now: number,
   alive: (pid: number) => boolean,
-  reclaimExpiredLiveOwner: boolean,
 ): RegistryLockSnapshot | null {
   const raw = readFileSync(lockPath, 'utf8');
   const stats = statSync(lockPath);
@@ -200,12 +196,7 @@ function getStaleLockSnapshot(
     modifiedAt: stats.mtimeMs,
   };
   const owner = parseLockOwner(raw);
-  if (owner) {
-    const expired = now - owner.startedAt >= LOCK_MAX_HOLD_MS;
-    return alive(owner.pid) && (!reclaimExpiredLiveOwner || !expired)
-      ? null
-      : snapshot;
-  }
+  if (owner) return alive(owner.pid) ? null : snapshot;
   return snapshot;
 }
 
@@ -237,7 +228,6 @@ function tryAcquireReaperGuard(
   lockPath: string,
   now: number,
   alive: (pid: number) => boolean,
-  reclaimExpiredLiveOwner: boolean,
 ): RegistryLockLease | null {
   const guardPath = `${lockPath}.reap`;
   for (let attempt = 0; attempt < 3; attempt += 1) {
@@ -256,12 +246,7 @@ function tryAcquireReaperGuard(
 
     let stale: RegistryLockSnapshot | null = null;
     try {
-      stale = getStaleLockSnapshot(
-        guardPath,
-        now,
-        alive,
-        reclaimExpiredLiveOwner,
-      );
+      stale = getStaleLockSnapshot(guardPath, alive);
     } catch (readErr) {
       if ((readErr as NodeJS.ErrnoException).code === 'ENOENT') continue;
       throw readErr;
@@ -274,14 +259,10 @@ function tryAcquireReaperGuard(
 
 export function tryAcquireRegistryLock(
   lockPath = getRegistryLockPath(),
-  options: Pick<
-    RegistryLockOptions,
-    'now' | 'isAlive' | 'reclaimExpiredLiveOwner'
-  > = {},
+  options: Pick<RegistryLockOptions, 'now' | 'isAlive'> = {},
 ): RegistryLockLease | null {
   const now = options.now?.() ?? Date.now();
   const alive = options.isAlive ?? isPidAlive;
-  const reclaimExpiredLiveOwner = options.reclaimExpiredLiveOwner ?? true;
   mkdirSync(dirname(lockPath), { recursive: true, mode: 0o700 });
 
   for (let attempt = 0; attempt < 3; attempt += 1) {
@@ -300,33 +281,18 @@ export function tryAcquireRegistryLock(
 
     let stale: RegistryLockSnapshot | null = null;
     try {
-      stale = getStaleLockSnapshot(
-        lockPath,
-        now,
-        alive,
-        reclaimExpiredLiveOwner,
-      );
+      stale = getStaleLockSnapshot(lockPath, alive);
     } catch (readErr) {
       if ((readErr as NodeJS.ErrnoException).code === 'ENOENT') continue;
       throw readErr;
     }
     if (!stale) return null;
-    const reaperLease = tryAcquireReaperGuard(
-      lockPath,
-      now,
-      alive,
-      reclaimExpiredLiveOwner,
-    );
+    const reaperLease = tryAcquireReaperGuard(lockPath, now, alive);
     if (!reaperLease) return null;
     try {
       let currentStale: RegistryLockSnapshot | null = null;
       try {
-        currentStale = getStaleLockSnapshot(
-          lockPath,
-          now,
-          alive,
-          reclaimExpiredLiveOwner,
-        );
+        currentStale = getStaleLockSnapshot(lockPath, alive);
       } catch (readErr) {
         if ((readErr as NodeJS.ErrnoException).code === 'ENOENT') continue;
         throw readErr;
@@ -348,7 +314,23 @@ function sleepSync(ms: number): void {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
-function lockTimeoutError(lockPath: string, waitMs: number): Error {
+function lockTimeoutError(
+  lockPath: string,
+  waitMs: number,
+  alive: (pid: number) => boolean,
+): Error {
+  let owner: RegistryLockOwner | null = null;
+  try {
+    owner = parseLockOwner(readFileSync(lockPath, 'utf8'));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+  if (owner && alive(owner.pid)) {
+    return new Error(
+      `Timed out after ${waitMs}ms waiting for lock held by clodex process ` +
+        `(pid ${owner.pid}): ${lockPath}`,
+    );
+  }
   return new Error(
     `Timed out after ${waitMs}ms waiting for lock: ${lockPath}`,
   );
@@ -372,10 +354,10 @@ export async function withRegistryWriteLock<T>(
     lease = tryAcquireRegistryLock(lockPath, {
       now,
       isAlive: options.isAlive,
-      reclaimExpiredLiveOwner: options.reclaimExpiredLiveOwner,
     });
     if (lease) break;
-    if (now() >= deadline) throw lockTimeoutError(lockPath, waitMs);
+    if (now() >= deadline)
+      throw lockTimeoutError(lockPath, waitMs, options.isAlive ?? isPidAlive);
     await sleep(retryMs);
   }
 
@@ -409,10 +391,10 @@ export function withRegistryWriteLockSync<T>(
     lease = tryAcquireRegistryLock(lockPath, {
       now,
       isAlive: options.isAlive,
-      reclaimExpiredLiveOwner: options.reclaimExpiredLiveOwner,
     });
     if (lease) break;
-    if (now() >= deadline) throw lockTimeoutError(lockPath, waitMs);
+    if (now() >= deadline)
+      throw lockTimeoutError(lockPath, waitMs, options.isAlive ?? isPidAlive);
     sleepSync(retryMs);
   }
 
@@ -442,6 +424,5 @@ export function withCredentialMutationLock<T>(
 ): Promise<T> {
   return withRegistryWriteLock(operation, {
     lockPath: getCredentialMutationLockPath(authRef),
-    reclaimExpiredLiveOwner: false,
   });
 }

--- a/src/registry/lock.ts
+++ b/src/registry/lock.ts
@@ -1,7 +1,10 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import {
   closeSync,
+  fstatSync,
+  fsyncSync,
+  linkSync,
   mkdirSync,
   openSync,
   readFileSync,
@@ -15,7 +18,6 @@ import { getProvidersPath } from '../paths.js';
 const DEFAULT_WAIT_MS = 30_000;
 const DEFAULT_RETRY_MS = 25;
 const LOCK_MAX_HOLD_MS = 10 * 60 * 1000;
-const INVALID_LOCK_STALE_MS = 10 * 60 * 1000;
 
 interface RegistryLockOwner {
   pid: number;
@@ -36,17 +38,31 @@ interface RegistryLockOptions {
   retryMs?: number;
   now?: () => number;
   isAlive?: (pid: number) => boolean;
+  reclaimExpiredLiveOwner?: boolean;
 }
 
 interface RegistryLockContext {
   leases: ReadonlyMap<string, RegistryLockLease>;
 }
 
-interface RegistryLockLease {
+export interface RegistryLockLease {
   active: boolean;
+  readonly lockPath: string;
+  readonly token: string;
+  readonly device: number;
+  readonly inode: number;
+  assertOwned: () => void;
+  release: () => void;
 }
 
 const registryLockContext = new AsyncLocalStorage<RegistryLockContext>();
+
+export class RegistryLockLostError extends Error {
+  constructor(lockPath: string) {
+    super(`Provider registry lock ownership was lost before write: ${lockPath}`);
+    this.name = 'RegistryLockLostError';
+  }
+}
 
 export function getRegistryLockPath(): string {
   return `${getProvidersPath()}.lock`;
@@ -78,10 +94,102 @@ function parseLockOwner(raw: string): RegistryLockOwner | null {
   }
 }
 
+function createLockRecord(
+  lockPath: string,
+  owner: RegistryLockOwner,
+): RegistryLockSnapshot | null {
+  const raw = JSON.stringify(owner);
+  const tempPath = `${lockPath}.${process.pid}.${owner.token}.tmp`;
+  let fd: number | undefined;
+  try {
+    fd = openSync(tempPath, 'wx', 0o600);
+    writeFileSync(fd, raw);
+    fsyncSync(fd);
+    const stats = fstatSync(fd);
+    try {
+      linkSync(tempPath, lockPath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'EEXIST') return null;
+      throw err;
+    }
+    return {
+      raw,
+      device: stats.dev,
+      inode: stats.ino,
+      modifiedAt: stats.mtimeMs,
+    };
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+    try {
+      unlinkSync(tempPath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    }
+  }
+}
+
+function lockFileMatchesLease(lease: RegistryLockLease): boolean {
+  let fd: number | undefined;
+  try {
+    fd = openSync(lease.lockPath, 'r');
+    const openedStats = fstatSync(fd);
+    const owner = parseLockOwner(readFileSync(fd, 'utf8'));
+    const pathStats = statSync(lease.lockPath);
+    return (
+      owner?.token === lease.token &&
+      openedStats.dev === lease.device &&
+      openedStats.ino === lease.inode &&
+      pathStats.dev === lease.device &&
+      pathStats.ino === lease.inode
+    );
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw err;
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+}
+
+function createLease(
+  lockPath: string,
+  owner: RegistryLockOwner,
+  snapshot: RegistryLockSnapshot,
+): RegistryLockLease {
+  const lease: RegistryLockLease = {
+    active: true,
+    lockPath,
+    token: owner.token,
+    device: snapshot.device,
+    inode: snapshot.inode,
+    assertOwned: () => {
+      if (!lease.active || !lockFileMatchesLease(lease)) {
+        lease.active = false;
+        throw new RegistryLockLostError(lockPath);
+      }
+    },
+    release: () => {
+      if (!lease.active) return;
+      lease.active = false;
+      if (lockFileMatchesLease(lease)) unlinkSync(lockPath);
+    },
+  };
+  return lease;
+}
+
+export function assertRegistryWriteOwnership(
+  registryPath = getProvidersPath(),
+): void {
+  const lockPath = `${registryPath}.lock`;
+  const lease = registryLockContext.getStore()?.leases.get(lockPath);
+  if (!lease) throw new RegistryLockLostError(lockPath);
+  lease.assertOwned();
+}
+
 function getStaleLockSnapshot(
   lockPath: string,
   now: number,
   alive: (pid: number) => boolean,
+  reclaimExpiredLiveOwner: boolean,
 ): RegistryLockSnapshot | null {
   const raw = readFileSync(lockPath, 'utf8');
   const stats = statSync(lockPath);
@@ -94,12 +202,11 @@ function getStaleLockSnapshot(
   const owner = parseLockOwner(raw);
   if (owner) {
     const expired = now - owner.startedAt >= LOCK_MAX_HOLD_MS;
-    return alive(owner.pid) && !expired ? null : snapshot;
+    return alive(owner.pid) && (!reclaimExpiredLiveOwner || !expired)
+      ? null
+      : snapshot;
   }
-
-  // A process can be between exclusive creation and writing its owner record.
-  // Only reap malformed locks after a long grace period.
-  return now - snapshot.modifiedAt >= INVALID_LOCK_STALE_MS ? snapshot : null;
+  return snapshot;
 }
 
 function removeStaleLock(
@@ -130,119 +237,104 @@ function tryAcquireReaperGuard(
   lockPath: string,
   now: number,
   alive: (pid: number) => boolean,
-): (() => void) | null {
+  reclaimExpiredLiveOwner: boolean,
+): RegistryLockLease | null {
   const guardPath = `${lockPath}.reap`;
   for (let attempt = 0; attempt < 3; attempt += 1) {
-    const token = randomUUID();
-    let fd: number | undefined;
+    const owner: RegistryLockOwner = {
+      pid: process.pid,
+      startedAt: now,
+      token: randomUUID(),
+    };
     try {
-      fd = openSync(guardPath, 'wx', 0o600);
-      const owner: RegistryLockOwner = {
-        pid: process.pid,
-        startedAt: now,
-        token,
-      };
-      writeFileSync(fd, JSON.stringify(owner));
-      closeSync(fd);
-      fd = undefined;
-      return () => {
-        try {
-          const current = parseLockOwner(readFileSync(guardPath, 'utf8'));
-          if (current?.token === token) unlinkSync(guardPath);
-        } catch (err) {
-          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
-        }
-      };
+      const snapshot = createLockRecord(guardPath, owner);
+      if (snapshot) return createLease(guardPath, owner, snapshot);
     } catch (err) {
-      if (fd !== undefined) {
-        try {
-          closeSync(fd);
-        } catch {
-          // The original error remains authoritative.
-        }
-        removeStaleLock(guardPath);
-        throw err;
-      }
-      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
-
-      let stale: RegistryLockSnapshot | null = null;
-      try {
-        stale = getStaleLockSnapshot(guardPath, now, alive);
-      } catch (readErr) {
-        if ((readErr as NodeJS.ErrnoException).code === 'ENOENT') continue;
-        throw readErr;
-      }
-      if (!stale) return null;
-      if (!removeStaleLock(guardPath, stale)) continue;
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      throw err;
     }
+
+    let stale: RegistryLockSnapshot | null = null;
+    try {
+      stale = getStaleLockSnapshot(
+        guardPath,
+        now,
+        alive,
+        reclaimExpiredLiveOwner,
+      );
+    } catch (readErr) {
+      if ((readErr as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      throw readErr;
+    }
+    if (!stale) return null;
+    if (!removeStaleLock(guardPath, stale)) continue;
   }
   return null;
 }
 
 export function tryAcquireRegistryLock(
   lockPath = getRegistryLockPath(),
-  options: Pick<RegistryLockOptions, 'now' | 'isAlive'> = {},
-): (() => void) | null {
+  options: Pick<
+    RegistryLockOptions,
+    'now' | 'isAlive' | 'reclaimExpiredLiveOwner'
+  > = {},
+): RegistryLockLease | null {
   const now = options.now?.() ?? Date.now();
   const alive = options.isAlive ?? isPidAlive;
+  const reclaimExpiredLiveOwner = options.reclaimExpiredLiveOwner ?? true;
   mkdirSync(dirname(lockPath), { recursive: true, mode: 0o700 });
 
   for (let attempt = 0; attempt < 3; attempt += 1) {
-    const token = randomUUID();
-    let fd: number | undefined;
+    const owner: RegistryLockOwner = {
+      pid: process.pid,
+      startedAt: now,
+      token: randomUUID(),
+    };
     try {
-      fd = openSync(lockPath, 'wx', 0o600);
-      const owner: RegistryLockOwner = {
-        pid: process.pid,
-        startedAt: now,
-        token,
-      };
-      writeFileSync(fd, JSON.stringify(owner));
-      closeSync(fd);
-      fd = undefined;
-      return () => {
-        try {
-          const current = parseLockOwner(readFileSync(lockPath, 'utf8'));
-          if (current?.token === token) unlinkSync(lockPath);
-        } catch (err) {
-          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
-        }
-      };
+      const snapshot = createLockRecord(lockPath, owner);
+      if (snapshot) return createLease(lockPath, owner, snapshot);
     } catch (err) {
-      if (fd !== undefined) {
-        try {
-          closeSync(fd);
-        } catch {
-          // The original error remains authoritative.
-        }
-        removeStaleLock(lockPath);
-        throw err;
-      }
-      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      throw err;
+    }
 
-      let stale: RegistryLockSnapshot | null = null;
+    let stale: RegistryLockSnapshot | null = null;
+    try {
+      stale = getStaleLockSnapshot(
+        lockPath,
+        now,
+        alive,
+        reclaimExpiredLiveOwner,
+      );
+    } catch (readErr) {
+      if ((readErr as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      throw readErr;
+    }
+    if (!stale) return null;
+    const reaperLease = tryAcquireReaperGuard(
+      lockPath,
+      now,
+      alive,
+      reclaimExpiredLiveOwner,
+    );
+    if (!reaperLease) return null;
+    try {
+      let currentStale: RegistryLockSnapshot | null = null;
       try {
-        stale = getStaleLockSnapshot(lockPath, now, alive);
+        currentStale = getStaleLockSnapshot(
+          lockPath,
+          now,
+          alive,
+          reclaimExpiredLiveOwner,
+        );
       } catch (readErr) {
         if ((readErr as NodeJS.ErrnoException).code === 'ENOENT') continue;
         throw readErr;
       }
-      if (!stale) return null;
-      const releaseReaper = tryAcquireReaperGuard(lockPath, now, alive);
-      if (!releaseReaper) return null;
-      try {
-        let currentStale: RegistryLockSnapshot | null = null;
-        try {
-          currentStale = getStaleLockSnapshot(lockPath, now, alive);
-        } catch (readErr) {
-          if ((readErr as NodeJS.ErrnoException).code === 'ENOENT') continue;
-          throw readErr;
-        }
-        if (!currentStale) return null;
-        if (!removeStaleLock(lockPath, currentStale)) continue;
-      } finally {
-        releaseReaper();
-      }
+      if (!currentStale) return null;
+      if (!removeStaleLock(lockPath, currentStale)) continue;
+    } finally {
+      reaperLease.release();
     }
   }
   return null;
@@ -258,7 +350,7 @@ function sleepSync(ms: number): void {
 
 function lockTimeoutError(lockPath: string, waitMs: number): Error {
   return new Error(
-    `Timed out after ${waitMs}ms waiting for provider registry lock: ${lockPath}`,
+    `Timed out after ${waitMs}ms waiting for lock: ${lockPath}`,
   );
 }
 
@@ -274,19 +366,19 @@ export async function withRegistryWriteLock<T>(
   const retryMs = options.retryMs ?? DEFAULT_RETRY_MS;
   const now = options.now ?? Date.now;
   const deadline = now() + waitMs;
-  let release: (() => void) | null = null;
+  let lease: RegistryLockLease | null = null;
 
-  while (!release) {
-    release = tryAcquireRegistryLock(lockPath, {
+  while (!lease) {
+    lease = tryAcquireRegistryLock(lockPath, {
       now,
       isAlive: options.isAlive,
+      reclaimExpiredLiveOwner: options.reclaimExpiredLiveOwner,
     });
-    if (release) break;
+    if (lease) break;
     if (now() >= deadline) throw lockTimeoutError(lockPath, waitMs);
     await sleep(retryMs);
   }
 
-  const lease: RegistryLockLease = { active: true };
   const leases = new Map(inheritedLeases);
   leases.set(lockPath, lease);
   const context: RegistryLockContext = { leases };
@@ -294,8 +386,7 @@ export async function withRegistryWriteLock<T>(
     try {
       return await operation();
     } finally {
-      lease.active = false;
-      release?.();
+      lease.release();
     }
   });
 }
@@ -312,19 +403,19 @@ export function withRegistryWriteLockSync<T>(
   const retryMs = options.retryMs ?? DEFAULT_RETRY_MS;
   const now = options.now ?? Date.now;
   const deadline = now() + waitMs;
-  let release: (() => void) | null = null;
+  let lease: RegistryLockLease | null = null;
 
-  while (!release) {
-    release = tryAcquireRegistryLock(lockPath, {
+  while (!lease) {
+    lease = tryAcquireRegistryLock(lockPath, {
       now,
       isAlive: options.isAlive,
+      reclaimExpiredLiveOwner: options.reclaimExpiredLiveOwner,
     });
-    if (release) break;
+    if (lease) break;
     if (now() >= deadline) throw lockTimeoutError(lockPath, waitMs);
     sleepSync(retryMs);
   }
 
-  const lease: RegistryLockLease = { active: true };
   const leases = new Map(inheritedLeases);
   leases.set(lockPath, lease);
   const context: RegistryLockContext = { leases };
@@ -332,8 +423,25 @@ export function withRegistryWriteLockSync<T>(
     try {
       return operation();
     } finally {
-      lease.active = false;
-      release?.();
+      lease.release();
     }
+  });
+}
+
+export function getCredentialMutationLockPath(authRef: string): string {
+  const digest = createHash('sha256')
+    .update('clodex-credential-mutation\0')
+    .update(authRef)
+    .digest('hex');
+  return `${getProvidersPath()}.credential-${digest}.lock`;
+}
+
+export function withCredentialMutationLock<T>(
+  authRef: string,
+  operation: () => Promise<T> | T,
+): Promise<T> {
+  return withRegistryWriteLock(operation, {
+    lockPath: getCredentialMutationLockPath(authRef),
+    reclaimExpiredLiveOwner: false,
   });
 }

--- a/src/registry/lock.ts
+++ b/src/registry/lock.ts
@@ -14,6 +14,7 @@ import { getProvidersPath } from '../paths.js';
 
 const DEFAULT_WAIT_MS = 30_000;
 const DEFAULT_RETRY_MS = 25;
+const LOCK_MAX_HOLD_MS = 10 * 60 * 1000;
 const INVALID_LOCK_STALE_MS = 10 * 60 * 1000;
 
 interface RegistryLockOwner {
@@ -91,7 +92,10 @@ function getStaleLockSnapshot(
     modifiedAt: stats.mtimeMs,
   };
   const owner = parseLockOwner(raw);
-  if (owner) return alive(owner.pid) ? null : snapshot;
+  if (owner) {
+    const expired = now - owner.startedAt >= LOCK_MAX_HOLD_MS;
+    return alive(owner.pid) && !expired ? null : snapshot;
+  }
 
   // A process can be between exclusive creation and writing its owner record.
   // Only reap malformed locks after a long grace period.

--- a/src/registry/materialize.ts
+++ b/src/registry/materialize.ts
@@ -8,7 +8,6 @@ import { normalizeGoogleDisplayName, normalizeGoogleModelId } from './google-mod
 import { findModelsDevModel } from './models-dev.js';
 import type { CachedModel, ProviderRegistry, RegistryProvider } from './types.js';
 import { isValidProviderId } from './validate.js';
-import { getTemplateById } from '../provider-templates.js';
 import { classifyFreeStatus, isFreeStatus } from '../free-models.js';
 
 export type CredentialResolver = (provider: RegistryProvider) => string | null;
@@ -83,9 +82,14 @@ export function cachedModelToLocal(
   };
 }
 
-function providerAllowsAnonymousFreeModels(provider: RegistryProvider): boolean {
-  const template = getTemplateById(provider.templateId) ?? getTemplateById(provider.id);
-  return template?.anonymousFreeModels === true;
+export function isAnonymousProvider(
+  provider: Pick<RegistryProvider, 'authRef' | 'authType'>
+    & Partial<Pick<RegistryProvider, 'id'>>,
+): boolean {
+  if (provider.authType !== 'none') return false;
+  if (provider.authRef === 'none:anonymous') return true;
+  return provider.id !== undefined
+    && provider.authRef === `keyring:provider:${provider.id}`;
 }
 
 function materializeOne(
@@ -97,8 +101,8 @@ function materializeOne(
   if (!isValidProviderId(provider.id)) return null;
 
   const freeOnly = provider.subscriptionFilter === 'free';
-  const apiKey = resolveCredential(provider) ?? '';
-  const anonymousFreeOnly = !apiKey.trim() && providerAllowsAnonymousFreeModels(provider);
+  const anonymous = isAnonymousProvider(provider);
+  const apiKey = anonymous ? '' : resolveCredential(provider) ?? '';
   const models: LocalProviderModel[] = [];
   for (const cached of provider.modelsCache?.models ?? []) {
     const freeStatus = classifyFreeStatus({
@@ -106,7 +110,7 @@ function materializeOne(
       providerId: provider.id,
       templateId: provider.templateId,
     });
-    if ((freeOnly || anonymousFreeOnly) && !isFreeStatus(freeStatus)) continue;
+    if (freeOnly && !isFreeStatus(freeStatus)) continue;
     const model = cachedModelToLocal(cached, provider);
     if (!model) continue;
     if (shouldHideModel({ providerId: provider.id, modelId: model.id, agent })) continue;
@@ -114,13 +118,13 @@ function materializeOne(
   }
   if (models.length === 0) return null;
 
-  if (!apiKey.trim() && !anonymousFreeOnly) return null;
+  if (!apiKey.trim() && !anonymous) return null;
 
   return {
     id: provider.id,
     name: provider.name,
     apiKey,
-    authRef: provider.authRef,
+    authRef: anonymous ? 'none:anonymous' : provider.authRef,
     authType: provider.authType,
     headers: provider.api.headers,
     models,

--- a/src/registry/materialize.ts
+++ b/src/registry/materialize.ts
@@ -92,6 +92,16 @@ export function isAnonymousProvider(
     && provider.authRef === `keyring:provider:${provider.id}`;
 }
 
+function isLegacyAnonymousCustomEndpoint(
+  provider: RegistryProvider,
+  credential: string | null,
+): boolean {
+  return provider.authType === undefined
+    && (provider.templateId === 'custom-openai' || provider.templateId === 'custom-anthropic')
+    && provider.authRef === `keyring:provider:${provider.id}`
+    && credential === 'local';
+}
+
 function materializeOne(
   provider: RegistryProvider,
   resolveCredential: CredentialResolver,
@@ -101,8 +111,12 @@ function materializeOne(
   if (!isValidProviderId(provider.id)) return null;
 
   const freeOnly = provider.subscriptionFilter === 'free';
-  const anonymous = isAnonymousProvider(provider);
-  const apiKey = anonymous ? '' : resolveCredential(provider) ?? '';
+  const explicitAnonymous = isAnonymousProvider(provider);
+  const credential = explicitAnonymous ? null : resolveCredential(provider);
+  const legacyAnonymous = isLegacyAnonymousCustomEndpoint(provider, credential);
+  if (provider.authType === undefined && credential === 'local' && !legacyAnonymous) return null;
+  const anonymous = explicitAnonymous || legacyAnonymous;
+  const apiKey = anonymous ? '' : credential ?? '';
   const models: LocalProviderModel[] = [];
   for (const cached of provider.modelsCache?.models ?? []) {
     const freeStatus = classifyFreeStatus({
@@ -125,7 +139,7 @@ function materializeOne(
     name: provider.name,
     apiKey,
     authRef: anonymous ? 'none:anonymous' : provider.authRef,
-    authType: provider.authType,
+    authType: anonymous ? 'none' : provider.authType,
     headers: provider.api.headers,
     models,
   };

--- a/src/registry/materialize.ts
+++ b/src/registry/materialize.ts
@@ -120,6 +120,7 @@ function materializeOne(
     id: provider.id,
     name: provider.name,
     apiKey,
+    authRef: provider.authRef,
     authType: provider.authType,
     headers: provider.api.headers,
     models,

--- a/src/registry/pricing.ts
+++ b/src/registry/pricing.ts
@@ -22,6 +22,7 @@ import bundledPricing from '../data/pricing-cache.json';
 import { getAppHome } from '../paths.js';
 import type { CachedModel } from './types.js';
 import { loadRegistry, saveRegistry } from './io.js';
+import { withRegistryWriteLock, withRegistryWriteLockSync } from './lock.js';
 import { classifyFreeStatus, isFreeStatus } from '../free-models.js';
 
 export const PRICING_API_URL = 'https://ai-model-pricing.com/api/v1/pricing.json';
@@ -243,11 +244,13 @@ export function applyPricingToRegistryProviders(
 
 /** Apply bundled or on-disk pricing cache synchronously (non-blocking enrich baseline). */
 export function applyCachedPricing(): boolean {
-  const registry = loadRegistry();
-  const cache = loadPricingCache();
-  const changed = applyPricingToRegistryProviders(registry, cache);
-  if (changed) saveRegistry(registry);
-  return changed;
+  return withRegistryWriteLockSync(() => {
+    const registry = loadRegistry();
+    const cache = loadPricingCache();
+    const changed = applyPricingToRegistryProviders(registry, cache);
+    if (changed) saveRegistry(registry);
+    return changed;
+  });
 }
 
 /** Fetch latest pricing in the background; updates registry when complete. */
@@ -255,11 +258,14 @@ export function enrichPricingAsync(onComplete?: (updated: boolean) => void): voi
   void (async () => {
     const fetched = await fetchPricingCache();
     const cache = fetched ?? loadPricingCache();
-    const registry = loadRegistry();
-    const changed = applyPricingToRegistryProviders(registry, cache);
-    if (changed) saveRegistry(registry);
+    const changed = await withRegistryWriteLock(() => {
+      const registry = loadRegistry();
+      const updated = applyPricingToRegistryProviders(registry, cache);
+      if (updated) saveRegistry(registry);
+      return updated;
+    });
     onComplete?.(changed);
-  })();
+  })().catch(() => onComplete?.(false));
 }
 
 export function pricingPlatformForProvider(templateId: string, providerId: string): string | undefined {

--- a/src/registry/provider-auth.ts
+++ b/src/registry/provider-auth.ts
@@ -4,7 +4,10 @@ import { printOAuthStepsPanel } from '../ui.js';
 import pc from 'picocolors';
 import * as p from '@clack/prompts';
 import open from 'open';
-import { saveProviderCredential } from '../env.js';
+import {
+  probeProviderCredentialStore,
+  saveProviderCredential,
+} from '../env.js';
 import { runOpenAiDeviceCodeFlow } from '../oauth/openai.js';
 import {
   supportsNativeOAuth,
@@ -74,14 +77,15 @@ export async function saveNativeOAuthCredential(
 ): Promise<void> {
   const cred = tokensToStoredCredential(tokens, undefined, accountId, providerData);
   const registryId = toOAuthRegistryId(providerId);
+  const authRef = oauthAuthRef(registryId);
   let diagMsg = '';
   const saved = await saveProviderCredential(
-    oauthAuthRef(registryId),
+    authRef,
     oauthCredentialToKeychainJson(cred),
     (msg) => { diagMsg = msg; },
   );
-  if (!saved) throw new Error(`Could not save OAuth tokens to Keychain${diagMsg ? ` — ${diagMsg}` : ' — grant access and try again'}`);
-  await upsertOAuthProvider(providerId, cred);
+  if (!saved) throw new Error(`Could not save OAuth tokens to the credential store${diagMsg ? ` — ${diagMsg}` : ' — check access and try again'}`);
+  await upsertOAuthProvider(providerId, cred, authRef);
 }
 
 /**
@@ -93,12 +97,15 @@ function oauthDisplayName(registryId: string, fallbackName: string): string {
   return fallbackName;
 }
 
-async function upsertOAuthProvider(providerId: string, cred: StoredOAuthCredential): Promise<RegistryProvider> {
+async function upsertOAuthProvider(
+  providerId: string,
+  cred: StoredOAuthCredential,
+  authRef: string,
+): Promise<RegistryProvider> {
   const registryId = toOAuthRegistryId(providerId);
   const templateId = providerId.replace(/-oauth$/, '') || providerId;
 
   const registry = loadRegistry();
-  const authRef = oauthAuthRef(registryId);
   const template = getTemplateById(templateId);
   let entry: RegistryProvider | undefined = registry.providers.find(pr => pr.id === registryId);
 
@@ -142,19 +149,26 @@ export async function authenticateProvider(
     throw new Error('OAuth sign-in is only available for openai (ChatGPT Plus/Pro).');
   }
 
+  const authRef = oauthAuthRef(registryId);
+  let storeDiagMsg = '';
+  const storeReady = await probeProviderCredentialStore(authRef, (msg) => { storeDiagMsg = msg; });
+  if (!storeReady) {
+    throw new Error(`Credential store is unavailable${storeDiagMsg ? ` — ${storeDiagMsg}` : ''}`);
+  }
+
   const cred = await runNativeDeviceCode(providerId);
 
   let nativeDiagMsg = '';
   const saved = await saveProviderCredential(
-    oauthAuthRef(registryId),
+    authRef,
     oauthCredentialToKeychainJson(cred),
     (msg) => { nativeDiagMsg = msg; },
   );
   if (!saved) {
-    p.log.warn(`Could not save OAuth tokens to Keychain — ${nativeDiagMsg || 'session may not persist.'}`);
+    p.log.warn(`Could not save OAuth tokens to the credential store — ${nativeDiagMsg || 'session may not persist.'}`);
   }
 
-  const registryProvider = await upsertOAuthProvider(providerId, cred);
+  const registryProvider = await upsertOAuthProvider(providerId, cred, authRef);
 
   const refreshSpinner = p.spinner();
   refreshSpinner.start('Refreshing model list...');

--- a/src/registry/provider-auth.ts
+++ b/src/registry/provider-auth.ts
@@ -19,7 +19,10 @@ import {
 import { getTemplateById } from '../provider-templates.js';
 import { oauthAuthRef, toOAuthRegistryId } from './import-build.js';
 import { loadRegistry, saveRegistry } from './io.js';
-import { withRegistryWriteLock } from './lock.js';
+import {
+  withCredentialMutationLock,
+  withRegistryWriteLock,
+} from './lock.js';
 import { refreshProviderModels } from './refresh-models.js';
 import type { RegistryProvider } from './types.js';
 
@@ -79,14 +82,16 @@ export async function saveNativeOAuthCredential(
   const cred = tokensToStoredCredential(tokens, undefined, accountId, providerData);
   const registryId = toOAuthRegistryId(providerId);
   const authRef = oauthAuthRef(registryId);
-  let diagMsg = '';
-  const saved = await saveProviderCredential(
-    authRef,
-    oauthCredentialToKeychainJson(cred),
-    (msg) => { diagMsg = msg; },
-  );
-  if (!saved) throw new Error(`Could not save OAuth tokens to the credential store${diagMsg ? ` — ${diagMsg}` : ' — check access and try again'}`);
-  await upsertOAuthProvider(providerId, cred, authRef);
+  await withCredentialMutationLock(authRef, async () => {
+    let diagMsg = '';
+    const saved = await saveProviderCredential(
+      authRef,
+      oauthCredentialToKeychainJson(cred),
+      (msg) => { diagMsg = msg; },
+    );
+    if (!saved) throw new Error(`Could not save OAuth tokens to the credential store${diagMsg ? ` — ${diagMsg}` : ' — check access and try again'}`);
+    await upsertOAuthProvider(providerId, cred, authRef);
+  });
 }
 
 /**
@@ -156,22 +161,32 @@ export async function authenticateProvider(
   let storeDiagMsg = '';
   const storeReady = await probeProviderCredentialStore(authRef, (msg) => { storeDiagMsg = msg; });
   if (!storeReady) {
-    throw new Error(`Credential store is unavailable${storeDiagMsg ? ` — ${storeDiagMsg}` : ''}`);
+    throw new Error(
+      `Credential store is unavailable${storeDiagMsg ? `: ${storeDiagMsg}` : ''}. `
+      + 'Set CLODEX_CREDENTIAL_HELPER to an absolute path to an external credential helper and try again.',
+    );
   }
 
   const cred = await runNativeDeviceCode(providerId);
 
-  let nativeDiagMsg = '';
-  const saved = await saveProviderCredential(
-    authRef,
-    oauthCredentialToKeychainJson(cred),
-    (msg) => { nativeDiagMsg = msg; },
-  );
-  if (!saved) {
-    p.log.warn(`Could not save OAuth tokens to the credential store — ${nativeDiagMsg || 'session may not persist.'}`);
+  const persisted = await withCredentialMutationLock(authRef, async () => {
+    let nativeDiagMsg = '';
+    const saved = await saveProviderCredential(
+      authRef,
+      oauthCredentialToKeychainJson(cred),
+      (msg) => { nativeDiagMsg = msg; },
+    );
+    const registryProvider = await upsertOAuthProvider(
+      providerId,
+      cred,
+      authRef,
+    );
+    return { saved, nativeDiagMsg, registryProvider };
+  });
+  if (!persisted.saved) {
+    p.log.warn(`Could not save OAuth tokens to the credential store — ${persisted.nativeDiagMsg || 'session may not persist.'}`);
   }
-
-  const registryProvider = await upsertOAuthProvider(providerId, cred, authRef);
+  const { registryProvider } = persisted;
 
   const refreshSpinner = p.spinner();
   refreshSpinner.start('Refreshing model list...');

--- a/src/registry/provider-auth.ts
+++ b/src/registry/provider-auth.ts
@@ -19,6 +19,7 @@ import {
 import { getTemplateById } from '../provider-templates.js';
 import { oauthAuthRef, toOAuthRegistryId } from './import-build.js';
 import { loadRegistry, saveRegistry } from './io.js';
+import { withRegistryWriteLock } from './lock.js';
 import { refreshProviderModels } from './refresh-models.js';
 import type { RegistryProvider } from './types.js';
 
@@ -102,41 +103,43 @@ async function upsertOAuthProvider(
   cred: StoredOAuthCredential,
   authRef: string,
 ): Promise<RegistryProvider> {
-  const registryId = toOAuthRegistryId(providerId);
-  const templateId = providerId.replace(/-oauth$/, '') || providerId;
+  return withRegistryWriteLock(() => {
+    const registryId = toOAuthRegistryId(providerId);
+    const templateId = providerId.replace(/-oauth$/, '') || providerId;
 
-  const registry = loadRegistry();
-  const template = getTemplateById(templateId);
-  let entry: RegistryProvider | undefined = registry.providers.find(pr => pr.id === registryId);
+    const registry = loadRegistry();
+    const template = getTemplateById(templateId);
+    let entry: RegistryProvider | undefined = registry.providers.find(pr => pr.id === registryId);
 
-  if (!entry) {
-    if (!template) {
-      throw new Error(`Provider "${providerId}" is not in your registry and has no template`);
+    if (!entry) {
+      if (!template) {
+        throw new Error(`Provider "${providerId}" is not in your registry and has no template`);
+      }
+      const displayName = oauthDisplayName(registryId, template.name);
+      entry = {
+        id: registryId,
+        templateId,
+        name: displayName,
+        enabled: true,
+        authRef,
+        authType: 'oauth',
+        api: {
+          npm: template.npm,
+          url: template.defaultBaseUrl ?? '',
+          ...(template.headers ? { headers: template.headers } : {}),
+        },
+        addedAt: new Date().toISOString(),
+      };
+    } else {
+      entry = { ...entry, authType: 'oauth', authRef, templateId };
     }
-    const displayName = oauthDisplayName(registryId, template.name);
-    entry = {
-      id: registryId,
-      templateId,
-      name: displayName,
-      enabled: true,
-      authRef,
-      authType: 'oauth',
-      api: {
-        npm: template.npm,
-        url: template.defaultBaseUrl ?? '',
-        ...(template.headers ? { headers: template.headers } : {}),
-      },
-      addedAt: new Date().toISOString(),
-    };
-  } else {
-    entry = { ...entry, authType: 'oauth', authRef, templateId };
-  }
 
-  const idx = registry.providers.findIndex(pr => pr.id === registryId);
-  if (idx >= 0) registry.providers[idx] = entry;
-  else registry.providers.push(entry);
-  saveRegistry(registry);
-  return entry;
+    const idx = registry.providers.findIndex(pr => pr.id === registryId);
+    if (idx >= 0) registry.providers[idx] = entry;
+    else registry.providers.push(entry);
+    saveRegistry(registry);
+    return entry;
+  });
 }
 
 export async function authenticateProvider(

--- a/src/registry/refresh-credentials.ts
+++ b/src/registry/refresh-credentials.ts
@@ -1,5 +1,6 @@
 // src/registry/refresh-credentials.ts — keys for refresh-models (OpenCode placeholders, env fallbacks)
 
+import { isAnonymousProvider } from './materialize.js';
 import type { RegistryProvider } from './types.js';
 
 /** OpenCode uses these when OAuth/env supplies the real credential at runtime. */
@@ -55,6 +56,8 @@ export async function resolveRefreshCredential(
   provider: RegistryProvider,
   resolveKey: (provider: RegistryProvider) => Promise<string | null>,
 ): Promise<string | null> {
+  if (isAnonymousProvider(provider)) return null;
+
   // OAuth token refresh (e.g. an expired/revoked refresh token returning 401) throws
   // rather than resolving to null. Treat that the same as "no key" so callers fall
   // through to refreshProviderModels' existing friendly "sign in again" messaging

--- a/src/registry/refresh-models.ts
+++ b/src/registry/refresh-models.ts
@@ -1,8 +1,10 @@
 // src/registry/refresh-models.ts — user-initiated model list refresh per modelSource
 
+import { isDeepStrictEqual } from 'node:util';
 import { fetchAnthropicModels } from './custom-endpoint.js';
 import { fetchTemplateModels } from './fetch-template-models.js';
 import { loadRegistry, saveRegistry } from './io.js';
+import { withRegistryWriteLock } from './lock.js';
 import { resolveModelSource } from './model-source.js';
 import { validateCustomEndpointUrl } from './url-security.js';
 import {
@@ -299,12 +301,23 @@ function updateProviderCache(
   };
 }
 
+function providerDiscoveryInputsMatch(
+  current: RegistryProvider,
+  started: RegistryProvider,
+): boolean {
+  return current.authRef === started.authRef
+    && current.authType === started.authType
+    && current.templateId === started.templateId
+    && isDeepStrictEqual(current.api, started.api);
+}
+
 export async function refreshProviderModels(
   providerId: string,
   apiKey: string | null,
-  registry = loadRegistry(),
+  registry?: ProviderRegistry,
 ): Promise<RefreshProviderResult> {
-  const provider = registry.providers.find(p => p.id === providerId);
+  const workingRegistry = registry ?? loadRegistry();
+  const provider = workingRegistry.providers.find(p => p.id === providerId);
   if (!provider) {
     return { id: providerId, name: providerId, ok: false, reason: 'Provider not found.' };
   }
@@ -410,8 +423,19 @@ export async function refreshProviderModels(
     const platform = pricingPlatformForProvider(provider.templateId, provider.id);
     const enriched = enrichModelsWithPricing(models, buildPricingIndex(pricingCache), platform);
 
-    updateProviderCache(registry, providerId, enriched, baseUrl);
-    saveRegistry(registry);
+    await withRegistryWriteLock(() => {
+      const currentRegistry = loadRegistry();
+      const currentProvider = currentRegistry.providers.find(candidate => candidate.id === providerId);
+      if (!currentProvider) throw new Error('Provider was removed while models were refreshing.');
+      if (currentProvider.authRef !== provider.authRef) {
+        throw new Error('Provider credentials changed while models were refreshing.');
+      }
+      if (!providerDiscoveryInputsMatch(currentProvider, provider)) {
+        throw new Error('Provider configuration changed while models were refreshing.');
+      }
+      updateProviderCache(currentRegistry, providerId, enriched, baseUrl);
+      saveRegistry(currentRegistry);
+    });
     enrichPricingAsync();
 
     return {
@@ -442,7 +466,7 @@ export async function refreshAllProviderModels(
 
   for (const provider of enabledProviders) {
     const key = await resolveRefreshCredential(provider, resolveKey);
-    refreshed.push(await refreshProviderModels(provider.id, key, registry));
+    refreshed.push(await refreshProviderModels(provider.id, key));
   }
 
   return { refreshed };

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,7 @@ export interface LocalProvider {
   id: string;
   name: string;
   apiKey: string;
+  authRef?: string;
   authType?: 'api' | 'oauth' | 'none';
   oauthAccountId?: string;
   providerData?: Record<string, unknown>;

--- a/tests/credential-helper.test.ts
+++ b/tests/credential-helper.test.ts
@@ -1,0 +1,183 @@
+import { chmodSync, copyFileSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  CREDENTIAL_HELPER_ENV,
+  configuredCredentialHelper,
+  configuredCredentialHelperPath,
+  credentialAuthRef,
+  deleteCredentialHelperAccount,
+  readCredentialHelperAccount,
+  writeCredentialHelperAccount,
+} from '../src/credential-helper.js';
+import {
+  deleteProviderCredential,
+  probeProviderCredentialStore,
+  resolveProviderCredential,
+  saveProviderCredential,
+} from '../src/env.js';
+
+const helperPath = fileURLToPath(new URL('./fixtures/credential-helper.mjs', import.meta.url));
+
+async function waitForPath(path: string): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (!existsSync(path) && Date.now() < deadline) {
+    await new Promise(resolve => setTimeout(resolve, 5));
+  }
+  if (!existsSync(path)) throw new Error(`Timed out waiting for ${path}`);
+}
+
+describe('external credential helper', () => {
+  let tempDir = '';
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'clodex-credential-helper-'));
+    process.env[CREDENTIAL_HELPER_ENV] = helperPath;
+    process.env.CLODEX_TEST_CREDENTIAL_HELPER_STORE = join(tempDir, 'credentials.json');
+    delete process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE;
+  });
+
+  afterEach(() => {
+    delete process.env[CREDENTIAL_HELPER_ENV];
+    delete process.env.CLODEX_TEST_CREDENTIAL_HELPER_STORE;
+    delete process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('selects helper auth refs only when an executable helper is configured', () => {
+    expect(configuredCredentialHelperPath()).toBe(helperPath);
+    const helper = configuredCredentialHelper();
+    expect(helper).not.toBeNull();
+    const authRef = credentialAuthRef('provider:openai');
+    expect(authRef).toBe(`helper:v1:${helper!.id}:provider:openai`);
+    expect(authRef).not.toContain(helperPath);
+    delete process.env[CREDENTIAL_HELPER_ENV];
+    expect(credentialAuthRef('provider:openai')).toBe('keyring:provider:openai');
+  });
+
+  it('rejects relative helper paths', () => {
+    process.env[CREDENTIAL_HELPER_ENV] = 'credential-helper';
+    expect(() => configuredCredentialHelperPath()).toThrow('absolute executable path');
+  });
+
+  it('rejects missing, directory, and non-executable helper paths', () => {
+    process.env[CREDENTIAL_HELPER_ENV] = join(tempDir, 'missing-helper');
+    expect(() => configuredCredentialHelperPath()).toThrow('not an executable file');
+
+    process.env[CREDENTIAL_HELPER_ENV] = tempDir;
+    expect(() => configuredCredentialHelperPath()).toThrow('must point to a file');
+
+    const nonExecutable = join(tempDir, 'non-executable-helper');
+    writeFileSync(nonExecutable, '#!/bin/sh\n', { encoding: 'utf8', mode: 0o600 });
+    process.env[CREDENTIAL_HELPER_ENV] = nonExecutable;
+    expect(() => configuredCredentialHelperPath()).toThrow('not an executable file');
+  });
+
+  it('round-trips opaque values without adding output whitespace', async () => {
+    const value = '{"type":"oauth","access":"token","refresh":"rotating-token"}';
+    await writeCredentialHelperAccount('oauth:provider:test', value);
+    await expect(readCredentialHelperAccount('oauth:provider:test')).resolves.toBe(value);
+    await deleteCredentialHelperAccount('oauth:provider:test');
+    await expect(readCredentialHelperAccount('oauth:provider:test')).resolves.toBeNull();
+  });
+
+  it('writes and verifies helper-backed provider credentials', async () => {
+    const authRef = credentialAuthRef('provider:test');
+    await expect(saveProviderCredential(authRef, 'secret-value')).resolves.toBe(true);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe('secret-value');
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+  });
+
+  it('probes the helper with a disposable round trip', async () => {
+    await expect(probeProviderCredentialStore(credentialAuthRef('oauth:provider:test'))).resolves.toBe(true);
+  });
+
+  it('fails the probe when its disposable credential cannot be removed', async () => {
+    process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE = 'fail-delete';
+    const diagnostics: string[] = [];
+    await expect(probeProviderCredentialStore(credentialAuthRef('oauth:provider:test'), message => {
+      diagnostics.push(message);
+    })).resolves.toBe(false);
+    expect(diagnostics).toContain('credential store probe cleanup failed');
+  });
+
+  it('rejects a helper write whose read-back does not match', async () => {
+    process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE = 'mismatch';
+    const diagnostics: string[] = [];
+    await expect(saveProviderCredential(credentialAuthRef('provider:test'), 'secret-value', message => {
+      diagnostics.push(message);
+    })).resolves.toBe(false);
+    expect(diagnostics).toContain('credential store read-back verification failed');
+  });
+
+  it('never deletes a newer credential after a concurrent read-back mismatch', async () => {
+    process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE = 'interleave-readback';
+    const authRef = credentialAuthRef('provider:test');
+    const storePath = process.env.CLODEX_TEST_CREDENTIAL_HELPER_STORE!;
+
+    const firstWrite = saveProviderCredential(authRef, 'first-value');
+    await waitForPath(`${storePath}.first-get`);
+    const secondWrite = saveProviderCredential(authRef, 'second-value');
+
+    await expect(firstWrite).resolves.toBe(false);
+    await expect(secondWrite).resolves.toBe(true);
+    await expect(readCredentialHelperAccount('provider:test')).resolves.toBe('second-value');
+  });
+
+  it('does not silently fall back when the configured helper fails', async () => {
+    process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE = 'fail';
+    const diagnostics: string[] = [];
+    await expect(saveProviderCredential(credentialAuthRef('provider:test'), 'secret-value', message => {
+      diagnostics.push(message);
+    })).resolves.toBe(false);
+    expect(diagnostics.join('\n')).toContain('credential helper set failed');
+  });
+
+  it('refuses to redirect a credential reference to a different helper path', async () => {
+    const authRef = credentialAuthRef('provider:test');
+    await expect(saveProviderCredential(authRef, 'secret-value')).resolves.toBe(true);
+
+    const replacementHelper = join(tempDir, 'replacement-helper.mjs');
+    copyFileSync(helperPath, replacementHelper);
+    chmodSync(replacementHelper, 0o700);
+    process.env[CREDENTIAL_HELPER_ENV] = replacementHelper;
+    const diagnostics: string[] = [];
+
+    await expect(resolveProviderCredential('test', authRef, message => diagnostics.push(message))).resolves.toBeNull();
+    await expect(deleteProviderCredential(authRef, message => diagnostics.push(message))).resolves.toBe(false);
+    expect(diagnostics.join('\n')).toContain('does not match the helper that owns this credential');
+  });
+
+  it('force-kills a helper that exceeds the runtime limit', async () => {
+    process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE = 'hang-ignore-term';
+    const storePath = process.env.CLODEX_TEST_CREDENTIAL_HELPER_STORE!;
+    const realSetTimeout = globalThis.setTimeout;
+    vi.useFakeTimers();
+    try {
+      const outcome = readCredentialHelperAccount('provider:test').catch(error => error);
+      await new Promise(resolve => realSetTimeout(resolve, 100));
+      const pid = Number.parseInt(readFileSync(`${storePath}.helper-pid`, 'utf8'), 10);
+
+      await vi.advanceTimersByTimeAsync(10_001);
+      await expect(outcome).resolves.toMatchObject({ message: 'credential helper get timed out' });
+
+      vi.useRealTimers();
+      let running = true;
+      const deadline = Date.now() + 2_000;
+      while (running && Date.now() < deadline) {
+        try {
+          process.kill(pid, 0);
+          await new Promise(resolve => realSetTimeout(resolve, 10));
+        } catch {
+          running = false;
+        }
+      }
+      expect(running).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/credential-helper.test.ts
+++ b/tests/credential-helper.test.ts
@@ -18,8 +18,11 @@ import {
   resolveProviderCredential,
   saveProviderCredential,
 } from '../src/env.js';
+import { removeProviderFromRegistry } from '../src/registry/crud.js';
+import { emptyRegistry, loadRegistry, saveRegistry } from '../src/registry/io.js';
 
 const helperPath = fileURLToPath(new URL('./fixtures/credential-helper.mjs', import.meta.url));
+const previousClodexHome = process.env.CLODEX_HOME;
 
 async function waitForPath(path: string): Promise<void> {
   const deadline = Date.now() + 5_000;
@@ -34,12 +37,15 @@ describe('external credential helper', () => {
 
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'clodex-credential-helper-'));
+    process.env.CLODEX_HOME = tempDir;
     process.env[CREDENTIAL_HELPER_ENV] = helperPath;
     process.env.CLODEX_TEST_CREDENTIAL_HELPER_STORE = join(tempDir, 'credentials.json');
     delete process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE;
   });
 
   afterEach(() => {
+    if (previousClodexHome === undefined) delete process.env.CLODEX_HOME;
+    else process.env.CLODEX_HOME = previousClodexHome;
     delete process.env[CREDENTIAL_HELPER_ENV];
     delete process.env.CLODEX_TEST_CREDENTIAL_HELPER_STORE;
     delete process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE;
@@ -89,6 +95,32 @@ describe('external credential helper', () => {
     await expect(resolveProviderCredential('test', authRef)).resolves.toBe('secret-value');
     await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
     await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+  });
+
+  it('removes a helper-backed credential with its provider', async () => {
+    const authRef = credentialAuthRef('provider:openai');
+    await expect(saveProviderCredential(authRef, 'secret-value')).resolves.toBe(true);
+    const registry = emptyRegistry();
+    registry.providers.push({
+      id: 'openai',
+      templateId: 'openai',
+      name: 'OpenAI',
+      enabled: true,
+      authRef,
+      authType: 'api',
+      api: { npm: '@ai-sdk/openai', url: 'https://api.openai.com/v1' },
+      addedAt: '2026-07-21T00:00:00.000Z',
+    });
+    saveRegistry(registry);
+
+    const result = await removeProviderFromRegistry('openai');
+
+    expect(result).toMatchObject({
+      removed: true,
+      credentialDeleted: true,
+    });
+    expect(loadRegistry().providers).toHaveLength(0);
+    await expect(readCredentialHelperAccount('provider:openai')).resolves.toBeNull();
   });
 
   it('probes the helper with a disposable round trip', async () => {

--- a/tests/credential-helper.test.ts
+++ b/tests/credential-helper.test.ts
@@ -20,6 +20,7 @@ import {
 } from '../src/env.js';
 import { removeProviderFromRegistry } from '../src/registry/crud.js';
 import { emptyRegistry, loadRegistry, saveRegistry } from '../src/registry/io.js';
+import { withRegistryWriteLockSync } from '../src/registry/lock.js';
 
 const helperPath = fileURLToPath(new URL('./fixtures/credential-helper.mjs', import.meta.url));
 const previousClodexHome = process.env.CLODEX_HOME;
@@ -111,7 +112,7 @@ describe('external credential helper', () => {
       api: { npm: '@ai-sdk/openai', url: 'https://api.openai.com/v1' },
       addedAt: '2026-07-21T00:00:00.000Z',
     });
-    saveRegistry(registry);
+    withRegistryWriteLockSync(() => saveRegistry(registry));
 
     const result = await removeProviderFromRegistry('openai');
 
@@ -145,16 +146,19 @@ describe('external credential helper', () => {
     expect(diagnostics).toContain('credential store read-back verification failed');
   });
 
-  it('never deletes a newer credential after a concurrent read-back mismatch', async () => {
-    process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE = 'interleave-readback';
+  it('serializes concurrent writes to the same helper credential', async () => {
+    process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE = 'detect-overlap';
     const authRef = credentialAuthRef('provider:test');
     const storePath = process.env.CLODEX_TEST_CREDENTIAL_HELPER_STORE!;
 
     const firstWrite = saveProviderCredential(authRef, 'first-value');
-    await waitForPath(`${storePath}.first-get`);
+    await waitForPath(`${storePath}.set-started`);
     const secondWrite = saveProviderCredential(authRef, 'second-value');
+    await new Promise(resolve => setTimeout(resolve, 50));
 
-    await expect(firstWrite).resolves.toBe(false);
+    expect(existsSync(`${storePath}.overlapping-set`)).toBe(false);
+    writeFileSync(`${storePath}.release-set`, '', { encoding: 'utf8', mode: 0o600 });
+    await expect(firstWrite).resolves.toBe(true);
     await expect(secondWrite).resolves.toBe(true);
     await expect(readCredentialHelperAccount('provider:test')).resolves.toBe('second-value');
   });

--- a/tests/custom-endpoint.test.ts
+++ b/tests/custom-endpoint.test.ts
@@ -6,6 +6,7 @@ const registryState = vi.hoisted(() => ({
 }));
 const lockState = vi.hoisted(() => ({
   active: false,
+  credentialActive: false,
   entries: 0,
 }));
 
@@ -31,6 +32,20 @@ vi.mock('../src/registry/lock.js', () => ({
       return await operation();
     } finally {
       lockState.active = false;
+    }
+  }),
+  withCredentialMutationLock: vi.fn(async <T>(
+    _authRef: string,
+    operation: () => Promise<T> | T,
+  ): Promise<T> => {
+    if (lockState.credentialActive) {
+      throw new Error('credential lock re-entered');
+    }
+    lockState.credentialActive = true;
+    try {
+      return await operation();
+    } finally {
+      lockState.credentialActive = false;
     }
   }),
 }));
@@ -78,6 +93,7 @@ describe('custom endpoint registry updates', () => {
   beforeEach(() => {
     registryState.current = { schemaVersion: 1, providers: [] };
     lockState.active = false;
+    lockState.credentialActive = false;
     lockState.entries = 0;
 
     vi.mocked(saveProviderCredential).mockReset().mockResolvedValue(true);
@@ -104,11 +120,16 @@ describe('custom endpoint registry updates', () => {
       observedLockStates.push(lockState.active);
       return successfulDiscovery();
     });
+    vi.mocked(saveProviderCredential).mockImplementation(async () => {
+      observedLockStates.push(lockState.active);
+      expect(lockState.credentialActive).toBe(true);
+      return true;
+    });
 
     const result = await addCustomEndpointProvider(endpointInput);
 
     expect(result.added).toBe(true);
-    expect(observedLockStates).toEqual([false]);
+    expect(observedLockStates).toEqual([false, false]);
     expect(lockState.entries).toBe(1);
     expect(lockState.active).toBe(false);
   });
@@ -177,8 +198,11 @@ describe('custom endpoint registry updates', () => {
       added: true,
       provider: { id: 'custom-test-endpoint-2' },
     });
+    expect(result.provider?.authRef).toMatch(
+      /^keyring:provider:custom-test-endpoint:[0-9a-f-]{36}$/,
+    );
     expect(saveProviderCredential).toHaveBeenCalledWith(
-      'keyring:provider:custom-test-endpoint-2',
+      result.provider?.authRef,
       endpointInput.apiKey,
     );
     expect(registryState.current.providers.map((provider) => provider.id)).toEqual([

--- a/tests/custom-endpoint.test.ts
+++ b/tests/custom-endpoint.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProviderRegistry } from '../src/registry/types.js';
+
+const registryState = vi.hoisted(() => ({
+  current: { schemaVersion: 1, providers: [] } as ProviderRegistry,
+}));
+const lockState = vi.hoisted(() => ({
+  active: false,
+  entries: 0,
+}));
+
+vi.mock('../src/env.js', () => ({
+  saveProviderCredential: vi.fn(),
+}));
+vi.mock('../src/registry/fetch-template-models.js', () => ({
+  fetchTemplateModels: vi.fn(),
+}));
+vi.mock('../src/registry/io.js', () => ({
+  loadRegistry: vi.fn(() => structuredClone(registryState.current)),
+  saveRegistry: vi.fn((registry: ProviderRegistry) => {
+    registryState.current = structuredClone(registry);
+  }),
+}));
+vi.mock('../src/registry/lock.js', () => ({
+  withRegistryWriteLock: vi.fn(async <T>(operation: () => Promise<T> | T): Promise<T> => {
+    lockState.entries += 1;
+    if (lockState.active) throw new Error('registry lock re-entered');
+    lockState.active = true;
+    try {
+      return await operation();
+    } finally {
+      lockState.active = false;
+    }
+  }),
+}));
+vi.mock('../src/registry/url-security.js', () => ({
+  validateCustomEndpointUrl: vi.fn(),
+}));
+
+import { saveProviderCredential } from '../src/env.js';
+import { addCustomEndpointProvider } from '../src/registry/custom-endpoint.js';
+import { fetchTemplateModels } from '../src/registry/fetch-template-models.js';
+import { saveRegistry } from '../src/registry/io.js';
+import { validateCustomEndpointUrl } from '../src/registry/url-security.js';
+
+const endpointInput = {
+  displayName: 'Test Endpoint',
+  baseUrl: 'https://api.example.com/v1',
+  apiKey: 'test-key',
+  kind: 'openai' as const,
+};
+
+function successfulDiscovery() {
+  return {
+    models: [
+      {
+        id: 'model-1',
+        name: 'Model 1',
+        upstreamModelId: 'model-1',
+        family: 'test',
+        brand: 'test',
+        modelFormat: 'openai' as const,
+      },
+    ],
+    baseUrl: endpointInput.baseUrl,
+  };
+}
+
+describe('custom endpoint registry updates', () => {
+  beforeEach(() => {
+    registryState.current = { schemaVersion: 1, providers: [] };
+    lockState.active = false;
+    lockState.entries = 0;
+
+    vi.mocked(saveProviderCredential).mockReset().mockResolvedValue(true);
+    vi.mocked(fetchTemplateModels).mockReset().mockResolvedValue(successfulDiscovery());
+    vi.mocked(validateCustomEndpointUrl).mockReset().mockResolvedValue({
+      ok: true,
+      normalizedUrl: endpointInput.baseUrl,
+    });
+    vi.mocked(saveRegistry)
+      .mockReset()
+      .mockImplementation((registry) => {
+        registryState.current = structuredClone(registry);
+      });
+  });
+
+  it('discovers models before entering the registry write lock', async () => {
+    const observedLockStates: boolean[] = [];
+    vi.mocked(fetchTemplateModels).mockImplementation(async () => {
+      observedLockStates.push(lockState.active);
+      return successfulDiscovery();
+    });
+
+    const result = await addCustomEndpointProvider(endpointInput);
+
+    expect(result.added).toBe(true);
+    expect(observedLockStates).toEqual([false]);
+    expect(lockState.entries).toBe(1);
+    expect(lockState.active).toBe(false);
+  });
+
+  it('allocates the provider id from state reloaded after discovery', async () => {
+    vi.mocked(fetchTemplateModels).mockImplementation(async () => {
+      registryState.current.providers.push({
+        id: 'custom-test-endpoint',
+        templateId: 'custom-openai',
+        name: 'Concurrent endpoint',
+        enabled: true,
+        authRef: 'keyring:provider:custom-test-endpoint',
+        api: { npm: '@ai-sdk/openai-compatible', url: endpointInput.baseUrl },
+        addedAt: '2026-01-01T00:00:00.000Z',
+      });
+      return successfulDiscovery();
+    });
+
+    const result = await addCustomEndpointProvider(endpointInput);
+
+    expect(result).toMatchObject({
+      added: true,
+      provider: { id: 'custom-test-endpoint-2' },
+    });
+    expect(saveProviderCredential).toHaveBeenCalledWith(
+      'keyring:provider:custom-test-endpoint-2',
+      endpointInput.apiKey,
+    );
+    expect(registryState.current.providers.map((provider) => provider.id)).toEqual([
+      'custom-test-endpoint',
+      'custom-test-endpoint-2',
+    ]);
+  });
+});

--- a/tests/custom-endpoint.test.ts
+++ b/tests/custom-endpoint.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ProviderRegistry } from '../src/registry/types.js';
 
 const registryState = vi.hoisted(() => ({
@@ -9,7 +9,8 @@ const lockState = vi.hoisted(() => ({
   entries: 0,
 }));
 
-vi.mock('../src/env.js', () => ({
+vi.mock('../src/env.js', async importOriginal => ({
+  ...await importOriginal<typeof import('../src/env.js')>(),
   saveProviderCredential: vi.fn(),
 }));
 vi.mock('../src/registry/fetch-template-models.js', () => ({
@@ -37,8 +38,15 @@ vi.mock('../src/registry/url-security.js', () => ({
   validateCustomEndpointUrl: vi.fn(),
 }));
 
-import { saveProviderCredential } from '../src/env.js';
-import { addCustomEndpointProvider } from '../src/registry/custom-endpoint.js';
+import {
+  clodexKeyEnvVar,
+  resolveProviderCredential,
+  saveProviderCredential,
+} from '../src/env.js';
+import {
+  addCustomEndpointProvider,
+  fetchAnthropicModels,
+} from '../src/registry/custom-endpoint.js';
 import { fetchTemplateModels } from '../src/registry/fetch-template-models.js';
 import { saveRegistry } from '../src/registry/io.js';
 import { validateCustomEndpointUrl } from '../src/registry/url-security.js';
@@ -85,6 +93,11 @@ describe('custom endpoint registry updates', () => {
       });
   });
 
+  afterEach(() => {
+    delete process.env[clodexKeyEnvVar('custom-test-endpoint')];
+    vi.unstubAllGlobals();
+  });
+
   it('discovers models before entering the registry write lock', async () => {
     const observedLockStates: boolean[] = [];
     vi.mocked(fetchTemplateModels).mockImplementation(async () => {
@@ -98,6 +111,50 @@ describe('custom endpoint registry updates', () => {
     expect(observedLockStates).toEqual([false]);
     expect(lockState.entries).toBe(1);
     expect(lockState.active).toBe(false);
+  });
+
+  it('represents a blank key as anonymous without writing a placeholder credential', async () => {
+    process.env[clodexKeyEnvVar('custom-test-endpoint')] = 'stale-provider-key';
+    const result = await addCustomEndpointProvider({
+      ...endpointInput,
+      apiKey: '   ',
+    });
+
+    expect(result).toMatchObject({
+      added: true,
+      provider: {
+        authRef: 'none:anonymous',
+        authType: 'none',
+      },
+    });
+    expect(fetchTemplateModels).toHaveBeenCalledWith(
+      expect.objectContaining({ authType: 'none' }),
+      '',
+      endpointInput.baseUrl,
+      undefined,
+    );
+    expect(saveProviderCredential).not.toHaveBeenCalled();
+    expect(registryState.current.providers[0]).toMatchObject({
+      authRef: 'none:anonymous',
+      authType: 'none',
+    });
+    await expect(resolveProviderCredential(
+      result.provider!.id,
+      result.provider!.authRef,
+    )).resolves.toBeNull();
+  });
+
+  it('omits the Anthropic API key header for anonymous discovery', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      data: [{ id: 'local-model', name: 'Local Model' }],
+    }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchAnthropicModels('https://local.example/v1', '');
+
+    expect(result.models).toHaveLength(1);
+    const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(new Headers(requestInit.headers).has('x-api-key')).toBe(false);
   });
 
   it('allocates the provider id from state reloaded after discovery', async () => {

--- a/tests/env-oauth-refresh.test.ts
+++ b/tests/env-oauth-refresh.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  readCredential: vi.fn(),
+  refreshCredential: vi.fn(),
+  writeCredential: vi.fn(),
+  withCredentialMutationLock: vi.fn(
+    async (_authRef: string, operation: () => Promise<unknown>) => operation(),
+  ),
+}));
+
+vi.mock('../src/credential-helper.js', () => ({
+  deleteCredentialHelperAccount: vi.fn(),
+  readCredentialHelperAccount: mocks.readCredential,
+  writeCredentialHelperAccount: mocks.writeCredential,
+}));
+
+vi.mock('../src/oauth/refresh.js', () => ({
+  oauthCredentialShouldRefresh: (credential: { expires: number }) =>
+    credential.expires <= Date.now() + 120_000,
+  refreshStoredOAuthCredential: mocks.refreshCredential,
+}));
+
+vi.mock('../src/registry/lock.js', () => ({
+  withCredentialMutationLock: mocks.withCredentialMutationLock,
+}));
+
+import { resolveProviderCredential } from '../src/env.js';
+
+const HELPER_ID = 'a'.repeat(64);
+const AUTH_REF = `helper:v1:${HELPER_ID}:oauth:provider:openai-oauth`;
+
+function oauthCredential(access: string, expires: number): string {
+  return JSON.stringify({
+    type: 'oauth',
+    access,
+    refresh: `${access}-refresh`,
+    expires,
+  });
+}
+
+describe('OAuth credential refresh serialization', () => {
+  beforeEach(() => {
+    mocks.readCredential.mockReset();
+    mocks.refreshCredential.mockReset();
+    mocks.writeCredential.mockReset();
+    mocks.withCredentialMutationLock.mockClear();
+    delete process.env.CLODEX_KEY_OPENAI_OAUTH;
+  });
+
+  it('re-reads the credential after acquiring its mutation lock', async () => {
+    const stale = oauthCredential('stale', 0);
+    const replacement = oauthCredential('replacement', Date.now() + 3_600_000);
+    mocks.readCredential
+      .mockResolvedValueOnce(stale)
+      .mockResolvedValueOnce(replacement);
+
+    await expect(
+      resolveProviderCredential('openai-oauth', AUTH_REF),
+    ).resolves.toBe('replacement');
+
+    expect(mocks.withCredentialMutationLock).toHaveBeenCalledWith(
+      AUTH_REF,
+      expect.any(Function),
+    );
+    expect(mocks.refreshCredential).not.toHaveBeenCalled();
+    expect(mocks.writeCredential).not.toHaveBeenCalled();
+  });
+
+  it('persists a refreshed credential while holding the mutation lock', async () => {
+    const stale = oauthCredential('stale', 0);
+    const refreshed = {
+      type: 'oauth' as const,
+      access: 'refreshed',
+      refresh: 'rotated-refresh',
+      expires: Date.now() + 3_600_000,
+    };
+    mocks.readCredential
+      .mockResolvedValueOnce(stale)
+      .mockResolvedValueOnce(stale)
+      .mockResolvedValueOnce(JSON.stringify(refreshed));
+    mocks.refreshCredential.mockResolvedValue(refreshed);
+    mocks.writeCredential.mockResolvedValue(undefined);
+
+    await expect(
+      resolveProviderCredential('openai-oauth', AUTH_REF),
+    ).resolves.toBe('refreshed');
+
+    expect(mocks.refreshCredential).toHaveBeenCalledOnce();
+    expect(mocks.writeCredential).toHaveBeenCalledWith(
+      'oauth:provider:openai-oauth',
+      JSON.stringify(refreshed),
+      HELPER_ID,
+    );
+  });
+});

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -97,6 +97,7 @@ describe('provider credentials', () => {
     });
     expect(parseAuthRef('helper:oauth:provider:openai-oauth')).toBeNull();
     expect(parseAuthRef('env:OPENAI_API_KEY')).toEqual({ kind: 'env', varName: 'OPENAI_API_KEY' });
+    expect(parseAuthRef('none:anonymous')).toEqual({ kind: 'none' });
     expect(parseAuthRef('bad')).toBeNull();
   });
 
@@ -109,6 +110,12 @@ describe('provider credentials', () => {
     process.env[clodexKeyEnvVar('openai')] = 'env-openai-key';
     const key = await resolveProviderCredential('openai', 'keyring:provider:openai');
     expect(key).toBe('env-openai-key');
+    delete process.env[clodexKeyEnvVar('openai')];
+  });
+
+  it('keeps explicit anonymous access authoritative over provider environment keys', async () => {
+    process.env[clodexKeyEnvVar('openai')] = 'stale-provider-key';
+    await expect(resolveProviderCredential('openai', 'none:anonymous')).resolves.toBeNull();
     delete process.env[clodexKeyEnvVar('openai')];
   });
 

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -10,6 +10,8 @@ import {
   clodexKeyEnvVar,
   resolveProviderCredential,
 } from '../src/env.js';
+
+const TEST_HELPER_ID = 'a'.repeat(64);
 import { CONFLICTING_ENV_VARS } from '../src/constants.js';
 
 const UPSTREAM_URL = 'https://api.example.com';
@@ -88,6 +90,12 @@ describe('provider credentials', () => {
   it('parses authRef strings', () => {
     expect(parseAuthRef('keyring:provider:openai')).toEqual({ kind: 'keyring', account: 'provider:openai' });
     expect(parseAuthRef('keyring:oauth:provider:openai-oauth')).toEqual({ kind: 'keyring', account: 'oauth:provider:openai-oauth' });
+    expect(parseAuthRef(`helper:v1:${TEST_HELPER_ID}:oauth:provider:openai-oauth`)).toEqual({
+      kind: 'helper',
+      helperId: TEST_HELPER_ID,
+      account: 'oauth:provider:openai-oauth',
+    });
+    expect(parseAuthRef('helper:oauth:provider:openai-oauth')).toBeNull();
     expect(parseAuthRef('env:OPENAI_API_KEY')).toEqual({ kind: 'env', varName: 'OPENAI_API_KEY' });
     expect(parseAuthRef('bad')).toBeNull();
   });

--- a/tests/first-run.test.ts
+++ b/tests/first-run.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { needsFirstRunSetup } from '../src/first-run.js';
 import { emptyRegistry, saveRegistry } from '../src/registry/io.js';
+import { withRegistryWriteLockSync } from '../src/registry/lock.js';
 
 describe('needsFirstRunSetup', () => {
   let home: string;
@@ -36,7 +37,7 @@ describe('needsFirstRunSetup', () => {
       api: { npm: '@ai-sdk/openai' },
       addedAt: new Date().toISOString(),
     });
-    saveRegistry(registry);
+    withRegistryWriteLockSync(() => saveRegistry(registry));
     expect(await needsFirstRunSetup()).toBe(false);
   });
 });

--- a/tests/fixtures/credential-helper.mjs
+++ b/tests/fixtures/credential-helper.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+import { closeSync, existsSync, openSync, readFileSync, writeFileSync } from 'node:fs';
+
+const [operation, service, account] = process.argv.slice(2);
+const storePath = process.env.CLODEX_TEST_CREDENTIAL_HELPER_STORE;
+const mode = process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE;
+
+if (!operation || !service || !account || !storePath) process.exit(1);
+if (mode === 'fail' || mode === `fail-${operation}`) process.exit(1);
+if (mode === 'hang-ignore-term') {
+  writeFileSync(`${storePath}.helper-pid`, String(process.pid), { encoding: 'utf8', mode: 0o600 });
+  process.on('SIGTERM', () => {});
+  setInterval(() => {}, 1_000);
+  await new Promise(() => {});
+}
+
+let store = {};
+try {
+  store = JSON.parse(readFileSync(storePath, 'utf8'));
+} catch {
+  store = {};
+}
+
+const key = `${service}\u0000${account}`;
+
+if (operation === 'get') {
+  if (mode === 'interleave-readback') {
+    const firstGetPath = `${storePath}.first-get`;
+    const secondSetPath = `${storePath}.second-set`;
+    let firstGet = false;
+    try {
+      const fd = openSync(firstGetPath, 'wx');
+      closeSync(fd);
+      firstGet = true;
+    } catch {
+      firstGet = false;
+    }
+    if (firstGet) {
+      const deadline = Date.now() + 5_000;
+      while (!existsSync(secondSetPath) && Date.now() < deadline) {
+        await new Promise(resolve => setTimeout(resolve, 5));
+      }
+      if (!existsSync(secondSetPath)) process.exit(1);
+      store = JSON.parse(readFileSync(storePath, 'utf8'));
+    }
+  }
+  if (!(key in store)) process.exit(2);
+  process.stdout.write(mode === 'mismatch' ? 'different-value' : store[key]);
+  process.exit(0);
+}
+
+if (operation === 'set') {
+  let value = '';
+  process.stdin.setEncoding('utf8');
+  for await (const chunk of process.stdin) value += chunk;
+  store[key] = value;
+  writeFileSync(storePath, JSON.stringify(store), { encoding: 'utf8', mode: 0o600 });
+  if (mode === 'interleave-readback') {
+    const setCountPath = `${storePath}.set-count`;
+    let setCount = 0;
+    try {
+      setCount = Number.parseInt(readFileSync(setCountPath, 'utf8'), 10) || 0;
+    } catch {
+      setCount = 0;
+    }
+    setCount += 1;
+    writeFileSync(setCountPath, String(setCount), { encoding: 'utf8', mode: 0o600 });
+    if (setCount >= 2) {
+      writeFileSync(`${storePath}.second-set`, '', { encoding: 'utf8', mode: 0o600 });
+    }
+  }
+  process.exit(0);
+}
+
+if (operation === 'delete') {
+  if (!(key in store)) process.exit(2);
+  delete store[key];
+  writeFileSync(storePath, JSON.stringify(store), { encoding: 'utf8', mode: 0o600 });
+  process.exit(0);
+}
+
+process.exit(1);

--- a/tests/fixtures/credential-helper.mjs
+++ b/tests/fixtures/credential-helper.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { closeSync, existsSync, openSync, readFileSync, writeFileSync } from 'node:fs';
+import { closeSync, existsSync, openSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 
 const [operation, service, account] = process.argv.slice(2);
 const storePath = process.env.CLODEX_TEST_CREDENTIAL_HELPER_STORE;
@@ -25,26 +25,6 @@ try {
 const key = `${service}\u0000${account}`;
 
 if (operation === 'get') {
-  if (mode === 'interleave-readback') {
-    const firstGetPath = `${storePath}.first-get`;
-    const secondSetPath = `${storePath}.second-set`;
-    let firstGet = false;
-    try {
-      const fd = openSync(firstGetPath, 'wx');
-      closeSync(fd);
-      firstGet = true;
-    } catch {
-      firstGet = false;
-    }
-    if (firstGet) {
-      const deadline = Date.now() + 5_000;
-      while (!existsSync(secondSetPath) && Date.now() < deadline) {
-        await new Promise(resolve => setTimeout(resolve, 5));
-      }
-      if (!existsSync(secondSetPath)) process.exit(1);
-      store = JSON.parse(readFileSync(storePath, 'utf8'));
-    }
-  }
   if (!(key in store)) process.exit(2);
   process.stdout.write(mode === 'mismatch' ? 'different-value' : store[key]);
   process.exit(0);
@@ -54,22 +34,27 @@ if (operation === 'set') {
   let value = '';
   process.stdin.setEncoding('utf8');
   for await (const chunk of process.stdin) value += chunk;
-  store[key] = value;
-  writeFileSync(storePath, JSON.stringify(store), { encoding: 'utf8', mode: 0o600 });
-  if (mode === 'interleave-readback') {
-    const setCountPath = `${storePath}.set-count`;
-    let setCount = 0;
+  let activeSetPath;
+  if (mode === 'detect-overlap') {
+    activeSetPath = `${storePath}.active-set`;
     try {
-      setCount = Number.parseInt(readFileSync(setCountPath, 'utf8'), 10) || 0;
+      const fd = openSync(activeSetPath, 'wx');
+      closeSync(fd);
+      writeFileSync(`${storePath}.set-started`, '', { encoding: 'utf8', mode: 0o600 });
+      const releasePath = `${storePath}.release-set`;
+      const deadline = Date.now() + 5_000;
+      while (!existsSync(releasePath) && Date.now() < deadline) {
+        await new Promise(resolve => setTimeout(resolve, 5));
+      }
+      if (!existsSync(releasePath)) process.exit(1);
     } catch {
-      setCount = 0;
-    }
-    setCount += 1;
-    writeFileSync(setCountPath, String(setCount), { encoding: 'utf8', mode: 0o600 });
-    if (setCount >= 2) {
-      writeFileSync(`${storePath}.second-set`, '', { encoding: 'utf8', mode: 0o600 });
+      writeFileSync(`${storePath}.overlapping-set`, '', { encoding: 'utf8', mode: 0o600 });
+      activeSetPath = undefined;
     }
   }
+  store[key] = value;
+  writeFileSync(storePath, JSON.stringify(store), { encoding: 'utf8', mode: 0o600 });
+  if (activeSetPath) unlinkSync(activeSetPath);
   process.exit(0);
 }
 

--- a/tests/fixtures/registry-lock-worker.ts
+++ b/tests/fixtures/registry-lock-worker.ts
@@ -1,0 +1,291 @@
+import fs from 'node:fs';
+import { syncBuiltinESMExports } from 'node:module';
+import { join } from 'node:path';
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required environment variable: ${name}`);
+  return value;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function writeJson(path: string, value: unknown): void {
+  fs.writeFileSync(path, `${JSON.stringify(value)}\n`, { mode: 0o600 });
+}
+
+async function waitForFile(path: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!fs.existsSync(path)) {
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for signal: ${path}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+function waitForFileSync(path: string, timeoutMs: number): void {
+  const deadline = Date.now() + timeoutMs;
+  const sleeper = new Int32Array(new SharedArrayBuffer(4));
+  while (!fs.existsSync(path)) {
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for signal: ${path}`);
+    }
+    Atomics.wait(sleeper, 0, 0, 10);
+  }
+}
+
+const role = requiredEnv('REGISTRY_LOCK_WORKER_ROLE');
+const root = requiredEnv('CLODEX_HOME');
+const registryPath = join(root, 'providers.json');
+const lockPath = `${registryPath}.lock`;
+
+async function runHolder(): Promise<void> {
+  const { withRegistryWriteLock } = await import('../../src/registry/lock.js');
+  const { emptyRegistry, saveRegistry } =
+    await import('../../src/registry/io.js');
+  const readyPath = join(root, 'holder-ready.json');
+  const releasePath = join(root, 'release-holder');
+  const resultPath = join(root, 'holder-result.json');
+
+  try {
+    await withRegistryWriteLock(
+      async () => {
+        saveRegistry(
+          { ...emptyRegistry(), importedAt: 'holder-initial' },
+          registryPath,
+        );
+        const owner = JSON.parse(fs.readFileSync(lockPath, 'utf8')) as {
+          pid: number;
+          token: string;
+        };
+        writeJson(readyPath, { pid: owner.pid, token: owner.token });
+        await waitForFile(releasePath, 10_000);
+        saveRegistry(
+          { ...emptyRegistry(), importedAt: 'holder-final' },
+          registryPath,
+        );
+      },
+      { lockPath, waitMs: 2_000, retryMs: 10 },
+    );
+    writeJson(resultPath, { ok: true });
+  } catch (error) {
+    writeJson(resultPath, { ok: false, error: errorMessage(error) });
+    throw error;
+  }
+}
+
+async function runContender(): Promise<void> {
+  const { withRegistryWriteLock } = await import('../../src/registry/lock.js');
+  const { emptyRegistry, saveRegistry } =
+    await import('../../src/registry/io.js');
+  const resultPath = join(root, 'contender-result.json');
+
+  try {
+    await withRegistryWriteLock(
+      () => {
+        saveRegistry(
+          { ...emptyRegistry(), importedAt: 'contender' },
+          registryPath,
+        );
+      },
+      { lockPath, waitMs: 250, retryMs: 10 },
+    );
+    writeJson(resultPath, { acquired: true });
+  } catch (error) {
+    writeJson(resultPath, {
+      acquired: false,
+      error: errorMessage(error),
+    });
+  }
+}
+
+async function runLeaseLoss(): Promise<void> {
+  const resultPath = join(root, 'lease-loss-result.json');
+  const originalOpenSync = fs.openSync;
+  const originalWriteSync = fs.writeSync;
+  let registryTempFd: number | undefined;
+  let replacementPublished = false;
+
+  fs.openSync = ((...args: unknown[]) => {
+    const fd = Reflect.apply(originalOpenSync, fs, args) as number;
+    const path = args[0];
+    if (
+      typeof path === 'string' &&
+      path.startsWith(`${registryPath}.${process.pid}.`) &&
+      path.endsWith('.tmp')
+    ) {
+      registryTempFd = fd;
+    }
+    return fd;
+  }) as typeof fs.openSync;
+  fs.writeSync = ((...args: unknown[]) => {
+    const written = Reflect.apply(originalWriteSync, fs, args) as number;
+    if (args[0] === registryTempFd && !replacementPublished) {
+      const owner = JSON.parse(fs.readFileSync(lockPath, 'utf8')) as {
+        pid: number;
+        startedAt: number;
+        token: string;
+      };
+      fs.unlinkSync(lockPath);
+      writeJson(lockPath, {
+        ...owner,
+        token: 'replacement-owner',
+      });
+      replacementPublished = true;
+    }
+    return written;
+  }) as typeof fs.writeSync;
+  syncBuiltinESMExports();
+
+  const { withRegistryWriteLockSync } =
+    await import('../../src/registry/lock.js');
+  const { emptyRegistry, saveRegistry } =
+    await import('../../src/registry/io.js');
+  fs.writeFileSync(
+    registryPath,
+    `${JSON.stringify({ ...emptyRegistry(), importedAt: 'sentinel' })}\n`,
+    { mode: 0o600 },
+  );
+
+  let error: unknown;
+  try {
+    withRegistryWriteLockSync(
+      () => {
+        saveRegistry(
+          { ...emptyRegistry(), importedAt: 'unwanted' },
+          registryPath,
+        );
+      },
+      { lockPath },
+    );
+  } catch (caught) {
+    error = caught;
+  }
+
+  const registry = JSON.parse(fs.readFileSync(registryPath, 'utf8')) as {
+    importedAt?: string;
+  };
+  const replacement = JSON.parse(fs.readFileSync(lockPath, 'utf8')) as {
+    token?: string;
+  };
+  const temporaryArtifacts = fs
+    .readdirSync(root)
+    .filter((name) => name.endsWith('.tmp'));
+  writeJson(resultPath, {
+    errorName: error instanceof Error ? error.name : null,
+    error: errorMessage(error),
+    importedAt: registry.importedAt,
+    replacementPublished,
+    replacementToken: replacement.token,
+    temporaryArtifacts,
+  });
+  fs.unlinkSync(lockPath);
+}
+
+async function runAtomicAcquire(): Promise<void> {
+  const readyPath = join(root, 'atomic-acquire-ready.json');
+  const releasePath = join(root, 'release-atomic-acquire');
+  const resultPath = join(root, 'atomic-acquire-result.json');
+  const originalOpenSync = fs.openSync;
+  const originalWriteFileSync = fs.writeFileSync;
+  let recordFd: number | undefined;
+  let candidatePath: string | undefined;
+  let paused = false;
+
+  fs.openSync = ((...args: unknown[]) => {
+    const fd = Reflect.apply(originalOpenSync, fs, args) as number;
+    const path = args[0];
+    const flags = args[1];
+    if (
+      typeof path === 'string' &&
+      flags === 'wx' &&
+      (path === lockPath || path.startsWith(`${lockPath}.`))
+    ) {
+      recordFd = fd;
+      candidatePath = path;
+    }
+    return fd;
+  }) as typeof fs.openSync;
+  fs.writeFileSync = ((...args: unknown[]) => {
+    if (args[0] === recordFd && !paused) {
+      paused = true;
+      writeJson(readyPath, { candidatePath, pid: process.pid });
+      waitForFileSync(releasePath, 5_000);
+    }
+    return Reflect.apply(originalWriteFileSync, fs, args) as void;
+  }) as typeof fs.writeFileSync;
+  syncBuiltinESMExports();
+
+  const { tryAcquireRegistryLock } = await import('../../src/registry/lock.js');
+  const lease = tryAcquireRegistryLock(lockPath);
+  if (!lease) throw new Error('Atomic acquisition worker did not get the lock');
+  const owner = JSON.parse(fs.readFileSync(lockPath, 'utf8')) as {
+    pid: number;
+    token: string;
+  };
+  lease.release();
+  writeJson(resultPath, {
+    acquired: true,
+    ownerPid: owner.pid,
+    ownerToken: owner.token,
+  });
+}
+
+const credentialAuthRef = 'keyring:provider:openai';
+
+async function runCredentialHolder(): Promise<void> {
+  const { getCredentialMutationLockPath, withCredentialMutationLock } =
+    await import('../../src/registry/lock.js');
+  const readyPath = join(root, 'credential-holder-ready.json');
+  const releasePath = join(root, 'release-credential-holder');
+  const resultPath = join(root, 'credential-holder-result.json');
+
+  await withCredentialMutationLock(credentialAuthRef, async () => {
+    writeJson(readyPath, {
+      pid: process.pid,
+      lockPath: getCredentialMutationLockPath(credentialAuthRef),
+    });
+    await waitForFile(releasePath, 5_000);
+  });
+  writeJson(resultPath, { ok: true });
+}
+
+async function runCredentialContender(): Promise<void> {
+  const { withCredentialMutationLock } =
+    await import('../../src/registry/lock.js');
+  const readyPath = join(root, 'credential-contender-ready.json');
+  const enteredPath = join(root, 'credential-contender-entered.json');
+  const resultPath = join(root, 'credential-contender-result.json');
+
+  writeJson(readyPath, { pid: process.pid });
+  await withCredentialMutationLock(credentialAuthRef, () => {
+    writeJson(enteredPath, { pid: process.pid });
+  });
+  writeJson(resultPath, { ok: true });
+}
+
+switch (role) {
+  case 'holder':
+    await runHolder();
+    break;
+  case 'contender':
+    await runContender();
+    break;
+  case 'lease-loss':
+    await runLeaseLoss();
+    break;
+  case 'atomic-acquire':
+    await runAtomicAcquire();
+    break;
+  case 'credential-holder':
+    await runCredentialHolder();
+    break;
+  case 'credential-contender':
+    await runCredentialContender();
+    break;
+  default:
+    throw new Error(`Unsupported registry lock worker role: ${role}`);
+}

--- a/tests/provider-auth.test.ts
+++ b/tests/provider-auth.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
+const lockState = vi.hoisted(() => ({ active: false }));
+
 vi.mock('../src/ui.js', () => ({
   printOAuthStepsPanel: vi.fn(),
 }));
@@ -20,6 +22,16 @@ vi.mock('../src/registry/io.js', () => ({
 vi.mock('../src/registry/refresh-models.js', () => ({
   refreshProviderModels: vi.fn(),
 }));
+vi.mock('../src/registry/lock.js', () => ({
+  withRegistryWriteLock: vi.fn(async (operation: () => unknown) => {
+    lockState.active = true;
+    try {
+      return await operation();
+    } finally {
+      lockState.active = false;
+    }
+  }),
+}));
 vi.mock('@clack/prompts', () => ({
   log: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), success: vi.fn() },
   spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
@@ -31,14 +43,17 @@ import { probeProviderCredentialStore, saveProviderCredential } from '../src/env
 import { saveRegistry } from '../src/registry/io.js';
 import { authenticateProvider } from '../src/registry/provider-auth.js';
 import { runOpenAiDeviceCodeFlow } from '../src/oauth/openai.js';
+import { refreshProviderModels } from '../src/registry/refresh-models.js';
 import * as prompts from '@clack/prompts';
 
 describe('authenticateProvider', () => {
   beforeEach(() => {
     vi.mocked(probeProviderCredentialStore).mockReset().mockResolvedValue(true);
+    lockState.active = false;
     vi.mocked(saveProviderCredential).mockClear();
     vi.mocked(saveRegistry).mockClear();
     vi.mocked(runOpenAiDeviceCodeFlow).mockClear();
+    vi.mocked(refreshProviderModels).mockClear();
     vi.mocked(prompts.select).mockClear();
   });
 
@@ -70,6 +85,32 @@ describe('authenticateProvider', () => {
     expect(saveProviderCredential).toHaveBeenCalled();
     expect(saveRegistry).toHaveBeenCalled();
     expect(result.providerId).toBe('openai-oauth');
+  });
+
+  it('holds the registry lock only while persisting the provider entry', async () => {
+    const observations: Array<[string, boolean]> = [];
+    vi.mocked(runOpenAiDeviceCodeFlow).mockImplementationOnce(async () => {
+      observations.push(['authorization', lockState.active]);
+      return {
+        tokens: { access_token: 'access-token', refresh_token: 'refresh-token', expires_in: 3600 },
+        accountId: 'account-id',
+      };
+    });
+    vi.mocked(saveRegistry).mockImplementationOnce(() => {
+      observations.push(['registry-write', lockState.active]);
+    });
+    vi.mocked(refreshProviderModels).mockImplementationOnce(async () => {
+      observations.push(['model-refresh', lockState.active]);
+      return { id: 'openai-oauth', name: 'OpenAI', ok: true };
+    });
+
+    await authenticateProvider('openai');
+
+    expect(observations).toEqual([
+      ['authorization', false],
+      ['registry-write', true],
+      ['model-refresh', false],
+    ]);
   });
 
   it('rejects non-OpenAI providers', async () => {

--- a/tests/provider-auth.test.ts
+++ b/tests/provider-auth.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
-const lockState = vi.hoisted(() => ({ active: false }));
+const lockState = vi.hoisted(() => ({
+  active: false,
+  credentialActive: false,
+}));
 
 vi.mock('../src/ui.js', () => ({
   printOAuthStepsPanel: vi.fn(),
@@ -31,6 +34,17 @@ vi.mock('../src/registry/lock.js', () => ({
       lockState.active = false;
     }
   }),
+  withCredentialMutationLock: vi.fn(async (
+    _authRef: string,
+    operation: () => unknown,
+  ) => {
+    lockState.credentialActive = true;
+    try {
+      return await operation();
+    } finally {
+      lockState.credentialActive = false;
+    }
+  }),
 }));
 vi.mock('@clack/prompts', () => ({
   log: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), success: vi.fn() },
@@ -50,6 +64,7 @@ describe('authenticateProvider', () => {
   beforeEach(() => {
     vi.mocked(probeProviderCredentialStore).mockReset().mockResolvedValue(true);
     lockState.active = false;
+    lockState.credentialActive = false;
     vi.mocked(saveProviderCredential).mockClear();
     vi.mocked(saveRegistry).mockClear();
     vi.mocked(runOpenAiDeviceCodeFlow).mockClear();
@@ -58,6 +73,11 @@ describe('authenticateProvider', () => {
   });
 
   it('runs the OpenAI device-code flow and stores the openai-oauth registry entry', async () => {
+    vi.mocked(saveProviderCredential).mockImplementationOnce(async () => {
+      expect(lockState.active).toBe(false);
+      expect(lockState.credentialActive).toBe(true);
+      return true;
+    });
     const result = await authenticateProvider('openai');
 
     expect(prompts.select).not.toHaveBeenCalled();
@@ -73,8 +93,14 @@ describe('authenticateProvider', () => {
   });
 
   it('stops before device authorization when the credential store preflight fails', async () => {
-    vi.mocked(probeProviderCredentialStore).mockResolvedValue(false);
-    await expect(authenticateProvider('openai')).rejects.toThrow('Credential store is unavailable');
+    vi.mocked(probeProviderCredentialStore).mockImplementationOnce(async (_authRef, diagnostic) => {
+      diagnostic?.('native keyring probe failed');
+      return false;
+    });
+    await expect(authenticateProvider('openai')).rejects.toThrow(
+      'Credential store is unavailable: native keyring probe failed. '
+      + 'Set CLODEX_CREDENTIAL_HELPER to an absolute path to an external credential helper and try again.',
+    );
     expect(runOpenAiDeviceCodeFlow).not.toHaveBeenCalled();
     expect(saveProviderCredential).not.toHaveBeenCalled();
     expect(saveRegistry).not.toHaveBeenCalled();

--- a/tests/provider-auth.test.ts
+++ b/tests/provider-auth.test.ts
@@ -10,6 +10,7 @@ vi.mock('../src/oauth/openai.js', () => ({
   })),
 }));
 vi.mock('../src/env.js', () => ({
+  probeProviderCredentialStore: vi.fn(async () => true),
   saveProviderCredential: vi.fn(async () => false),
 }));
 vi.mock('../src/registry/io.js', () => ({
@@ -26,7 +27,7 @@ vi.mock('@clack/prompts', () => ({
   isCancel: vi.fn(() => false),
 }));
 
-import { saveProviderCredential } from '../src/env.js';
+import { probeProviderCredentialStore, saveProviderCredential } from '../src/env.js';
 import { saveRegistry } from '../src/registry/io.js';
 import { authenticateProvider } from '../src/registry/provider-auth.js';
 import { runOpenAiDeviceCodeFlow } from '../src/oauth/openai.js';
@@ -34,6 +35,7 @@ import * as prompts from '@clack/prompts';
 
 describe('authenticateProvider', () => {
   beforeEach(() => {
+    vi.mocked(probeProviderCredentialStore).mockReset().mockResolvedValue(true);
     vi.mocked(saveProviderCredential).mockClear();
     vi.mocked(saveRegistry).mockClear();
     vi.mocked(runOpenAiDeviceCodeFlow).mockClear();
@@ -44,11 +46,23 @@ describe('authenticateProvider', () => {
     const result = await authenticateProvider('openai');
 
     expect(prompts.select).not.toHaveBeenCalled();
+    expect(probeProviderCredentialStore).toHaveBeenCalledWith(
+      'keyring:oauth:provider:openai-oauth',
+      expect.any(Function),
+    );
     expect(runOpenAiDeviceCodeFlow).toHaveBeenCalled();
     expect(saveRegistry).toHaveBeenCalled();
     expect(result.providerId).toBe('openai-oauth');
     expect(result.credential.access).toBe('openai-access');
     expect(result.registryProvider.name).toBe('OpenAI (ChatGPT)');
+  });
+
+  it('stops before device authorization when the credential store preflight fails', async () => {
+    vi.mocked(probeProviderCredentialStore).mockResolvedValue(false);
+    await expect(authenticateProvider('openai')).rejects.toThrow('Credential store is unavailable');
+    expect(runOpenAiDeviceCodeFlow).not.toHaveBeenCalled();
+    expect(saveProviderCredential).not.toHaveBeenCalled();
+    expect(saveRegistry).not.toHaveBeenCalled();
   });
 
   it('warns and continues when token persistence fails (graceful degradation)', async () => {

--- a/tests/provider-catalog-display.test.ts
+++ b/tests/provider-catalog-display.test.ts
@@ -10,6 +10,7 @@ import {
   resolveProvidersForDisplay,
 } from '../src/provider-catalog.js';
 import { emptyRegistry, saveRegistry } from '../src/registry/io.js';
+import { withRegistryWriteLockSync } from '../src/registry/lock.js';
 
 const TEST_HELPER_REF = `helper:v1:${'a'.repeat(64)}:oauth:provider:openai-oauth`;
 
@@ -64,7 +65,7 @@ describe('provider-catalog-display', () => {
         addedAt: new Date().toISOString(),
         modelsCache: { fetchedAt: new Date().toISOString(), models: [] },
       });
-      saveRegistry(registry);
+      withRegistryWriteLockSync(() => saveRegistry(registry));
 
       const provider = { id: 'groq', name: 'Groq', apiKey: '', models: [] } as any;
       expect(await resolveLocalProviderApiKey(provider)).toBe('opencode-key');
@@ -160,7 +161,7 @@ describe('provider-catalog-display', () => {
         addedAt: new Date().toISOString(),
         modelsCache: { fetchedAt: new Date().toISOString(), models: [] },
       });
-      saveRegistry(registry);
+      withRegistryWriteLockSync(() => saveRegistry(registry));
 
       const entries = await resolveProvidersForDisplay();
       expect(entries.map(e => e.id)).toEqual(['groq']);

--- a/tests/provider-catalog-display.test.ts
+++ b/tests/provider-catalog-display.test.ts
@@ -11,9 +11,12 @@ import {
 } from '../src/provider-catalog.js';
 import { emptyRegistry, saveRegistry } from '../src/registry/io.js';
 
+const TEST_HELPER_REF = `helper:v1:${'a'.repeat(64)}:oauth:provider:openai-oauth`;
+
 describe('provider-catalog-display', () => {
   let home: string;
   const prevHome = process.env.CLODEX_HOME;
+  const prevHelper = process.env.CLODEX_CREDENTIAL_HELPER;
 
   beforeEach(() => {
     home = mkdtempSync(join(tmpdir(), 'clodex-display-'));
@@ -23,6 +26,8 @@ describe('provider-catalog-display', () => {
   afterEach(() => {
     if (prevHome === undefined) delete process.env.CLODEX_HOME;
     else process.env.CLODEX_HOME = prevHome;
+    if (prevHelper === undefined) delete process.env.CLODEX_CREDENTIAL_HELPER;
+    else process.env.CLODEX_CREDENTIAL_HELPER = prevHelper;
     rmSync(home, { recursive: true, force: true });
     vi.restoreAllMocks();
   });
@@ -77,6 +82,24 @@ describe('provider-catalog-display', () => {
       expect(await resolveLocalProviderApiKey(provider)).toBe('oauth-key');
       expect(env.resolveProviderCredential).toHaveBeenCalledWith('openai', 'keyring:oauth:provider:openai');
     });
+
+    it('uses the materialized authRef even when the current environment selects another store', async () => {
+      vi.spyOn(env, 'resolveProviderCredential').mockResolvedValue('oauth-key');
+      const provider = {
+        id: 'openai-oauth',
+        name: 'OpenAI (ChatGPT)',
+        apiKey: '',
+        authType: 'oauth',
+        authRef: 'keyring:oauth:provider:openai-oauth',
+        models: [],
+      } as any;
+      process.env.CLODEX_CREDENTIAL_HELPER = process.execPath;
+      expect(await resolveLocalProviderApiKey(provider)).toBe('oauth-key');
+      expect(env.resolveProviderCredential).toHaveBeenCalledWith(
+        'openai-oauth',
+        'keyring:oauth:provider:openai-oauth',
+      );
+    });
   });
 
   describe('formatRegistryAuthLabel', () => {
@@ -89,6 +112,14 @@ describe('provider-catalog-display', () => {
         authRef: 'keyring:provider:groq',
         authType: 'api',
       } as any)).toBe('keychain (API key)');
+      expect(formatRegistryAuthLabel({
+        authRef: TEST_HELPER_REF,
+        authType: 'oauth',
+      } as any)).toBe('helper (OAuth)');
+      expect(formatRegistryAuthLabel({
+        authRef: `helper:v1:${'b'.repeat(64)}:provider:groq`,
+        authType: 'api',
+      } as any)).toBe('helper (API key)');
       expect(formatRegistryAuthLabel({
         authRef: 'env:OPENAI_API_KEY',
       } as any)).toBe('env:OPENAI_API_KEY');
@@ -117,4 +148,3 @@ describe('provider-catalog-display', () => {
     });
   });
 });
-

--- a/tests/provider-catalog-display.test.ts
+++ b/tests/provider-catalog-display.test.ts
@@ -76,6 +76,18 @@ describe('provider-catalog-display', () => {
       expect(await resolveLocalProviderApiKey(provider)).toBe('anonymous');
     });
 
+    it('does not resurrect a direct key for an explicitly anonymous provider', async () => {
+      const provider = {
+        id: 'local',
+        name: 'Local',
+        apiKey: 'stale-key',
+        authRef: 'none:anonymous',
+        authType: 'none',
+        models: [],
+      } as any;
+      expect(await resolveLocalProviderApiKey(provider)).toBe('anonymous');
+    });
+
     it('falls back to the OAuth keyring ref when there is no registry authRef and no zen/go/anonymous special case', async () => {
       vi.spyOn(env, 'resolveProviderCredential').mockResolvedValue('oauth-key');
       const provider = { id: 'openai', name: 'OpenAI', apiKey: '', models: [] } as any;
@@ -123,6 +135,15 @@ describe('provider-catalog-display', () => {
       expect(formatRegistryAuthLabel({
         authRef: 'env:OPENAI_API_KEY',
       } as any)).toBe('env:OPENAI_API_KEY');
+      expect(formatRegistryAuthLabel({
+        authRef: 'none:anonymous',
+        authType: 'none',
+      } as any)).toBe('anonymous');
+      expect(formatRegistryAuthLabel({
+        id: 'legacy-local',
+        authRef: 'keyring:provider:legacy-local',
+        authType: 'none',
+      } as any)).toBe('anonymous');
     });
   });
 

--- a/tests/providers-command.test.ts
+++ b/tests/providers-command.test.ts
@@ -8,6 +8,7 @@ import {
   toggleProviderEnabled,
 } from '../src/registry/crud.js';
 import { emptyRegistry, loadRegistry, saveRegistry } from '../src/registry/io.js';
+import { withRegistryWriteLockSync } from '../src/registry/lock.js';
 import { providerAuthHelpText } from '../src/registry/provider-auth.js';
 import type { RegistryProvider } from '../src/registry/types.js';
 import * as env from '../src/env.js';
@@ -118,7 +119,7 @@ describe('registry crud', () => {
   it('toggles provider enabled state', () => {
     const registry = emptyRegistry();
     registry.providers.push(openaiEntry());
-    saveRegistry(registry);
+    withRegistryWriteLockSync(() => saveRegistry(registry));
 
     expect(toggleProviderEnabled('openai')).toEqual({ toggled: true, enabled: false });
     expect(loadRegistry().providers[0]?.enabled).toBe(false);
@@ -127,7 +128,7 @@ describe('registry crud', () => {
   it('removes provider and deletes its credential', async () => {
     const registry = emptyRegistry();
     registry.providers.push(openaiEntry());
-    saveRegistry(registry);
+    withRegistryWriteLockSync(() => saveRegistry(registry));
 
     const deleteSpy = vi.spyOn(env, 'deleteProviderCredential').mockResolvedValue(true);
     const result = await removeProviderFromRegistry('openai');
@@ -143,7 +144,7 @@ describe('registry crud', () => {
       openaiEntry({ authRef: 'keyring:provider:shared' }),
       openaiEntry({ id: 'openai-oauth', name: 'OpenAI (ChatGPT)', authType: 'oauth', authRef: 'keyring:provider:shared' }),
     );
-    saveRegistry(registry);
+    withRegistryWriteLockSync(() => saveRegistry(registry));
 
     const deleteSpy = vi.spyOn(env, 'deleteProviderCredential').mockResolvedValue(true);
     const result = await removeProviderFromRegistry('openai');

--- a/tests/providers-command.test.ts
+++ b/tests/providers-command.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { parseProvidersArgs, providerHubChoiceValue, providersHelpText, runProvidersAdd } from '../src/providers-command.js';
+import {
+  parseProvidersArgs,
+  providerHubChoiceValue,
+  providersHelpText,
+  runProvidersAdd,
+  runProvidersRemove,
+} from '../src/providers-command.js';
 import {
   removeProviderFromRegistry,
   toggleProviderEnabled,
@@ -14,12 +20,19 @@ import type { RegistryProvider } from '../src/registry/types.js';
 import * as env from '../src/env.js';
 
 const selectMock = vi.hoisted(() => vi.fn());
+const logErrorMock = vi.hoisted(() => vi.fn());
+const logSuccessMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@clack/prompts', async importOriginal => {
   const actual = await importOriginal<typeof import('@clack/prompts')>();
   return {
     ...actual,
     select: selectMock,
+    log: {
+      ...actual.log,
+      error: logErrorMock,
+      success: logSuccessMock,
+    },
   };
 });
 
@@ -107,6 +120,8 @@ describe('registry crud', () => {
   beforeEach(() => {
     home = mkdtempSync(join(tmpdir(), 'clodex-crud-'));
     process.env.CLODEX_HOME = home;
+    logErrorMock.mockReset();
+    logSuccessMock.mockReset();
   });
 
   afterEach(() => {
@@ -136,6 +151,28 @@ describe('registry crud', () => {
     expect(result.credentialDeleted).toBe(true);
     expect(loadRegistry().providers).toHaveLength(0);
     expect(deleteSpy).toHaveBeenCalledWith('keyring:provider:openai');
+  });
+
+  it('returns failure and avoids success output when credential cleanup fails', async () => {
+    const authRef = 'keyring:provider:openai';
+    const registry = emptyRegistry();
+    registry.providers.push(openaiEntry({ authRef }));
+    withRegistryWriteLockSync(() => saveRegistry(registry));
+
+    const deleteSpy = vi.spyOn(env, 'deleteProviderCredential').mockResolvedValue(false);
+    const code = await runProvidersRemove('openai');
+
+    expect(code).toBe(1);
+    expect(loadRegistry().providers).toHaveLength(0);
+    expect(deleteSpy).toHaveBeenCalledWith(authRef);
+    expect(logErrorMock).toHaveBeenCalledWith(expect.stringContaining(authRef));
+    expect(logErrorMock.mock.calls[0]?.[0]).toMatch(
+      /credential.*(?:cleanup|deletion).*failed/i,
+    );
+    expect(logErrorMock.mock.calls[0]?.[0]).toContain(
+      'must be removed manually',
+    );
+    expect(logSuccessMock).not.toHaveBeenCalled();
   });
 
   it('keeps a shared credential when another provider still references it', async () => {

--- a/tests/refresh-credentials.test.ts
+++ b/tests/refresh-credentials.test.ts
@@ -46,10 +46,17 @@ describe('resolveRefreshCredential', () => {
   });
 
   it('swallows an exception from resolveKey (e.g. OAuth refresh 401) instead of throwing', async () => {
-    const key = await resolveRefreshCredential(makeProvider(), async () => {
-      throw new Error('OpenAI token refresh failed (401)');
-    });
-    expect(key).toBeNull();
+    const previous = process.env['OPENAI_API_KEY'];
+    delete process.env['OPENAI_API_KEY'];
+    try {
+      const key = await resolveRefreshCredential(makeProvider(), async () => {
+        throw new Error('OpenAI token refresh failed (401)');
+      });
+      expect(key).toBeNull();
+    } finally {
+      if (previous === undefined) delete process.env['OPENAI_API_KEY'];
+      else process.env['OPENAI_API_KEY'] = previous;
+    }
   });
 
   it('falls through to env fallback when resolveKey throws and an env var is set', async () => {
@@ -63,6 +70,31 @@ describe('resolveRefreshCredential', () => {
     } finally {
       if (prev === undefined) delete process.env['OPENAI_API_KEY'];
       else process.env['OPENAI_API_KEY'] = prev;
+    }
+  });
+
+  it('does not resolve credentials or environment fallbacks for anonymous access', async () => {
+    const previous = process.env['OPENAI_API_KEY'];
+    process.env['OPENAI_API_KEY'] = 'sk-from-env';
+    try {
+      for (const authRef of [
+        'none:anonymous',
+        'keyring:provider:openai',
+      ]) {
+        let called = false;
+        const key = await resolveRefreshCredential(
+          makeProvider({ authRef, authType: 'none' }),
+          async () => {
+            called = true;
+            return 'stale-key';
+          },
+        );
+        expect(key).toBeNull();
+        expect(called).toBe(false);
+      }
+    } finally {
+      if (previous === undefined) delete process.env['OPENAI_API_KEY'];
+      else process.env['OPENAI_API_KEY'] = previous;
     }
   });
 });

--- a/tests/refresh-models.test.ts
+++ b/tests/refresh-models.test.ts
@@ -13,6 +13,7 @@ vi.mock('../src/registry/io.js', () => ({
   saveRegistry: vi.fn(),
 }));
 vi.mock('../src/registry/lock.js', () => ({
+  withCredentialMutationLock: vi.fn(async (_authRef: string, operation: () => unknown) => operation()),
   withRegistryWriteLock: vi.fn(async (operation: () => unknown) => operation()),
 }));
 

--- a/tests/refresh-models.test.ts
+++ b/tests/refresh-models.test.ts
@@ -12,14 +12,139 @@ vi.mock('../src/registry/io.js', () => ({
   loadRegistry: vi.fn(() => ({ version: 1, providers: [] })),
   saveRegistry: vi.fn(),
 }));
+vi.mock('../src/registry/lock.js', () => ({
+  withRegistryWriteLock: vi.fn(async (operation: () => unknown) => operation()),
+}));
 
 import { fetchTemplateModels } from '../src/registry/fetch-template-models.js';
-import { saveRegistry } from '../src/registry/io.js';
+import { loadRegistry, saveRegistry } from '../src/registry/io.js';
 
 describe('refreshProviderModels', () => {
   beforeEach(() => {
     vi.mocked(fetchTemplateModels).mockReset();
+    vi.mocked(loadRegistry).mockReset();
     vi.mocked(saveRegistry).mockClear();
+  });
+
+  it('reloads persisted state before saving discovery results', async () => {
+    const initialRegistry: ProviderRegistry = {
+      schemaVersion: 1,
+      providers: [{
+        id: 'groq',
+        templateId: 'groq',
+        name: 'Groq',
+        enabled: true,
+        authRef: 'keyring:provider:groq',
+        authType: 'api',
+        api: { npm: '@ai-sdk/groq', url: 'https://api.groq.com/openai/v1' },
+        addedAt: '2026-01-01T00:00:00.000Z',
+      }],
+    };
+    const persistedRegistry: ProviderRegistry = {
+      schemaVersion: 1,
+      providers: [{
+        ...initialRegistry.providers[0]!,
+        name: 'Renamed while discovery was running',
+      }],
+    };
+    vi.mocked(loadRegistry).mockReturnValue(persistedRegistry);
+    vi.mocked(fetchTemplateModels).mockResolvedValue({
+      baseUrl: 'https://api.groq.com/openai/v1',
+      models: [{
+        id: 'live-a',
+        name: 'Live A',
+        upstreamModelId: 'live-a',
+        modelFormat: 'openai',
+      }],
+    });
+
+    const result = await refreshProviderModels('groq', 'test-key', initialRegistry);
+
+    expect(result).toMatchObject({ ok: true, modelCount: 1 });
+    expect(loadRegistry).toHaveBeenCalledOnce();
+    expect(saveRegistry).toHaveBeenCalledWith(persistedRegistry);
+    expect(persistedRegistry.providers[0]?.name).toBe('Renamed while discovery was running');
+    expect(persistedRegistry.providers[0]?.modelsCache?.models[0]?.id).toBe('live-a');
+  });
+
+  it('does not apply discovery results after credentials change', async () => {
+    const initialRegistry: ProviderRegistry = {
+      schemaVersion: 1,
+      providers: [{
+        id: 'groq',
+        templateId: 'groq',
+        name: 'Groq',
+        enabled: true,
+        authRef: 'keyring:provider:groq',
+        authType: 'api',
+        api: { npm: '@ai-sdk/groq', url: 'https://api.groq.com/openai/v1' },
+        addedAt: '2026-01-01T00:00:00.000Z',
+      }],
+    };
+    vi.mocked(loadRegistry).mockReturnValue({
+      schemaVersion: 1,
+      providers: [{
+        ...initialRegistry.providers[0]!,
+        authRef: 'keyring:provider:groq-replacement',
+      }],
+    });
+    vi.mocked(fetchTemplateModels).mockResolvedValue({
+      baseUrl: 'https://api.groq.com/openai/v1',
+      models: [{
+        id: 'live-a',
+        name: 'Live A',
+        upstreamModelId: 'live-a',
+        modelFormat: 'openai',
+      }],
+    });
+
+    const result = await refreshProviderModels('groq', 'test-key', initialRegistry);
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: 'Provider credentials changed while models were refreshing.',
+    });
+    expect(saveRegistry).not.toHaveBeenCalled();
+  });
+
+  it('does not apply discovery results after endpoint configuration changes', async () => {
+    const initialRegistry: ProviderRegistry = {
+      schemaVersion: 1,
+      providers: [{
+        id: 'groq',
+        templateId: 'groq',
+        name: 'Groq',
+        enabled: true,
+        authRef: 'keyring:provider:groq',
+        authType: 'api',
+        api: { npm: '@ai-sdk/groq', url: 'https://api.groq.com/openai/v1' },
+        addedAt: '2026-01-01T00:00:00.000Z',
+      }],
+    };
+    vi.mocked(loadRegistry).mockReturnValue({
+      schemaVersion: 1,
+      providers: [{
+        ...initialRegistry.providers[0]!,
+        api: { npm: '@ai-sdk/groq', url: 'https://replacement.example/v1' },
+      }],
+    });
+    vi.mocked(fetchTemplateModels).mockResolvedValue({
+      baseUrl: 'https://api.groq.com/openai/v1',
+      models: [{
+        id: 'live-a',
+        name: 'Live A',
+        upstreamModelId: 'live-a',
+        modelFormat: 'openai',
+      }],
+    });
+
+    const result = await refreshProviderModels('groq', 'test-key', initialRegistry);
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: 'Provider configuration changed while models were refreshing.',
+    });
+    expect(saveRegistry).not.toHaveBeenCalled();
   });
 
   it('rejects restricted provider API URLs before refreshing models', async () => {
@@ -82,6 +207,7 @@ describe('refreshProviderModels', () => {
         modelFormat: 'openai',
       }],
     });
+    vi.mocked(loadRegistry).mockReturnValue(registry);
 
     const first = await refreshProviderModels('groq', 'gsk-real-key', registry);
     const second = await refreshProviderModels('groq', 'gsk-real-key', registry);

--- a/tests/registry-add-template.test.ts
+++ b/tests/registry-add-template.test.ts
@@ -8,6 +8,8 @@ import * as pricing from '../src/registry/pricing.js';
 import type { ProviderTemplate } from '../src/provider-templates.js';
 import type { ProviderRegistry } from '../src/registry/types.js';
 
+const lockState = vi.hoisted(() => ({ active: false }));
+
 vi.mock('../src/env.js', () => ({ saveProviderCredential: vi.fn() }));
 vi.mock('../src/provider-factory.js', () => ({ isSdkMigratedNpm: vi.fn() }));
 vi.mock('../src/registry/fetch-template-models.js', () => ({ fetchTemplateModels: vi.fn() }));
@@ -18,6 +20,17 @@ vi.mock('../src/registry/pricing.js', () => ({
   enrichPricingAsync: vi.fn(),
   pricingPlatformForProvider: vi.fn(),
   buildPricingIndex: vi.fn(),
+}));
+vi.mock('../src/registry/lock.js', () => ({
+  withRegistryWriteLock: vi.fn(async (operation: () => unknown) => {
+    if (lockState.active) return operation();
+    lockState.active = true;
+    try {
+      return await operation();
+    } finally {
+      lockState.active = false;
+    }
+  }),
 }));
 
 describe('registry/add-template', () => {
@@ -32,6 +45,7 @@ describe('registry/add-template', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    lockState.active = false;
 
     vi.mocked(providerFactory.isSdkMigratedNpm).mockReturnValue(true);
     vi.mocked(env.saveProviderCredential).mockResolvedValue(true);
@@ -93,6 +107,51 @@ describe('registry/add-template', () => {
     const res = await addProviderFromTemplate(dummyTemplate, 'key');
     expect(res.added).toBe(false);
     expect(res.error).toBe('Network failure');
+  });
+
+  it('keeps model discovery and background pricing outside the registry lock', async () => {
+    vi.mocked(fetchTemplate.fetchTemplateModels).mockImplementation(async () => {
+      expect(lockState.active).toBe(false);
+      return {
+        models: [{ id: 'model-1', name: 'Model 1', upstreamModelId: 'model-1', family: 'fam', brand: 'brand', modelFormat: 'openai' }],
+        baseUrl: 'https://api.example.com',
+      };
+    });
+    vi.mocked(pricing.enrichPricingAsync).mockImplementation(() => {
+      expect(lockState.active).toBe(false);
+    });
+
+    const res = await addProviderFromTemplate(dummyTemplate, 'key');
+
+    expect(res.added).toBe(true);
+    expect(fetchTemplate.fetchTemplateModels).toHaveBeenCalledOnce();
+    expect(pricing.enrichPricingAsync).toHaveBeenCalledOnce();
+  });
+
+  it('revalidates provider existence after model discovery', async () => {
+    vi.mocked(io.loadRegistry)
+      .mockReturnValueOnce({ schemaVersion: 1, providers: [] })
+      .mockReturnValueOnce({
+        schemaVersion: 1,
+        providers: [{
+          id: 'test-template',
+          templateId: 'test-template',
+          name: 'Concurrent provider',
+          enabled: true,
+          authType: 'api',
+          authRef: 'keyring:provider:test-template',
+          api: {},
+          addedAt: '2026-01-01T00:00:00.000Z',
+        }],
+      });
+
+    const res = await addProviderFromTemplate(dummyTemplate, 'key');
+
+    expect(res.added).toBe(false);
+    expect(res.error).toContain('is already configured');
+    expect(fetchTemplate.fetchTemplateModels).toHaveBeenCalledOnce();
+    expect(env.saveProviderCredential).not.toHaveBeenCalled();
+    expect(io.saveRegistry).not.toHaveBeenCalled();
   });
 
   it('fails if credential cannot be saved', async () => {

--- a/tests/registry-add-template.test.ts
+++ b/tests/registry-add-template.test.ts
@@ -175,6 +175,51 @@ describe('registry/add-template', () => {
     expect(io.saveRegistry).toHaveBeenCalled();
   });
 
+  it('represents optional no-key access without a stored credential reference', async () => {
+    const anonymousTemplate = { ...dummyTemplate, apiKeyOptional: true };
+
+    const res = await addProviderFromTemplate(anonymousTemplate, '');
+
+    expect(res.added).toBe(true);
+    expect(res.provider).toMatchObject({
+      authRef: 'none:anonymous',
+      authType: 'none',
+    });
+    expect(env.saveProviderCredential).not.toHaveBeenCalled();
+    const savedRegistry = vi.mocked(io.saveRegistry).mock.calls.at(-1)?.[0] as ProviderRegistry;
+    expect(savedRegistry.providers[0]?.authRef).toBe('none:anonymous');
+  });
+
+  it('persists free-only filtering for anonymous free-model access', async () => {
+    const anonymousTemplate = {
+      ...dummyTemplate,
+      apiKeyOptional: true,
+      anonymousFreeModels: true,
+    };
+    vi.mocked(fetchTemplate.fetchTemplateModels).mockResolvedValue({
+      models: [{
+        id: 'free-model',
+        name: 'Free Model',
+        upstreamModelId: 'free-model',
+        family: 'fam',
+        brand: 'brand',
+        modelFormat: 'openai',
+        isFree: true,
+      }],
+      baseUrl: 'https://api.example.com',
+    });
+
+    const res = await addProviderFromTemplate(anonymousTemplate, '');
+
+    expect(res.added).toBe(true);
+    expect(res.provider).toMatchObject({
+      authRef: 'none:anonymous',
+      authType: 'none',
+      subscriptionFilter: 'free',
+    });
+    expect(res.modelCount).toBe(1);
+  });
+
   it('replaces existing provider if replaceExisting is true', async () => {
     vi.mocked(io.loadRegistry).mockReturnValue({
       version: 1,

--- a/tests/registry-add-template.test.ts
+++ b/tests/registry-add-template.test.ts
@@ -8,7 +8,11 @@ import * as pricing from '../src/registry/pricing.js';
 import type { ProviderTemplate } from '../src/provider-templates.js';
 import type { ProviderRegistry } from '../src/registry/types.js';
 
-const lockState = vi.hoisted(() => ({ active: false }));
+const lockState = vi.hoisted(() => ({
+  active: false,
+  credentialActive: false,
+  credentialTails: new Map<string, Promise<void>>(),
+}));
 
 vi.mock('../src/env.js', () => ({ saveProviderCredential: vi.fn() }));
 vi.mock('../src/provider-factory.js', () => ({ isSdkMigratedNpm: vi.fn() }));
@@ -31,6 +35,29 @@ vi.mock('../src/registry/lock.js', () => ({
       lockState.active = false;
     }
   }),
+  withCredentialMutationLock: vi.fn(async (
+    authRef: string,
+    operation: () => unknown,
+  ) => {
+    const previous = lockState.credentialTails.get(authRef) ?? Promise.resolve();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = previous.then(() => gate);
+    lockState.credentialTails.set(authRef, tail);
+    await previous;
+    lockState.credentialActive = true;
+    try {
+      return await operation();
+    } finally {
+      lockState.credentialActive = false;
+      release();
+      if (lockState.credentialTails.get(authRef) === tail) {
+        lockState.credentialTails.delete(authRef);
+      }
+    }
+  }),
 }));
 
 describe('registry/add-template', () => {
@@ -46,6 +73,8 @@ describe('registry/add-template', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     lockState.active = false;
+    lockState.credentialActive = false;
+    lockState.credentialTails.clear();
 
     vi.mocked(providerFactory.isSdkMigratedNpm).mockReturnValue(true);
     vi.mocked(env.saveProviderCredential).mockResolvedValue(true);
@@ -120,12 +149,39 @@ describe('registry/add-template', () => {
     vi.mocked(pricing.enrichPricingAsync).mockImplementation(() => {
       expect(lockState.active).toBe(false);
     });
+    vi.mocked(env.saveProviderCredential).mockImplementation(async () => {
+      expect(lockState.active).toBe(false);
+      expect(lockState.credentialActive).toBe(true);
+      return true;
+    });
 
     const res = await addProviderFromTemplate(dummyTemplate, 'key');
 
     expect(res.added).toBe(true);
     expect(fetchTemplate.fetchTemplateModels).toHaveBeenCalledOnce();
     expect(pricing.enrichPricingAsync).toHaveBeenCalledOnce();
+  });
+
+  it('serializes concurrent writes to the same provider credential', async () => {
+    let registry: ProviderRegistry = { schemaVersion: 1, providers: [] };
+    vi.mocked(io.loadRegistry).mockImplementation(() =>
+      structuredClone(registry));
+    vi.mocked(io.saveRegistry).mockImplementation((next) => {
+      registry = structuredClone(next);
+    });
+
+    const results = await Promise.all([
+      addProviderFromTemplate(dummyTemplate, 'first-key'),
+      addProviderFromTemplate(dummyTemplate, 'second-key'),
+    ]);
+
+    expect(results.filter(result => result.added)).toHaveLength(1);
+    expect(results.filter(result => !result.added)).toHaveLength(1);
+    expect(env.saveProviderCredential).toHaveBeenCalledOnce();
+    const [savedAuthRef, savedKey] = vi.mocked(env.saveProviderCredential).mock.calls[0]!;
+    expect(savedAuthRef).toBe('keyring:provider:test-template');
+    expect(['first-key', 'second-key']).toContain(savedKey);
+    expect(registry.providers).toHaveLength(1);
   });
 
   it('revalidates provider existence after model discovery', async () => {

--- a/tests/registry-crud.test.ts
+++ b/tests/registry-crud.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProviderRegistry } from '../src/registry/types.js';
+
+const registryState = vi.hoisted(() => ({
+  current: { schemaVersion: 1, providers: [] } as ProviderRegistry,
+}));
+const lockState = vi.hoisted(() => ({
+  active: false,
+  credentialActive: false,
+  credentialTails: new Map<string, Promise<void>>(),
+}));
+
+vi.mock('../src/env.js', () => ({
+  deleteProviderCredential: vi.fn(),
+}));
+vi.mock('../src/registry/io.js', () => ({
+  loadRegistry: vi.fn(() => structuredClone(registryState.current)),
+  saveRegistry: vi.fn((registry: ProviderRegistry) => {
+    if (!lockState.active) throw new Error('registry write escaped its lock');
+    registryState.current = structuredClone(registry);
+  }),
+}));
+vi.mock('../src/registry/lock.js', () => ({
+  withRegistryWriteLock: vi.fn(
+    async <T>(operation: () => Promise<T> | T): Promise<T> => {
+      if (lockState.active) throw new Error('registry lock re-entered');
+      lockState.active = true;
+      try {
+        return await operation();
+      } finally {
+        lockState.active = false;
+      }
+    },
+  ),
+  withCredentialMutationLock: vi.fn(async <T>(
+    authRef: string,
+    operation: () => Promise<T> | T,
+  ): Promise<T> => {
+    const previous = lockState.credentialTails.get(authRef) ?? Promise.resolve();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = previous.then(() => gate);
+    lockState.credentialTails.set(authRef, tail);
+    await previous;
+    lockState.credentialActive = true;
+    try {
+      return await operation();
+    } finally {
+      lockState.credentialActive = false;
+      release();
+      if (lockState.credentialTails.get(authRef) === tail) {
+        lockState.credentialTails.delete(authRef);
+      }
+    }
+  }),
+  withRegistryWriteLockSync: vi.fn(),
+}));
+
+import { deleteProviderCredential } from '../src/env.js';
+import { removeProviderFromRegistry } from '../src/registry/crud.js';
+import {
+  withCredentialMutationLock,
+  withRegistryWriteLock,
+} from '../src/registry/lock.js';
+
+describe('registry provider removal', () => {
+  beforeEach(() => {
+    lockState.active = false;
+    lockState.credentialActive = false;
+    lockState.credentialTails.clear();
+    registryState.current = {
+      schemaVersion: 1,
+      providers: [
+        {
+          id: 'openai',
+          templateId: 'openai',
+          name: 'OpenAI',
+          enabled: true,
+          authRef: 'keyring:provider:openai',
+          authType: 'api',
+          api: { npm: '@ai-sdk/openai', url: 'https://api.openai.com/v1' },
+          addedAt: '2026-07-21T00:00:00.000Z',
+        },
+      ],
+    };
+    vi.mocked(deleteProviderCredential).mockReset().mockImplementation(
+      async () => {
+        expect(lockState.active).toBe(false);
+        expect(lockState.credentialActive).toBe(true);
+        return true;
+      },
+    );
+  });
+
+  it('commits the registry mutation before deleting the credential outside the lock', async () => {
+    const result = await removeProviderFromRegistry('openai');
+
+    expect(result).toMatchObject({
+      removed: true,
+      credentialDeleted: true,
+    });
+    expect(registryState.current.providers).toHaveLength(0);
+    expect(deleteProviderCredential).toHaveBeenCalledWith(
+      'keyring:provider:openai',
+    );
+    expect(lockState.active).toBe(false);
+  });
+
+  it('serializes deletion against reattaching the same credential reference', async () => {
+    let startDelete!: () => void;
+    const deleteStarted = new Promise<void>((resolve) => {
+      startDelete = resolve;
+    });
+    let finishDelete!: () => void;
+    const deleteGate = new Promise<void>((resolve) => {
+      finishDelete = resolve;
+    });
+    let credentialValue: string | null = 'old-key';
+    vi.mocked(deleteProviderCredential).mockImplementation(async () => {
+      startDelete();
+      await deleteGate;
+      credentialValue = null;
+      return true;
+    });
+
+    const removal = removeProviderFromRegistry('openai');
+    await deleteStarted;
+    let replacementEntered = false;
+    const replacement = withCredentialMutationLock(
+      'keyring:provider:openai',
+      async () => {
+        replacementEntered = true;
+        credentialValue = 'new-key';
+        await withRegistryWriteLock(() => {
+          registryState.current.providers.push({
+            id: 'openai',
+            templateId: 'openai',
+            name: 'OpenAI',
+            enabled: true,
+            authRef: 'keyring:provider:openai',
+            authType: 'api',
+            api: {
+              npm: '@ai-sdk/openai',
+              url: 'https://api.openai.com/v1',
+            },
+            addedAt: '2026-07-21T01:00:00.000Z',
+          });
+        });
+      },
+    );
+
+    await Promise.resolve();
+    expect(replacementEntered).toBe(false);
+    finishDelete();
+    await Promise.all([removal, replacement]);
+
+    expect(credentialValue).toBe('new-key');
+    expect(registryState.current.providers).toHaveLength(1);
+  });
+});

--- a/tests/registry-crud.test.ts
+++ b/tests/registry-crud.test.ts
@@ -108,6 +108,30 @@ describe('registry provider removal', () => {
     expect(lockState.active).toBe(false);
   });
 
+  it('reports a credential cleanup failure with the credential reference', async () => {
+    vi.mocked(deleteProviderCredential).mockImplementation(async () => {
+      expect(lockState.active).toBe(false);
+      expect(lockState.credentialActive).toBe(true);
+      return false;
+    });
+
+    const result = await removeProviderFromRegistry('openai');
+
+    expect(result).toMatchObject({
+      removed: true,
+      credentialDeleted: false,
+      error: expect.stringContaining('keyring:provider:openai'),
+    });
+    expect(result.error).toMatch(/credential.*(?:cleanup|deletion).*failed/i);
+    expect(result.error).toContain('must be removed manually');
+    expect(registryState.current.providers).toHaveLength(0);
+    expect(deleteProviderCredential).toHaveBeenCalledWith(
+      'keyring:provider:openai',
+    );
+    expect(lockState.active).toBe(false);
+    expect(lockState.credentialActive).toBe(false);
+  });
+
   it('serializes deletion against reattaching the same credential reference', async () => {
     let startDelete!: () => void;
     const deleteStarted = new Promise<void>((resolve) => {

--- a/tests/registry-lock.test.ts
+++ b/tests/registry-lock.test.ts
@@ -1,6 +1,17 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { spawn, type ChildProcess } from 'node:child_process';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'tsup';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   RegistryLockLostError,
@@ -13,14 +24,146 @@ import {
 import { emptyRegistry, saveRegistry } from '../src/registry/io.js';
 
 const roots: string[] = [];
+const workers = new Set<WorkerProcess>();
 
-function temporaryLockPath(): string {
-  const root = mkdtempSync(join(tmpdir(), 'registry-lock-'));
-  roots.push(root);
-  return join(root, 'providers.lock');
+type WorkerRole =
+  | 'holder'
+  | 'contender'
+  | 'lease-loss'
+  | 'atomic-acquire'
+  | 'credential-holder'
+  | 'credential-contender';
+
+interface WorkerExit {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
 }
 
-afterEach(() => {
+interface WorkerProcess {
+  child: ChildProcess;
+  exit: Promise<WorkerExit>;
+}
+
+function temporaryRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'registry-lock-'));
+  roots.push(root);
+  return root;
+}
+
+function temporaryLockPath(): string {
+  return join(temporaryRoot(), 'providers.lock');
+}
+
+function workerEnvironment(
+  root: string,
+  role: WorkerRole,
+): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = {
+    CLODEX_HOME: root,
+    REGISTRY_LOCK_WORKER_ROLE: role,
+  };
+  for (const key of [
+    'HOME',
+    'PATH',
+    'TMPDIR',
+    'TEMP',
+    'TMP',
+    'SystemRoot',
+    'ComSpec',
+    'PATHEXT',
+  ]) {
+    if (process.env[key] !== undefined) environment[key] = process.env[key];
+  }
+  return environment;
+}
+
+function spawnWorker(
+  workerPath: string,
+  root: string,
+  role: WorkerRole,
+): WorkerProcess {
+  const child = spawn(process.execPath, [workerPath], {
+    cwd: process.cwd(),
+    env: workerEnvironment(root, role),
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stdout = '';
+  let stderr = '';
+  child.stdout?.setEncoding('utf8');
+  child.stderr?.setEncoding('utf8');
+  child.stdout?.on('data', (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr?.on('data', (chunk: string) => {
+    stderr += chunk;
+  });
+  const exit = new Promise<WorkerExit>((resolve, reject) => {
+    child.once('error', reject);
+    child.once('close', (code, signal) => {
+      resolve({ code, signal, stdout, stderr });
+    });
+  });
+  const worker = { child, exit };
+  workers.add(worker);
+  void exit.then(
+    () => workers.delete(worker),
+    () => workers.delete(worker),
+  );
+  return worker;
+}
+
+async function buildWorker(root: string): Promise<string> {
+  const outDir = join(root, 'worker-build');
+  await build({
+    entry: [
+      fileURLToPath(
+        new URL('./fixtures/registry-lock-worker.ts', import.meta.url),
+      ),
+    ],
+    outDir,
+    outExtension: () => ({ js: '.mjs' }),
+    format: ['esm'],
+    platform: 'node',
+    target: 'node22',
+    splitting: false,
+    sourcemap: false,
+    clean: false,
+    silent: true,
+    config: false,
+  });
+  return join(outDir, 'registry-lock-worker.mjs');
+}
+
+async function waitForJson<T>(path: string, timeoutMs = 5_000): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(path)) {
+      try {
+        return JSON.parse(readFileSync(path, 'utf8')) as T;
+      } catch {
+        // Retry while the creating process finishes its synchronous write.
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for JSON result: ${path}`);
+}
+
+function lockArtifacts(root: string): string[] {
+  return readdirSync(root)
+    .filter((name) => name.includes('.lock') || name.endsWith('.tmp'))
+    .sort();
+}
+
+afterEach(async () => {
+  for (const worker of workers) {
+    if (worker.child.exitCode === null && worker.child.signalCode === null) {
+      worker.child.kill('SIGTERM');
+    }
+  }
+  await Promise.allSettled([...workers].map((worker) => worker.exit));
   for (const root of roots.splice(0))
     rmSync(root, { recursive: true, force: true });
 });
@@ -60,7 +203,7 @@ describe('provider registry lock', () => {
     lease?.release();
   });
 
-  it('reaps an expired lock even when its owner process is still alive', () => {
+  it('retains a lock whose owner remains alive regardless of age', () => {
     const lockPath = temporaryLockPath();
     const now = Date.now();
     writeFileSync(
@@ -72,37 +215,15 @@ describe('provider registry lock', () => {
       }),
     );
 
-    const lease = tryAcquireRegistryLock(lockPath, {
-      now: () => now,
-      isAlive: () => true,
-    });
-
-    expect(lease).toMatchObject({ active: true });
-    expect(JSON.parse(readFileSync(lockPath, 'utf8')).token).not.toBe(
-      'expired-owner',
-    );
-    lease?.release();
-  });
-
-  it('does not reap an expired live owner for a credential mutation lock', () => {
-    const lockPath = temporaryLockPath();
-    const now = Date.now();
-    writeFileSync(
-      lockPath,
-      JSON.stringify({
-        pid: 1234,
-        startedAt: now - 10 * 60 * 1000,
-        token: 'live-credential-owner',
-      }),
-    );
-
     expect(
       tryAcquireRegistryLock(lockPath, {
         now: () => now,
         isAlive: () => true,
-        reclaimExpiredLiveOwner: false,
       }),
     ).toBeNull();
+    expect(JSON.parse(readFileSync(lockPath, 'utf8')).token).toBe(
+      'expired-owner',
+    );
   });
 
   it('does not remove a replacement created during stale-lock reclamation', () => {
@@ -417,64 +538,201 @@ describe('provider registry lock', () => {
     );
   });
 
-  it('rejects an expired owner before it can overwrite a newer registry', async () => {
-    const lockPath = temporaryLockPath();
-    const registryPath = lockPath.replace(/\.lock$/, '');
-    let now = Date.now();
-    let firstEntered!: () => void;
-    const entered = new Promise<void>((resolve) => {
-      firstEntered = resolve;
-    });
-    let resumeFirst!: () => void;
-    const firstGate = new Promise<void>((resolve) => {
-      resumeFirst = resolve;
-    });
+  it('does not age-evict a live owner across processes', async () => {
+    const root = temporaryRoot();
+    const workerPath = await buildWorker(root);
+    const registryPath = join(root, 'providers.json');
+    const lockPath = `${registryPath}.lock`;
+    const releasePath = join(root, 'release-holder');
+    const holder = spawnWorker(workerPath, root, 'holder');
 
-    const first = withRegistryWriteLock(
-      async () => {
-        firstEntered();
-        await firstGate;
-        saveRegistry({ ...emptyRegistry(), importedAt: 'first' }, registryPath);
-      },
-      { lockPath, now: () => now, isAlive: () => true },
-    );
-    await entered;
+    try {
+      const ready = await waitForJson<{ pid: number; token: string }>(
+        join(root, 'holder-ready.json'),
+      );
+      const owner = JSON.parse(readFileSync(lockPath, 'utf8')) as {
+        pid: number;
+        startedAt: number;
+        token: string;
+      };
+      expect(owner).toMatchObject(ready);
+      writeFileSync(
+        lockPath,
+        JSON.stringify({
+          ...owner,
+          startedAt: Date.now() - 11 * 60 * 1000,
+        }),
+      );
 
-    let secondSaved!: () => void;
-    const secondSavedGate = new Promise<void>((resolve) => {
-      secondSaved = resolve;
-    });
-    let releaseSecond!: () => void;
-    const secondGate = new Promise<void>((resolve) => {
-      releaseSecond = resolve;
-    });
+      const contender = spawnWorker(workerPath, root, 'contender');
+      const contenderExit = await contender.exit;
+      expect(
+        contenderExit.code,
+        `contender stderr:\n${contenderExit.stderr}\nstdout:\n${contenderExit.stdout}`,
+      ).toBe(0);
+      const contenderResult = await waitForJson<{
+        acquired: boolean;
+        error?: string;
+      }>(join(root, 'contender-result.json'));
+      expect(contenderResult.acquired).toBe(false);
+      expect(contenderResult.error).toContain(
+        'Timed out after 250ms waiting for lock',
+      );
+      expect(contenderResult.error).toContain(String(ready.pid));
 
-    now += 10 * 60 * 1000;
-    const second = withRegistryWriteLock(
-      async () => {
-        saveRegistry({ ...emptyRegistry(), importedAt: 'second' }, registryPath);
-        secondSaved();
-        await secondGate;
-      },
-      { lockPath, now: () => now, isAlive: () => true },
-    );
-    await secondSavedGate;
-    const secondToken = JSON.parse(readFileSync(lockPath, 'utf8')).token;
+      const retainedOwner = JSON.parse(readFileSync(lockPath, 'utf8')) as {
+        pid: number;
+        token: string;
+      };
+      expect(retainedOwner).toMatchObject(ready);
+      expect(JSON.parse(readFileSync(registryPath, 'utf8')).importedAt).toBe(
+        'holder-initial',
+      );
 
-    resumeFirst();
-    await expect(first).rejects.toBeInstanceOf(RegistryLockLostError);
-    expect(JSON.parse(readFileSync(lockPath, 'utf8')).token).toBe(secondToken);
+      writeFileSync(releasePath, 'release\n');
+      const holderExit = await holder.exit;
+      expect(
+        holderExit.code,
+        `holder stderr:\n${holderExit.stderr}\nstdout:\n${holderExit.stdout}`,
+      ).toBe(0);
+      expect(await waitForJson(join(root, 'holder-result.json'))).toEqual({
+        ok: true,
+      });
+      expect(JSON.parse(readFileSync(registryPath, 'utf8')).importedAt).toBe(
+        'holder-final',
+      );
+      expect(lockArtifacts(root)).toEqual([]);
+    } finally {
+      if (!existsSync(releasePath)) writeFileSync(releasePath, 'release\n');
+      if (holder.child.exitCode === null && holder.child.signalCode === null) {
+        await holder.exit;
+      }
+    }
+  }, 15_000);
+
+  it('prepares the complete lock record before publishing its path', async () => {
+    const root = temporaryRoot();
+    const workerPath = await buildWorker(root);
+    const lockPath = join(root, 'providers.json.lock');
+    const releasePath = join(root, 'release-atomic-acquire');
+    const worker = spawnWorker(workerPath, root, 'atomic-acquire');
+
+    try {
+      const ready = await waitForJson<{
+        candidatePath: string;
+        pid: number;
+      }>(join(root, 'atomic-acquire-ready.json'));
+      expect(ready.candidatePath).not.toBe(lockPath);
+      expect(existsSync(lockPath)).toBe(false);
+      expect(existsSync(ready.candidatePath)).toBe(true);
+      expect(statSync(ready.candidatePath).size).toBe(0);
+
+      writeFileSync(releasePath, 'release\n');
+      const workerExit = await worker.exit;
+      expect(
+        workerExit.code,
+        `worker stderr:\n${workerExit.stderr}\nstdout:\n${workerExit.stdout}`,
+      ).toBe(0);
+      expect(
+        await waitForJson(join(root, 'atomic-acquire-result.json')),
+      ).toEqual({
+        acquired: true,
+        ownerPid: ready.pid,
+        ownerToken: expect.any(String),
+      });
+      expect(lockArtifacts(root)).toEqual([]);
+    } finally {
+      if (!existsSync(releasePath)) writeFileSync(releasePath, 'release\n');
+      if (worker.child.exitCode === null && worker.child.signalCode === null) {
+        await worker.exit;
+      }
+    }
+  }, 10_000);
+
+  it('serializes the same credential reference across processes', async () => {
+    const root = temporaryRoot();
+    const workerPath = await buildWorker(root);
+    const releasePath = join(root, 'release-credential-holder');
+    const enteredPath = join(root, 'credential-contender-entered.json');
+    const holder = spawnWorker(workerPath, root, 'credential-holder');
+    let contender: WorkerProcess | undefined;
+
+    try {
+      const holderReady = await waitForJson<{
+        pid: number;
+        lockPath: string;
+      }>(join(root, 'credential-holder-ready.json'));
+      expect(existsSync(holderReady.lockPath)).toBe(true);
+
+      contender = spawnWorker(workerPath, root, 'credential-contender');
+      const contenderReady = await waitForJson<{ pid: number }>(
+        join(root, 'credential-contender-ready.json'),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 125));
+      expect(existsSync(enteredPath)).toBe(false);
+      expect(contender.child.exitCode).toBeNull();
+
+      writeFileSync(releasePath, 'release\n');
+      const [holderExit, contenderExit] = await Promise.all([
+        holder.exit,
+        contender.exit,
+      ]);
+      expect(
+        holderExit.code,
+        `holder stderr:\n${holderExit.stderr}\nstdout:\n${holderExit.stdout}`,
+      ).toBe(0);
+      expect(
+        contenderExit.code,
+        `contender stderr:\n${contenderExit.stderr}\nstdout:\n${contenderExit.stdout}`,
+      ).toBe(0);
+      expect(await waitForJson(enteredPath)).toEqual({
+        pid: contenderReady.pid,
+      });
+      expect(
+        await waitForJson(join(root, 'credential-holder-result.json')),
+      ).toEqual({ ok: true });
+      expect(
+        await waitForJson(join(root, 'credential-contender-result.json')),
+      ).toEqual({ ok: true });
+      expect(lockArtifacts(root)).toEqual([]);
+    } finally {
+      if (!existsSync(releasePath)) writeFileSync(releasePath, 'release\n');
+      for (const worker of [holder, contender]) {
+        if (
+          worker &&
+          worker.child.exitCode === null &&
+          worker.child.signalCode === null
+        ) {
+          await worker.exit;
+        }
+      }
+    }
+  }, 10_000);
+
+  it('rejects publication when the lease changes after the temporary write', async () => {
+    const root = temporaryRoot();
+    const workerPath = await buildWorker(root);
+    const worker = spawnWorker(workerPath, root, 'lease-loss');
+    const workerExit = await worker.exit;
     expect(
-      tryAcquireRegistryLock(lockPath, {
-        now: () => now,
-        isAlive: () => true,
-      }),
-    ).toBeNull();
+      workerExit.code,
+      `worker stderr:\n${workerExit.stderr}\nstdout:\n${workerExit.stdout}`,
+    ).toBe(0);
 
-    releaseSecond();
-    await second;
-    expect(JSON.parse(readFileSync(registryPath, 'utf8')).importedAt).toBe(
-      'second',
-    );
-  });
+    const result = await waitForJson<{
+      errorName: string | null;
+      importedAt?: string;
+      replacementPublished: boolean;
+      replacementToken?: string;
+      temporaryArtifacts: string[];
+    }>(join(root, 'lease-loss-result.json'));
+    expect(result).toMatchObject({
+      errorName: 'RegistryLockLostError',
+      importedAt: 'sentinel',
+      replacementPublished: true,
+      replacementToken: 'replacement-owner',
+      temporaryArtifacts: [],
+    });
+    expect(lockArtifacts(root)).toEqual([]);
+  }, 10_000);
 });

--- a/tests/registry-lock.test.ts
+++ b/tests/registry-lock.test.ts
@@ -34,21 +34,48 @@ describe('provider registry lock', () => {
     nextRelease?.();
   });
 
-  it('reaps a lock owned by a dead process but not an old live owner', () => {
+  it('retains a fresh lock owned by a live process and reaps a dead owner', () => {
     const lockPath = temporaryLockPath();
-    const old = Date.now() - 24 * 60 * 60 * 1000;
+    const now = Date.now();
     writeFileSync(
       lockPath,
-      JSON.stringify({ pid: 1234, startedAt: old, token: 'old-owner' }),
+      JSON.stringify({ pid: 1234, startedAt: now, token: 'first-owner' }),
     );
 
     expect(
-      tryAcquireRegistryLock(lockPath, { isAlive: () => true }),
+      tryAcquireRegistryLock(lockPath, { now: () => now, isAlive: () => true }),
     ).toBeNull();
-    const release = tryAcquireRegistryLock(lockPath, { isAlive: () => false });
+    const release = tryAcquireRegistryLock(lockPath, {
+      now: () => now,
+      isAlive: () => false,
+    });
     expect(release).toBeTypeOf('function');
     expect(JSON.parse(readFileSync(lockPath, 'utf8')).token).not.toBe(
-      'old-owner',
+      'first-owner',
+    );
+    release?.();
+  });
+
+  it('reaps an expired lock even when its owner process is still alive', () => {
+    const lockPath = temporaryLockPath();
+    const now = Date.now();
+    writeFileSync(
+      lockPath,
+      JSON.stringify({
+        pid: 1234,
+        startedAt: now - 10 * 60 * 1000,
+        token: 'expired-owner',
+      }),
+    );
+
+    const release = tryAcquireRegistryLock(lockPath, {
+      now: () => now,
+      isAlive: () => true,
+    });
+
+    expect(release).toBeTypeOf('function');
+    expect(JSON.parse(readFileSync(lockPath, 'utf8')).token).not.toBe(
+      'expired-owner',
     );
     release?.();
   });

--- a/tests/registry-lock.test.ts
+++ b/tests/registry-lock.test.ts
@@ -1,0 +1,287 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  tryAcquireRegistryLock,
+  withRegistryWriteLock,
+  withRegistryWriteLockSync,
+} from '../src/registry/lock.js';
+
+const roots: string[] = [];
+
+function temporaryLockPath(): string {
+  const root = mkdtempSync(join(tmpdir(), 'registry-lock-'));
+  roots.push(root);
+  return join(root, 'providers.lock');
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0))
+    rmSync(root, { recursive: true, force: true });
+});
+
+describe('provider registry lock', () => {
+  it('allows only one owner until the matching release runs', () => {
+    const lockPath = temporaryLockPath();
+    const release = tryAcquireRegistryLock(lockPath);
+    expect(release).toBeTypeOf('function');
+    expect(tryAcquireRegistryLock(lockPath)).toBeNull();
+
+    release?.();
+    const nextRelease = tryAcquireRegistryLock(lockPath);
+    expect(nextRelease).toBeTypeOf('function');
+    nextRelease?.();
+  });
+
+  it('reaps a lock owned by a dead process but not an old live owner', () => {
+    const lockPath = temporaryLockPath();
+    const old = Date.now() - 24 * 60 * 60 * 1000;
+    writeFileSync(
+      lockPath,
+      JSON.stringify({ pid: 1234, startedAt: old, token: 'old-owner' }),
+    );
+
+    expect(
+      tryAcquireRegistryLock(lockPath, { isAlive: () => true }),
+    ).toBeNull();
+    const release = tryAcquireRegistryLock(lockPath, { isAlive: () => false });
+    expect(release).toBeTypeOf('function');
+    expect(JSON.parse(readFileSync(lockPath, 'utf8')).token).not.toBe(
+      'old-owner',
+    );
+    release?.();
+  });
+
+  it('does not remove a replacement created during stale-lock reclamation', () => {
+    const lockPath = temporaryLockPath();
+    const stalePid = 1234;
+    writeFileSync(
+      lockPath,
+      JSON.stringify({
+        pid: stalePid,
+        startedAt: Date.now() - 60_000,
+        token: 'stale-owner',
+      }),
+    );
+
+    let competingRelease: (() => void) | null = null;
+    let interleaved = false;
+    const release = tryAcquireRegistryLock(lockPath, {
+      isAlive: (pid) => {
+        if (pid === stalePid && !interleaved) {
+          interleaved = true;
+          competingRelease = tryAcquireRegistryLock(lockPath, {
+            isAlive: () => false,
+          });
+        }
+        return pid !== stalePid;
+      },
+    });
+
+    try {
+      expect(competingRelease).toBeTypeOf('function');
+      expect(release).toBeNull();
+    } finally {
+      release?.();
+      competingRelease?.();
+    }
+  });
+
+  it('serializes stale reclamation through a separate reaper guard', () => {
+    const lockPath = temporaryLockPath();
+    writeFileSync(
+      lockPath,
+      JSON.stringify({
+        pid: 1234,
+        startedAt: Date.now() - 60_000,
+        token: 'stale-owner',
+      }),
+    );
+    writeFileSync(
+      `${lockPath}.reap`,
+      JSON.stringify({
+        pid: process.pid,
+        startedAt: Date.now(),
+        token: 'active-reaper',
+      }),
+    );
+
+    expect(
+      tryAcquireRegistryLock(lockPath, {
+        isAlive: (pid) => pid === process.pid,
+      }),
+    ).toBeNull();
+    expect(JSON.parse(readFileSync(lockPath, 'utf8')).token).toBe(
+      'stale-owner',
+    );
+  });
+
+  it('recovers when a dead process leaves the reaper guard behind', () => {
+    const lockPath = temporaryLockPath();
+    const deadOwner = {
+      pid: 2_147_483_647,
+      startedAt: Date.now() - 60_000,
+      token: 'dead-owner',
+    };
+    writeFileSync(lockPath, JSON.stringify(deadOwner));
+    writeFileSync(`${lockPath}.reap`, JSON.stringify(deadOwner));
+
+    const release = tryAcquireRegistryLock(lockPath, { isAlive: () => false });
+
+    expect(release).toBeTypeOf('function');
+    expect(JSON.parse(readFileSync(lockPath, 'utf8')).token).not.toBe(
+      'dead-owner',
+    );
+    release?.();
+  });
+
+  it('acquires nested locks when their paths differ', async () => {
+    const firstPath = temporaryLockPath();
+    const secondPath = temporaryLockPath();
+
+    await withRegistryWriteLock(
+      async () => {
+        await withRegistryWriteLock(
+          () => {
+            expect(tryAcquireRegistryLock(secondPath)).toBeNull();
+          },
+          { lockPath: secondPath },
+        );
+      },
+      { lockPath: firstPath },
+    );
+
+    const release = tryAcquireRegistryLock(secondPath);
+    expect(release).toBeTypeOf('function');
+    release?.();
+  });
+
+  it('serializes independent asynchronous callers', async () => {
+    const lockPath = temporaryLockPath();
+    const events: string[] = [];
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const first = withRegistryWriteLock(
+      async () => {
+        events.push('first-enter');
+        await firstGate;
+        events.push('first-exit');
+      },
+      { lockPath, waitMs: 1_000, retryMs: 5 },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const second = withRegistryWriteLock(
+      () => {
+        events.push('second-enter');
+      },
+      { lockPath, waitMs: 1_000, retryMs: 5 },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(events).toEqual(['first-enter']);
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(events).toEqual(['first-enter', 'first-exit', 'second-enter']);
+  });
+
+  it('invalidates inherited asynchronous ownership after releasing the lock', async () => {
+    const lockPath = temporaryLockPath();
+    const events: string[] = [];
+    let startDetached!: () => void;
+    const detachedGate = new Promise<void>((resolve) => {
+      startDetached = resolve;
+    });
+    let detached: Promise<void> | undefined;
+
+    await withRegistryWriteLock(
+      () => {
+        detached = (async () => {
+          await detachedGate;
+          await withRegistryWriteLock(
+            () => {
+              events.push('detached-enter');
+            },
+            { lockPath, waitMs: 1_000, retryMs: 5 },
+          );
+        })();
+      },
+      { lockPath, waitMs: 1_000, retryMs: 5 },
+    );
+
+    let releaseSecond!: () => void;
+    const secondGate = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+    let markSecondEntered!: () => void;
+    const secondEntered = new Promise<void>((resolve) => {
+      markSecondEntered = resolve;
+    });
+    const second = withRegistryWriteLock(
+      async () => {
+        events.push('second-enter');
+        markSecondEntered();
+        await secondGate;
+        events.push('second-exit');
+      },
+      { lockPath, waitMs: 1_000, retryMs: 5 },
+    );
+
+    await secondEntered;
+    startDetached();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(events).toEqual(['second-enter']);
+
+    releaseSecond();
+    await Promise.all([second, detached]);
+    expect(events).toEqual(['second-enter', 'second-exit', 'detached-enter']);
+  });
+
+  it('invalidates inherited synchronous ownership after releasing the lock', async () => {
+    const lockPath = temporaryLockPath();
+    const events: string[] = [];
+    let detachedError: unknown;
+    let finishDetached!: () => void;
+    const detachedFinished = new Promise<void>((resolve) => {
+      finishDetached = resolve;
+    });
+
+    withRegistryWriteLockSync(
+      () => {
+        setImmediate(() => {
+          try {
+            withRegistryWriteLockSync(
+              () => {
+                events.push('detached-enter');
+              },
+              { lockPath, waitMs: 0 },
+            );
+          } catch (error) {
+            detachedError = error;
+          } finally {
+            finishDetached();
+          }
+        });
+      },
+      { lockPath },
+    );
+
+    const release = tryAcquireRegistryLock(lockPath);
+    expect(release).toBeTypeOf('function');
+    try {
+      await detachedFinished;
+    } finally {
+      release?.();
+    }
+
+    expect(events).toEqual([]);
+    expect(detachedError).toEqual(
+      expect.objectContaining({
+        message: expect.stringContaining('Timed out after 0ms'),
+      }),
+    );
+  });
+});

--- a/tests/registry-lock.test.ts
+++ b/tests/registry-lock.test.ts
@@ -1,12 +1,16 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
+  RegistryLockLostError,
+  getCredentialMutationLockPath,
   tryAcquireRegistryLock,
+  withCredentialMutationLock,
   withRegistryWriteLock,
   withRegistryWriteLockSync,
 } from '../src/registry/lock.js';
+import { emptyRegistry, saveRegistry } from '../src/registry/io.js';
 
 const roots: string[] = [];
 
@@ -24,14 +28,14 @@ afterEach(() => {
 describe('provider registry lock', () => {
   it('allows only one owner until the matching release runs', () => {
     const lockPath = temporaryLockPath();
-    const release = tryAcquireRegistryLock(lockPath);
-    expect(release).toBeTypeOf('function');
+    const lease = tryAcquireRegistryLock(lockPath);
+    expect(lease).toMatchObject({ active: true });
     expect(tryAcquireRegistryLock(lockPath)).toBeNull();
 
-    release?.();
-    const nextRelease = tryAcquireRegistryLock(lockPath);
-    expect(nextRelease).toBeTypeOf('function');
-    nextRelease?.();
+    lease?.release();
+    const nextLease = tryAcquireRegistryLock(lockPath);
+    expect(nextLease).toMatchObject({ active: true });
+    nextLease?.release();
   });
 
   it('retains a fresh lock owned by a live process and reaps a dead owner', () => {
@@ -45,15 +49,15 @@ describe('provider registry lock', () => {
     expect(
       tryAcquireRegistryLock(lockPath, { now: () => now, isAlive: () => true }),
     ).toBeNull();
-    const release = tryAcquireRegistryLock(lockPath, {
+    const lease = tryAcquireRegistryLock(lockPath, {
       now: () => now,
       isAlive: () => false,
     });
-    expect(release).toBeTypeOf('function');
+    expect(lease).toMatchObject({ active: true });
     expect(JSON.parse(readFileSync(lockPath, 'utf8')).token).not.toBe(
       'first-owner',
     );
-    release?.();
+    lease?.release();
   });
 
   it('reaps an expired lock even when its owner process is still alive', () => {
@@ -68,16 +72,37 @@ describe('provider registry lock', () => {
       }),
     );
 
-    const release = tryAcquireRegistryLock(lockPath, {
+    const lease = tryAcquireRegistryLock(lockPath, {
       now: () => now,
       isAlive: () => true,
     });
 
-    expect(release).toBeTypeOf('function');
+    expect(lease).toMatchObject({ active: true });
     expect(JSON.parse(readFileSync(lockPath, 'utf8')).token).not.toBe(
       'expired-owner',
     );
-    release?.();
+    lease?.release();
+  });
+
+  it('does not reap an expired live owner for a credential mutation lock', () => {
+    const lockPath = temporaryLockPath();
+    const now = Date.now();
+    writeFileSync(
+      lockPath,
+      JSON.stringify({
+        pid: 1234,
+        startedAt: now - 10 * 60 * 1000,
+        token: 'live-credential-owner',
+      }),
+    );
+
+    expect(
+      tryAcquireRegistryLock(lockPath, {
+        now: () => now,
+        isAlive: () => true,
+        reclaimExpiredLiveOwner: false,
+      }),
+    ).toBeNull();
   });
 
   it('does not remove a replacement created during stale-lock reclamation', () => {
@@ -92,13 +117,13 @@ describe('provider registry lock', () => {
       }),
     );
 
-    let competingRelease: (() => void) | null = null;
+    let competingLease: ReturnType<typeof tryAcquireRegistryLock> = null;
     let interleaved = false;
-    const release = tryAcquireRegistryLock(lockPath, {
+    const lease = tryAcquireRegistryLock(lockPath, {
       isAlive: (pid) => {
         if (pid === stalePid && !interleaved) {
           interleaved = true;
-          competingRelease = tryAcquireRegistryLock(lockPath, {
+          competingLease = tryAcquireRegistryLock(lockPath, {
             isAlive: () => false,
           });
         }
@@ -107,11 +132,11 @@ describe('provider registry lock', () => {
     });
 
     try {
-      expect(competingRelease).toBeTypeOf('function');
-      expect(release).toBeNull();
+      expect(competingLease).toMatchObject({ active: true });
+      expect(lease).toBeNull();
     } finally {
-      release?.();
-      competingRelease?.();
+      lease?.release();
+      competingLease?.release();
     }
   });
 
@@ -154,13 +179,13 @@ describe('provider registry lock', () => {
     writeFileSync(lockPath, JSON.stringify(deadOwner));
     writeFileSync(`${lockPath}.reap`, JSON.stringify(deadOwner));
 
-    const release = tryAcquireRegistryLock(lockPath, { isAlive: () => false });
+    const lease = tryAcquireRegistryLock(lockPath, { isAlive: () => false });
 
-    expect(release).toBeTypeOf('function');
+    expect(lease).toMatchObject({ active: true });
     expect(JSON.parse(readFileSync(lockPath, 'utf8')).token).not.toBe(
       'dead-owner',
     );
-    release?.();
+    lease?.release();
   });
 
   it('acquires nested locks when their paths differ', async () => {
@@ -179,9 +204,9 @@ describe('provider registry lock', () => {
       { lockPath: firstPath },
     );
 
-    const release = tryAcquireRegistryLock(secondPath);
-    expect(release).toBeTypeOf('function');
-    release?.();
+    const lease = tryAcquireRegistryLock(secondPath);
+    expect(lease).toMatchObject({ active: true });
+    lease?.release();
   });
 
   it('serializes independent asynchronous callers', async () => {
@@ -213,6 +238,46 @@ describe('provider registry lock', () => {
     releaseFirst();
     await Promise.all([first, second]);
     expect(events).toEqual(['first-enter', 'first-exit', 'second-enter']);
+  });
+
+  it('serializes mutations for the same credential reference', async () => {
+    const home = dirname(temporaryLockPath());
+    const previousHome = process.env.CLODEX_HOME;
+    process.env.CLODEX_HOME = home;
+    const events: string[] = [];
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    try {
+      const first = withCredentialMutationLock(
+        'keyring:provider:openai',
+        async () => {
+          events.push('first-enter');
+          await firstGate;
+          events.push('first-exit');
+        },
+      );
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      const second = withCredentialMutationLock(
+        'keyring:provider:openai',
+        () => {
+          events.push('second-enter');
+        },
+      );
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(events).toEqual(['first-enter']);
+      expect(getCredentialMutationLockPath('keyring:provider:openai')).not
+        .toContain('provider:openai');
+      releaseFirst();
+      await Promise.all([first, second]);
+      expect(events).toEqual(['first-enter', 'first-exit', 'second-enter']);
+    } finally {
+      if (previousHome === undefined) delete process.env.CLODEX_HOME;
+      else process.env.CLODEX_HOME = previousHome;
+    }
   });
 
   it('invalidates inherited asynchronous ownership after releasing the lock', async () => {
@@ -296,12 +361,12 @@ describe('provider registry lock', () => {
       { lockPath },
     );
 
-    const release = tryAcquireRegistryLock(lockPath);
-    expect(release).toBeTypeOf('function');
+    const lease = tryAcquireRegistryLock(lockPath);
+    expect(lease).toMatchObject({ active: true });
     try {
       await detachedFinished;
     } finally {
-      release?.();
+      lease?.release();
     }
 
     expect(events).toEqual([]);
@@ -309,6 +374,107 @@ describe('provider registry lock', () => {
       expect.objectContaining({
         message: expect.stringContaining('Timed out after 0ms'),
       }),
+    );
+  });
+
+  it('reclaims an incomplete lock without waiting for the normal timeout', () => {
+    const lockPath = temporaryLockPath();
+    writeFileSync(lockPath, '');
+
+    const lease = tryAcquireRegistryLock(lockPath, {
+      isAlive: () => true,
+    });
+
+    expect(lease).toMatchObject({ active: true });
+    expect(JSON.parse(readFileSync(lockPath, 'utf8'))).toEqual(
+      expect.objectContaining({
+        pid: process.pid,
+        token: expect.any(String),
+      }),
+    );
+    lease?.release();
+  });
+
+  it('rejects registry writes without an active matching lease', () => {
+    const registryPath = temporaryLockPath().replace(/\.lock$/, '');
+
+    expect(() => saveRegistry(emptyRegistry(), registryPath)).toThrow(
+      RegistryLockLostError,
+    );
+  });
+
+  it('does not use a lease to authorize a different registry path', () => {
+    const lockPath = temporaryLockPath();
+    const otherRegistryPath = temporaryLockPath().replace(/\.lock$/, '');
+
+    withRegistryWriteLockSync(
+      () => {
+        expect(() =>
+          saveRegistry(emptyRegistry(), otherRegistryPath),
+        ).toThrow(RegistryLockLostError);
+      },
+      { lockPath },
+    );
+  });
+
+  it('rejects an expired owner before it can overwrite a newer registry', async () => {
+    const lockPath = temporaryLockPath();
+    const registryPath = lockPath.replace(/\.lock$/, '');
+    let now = Date.now();
+    let firstEntered!: () => void;
+    const entered = new Promise<void>((resolve) => {
+      firstEntered = resolve;
+    });
+    let resumeFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      resumeFirst = resolve;
+    });
+
+    const first = withRegistryWriteLock(
+      async () => {
+        firstEntered();
+        await firstGate;
+        saveRegistry({ ...emptyRegistry(), importedAt: 'first' }, registryPath);
+      },
+      { lockPath, now: () => now, isAlive: () => true },
+    );
+    await entered;
+
+    let secondSaved!: () => void;
+    const secondSavedGate = new Promise<void>((resolve) => {
+      secondSaved = resolve;
+    });
+    let releaseSecond!: () => void;
+    const secondGate = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+
+    now += 10 * 60 * 1000;
+    const second = withRegistryWriteLock(
+      async () => {
+        saveRegistry({ ...emptyRegistry(), importedAt: 'second' }, registryPath);
+        secondSaved();
+        await secondGate;
+      },
+      { lockPath, now: () => now, isAlive: () => true },
+    );
+    await secondSavedGate;
+    const secondToken = JSON.parse(readFileSync(lockPath, 'utf8')).token;
+
+    resumeFirst();
+    await expect(first).rejects.toBeInstanceOf(RegistryLockLostError);
+    expect(JSON.parse(readFileSync(lockPath, 'utf8')).token).toBe(secondToken);
+    expect(
+      tryAcquireRegistryLock(lockPath, {
+        now: () => now,
+        isAlive: () => true,
+      }),
+    ).toBeNull();
+
+    releaseSecond();
+    await second;
+    expect(JSON.parse(readFileSync(registryPath, 'utf8')).importedAt).toBe(
+      'second',
     );
   });
 });

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -10,6 +10,7 @@ import {
   saveRegistry,
   slugifyProviderId,
 } from '../src/registry/index.js';
+import { withRegistryWriteLockSync } from '../src/registry/lock.js';
 
 describe('provider id validation', () => {
   it('accepts stable slugs', () => {
@@ -69,7 +70,7 @@ describe('registry io', () => {
         }],
       },
     });
-    saveRegistry(registry);
+    withRegistryWriteLockSync(() => saveRegistry(registry));
     const loaded = loadRegistry();
     expect(loaded.providers).toHaveLength(1);
     expect(loaded.providers[0]?.id).toBe('groq');
@@ -77,7 +78,7 @@ describe('registry io', () => {
   });
 
   it('writes providers.json with restrictive permissions', () => {
-    saveRegistry(emptyRegistry());
+    withRegistryWriteLockSync(() => saveRegistry(emptyRegistry()));
     const path = join(home, 'providers.json');
     expect(existsSync(path)).toBe(true);
     const mode = statSync(path).mode & 0o777;
@@ -227,6 +228,128 @@ describe('materializeRegistry', () => {
     expect(locals).toHaveLength(1);
     expect(locals[0]?.apiKey).toBe('');
     expect(locals[0]?.authRef).toBe('none:anonymous');
+  });
+
+  it('normalizes the current-main anonymous custom endpoint representation', () => {
+    const registry = emptyRegistry();
+    registry.providers.push({
+      id: 'legacy-custom',
+      templateId: 'custom-openai',
+      name: 'Legacy Custom',
+      enabled: true,
+      authRef: 'keyring:provider:legacy-custom',
+      api: {
+        npm: '@ai-sdk/openai-compatible',
+        url: 'https://legacy-custom.example/v1',
+      },
+      addedAt: '2026-06-09T00:00:00.000Z',
+      modelsCache: {
+        fetchedAt: '2026-06-09T00:00:00.000Z',
+        models: [{
+          id: 'local-model',
+          name: 'Local Model',
+          upstreamModelId: 'local-model',
+          modelFormat: 'openai',
+          npm: '@ai-sdk/openai-compatible',
+        }],
+      },
+    });
+
+    const locals = materializeRegistry(registry, () => 'local');
+
+    expect(locals).toHaveLength(1);
+    expect(locals[0]?.apiKey).toBe('');
+    expect(locals[0]?.authRef).toBe('none:anonymous');
+    expect(locals[0]?.authType).toBe('none');
+  });
+
+  it('rejects an ambiguous local sentinel with a mismatched credential reference', () => {
+    const registry = emptyRegistry();
+    registry.providers.push({
+      id: 'legacy-custom',
+      templateId: 'custom-openai',
+      name: 'Legacy Custom',
+      enabled: true,
+      authRef: 'keyring:provider:other-provider',
+      api: {
+        npm: '@ai-sdk/openai-compatible',
+        url: 'https://legacy-custom.example/v1',
+      },
+      addedAt: '2026-06-09T00:00:00.000Z',
+      modelsCache: {
+        fetchedAt: '2026-06-09T00:00:00.000Z',
+        models: [{
+          id: 'local-model',
+          name: 'Local Model',
+          upstreamModelId: 'local-model',
+          modelFormat: 'openai',
+          npm: '@ai-sdk/openai-compatible',
+        }],
+      },
+    });
+
+    expect(materializeRegistry(registry, () => 'local')).toHaveLength(0);
+  });
+
+  it('does not materialize a current-main anonymous candidate when its credential is missing', () => {
+    const registry = emptyRegistry();
+    registry.providers.push({
+      id: 'legacy-custom',
+      templateId: 'custom-openai',
+      name: 'Legacy Custom',
+      enabled: true,
+      authRef: 'keyring:provider:legacy-custom',
+      api: {
+        npm: '@ai-sdk/openai-compatible',
+        url: 'https://legacy-custom.example/v1',
+      },
+      addedAt: '2026-06-09T00:00:00.000Z',
+      modelsCache: {
+        fetchedAt: '2026-06-09T00:00:00.000Z',
+        models: [{
+          id: 'local-model',
+          name: 'Local Model',
+          upstreamModelId: 'local-model',
+          modelFormat: 'openai',
+          npm: '@ai-sdk/openai-compatible',
+        }],
+      },
+    });
+
+    expect(materializeRegistry(registry, () => null)).toHaveLength(0);
+  });
+
+  it('preserves a real credential on a custom endpoint without authType', () => {
+    const registry = emptyRegistry();
+    registry.providers.push({
+      id: 'legacy-custom',
+      templateId: 'custom-openai',
+      name: 'Legacy Custom',
+      enabled: true,
+      authRef: 'keyring:provider:legacy-custom',
+      api: {
+        npm: '@ai-sdk/openai-compatible',
+        url: 'https://legacy-custom.example/v1',
+      },
+      addedAt: '2026-06-09T00:00:00.000Z',
+      modelsCache: {
+        fetchedAt: '2026-06-09T00:00:00.000Z',
+        models: [{
+          id: 'local-model',
+          name: 'Local Model',
+          upstreamModelId: 'local-model',
+          modelFormat: 'openai',
+          npm: '@ai-sdk/openai-compatible',
+        }],
+      },
+    });
+
+    const locals = materializeRegistry(registry, () => 'sk-real-key');
+
+    expect(locals).toHaveLength(1);
+    expect(locals[0]?.apiKey).toBe('sk-real-key');
+    expect(locals[0]?.authRef).toBe('keyring:provider:legacy-custom');
+    expect(locals[0]?.authType).toBeUndefined();
   });
 
   it('normalizes the unambiguous legacy no-auth representation', () => {

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -108,6 +108,38 @@ describe('registry io', () => {
     expect(loaded.providers[0]?.id).toBe('groq');
   });
 
+  it('serializes migration writes and reloads state after acquiring the lock', () => {
+    const path = join(home, 'providers.json');
+    const lockPath = `${path}.lock`;
+    const raw = {
+      schemaVersion: 1,
+      providers: [{
+        id: 'openai',
+        templateId: 'openai',
+        name: 'OpenAI',
+        enabled: true,
+        authRef: 'keyring:oauth:provider:openai',
+        authType: 'oauth',
+        api: { npm: '@ai-sdk/openai' },
+        addedAt: '2026-06-09T00:00:00.000Z',
+      }],
+    };
+    mkdirSync(home, { recursive: true });
+    writeFileSync(path, JSON.stringify(raw));
+    writeFileSync(lockPath, JSON.stringify({
+      pid: 2_147_483_647,
+      startedAt: Date.now() - 60_000,
+      token: 'dead-owner',
+    }));
+
+    const loaded = loadRegistry(path);
+    const persisted = JSON.parse(readFileSync(path, 'utf8'));
+
+    expect(loaded.providers[0]?.id).toBe('openai-oauth');
+    expect(persisted.providers[0]?.id).toBe('openai-oauth');
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
 });
 
 describe('materializeRegistry', () => {

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -180,6 +180,7 @@ describe('materializeRegistry', () => {
       name: 'Groq',
       enabled: true,
       authRef: 'keyring:provider:groq',
+      authType: 'api',
       api: { npm: '@ai-sdk/groq' },
       addedAt: '2026-06-09T00:00:00.000Z',
       modelsCache: {
@@ -194,6 +195,73 @@ describe('materializeRegistry', () => {
       },
     });
     expect(materializeRegistry(registry, () => null)).toHaveLength(0);
+  });
+
+  it('materializes explicit anonymous access without consulting a credential resolver', () => {
+    const registry = emptyRegistry();
+    registry.providers.push({
+      id: 'anonymous-provider',
+      templateId: 'anonymous-provider',
+      name: 'Anonymous Provider',
+      enabled: true,
+      authRef: 'none:anonymous',
+      authType: 'none',
+      api: { npm: '@ai-sdk/openai-compatible', url: 'https://anonymous.example/v1' },
+      addedAt: '2026-06-09T00:00:00.000Z',
+      modelsCache: {
+        fetchedAt: '2026-06-09T00:00:00.000Z',
+        models: [{
+          id: 'free-model',
+          name: 'Free Model',
+          upstreamModelId: 'free-model',
+          modelFormat: 'openai',
+          npm: '@ai-sdk/openai-compatible',
+        }],
+      },
+    });
+
+    const locals = materializeRegistry(registry, () => {
+      throw new Error('anonymous access must not resolve a credential');
+    });
+
+    expect(locals).toHaveLength(1);
+    expect(locals[0]?.apiKey).toBe('');
+    expect(locals[0]?.authRef).toBe('none:anonymous');
+  });
+
+  it('normalizes the unambiguous legacy no-auth representation', () => {
+    const registry = emptyRegistry();
+    registry.providers.push({
+      id: 'legacy-anonymous',
+      templateId: 'custom-openai',
+      name: 'Legacy Anonymous',
+      enabled: true,
+      authRef: 'keyring:provider:legacy-anonymous',
+      authType: 'none',
+      api: {
+        npm: '@ai-sdk/openai-compatible',
+        url: 'https://legacy-anonymous.example/v1',
+      },
+      addedAt: '2026-06-09T00:00:00.000Z',
+      modelsCache: {
+        fetchedAt: '2026-06-09T00:00:00.000Z',
+        models: [{
+          id: 'local-model',
+          name: 'Local Model',
+          upstreamModelId: 'local-model',
+          modelFormat: 'openai',
+          npm: '@ai-sdk/openai-compatible',
+        }],
+      },
+    });
+
+    const locals = materializeRegistry(registry, () => {
+      throw new Error('legacy no-auth access must not resolve a credential');
+    });
+
+    expect(locals).toHaveLength(1);
+    expect(locals[0]?.apiKey).toBe('');
+    expect(locals[0]?.authRef).toBe('none:anonymous');
   });
 
   it('marks NVIDIA imported models as free provider access', () => {


### PR DESCRIPTION
## Summary

- Add an external credential-helper protocol with executable validation, bounded runtime, helper-bound references, and verified writes.
- Serialize registry writes and recover dead or expired lock holders without removing a replacement lock.
- Represent anonymous access explicitly so stale environment credentials cannot override no-auth providers, no placeholder secrets are persisted, and anonymous discovery omits credential headers.
- Normalize unambiguous existing no-auth entries and delete helper-backed credentials when their final provider reference is removed.

This combines the overlapping work from #13 and #14 into one branch as requested.

Fixes #7.

## Test plan

- [x] 96 affected tests across credential helpers, registry CRUD, anonymous endpoints, refresh, catalog display, and lock handling
- [x] 612 broader non-listener tests
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] GitHub Actions full test suite
