### PR TITLE
fix(transport): isolate connections by credential

### DIFF
--- a/src/oauth/responses-websocket.ts
+++ b/src/oauth/responses-websocket.ts
@@ -208,6 +208,12 @@ function hasResponsesLiteHeader(headers: Record<string, string>): boolean {
   );
 }
 
+function authorizationHeaderFingerprint(headers: Record<string, string>): string {
+  const authorization = Object.entries(headers)
+    .find(([key]) => key.toLowerCase() === 'authorization')?.[1];
+  return authorization ? createHash('sha256').update(authorization).digest('hex') : '';
+}
+
 function bodyToString(body: BodyInit | null | undefined): string {
   if (body == null) return '';
   if (typeof body === 'string') return body;
@@ -290,12 +296,15 @@ function instructionChangeSummary(previous: string | undefined, current: string 
  * Opaque socket partition key. Prompt fields intentionally are not part of this
  * key: Responses accepts fresh instructions/tools on each create, and Claude can
  * change them during a normal tool loop. Exact conversation lineage is validated
- * separately before previous_response_id is used.
+ * separately before previous_response_id is used. The authorization fingerprint
+ * prevents a refreshed credential from inheriting a socket authenticated with the
+ * token that the upstream rejected.
  */
 export function responsesWebSocketPartitionKey(
   wsUrl: string,
   payload: JsonObject,
   options: Pick<ResponsesWebSocketFetchOptions, 'providerId' | 'accountId'> = {},
+  authorizationFingerprint = '',
 ): string | undefined {
   const promptCacheKey = payload.prompt_cache_key;
   const model = payload.model;
@@ -311,6 +320,7 @@ export function responsesWebSocketPartitionKey(
     model,
     effort,
     promptCacheKey,
+    authorizationFingerprint,
   ].join('\x1f');
   return createHash('sha256').update(material).digest('hex');
 }
@@ -1113,7 +1123,13 @@ export function createResponsesWebSocketFetch(
     }
     if (hasResponsesLiteHeader(headers)) payload = applyResponsesLiteShape(payload);
 
-    const partitionKey = responsesWebSocketPartitionKey(wsUrl, payload, options);
+    const authorizationFingerprint = authorizationHeaderFingerprint(headers);
+    const partitionKey = responsesWebSocketPartitionKey(
+      wsUrl,
+      payload,
+      options,
+      authorizationFingerprint,
+    );
     const promptFingerprint = responsesWebSocketPromptFingerprint(payload);
     const promptFieldHashes = responsesWebSocketPromptFieldHashes(payload);
     const instructionsSnapshot = instructionsFromPayload(payload);

--- a/src/provider-factory.ts
+++ b/src/provider-factory.ts
@@ -144,8 +144,11 @@ export async function createLanguageModel(spec: ProviderModelSpec): Promise<Lang
   if (npm === '@ai-sdk/openai') {
     const { createOpenAI } = await import('@ai-sdk/openai');
     const useResponsesEndpoint = shouldUseOpenAiResponsesEndpoint(modelId);
+    const tokenAccountId = spec.authType === 'oauth'
+      ? extractOpenAiAccountId({ access_token: apiKey })?.trim()
+      : undefined;
     const accountId = spec.authType === 'oauth'
-      ? spec.oauthAccountId ?? extractOpenAiAccountId({ access_token: apiKey })
+      ? tokenAccountId || spec.oauthAccountId
       : undefined;
     const oauthOptions = spec.authType === 'oauth'
       ? {

--- a/tests/provider-factory.test.ts
+++ b/tests/provider-factory.test.ts
@@ -194,7 +194,8 @@ describe('effortProviderOptions + deepMergeProviderOptions', () => {
 });
 
 describe('createLanguageModel', () => {
-  it('routes OpenAI OAuth through the ChatGPT Codex backend with the account header', async () => {
+  it('prefers the current OpenAI OAuth token account claim over stored metadata', async () => {
+    vi.resetModules();
     const responses = vi.fn((modelId: string) => ({ modelId, provider: 'openai-responses' }));
     const chat = vi.fn((modelId: string) => ({ modelId, provider: 'openai-chat' }));
     const createOpenAI = vi.fn(() => ({ responses, chat }));
@@ -218,11 +219,43 @@ describe('createLanguageModel', () => {
       baseURL: 'https://chatgpt.com/backend-api/codex',
       fetch: expect.any(Function),
       headers: {
-        'ChatGPT-Account-Id': 'stored-acct-456',
+        'ChatGPT-Account-Id': 'acct-123',
         originator: 'clodex',
       },
     });
     expect(responses).toHaveBeenCalledWith('gpt-5.5');
+    vi.doUnmock('@ai-sdk/openai');
+  });
+
+  it('falls back to the stored OpenAI account id when the current token has no account claim', async () => {
+    vi.resetModules();
+    const responses = vi.fn((modelId: string) => ({
+      modelId,
+      provider: 'openai-responses',
+    }));
+    const chat = vi.fn((modelId: string) => ({
+      modelId,
+      provider: 'openai-chat',
+    }));
+    const createOpenAI = vi.fn(() => ({ responses, chat }));
+    vi.doMock('@ai-sdk/openai', () => ({ createOpenAI }));
+
+    const { createLanguageModel: create } = await import('../src/provider-factory.js');
+    await create({
+      npm: '@ai-sdk/openai',
+      modelId: 'gpt-5.5',
+      apiKey: 'opaque-access-token',
+      authType: 'oauth',
+      oauthAccountId: 'stored-acct-456',
+    });
+
+    expect(createOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'ChatGPT-Account-Id': 'stored-acct-456',
+        }),
+      }),
+    );
     vi.doUnmock('@ai-sdk/openai');
   });
 

--- a/tests/responses-websocket.test.ts
+++ b/tests/responses-websocket.test.ts
@@ -469,6 +469,69 @@ describe('createResponsesWebSocketFetch', () => {
     await readAll(second);
   });
 
+  it('reuses a socket only while the authorization credential is unchanged', async () => {
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const firstUser = {
+      role: 'user',
+      content: [{ type: 'input_text', text: 'first' }],
+    };
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
+      providerId: 'openai',
+      accountId: 'acct-token-rotation',
+      onDiagnostic: event => diagnostics.push(event),
+    });
+    const first = await wsFetch('https://x', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token-a' },
+      body: JSON.stringify(sessionPayload([firstUser])),
+    });
+    const firstSocket = lastSocket();
+    firstSocket.emit('open');
+    emitTextResponse(firstSocket, 'resp_token_a_1', 'first answer');
+    await readAll(first);
+
+    const firstAssistant = {
+      role: 'assistant',
+      content: [{ type: 'output_text', text: 'first answer' }],
+    };
+    const secondUser = {
+      role: 'user',
+      content: [{ type: 'input_text', text: 'second' }],
+    };
+    const secondInput = [firstUser, firstAssistant, secondUser];
+    const second = await wsFetch('https://x', {
+      method: 'POST',
+      headers: new Headers({ authorization: 'Bearer token-a' }),
+      body: JSON.stringify(sessionPayload(secondInput)),
+    });
+    expect(fakeSockets).toHaveLength(1);
+    emitTextResponse(firstSocket, 'resp_token_a_2', 'second answer');
+    await readAll(second);
+
+    const secondAssistant = {
+      role: 'assistant',
+      content: [{ type: 'output_text', text: 'second answer' }],
+    };
+    const thirdUser = {
+      role: 'user',
+      content: [{ type: 'input_text', text: 'third' }],
+    };
+    const third = await wsFetch('https://x', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token-b' },
+      body: JSON.stringify(sessionPayload([...secondInput, secondAssistant, thirdUser])),
+    });
+
+    expect(fakeSockets).toHaveLength(2);
+    const replacementSocket = lastSocket();
+    expect(replacementSocket).not.toBe(firstSocket);
+    expect(replacementSocket.options.headers?.Authorization).toBe('Bearer token-b');
+    replacementSocket.emit('open');
+    emitTextResponse(replacementSocket, 'resp_token_b_1', 'third answer');
+    await readAll(third);
+    expect(JSON.stringify(diagnostics)).not.toMatch(/token-[ab]/);
+  });
+
   it('emits correlated privacy-safe reasons when a history mismatch creates another head', async () => {
     const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
     const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
@@ -1130,19 +1193,51 @@ describe('createResponsesWebSocketFetch', () => {
     });
   });
 
-  it('partitions by provider, account, model, effort, and session only', () => {
+  it('partitions by provider, account, model, effort, session, and credential fingerprint', () => {
     const payload = sessionPayload([]);
-    const base = responsesWebSocketPartitionKey(WS_URL, payload, { providerId: 'openai', accountId: 'a' });
-    expect(base).not.toBe(responsesWebSocketPartitionKey(WS_URL, payload, { providerId: 'other', accountId: 'a' }));
-    expect(base).not.toBe(responsesWebSocketPartitionKey(WS_URL, payload, { providerId: 'openai', accountId: 'b' }));
-    expect(base).not.toBe(responsesWebSocketPartitionKey(WS_URL, { ...payload, model: 'gpt-other' }, { providerId: 'openai', accountId: 'a' }));
-    expect(base).not.toBe(responsesWebSocketPartitionKey(WS_URL, { ...payload, reasoning: { effort: 'low' } }, { providerId: 'openai', accountId: 'a' }));
-    expect(base).not.toBe(responsesWebSocketPartitionKey(WS_URL, { ...payload, prompt_cache_key: 'other-session' }, { providerId: 'openai', accountId: 'a' }));
+    const options = { providerId: 'openai', accountId: 'a' };
+    const base = responsesWebSocketPartitionKey(WS_URL, payload, options, 'credential-a');
+    expect(base).not.toBe(responsesWebSocketPartitionKey(
+      WS_URL,
+      payload,
+      { providerId: 'other', accountId: 'a' },
+      'credential-a',
+    ));
+    expect(base).not.toBe(responsesWebSocketPartitionKey(
+      WS_URL,
+      payload,
+      { providerId: 'openai', accountId: 'b' },
+      'credential-a',
+    ));
+    expect(base).not.toBe(responsesWebSocketPartitionKey(
+      WS_URL,
+      { ...payload, model: 'gpt-other' },
+      options,
+      'credential-a',
+    ));
+    expect(base).not.toBe(responsesWebSocketPartitionKey(
+      WS_URL,
+      { ...payload, reasoning: { effort: 'low' } },
+      options,
+      'credential-a',
+    ));
+    expect(base).not.toBe(responsesWebSocketPartitionKey(
+      WS_URL,
+      { ...payload, prompt_cache_key: 'other-session' },
+      options,
+      'credential-a',
+    ));
+    expect(base).not.toBe(responsesWebSocketPartitionKey(
+      WS_URL,
+      payload,
+      options,
+      'credential-b',
+    ));
     expect(base).toBe(responsesWebSocketPartitionKey(WS_URL, {
       ...payload,
       instructions: 'changed',
       tools: [{ type: 'function', name: 'Write' }],
-    }, { providerId: 'openai', accountId: 'a' }));
+    }, options, 'credential-a'));
   });
 
   it('canonicalizes object key ordering in prompt fingerprints', () => {


### PR DESCRIPTION
## Summary

- Partition reusable sockets by a one-way credential fingerprint.
- Open a replacement connection after credential rotation while preserving reuse for unchanged credentials.
- Prefer the current token's account claim over stale stored metadata.

## Test plan

- [x] Focused transport and provider tests: 62 passed.
- [x] Isolated non-listener suite: 571 passed.
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] Staged and committed secret scans
