### PR TITLE
fix(routing): prevent configured route bypasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ ANTHROPIC_BASE_URL=http://127.0.0.1:17645/anthropic
 OPENAI_BASE_URL=http://127.0.0.1:17645/openai/v1
 ```
 
-Use any API key locally; network mode requires the server password. Proxy mode prints `HTTPS_PROXY`, `HTTP_PROXY`, and `NODE_EXTRA_CA_CERTS` values to export — do **not** set `ANTHROPIC_BASE_URL` in that mode.
+Use any API key locally; network mode requires the server password. Proxy mode prints `HTTPS_PROXY`, `HTTP_PROXY`, `NODE_EXTRA_CA_CERTS`, and adjusted `NO_PROXY` / `no_proxy` values to export. The adjusted bypass lists preserve unrelated hosts while ensuring `api.anthropic.com` reaches the selective proxy. Do **not** set `ANTHROPIC_BASE_URL` in that mode.
 
 Several `clodex server` instances can run at once — each advertises itself in `~/.clodex/server-runtime.json`, and `clodex-claude` prefers a proxy-mode server (newest first) when bridging (see [docs/background-agents.md](docs/background-agents.md)). Pass `--no-discovery` to keep a server out of that file, e.g. a dedicated endpoint you point another tool at.
 

--- a/docs/background-agents.md
+++ b/docs/background-agents.md
@@ -13,6 +13,7 @@ This page explains how to bridge **every** Claude Code process on your machine �
 - Setting **`CLAUDE_CODE_PROCESS_WRAPPER`** to `clodex-claude` makes Claude Code invoke it as `clodex-claude <claude-binary-path> <args...>` for every process it spawns — agents view sessions and background agents are bridged automatically.
 - For your own terminal sessions, run **`clodex-claude`** instead of `claude` — same auto-discovery, no port or CA path to hardcode anywhere.
 - Set **`CLODEX_REQUIRE_SERVER=1`** in an isolated routed profile when bypassing Clodex must be impossible. `clodex-claude` then exits with an error if no advertised server passes its process and TCP checks. The default remains fail-open for ordinary installations.
+- Proxy-mode wrapper launches remove Anthropic entries from `NO_PROXY` and `no_proxy`, so inherited bypass settings cannot silently skip the selective proxy.
 
 ## Setup steps
 

--- a/docs/background-agents.md
+++ b/docs/background-agents.md
@@ -13,7 +13,7 @@ This page explains how to bridge **every** Claude Code process on your machine â
 - Setting **`CLAUDE_CODE_PROCESS_WRAPPER`** to `clodex-claude` makes Claude Code invoke it as `clodex-claude <claude-binary-path> <args...>` for every process it spawns â€” agents view sessions and background agents are bridged automatically.
 - For your own terminal sessions, run **`clodex-claude`** instead of `claude` â€” same auto-discovery, no port or CA path to hardcode anywhere.
 - Set **`CLODEX_REQUIRE_SERVER=1`** in an isolated routed profile when bypassing Clodex must be impossible. `clodex-claude` then exits with an error if no advertised server passes its process and TCP checks. The default remains fail-open for ordinary installations.
-- Proxy-mode wrapper launches remove Anthropic entries from `NO_PROXY` and `no_proxy`, so inherited bypass settings cannot silently skip the selective proxy.
+- Proxy-mode wrapper launches remove Anthropic entries from the union of `NO_PROXY` and `no_proxy`, while preserving unrelated bypasses. The manual server output prints the same adjusted values for users who export the proxy settings themselves.
 
 ## Setup steps
 
@@ -28,6 +28,8 @@ This page explains how to bridge **every** Claude Code process on your machine â
    ```bash
    clodex server --proxy
    ```
+
+   If the server prints `NO_PROXY` and `no_proxy`, export those adjusted values with the proxy and CA settings. Empty values intentionally clear inherited wildcard or Anthropic bypasses.
 
    Bridging only happens while this server is running. When it is not, `clodex-claude` falls back cleanly and launches `claude` with an untouched environment.
 

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -2,10 +2,16 @@
 import { MAX_MODEL_CATALOG } from './constants.js';
 import { claudeCodeClientModelId } from './context-model-id.js';
 import { resolveProviderCredential } from './env.js';
+import { modelAliasTarget } from './model-aliases.js';
 import { isSdkMigratedNpm } from './provider-factory.js';
 import { aliasModelId } from './proxy.js';
-import type { ProxyRoute } from './proxy.js';
-import type { FavoriteModel, LocalProvider, LocalProviderModel } from './types.js';
+import type { ProxyModelAlias, ProxyRoute } from './proxy.js';
+import type {
+  FavoriteModel,
+  LocalProvider,
+  LocalProviderModel,
+  ModelAlias,
+} from './types.js';
 
 export function localModelToRoute(lp: LocalProvider, model: LocalProviderModel): ProxyRoute | null {
   if (model.modelFormat === 'anthropic' && !model.baseUrl) return null;
@@ -52,6 +58,17 @@ export function makeRouteResolver(
     const model = provider?.models.find(m => m.id === modelId);
     return provider && model ? localModelToRoute(provider, model) ?? undefined : undefined;
   };
+}
+
+export function resolveCatalogModelAliases(
+  modelAliases: ModelAlias[],
+  resolveRoute: (providerId: string, modelId: string) => ProxyRoute | undefined,
+): ProxyModelAlias[] {
+  return modelAliases.map(alias => ({
+    name: alias.name,
+    routeId: resolveRoute(alias.providerId, alias.modelId)?.aliasId
+      ?? modelAliasTarget(alias),
+  }));
 }
 
 /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ import type { ProxyHandle, ProxyModelAlias, ProxyRoute } from './proxy.js';
 import {
   buildCatalogRoutes,
   makeRouteResolver,
+  resolveCatalogModelAliases,
 } from './catalog.js';
 import { runServerCommand } from './server/index.js';
 import { loadPreferences, savePreferences, recordLaunchSelection, resolveBridgeMode } from './config.js';
@@ -1228,10 +1229,7 @@ export async function runClaudeCommand(parsed: ParsedArgs): Promise<number> {
     return launchClaudeViaCatalog(
       catalogRoutes,
       startingRoute,
-      (prefs.modelAliases ?? []).map(alias => ({
-        name: alias.name,
-        routeId: modelAliasTarget(alias),
-      })),
+      resolveCatalogModelAliases(prefs.modelAliases ?? [], resolveRoute),
       selectedModel.contextWindow,
       trace,
       claudeArgs,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@ import { claudeCodeClientModelId } from './context-model-id.js';
 import { needsFirstRunSetup, runFirstRunWizard } from './first-run.js';
 import { MAX_MODEL_CATALOG } from './constants.js';
 import { startProxy, startProxyCatalog } from './proxy.js';
-import type { ProxyHandle, ProxyRoute } from './proxy.js';
+import type { ProxyHandle, ProxyModelAlias, ProxyRoute } from './proxy.js';
 import {
   buildCatalogRoutes,
   makeRouteResolver,
@@ -565,13 +565,22 @@ function printHelp(text: string): void {
 async function launchClaudeViaCatalog(
   catalogRoutes: ProxyRoute[],
   startingRoute: ProxyRoute,
+  modelAliases: ProxyModelAlias[],
   contextWindow: number | undefined,
   trace: boolean,
   claudeArgs: string[],
 ): Promise<number> {
   let proxyHandle: ProxyHandle;
   try {
-    proxyHandle = await startProxyCatalog(catalogRoutes, startingRoute.aliasId, trace);
+    proxyHandle = await startProxyCatalog(
+      catalogRoutes,
+      startingRoute.aliasId,
+      trace,
+      undefined,
+      undefined,
+      undefined,
+      modelAliases,
+    );
     p.log.info(
       `Switch menu active — proxy on port ${proxyHandle.port} ` +
       pc.dim(`(${catalogRoutes.length} model${catalogRoutes.length !== 1 ? 's' : ''} in /model)`),
@@ -1219,6 +1228,10 @@ export async function runClaudeCommand(parsed: ParsedArgs): Promise<number> {
     return launchClaudeViaCatalog(
       catalogRoutes,
       startingRoute,
+      (prefs.modelAliases ?? []).map(alias => ({
+        name: alias.name,
+        routeId: modelAliasTarget(alias),
+      })),
       selectedModel.contextWindow,
       trace,
       claudeArgs,

--- a/src/context-model-id.ts
+++ b/src/context-model-id.ts
@@ -12,6 +12,12 @@ export function hasOneMContextSuffix(modelId: string): boolean {
   return /\[1m\]$/i.test(modelId);
 }
 
+/** Canonical key for matching route ids across context suffix and Google prefix variants. */
+export function normalizeRouteLookupId(id: string): string {
+  const bare = stripOneMContextSuffix(id);
+  return bare.startsWith('models/') ? bare.slice('models/'.length) : bare;
+}
+
 /** Model id to pass to Claude Code (--model / ANTHROPIC_MODEL) for accurate context UX. */
 export function claudeCodeClientModelId(modelId: string, contextWindow?: number): string {
   const bare = stripOneMContextSuffix(modelId);
@@ -25,7 +31,7 @@ export function claudeCodeClientModelId(modelId: string, contextWindow?: number)
 /** Variants to match inbound Claude Code model ids against proxy catalog aliases. */
 export function routeLookupIds(id: string): string[] {
   const bare = stripOneMContextSuffix(id);
-  const googleBare = bare.startsWith('models/') ? bare.slice('models/'.length) : bare;
+  const googleBare = normalizeRouteLookupId(id);
   return [...new Set([
     id,
     bare,

--- a/src/env.ts
+++ b/src/env.ts
@@ -16,6 +16,7 @@ import {
 import { refreshStoredOAuthCredential, oauthCredentialShouldRefresh } from './oauth/refresh.js';
 import { withCredentialMutationLock } from './registry/lock.js';
 import type { ConflictInfo } from './types.js';
+import { removeAnthropicProxyBypass } from './wrapper-env.js';
 
 export function detectConflicts(): ConflictInfo[] {
   return CONFLICTING_ENV_VARS
@@ -83,31 +84,7 @@ export function buildHttpProxyChildEnv(proxyPort: number, caCertPath: string): N
   env['https_proxy'] = proxyUrl;
   env['http_proxy'] = proxyUrl;
   env['NODE_EXTRA_CA_CERTS'] = caCertPath;
-  const noProxy = env['NO_PROXY'] ?? env['no_proxy'];
-  if (noProxy !== undefined) {
-    const filtered = noProxy
-      .split(',')
-      .map(value => value.trim())
-      .filter(Boolean)
-      .filter(value => {
-        const entry = value.toLowerCase().replace(/^https?:\/\//, '');
-        const host = entry.replace(/:\d+$/, '');
-        if (host === '*') return false;
-        const suffix = host.startsWith('*.') ? host.slice(1) : host;
-        const bypassesAnthropic = suffix.startsWith('.')
-          ? 'api.anthropic.com'.endsWith(suffix)
-          : 'api.anthropic.com' === suffix || 'api.anthropic.com'.endsWith(`.${suffix}`);
-        return !bypassesAnthropic;
-      })
-      .join(',');
-    if (filtered) {
-      env['NO_PROXY'] = filtered;
-      env['no_proxy'] = filtered;
-    } else {
-      delete env['NO_PROXY'];
-      delete env['no_proxy'];
-    }
-  }
+  removeAnthropicProxyBypass(env);
   return env;
 }
 

--- a/src/http-proxy/index.ts
+++ b/src/http-proxy/index.ts
@@ -106,6 +106,7 @@ export async function startConfiguredHttpProxy(
     port,
     routes: loaded.routes,
     modelAliases: loaded.aliases,
+    reservedModelIds: loaded.unavailableAliases.map(alias => alias.name),
     debug,
     debugLogPath,
     inferenceLogPath,

--- a/src/http-proxy/index.ts
+++ b/src/http-proxy/index.ts
@@ -6,7 +6,7 @@ import { fetchProviderCatalog, resolveLocalProviderApiKey } from '../provider-ca
 import { providersForTarget } from '../target-compatibility.js';
 import type { ProxyRoute } from '../proxy.js';
 import { buildHttpProxyRoutes, type HttpProxyRouteResult } from './routes.js';
-import { startHttpProxy, type HttpProxyHandle } from './server.js';
+import { startHttpProxy, type HttpProxyHandle, type HttpProxyOptions } from './server.js';
 import { ensureHttpProxyCaBundle } from './ca.js';
 import { registerServerRuntimeState, unregisterServerRuntimeState } from '../server-runtime.js';
 import {
@@ -14,6 +14,7 @@ import {
   getSessionLogPath,
   writeProxyLifecycleLog,
 } from '../trace-log.js';
+import { removeAnthropicProxyBypass } from '../wrapper-env.js';
 
 export interface LoadedHttpProxyRoutes extends HttpProxyRouteResult {
   favoriteCount: number;
@@ -93,15 +94,15 @@ export function reportSkippedHttpProxyFavorites(loaded: LoadedHttpProxyRoutes): 
   }
 }
 
-export async function startConfiguredHttpProxy(
+export function buildConfiguredHttpProxyOptions(
+  loaded: LoadedHttpProxyRoutes,
   port: number,
   debug = false,
   inferenceLogPath = getInferenceRequestLogPath(),
   debugLogPath?: string,
   webSocketDiagnosticsLogPath?: string,
-): Promise<{ handle: HttpProxyHandle; loaded: LoadedHttpProxyRoutes }> {
-  const loaded = await loadHttpProxyRoutes();
-  const handle = await startHttpProxy({
+): HttpProxyOptions {
+  return {
     host: '127.0.0.1',
     port,
     routes: loaded.routes,
@@ -111,7 +112,42 @@ export async function startConfiguredHttpProxy(
     debugLogPath,
     inferenceLogPath,
     webSocketDiagnosticsLogPath,
-  });
+  };
+}
+
+export function formatHttpProxyEnvironmentLines(
+  handle: Pick<HttpProxyHandle, 'port' | 'caCertPath'>,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): string[] {
+  const env = { ...baseEnv };
+  const hadNoProxy = env['NO_PROXY'] !== undefined || env['no_proxy'] !== undefined;
+  removeAnthropicProxyBypass(env);
+  return [
+    `  HTTPS_PROXY=http://127.0.0.1:${handle.port}`,
+    `  HTTP_PROXY=http://127.0.0.1:${handle.port}`,
+    `  NODE_EXTRA_CA_CERTS=${handle.caCertPath}`,
+    ...(hadNoProxy
+      ? [`  NO_PROXY=${env['NO_PROXY'] ?? ''}`, `  no_proxy=${env['no_proxy'] ?? ''}`]
+      : []),
+  ];
+}
+
+export async function startConfiguredHttpProxy(
+  port: number,
+  debug = false,
+  inferenceLogPath = getInferenceRequestLogPath(),
+  debugLogPath?: string,
+  webSocketDiagnosticsLogPath?: string,
+): Promise<{ handle: HttpProxyHandle; loaded: LoadedHttpProxyRoutes }> {
+  const loaded = await loadHttpProxyRoutes();
+  const handle = await startHttpProxy(buildConfiguredHttpProxyOptions(
+    loaded,
+    port,
+    debug,
+    inferenceLogPath,
+    debugLogPath,
+    webSocketDiagnosticsLogPath,
+  ));
   handle.caCertPath = ensureHttpProxyCaBundle(
     handle.caCertPath,
     process.env['NODE_EXTRA_CA_CERTS'],
@@ -165,9 +201,7 @@ export async function runHttpProxyServerCommand(
   });
   console.log('');
   console.log(pc.bold(pc.green('clodex proxy-mode server running')));
-  console.log(`  HTTPS_PROXY=http://127.0.0.1:${handle.port}`);
-  console.log(`  HTTP_PROXY=http://127.0.0.1:${handle.port}`);
-  console.log(`  NODE_EXTRA_CA_CERTS=${handle.caCertPath}`);
+  for (const line of formatHttpProxyEnvironmentLines(handle)) console.log(line);
   console.log(`  Request log: ${handle.inferenceLogPath}`);
   if (handle.webSocketDiagnosticsLogPath) {
     console.log(`  WebSocket diagnostics: ${handle.webSocketDiagnosticsLogPath}`);

--- a/src/http-proxy/server.ts
+++ b/src/http-proxy/server.ts
@@ -143,6 +143,8 @@ export interface HttpProxyOptions {
   routes: ProxyRoute[];
   /** Short incoming model names mapped to canonical adapter route ids. */
   modelAliases?: ResolvedHttpProxyAlias[];
+  /** Configured local model ids that must never fall through to Anthropic. */
+  reservedModelIds?: string[];
   debug?: boolean;
   /** Per-process translated-adapter debug log used when debug is enabled. */
   debugLogPath?: string;
@@ -661,13 +663,18 @@ function forwardPlainHttp(req: http.IncomingMessage, res: http.ServerResponse): 
 export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpProxyHandle> {
   const certificates = ensureHttpProxyCertificates();
   const routesById = new Map<string, ProxyRoute>();
+  const reservedModelIds = new Set<string>();
   for (const route of options.routes) {
     for (const id of routeLookupIds(route.aliasId)) routesById.set(id, route);
   }
   for (const alias of options.modelAliases ?? []) {
+    for (const id of routeLookupIds(alias.name)) reservedModelIds.add(id);
     const route = routesById.get(alias.routeId);
     if (!route) continue;
     for (const id of routeLookupIds(alias.name)) routesById.set(id, route);
+  }
+  for (const modelId of options.reservedModelIds ?? []) {
+    for (const id of routeLookupIds(modelId)) reservedModelIds.add(id);
   }
   const anthropicOrigin = new URL(options.anthropicOrigin ?? 'https://api.anthropic.com');
   let adapter: ProxyHandle | null = options.adapterHandle ?? null;
@@ -714,18 +721,25 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
       const claudeSessionId = parsed
         ? extractClaudeSessionId(parsed, claudeSessionIdHeader)
         : undefined;
+      const requestedModel = typeof parsed?.model === 'string' ? parsed.model : undefined;
+      const unresolvedRoutedModel = !route && requestedModel !== undefined && (
+        requestedModel.startsWith('clodex:') || reservedModelIds.has(requestedModel)
+      );
+      const requestedProvider = unresolvedRoutedModel
+        ? (requestedModel?.startsWith('clodex:') ? requestedModel.split(':')[1] || 'unknown' : 'unknown')
+        : 'anthropic';
 
       if (messagesEndpoint === 'messages' && options.inferenceLogPath) {
         const provider = route
           ? (route.providerId ?? route.aliasId.split(':')[1] ?? 'unknown')
-          : 'anthropic';
+          : requestedProvider;
         writeInferenceRequestLog(options.inferenceLogPath, {
           requestId,
           claudeSessionId,
           modelId: typeof parsed?.model === 'string' ? parsed.model : 'unknown',
           effort: parsed ? anthropicEffortFromRequest(parsed) : undefined,
           provider,
-          route: route ? 'translated' : 'passthrough',
+          route: route || unresolvedRoutedModel ? 'translated' : 'passthrough',
           stream: Boolean(parsed?.stream),
           requestPreview: getLatestMessagePreview(parsed?.messages, parsed?.system),
         });
@@ -734,15 +748,35 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
       if (messagesEndpoint === 'messages' && options.webSocketDiagnosticsLogPath) {
         const provider = route
           ? (route.providerId ?? route.aliasId.split(':')[1] ?? 'unknown')
-          : 'anthropic';
+          : requestedProvider;
         writeWebSocketDiagnosticRequestLog(options.webSocketDiagnosticsLogPath, {
           requestId,
           claudeSessionId,
           provider,
-          route: route ? 'translated' : 'passthrough',
+          route: route || unresolvedRoutedModel ? 'translated' : 'passthrough',
           headers: req.headers,
           body: parsed ? parsed as unknown as Record<string, unknown> : {},
         });
+      }
+
+      if (unresolvedRoutedModel) {
+        const message = `Clodex model route is unavailable: ${requestedModel}`;
+        if (messagesEndpoint === 'messages' && options.inferenceLogPath) {
+          writeInferenceResponseErrorLog(options.inferenceLogPath, {
+            requestId,
+            modelId: requestedModel!,
+            provider: requestedProvider,
+            route: 'translated',
+            statusCode: 400,
+            errorContent: message,
+          });
+        }
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          type: 'error',
+          error: { type: 'invalid_request_error', message },
+        }));
+        return;
       }
 
       if (route && adapter) {

--- a/src/http-proxy/server.ts
+++ b/src/http-proxy/server.ts
@@ -746,7 +746,7 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
         : undefined;
       const requestedModel = typeof parsed?.model === 'string' ? parsed.model : undefined;
       const unresolvedRoutedModel = !route && requestedModel !== undefined && (
-        requestedModel.startsWith(HTTP_PROXY_MODEL_PREFIX)
+        normalizeRouteLookupId(requestedModel).startsWith(HTTP_PROXY_MODEL_PREFIX)
         || reservedModelIds.has(normalizeRouteLookupId(requestedModel))
       );
 

--- a/src/http-proxy/server.ts
+++ b/src/http-proxy/server.ts
@@ -7,16 +7,19 @@ import { URL } from 'node:url';
 import { createBrotliDecompress, createGunzip, createInflate } from 'node:zlib';
 import type { ProxyHandle, ProxyRoute } from '../proxy.js';
 import { startProxyCatalog } from '../proxy.js';
+import { decodeRequestBody } from '../http-utils.js';
 import { ensureHttpProxyCertificates } from './ca.js';
-import { routeLookupIds } from '../context-model-id.js';
-import type { ResolvedHttpProxyAlias } from './routes.js';
+import { normalizeRouteLookupId } from '../context-model-id.js';
 import { listenTcpServer } from '../listener-ready.js';
+import { routeUnavailableMessage } from '../route-unavailable.js';
+import { HTTP_PROXY_MODEL_PREFIX, type ResolvedHttpProxyAlias } from './routes.js';
 import { anthropicEffortFromRequest, extractClaudeSessionId, type AnthropicRequest } from '../sdk-adapter.js';
 import { anthropicMessagesEndpoint } from '../anthropic-endpoints.js';
 import {
   getLatestMessagePreview,
   INFERENCE_PROGRESS_INTERVAL_MS,
   writeInferenceRequestLog,
+  writeInferenceRouteUnavailableLog,
   writeInferenceResponseLifecycleLog,
   writeInferenceResponseErrorLog,
   writeWebSocketDiagnosticRequestLog,
@@ -665,16 +668,17 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
   const routesById = new Map<string, ProxyRoute>();
   const reservedModelIds = new Set<string>();
   for (const route of options.routes) {
-    for (const id of routeLookupIds(route.aliasId)) routesById.set(id, route);
+    routesById.set(normalizeRouteLookupId(route.aliasId), route);
   }
   for (const alias of options.modelAliases ?? []) {
-    for (const id of routeLookupIds(alias.name)) reservedModelIds.add(id);
-    const route = routesById.get(alias.routeId);
+    const aliasId = normalizeRouteLookupId(alias.name);
+    reservedModelIds.add(aliasId);
+    const route = routesById.get(normalizeRouteLookupId(alias.routeId));
     if (!route) continue;
-    for (const id of routeLookupIds(alias.name)) routesById.set(id, route);
+    routesById.set(aliasId, route);
   }
   for (const modelId of options.reservedModelIds ?? []) {
-    for (const id of routeLookupIds(modelId)) reservedModelIds.add(id);
+    reservedModelIds.add(normalizeRouteLookupId(modelId));
   }
   const anthropicOrigin = new URL(options.anthropicOrigin ?? 'https://api.anthropic.com');
   let adapter: ProxyHandle | null = options.adapterHandle ?? null;
@@ -709,11 +713,30 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
       const requestId = randomUUID();
       let parsed: AnthropicRequest | null = null;
       let route: ProxyRoute | undefined;
+      let adapterBody = rawBody;
+      const contentEncoding = (Array.isArray(req.headers['content-encoding'])
+        ? req.headers['content-encoding'].join(',')
+        : req.headers['content-encoding'] ?? '').trim().toLowerCase();
+      const encodedRequestBody = contentEncoding !== '' && contentEncoding !== 'identity';
       try {
-        parsed = JSON.parse(rawBody.toString('utf8')) as AnthropicRequest;
-        if (typeof parsed.model === 'string') route = routesById.get(parsed.model);
+        const decodedBody = decodeRequestBody(rawBody, req.headers['content-encoding']);
+        parsed = JSON.parse(decodedBody) as AnthropicRequest;
+        if (encodedRequestBody) adapterBody = Buffer.from(decodedBody);
+        if (typeof parsed.model === 'string') {
+          route = routesById.get(normalizeRouteLookupId(parsed.model));
+        }
       } catch {
-        // Fail safe: an unreadable body is Anthropic traffic, never a relay route.
+        if (encodedRequestBody) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            type: 'error',
+            error: {
+              type: 'invalid_request_error',
+              message: 'Unable to inspect compressed request body',
+            },
+          }));
+          return;
+        }
       }
       const claudeSessionIdHeader = Array.isArray(req.headers['x-claude-code-session-id'])
         ? req.headers['x-claude-code-session-id'][0]
@@ -723,52 +746,17 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
         : undefined;
       const requestedModel = typeof parsed?.model === 'string' ? parsed.model : undefined;
       const unresolvedRoutedModel = !route && requestedModel !== undefined && (
-        requestedModel.startsWith('clodex:') || reservedModelIds.has(requestedModel)
+        requestedModel.startsWith(HTTP_PROXY_MODEL_PREFIX)
+        || reservedModelIds.has(normalizeRouteLookupId(requestedModel))
       );
-      const requestedProvider = unresolvedRoutedModel
-        ? (requestedModel?.startsWith('clodex:') ? requestedModel.split(':')[1] || 'unknown' : 'unknown')
-        : 'anthropic';
-
-      if (messagesEndpoint === 'messages' && options.inferenceLogPath) {
-        const provider = route
-          ? (route.providerId ?? route.aliasId.split(':')[1] ?? 'unknown')
-          : requestedProvider;
-        writeInferenceRequestLog(options.inferenceLogPath, {
-          requestId,
-          claudeSessionId,
-          modelId: typeof parsed?.model === 'string' ? parsed.model : 'unknown',
-          effort: parsed ? anthropicEffortFromRequest(parsed) : undefined,
-          provider,
-          route: route || unresolvedRoutedModel ? 'translated' : 'passthrough',
-          stream: Boolean(parsed?.stream),
-          requestPreview: getLatestMessagePreview(parsed?.messages, parsed?.system),
-        });
-      }
-
-      if (messagesEndpoint === 'messages' && options.webSocketDiagnosticsLogPath) {
-        const provider = route
-          ? (route.providerId ?? route.aliasId.split(':')[1] ?? 'unknown')
-          : requestedProvider;
-        writeWebSocketDiagnosticRequestLog(options.webSocketDiagnosticsLogPath, {
-          requestId,
-          claudeSessionId,
-          provider,
-          route: route || unresolvedRoutedModel ? 'translated' : 'passthrough',
-          headers: req.headers,
-          body: parsed ? parsed as unknown as Record<string, unknown> : {},
-        });
-      }
 
       if (unresolvedRoutedModel) {
-        const message = `Clodex model route is unavailable: ${requestedModel}`;
+        const message = routeUnavailableMessage(requestedModel);
         if (messagesEndpoint === 'messages' && options.inferenceLogPath) {
-          writeInferenceResponseErrorLog(options.inferenceLogPath, {
+          writeInferenceRouteUnavailableLog(options.inferenceLogPath, {
             requestId,
-            modelId: requestedModel!,
-            provider: requestedProvider,
-            route: 'translated',
+            modelId: requestedModel,
             statusCode: 400,
-            errorContent: message,
           });
         }
         res.writeHead(400, { 'Content-Type': 'application/json' });
@@ -779,14 +767,44 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
         return;
       }
 
+      if (messagesEndpoint === 'messages' && options.inferenceLogPath) {
+        const provider = route
+          ? (route.providerId ?? route.aliasId.split(':')[1] ?? 'unknown')
+          : 'anthropic';
+        writeInferenceRequestLog(options.inferenceLogPath, {
+          requestId,
+          claudeSessionId,
+          modelId: typeof parsed?.model === 'string' ? parsed.model : 'unknown',
+          effort: parsed ? anthropicEffortFromRequest(parsed) : undefined,
+          provider,
+          route: route ? 'translated' : 'passthrough',
+          stream: Boolean(parsed?.stream),
+          requestPreview: getLatestMessagePreview(parsed?.messages, parsed?.system),
+        });
+      }
+
+      if (messagesEndpoint === 'messages' && options.webSocketDiagnosticsLogPath) {
+        const provider = route
+          ? (route.providerId ?? route.aliasId.split(':')[1] ?? 'unknown')
+          : 'anthropic';
+        writeWebSocketDiagnosticRequestLog(options.webSocketDiagnosticsLogPath, {
+          requestId,
+          claudeSessionId,
+          provider,
+          route: route ? 'translated' : 'passthrough',
+          headers: req.headers,
+          body: parsed ? parsed as unknown as Record<string, unknown> : {},
+        });
+      }
+
       if (route && adapter) {
-        // Forward the body untouched — the adapter resolves alias names itself
-        // (it is built from the same routes + modelAliases as routesById above)
-        // and must echo the client's requested model id in response messages.
+        // The adapter resolves alias names itself and must echo the client's
+        // requested model id in response messages. Encoded bodies are decoded
+        // for this local hop, but their JSON model value is not rewritten.
         // Claude Code resolves context windows from the response model field, so
         // substituting the canonical route id here breaks its window lookup for
         // patched/alias model ids (wrong auto-compact threshold → agent death).
-        await forwardToAdapter(req, res, rawBody, adapter, messagesEndpoint === 'messages' && options.inferenceLogPath
+        await forwardToAdapter(req, res, adapterBody, adapter, messagesEndpoint === 'messages' && options.inferenceLogPath
           ? {
               logPath: options.inferenceLogPath,
               requestId,

--- a/src/http-utils.ts
+++ b/src/http-utils.ts
@@ -7,7 +7,7 @@ import * as zlib from 'node:zlib';
  * `openai` provider zstd-compresses request bodies; without this they reach the
  * proxy as binary and JSON.parse fails with "Invalid JSON body".
  */
-function decodeRequestBody(raw: Buffer, encoding?: string | string[]): string {
+export function decodeRequestBody(raw: Buffer, encoding?: string | string[]): string {
   const enc = (Array.isArray(encoding) ? encoding.join(',') : encoding ?? '').toLowerCase().trim();
   if (!enc || enc === 'identity') return raw.toString();
   switch (enc) {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -381,7 +381,7 @@ export async function startProxyCatalog(
         : undefined;
       const configuredModelUnavailable = typeof originalModel === 'string'
         && (
-          originalModel.startsWith('clodex:')
+          normalizeRouteLookupId(originalModel).startsWith('clodex:')
           || configuredAliasNames.has(normalizeRouteLookupId(originalModel))
         );
       if (!resolvedRoute && configuredModelUnavailable) {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -284,6 +284,9 @@ export async function startProxyCatalog(
   }
 
   const byAlias = new Map(routes.map(r => [r.aliasId, r]));
+  const configuredAliasNames = new Set(
+    (modelAliases ?? []).flatMap(alias => routeLookupIds(alias.name)),
+  );
   for (const alias of modelAliases ?? []) {
     const route = byAlias.get(alias.routeId);
     if (route && !byAlias.has(alias.name)) byAlias.set(alias.name, route);
@@ -371,7 +374,14 @@ export async function startProxyCatalog(
       const relayRequestId = Array.isArray(relayRequestIdRaw) ? relayRequestIdRaw[0] : relayRequestIdRaw;
 
       // Per-request route resolution: look up the alias, fall back to default
-      const route = lookupRoute(byAlias, originalModel) ?? defaultRoute;
+      const resolvedRoute = lookupRoute(byAlias, originalModel);
+      const configuredModelUnavailable = typeof originalModel === 'string'
+        && (originalModel.startsWith('clodex:') || configuredAliasNames.has(originalModel));
+      if (!resolvedRoute && configuredModelUnavailable) {
+        anthropicError(res, 400, `Model '${originalModel}' is unavailable`);
+        return;
+      }
+      const route = resolvedRoute ?? defaultRoute;
       if (messagesEndpoint === 'count_tokens' && route.modelFormat !== 'anthropic') {
         const inputTokens = estimateAnthropicInputTokens(anthropicBody);
         plog(() => `token-count: local estimate model=${originalModel} input_tokens=${inputTokens}`);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,7 +6,12 @@ import type { AddressInfo } from 'node:net';
 import { appendFileSync, openSync, writeSync, closeSync } from 'node:fs';
 import { readBody, extractApiKey, sendJson } from './http-utils.js';
 import { formatAnthropicModelEntry, formatAnthropicModelList } from './server/models.js';
-import { claudeCodeClientModelId, routeLookupIds, stripOneMContextSuffix } from './context-model-id.js';
+import {
+  claudeCodeClientModelId,
+  normalizeRouteLookupId,
+  stripOneMContextSuffix,
+} from './context-model-id.js';
+import { routeUnavailableMessage } from './route-unavailable.js';
 import {
   getProxyDebugLogPath,
   INFERENCE_PROGRESS_INTERVAL_MS,
@@ -253,11 +258,7 @@ export function aliasModelId(realId: string, providerId: string): string {
 
 /** Resolve catalog alias when Claude Code or legacy registry ids differ by prefix/suffix. */
 function lookupRoute(byAlias: Map<string, ProxyRoute>, id: string): ProxyRoute | undefined {
-  for (const key of routeLookupIds(id)) {
-    const route = byAlias.get(key);
-    if (route) return route;
-  }
-  return undefined;
+  return byAlias.get(normalizeRouteLookupId(id));
 }
 
 /** Short alias name → route id, resolvable in request bodies alongside route aliasIds. */
@@ -283,15 +284,16 @@ export async function startProxyCatalog(
     throw new Error('Proxy catalog requires at least one route');
   }
 
-  const byAlias = new Map(routes.map(r => [r.aliasId, r]));
+  const byAlias = new Map(routes.map(r => [normalizeRouteLookupId(r.aliasId), r]));
   const configuredAliasNames = new Set(
-    (modelAliases ?? []).flatMap(alias => routeLookupIds(alias.name)),
+    (modelAliases ?? []).map(alias => normalizeRouteLookupId(alias.name)),
   );
   for (const alias of modelAliases ?? []) {
-    const route = byAlias.get(alias.routeId);
-    if (route && !byAlias.has(alias.name)) byAlias.set(alias.name, route);
+    const route = lookupRoute(byAlias, alias.routeId);
+    const aliasId = normalizeRouteLookupId(alias.name);
+    if (route && !byAlias.has(aliasId)) byAlias.set(aliasId, route);
   }
-  const defaultRoute = byAlias.get(defaultAliasId) ?? routes[0]!;
+  const defaultRoute = lookupRoute(byAlias, defaultAliasId) ?? routes[0]!;
 
   const plog = makeProxyLog(debug, debugLogPath);
 
@@ -374,11 +376,16 @@ export async function startProxyCatalog(
       const relayRequestId = Array.isArray(relayRequestIdRaw) ? relayRequestIdRaw[0] : relayRequestIdRaw;
 
       // Per-request route resolution: look up the alias, fall back to default
-      const resolvedRoute = lookupRoute(byAlias, originalModel);
+      const resolvedRoute = typeof originalModel === 'string'
+        ? lookupRoute(byAlias, originalModel)
+        : undefined;
       const configuredModelUnavailable = typeof originalModel === 'string'
-        && (originalModel.startsWith('clodex:') || configuredAliasNames.has(originalModel));
+        && (
+          originalModel.startsWith('clodex:')
+          || configuredAliasNames.has(normalizeRouteLookupId(originalModel))
+        );
       if (!resolvedRoute && configuredModelUnavailable) {
-        anthropicError(res, 400, `Model '${originalModel}' is unavailable`);
+        anthropicError(res, 400, routeUnavailableMessage(originalModel));
         return;
       }
       const route = resolvedRoute ?? defaultRoute;

--- a/src/route-unavailable.ts
+++ b/src/route-unavailable.ts
@@ -1,0 +1,3 @@
+export function routeUnavailableMessage(modelId: string): string {
+  return `Clodex model route '${modelId}' is unavailable. Run \`clodex models --list\` to see available routes, or \`clodex patch\` to refresh saved aliases.`;
+}

--- a/src/trace-log.ts
+++ b/src/trace-log.ts
@@ -205,6 +205,12 @@ export interface InferenceResponseErrorLogEntry {
   attemptCount?: number;
 }
 
+export interface InferenceRouteUnavailableLogEntry {
+  requestId: string;
+  modelId: string;
+  statusCode: number;
+}
+
 export type InferenceResponseLifecycleEvent =
   | 'translation_dispatched'
   | 'translation_started'
@@ -516,6 +522,20 @@ export function writeInferenceResponseErrorLog(
     ...(entry.isRetryable !== undefined ? { isRetryable: entry.isRetryable } : {}),
     ...(entry.attemptCount !== undefined ? { attemptCount: entry.attemptCount } : {}),
     ...(includeContent ? { errorContent: compactLogValueWithMarker(entry.errorContent!, RESPONSE_ERROR_MAX) } : {}),
+  }));
+}
+
+/** Append a local routing-policy rejection without attributing it to an upstream provider. */
+export function writeInferenceRouteUnavailableLog(
+  path: string,
+  entry: InferenceRouteUnavailableLogEntry,
+): void {
+  writeSecureLogLine(path, JSON.stringify({
+    timestamp: new Date().toISOString(),
+    event: 'route_unavailable',
+    requestId: compactLogValue(entry.requestId, 100),
+    modelId: compactLogValue(entry.modelId),
+    statusCode: entry.statusCode,
   }));
 }
 

--- a/src/wrapper-env.ts
+++ b/src/wrapper-env.ts
@@ -11,11 +11,12 @@ const PROXY_ENV_VARS = ['HTTPS_PROXY', 'HTTP_PROXY', 'https_proxy', 'http_proxy'
 export const REQUIRE_SERVER_ENV = 'CLODEX_REQUIRE_SERVER';
 
 export function removeAnthropicProxyBypass(env: NodeJS.ProcessEnv): void {
-  const noProxy = env['NO_PROXY'] ?? env['no_proxy'];
-  if (noProxy === undefined) return;
+  const noProxyValues = [env['NO_PROXY'], env['no_proxy']]
+    .filter((value): value is string => value !== undefined);
+  if (noProxyValues.length === 0) return;
 
-  const filtered = noProxy
-    .split(',')
+  const filtered = [...new Set(noProxyValues
+    .flatMap(value => value.split(','))
     .map(value => value.trim())
     .filter(Boolean)
     .filter(value => {
@@ -27,7 +28,7 @@ export function removeAnthropicProxyBypass(env: NodeJS.ProcessEnv): void {
         ? 'api.anthropic.com'.endsWith(suffix)
         : 'api.anthropic.com' === suffix || 'api.anthropic.com'.endsWith(`.${suffix}`);
       return !bypassesAnthropic;
-    })
+    }))]
     .join(',');
   if (filtered) {
     env['NO_PROXY'] = filtered;

--- a/src/wrapper-env.ts
+++ b/src/wrapper-env.ts
@@ -10,6 +10,34 @@ import type { ServerRuntimeState } from './server-runtime.js';
 const PROXY_ENV_VARS = ['HTTPS_PROXY', 'HTTP_PROXY', 'https_proxy', 'http_proxy'] as const;
 export const REQUIRE_SERVER_ENV = 'CLODEX_REQUIRE_SERVER';
 
+export function removeAnthropicProxyBypass(env: NodeJS.ProcessEnv): void {
+  const noProxy = env['NO_PROXY'] ?? env['no_proxy'];
+  if (noProxy === undefined) return;
+
+  const filtered = noProxy
+    .split(',')
+    .map(value => value.trim())
+    .filter(Boolean)
+    .filter(value => {
+      const entry = value.toLowerCase().replace(/^https?:\/\//, '');
+      const host = entry.replace(/:\d+$/, '');
+      if (host === '*') return false;
+      const suffix = host.startsWith('*.') ? host.slice(1) : host;
+      const bypassesAnthropic = suffix.startsWith('.')
+        ? 'api.anthropic.com'.endsWith(suffix)
+        : 'api.anthropic.com' === suffix || 'api.anthropic.com'.endsWith(`.${suffix}`);
+      return !bypassesAnthropic;
+    })
+    .join(',');
+  if (filtered) {
+    env['NO_PROXY'] = filtered;
+    env['no_proxy'] = filtered;
+  } else {
+    delete env['NO_PROXY'];
+    delete env['no_proxy'];
+  }
+}
+
 /**
  * Any non-empty key satisfies the local endpoint gateway (`isAuthorized`
  * accepts everything when no server password is set, i.e. local listen mode).
@@ -36,6 +64,7 @@ export function computeWrapperEnv(
     delete env['ANTHROPIC_BASE_URL'];
     for (const name of PROXY_ENV_VARS) env[name] = proxyUrl;
     if (state.caPath) env['NODE_EXTRA_CA_CERTS'] = state.caPath;
+    removeAnthropicProxyBypass(env);
     return env;
   }
 

--- a/tests/catalog.test.ts
+++ b/tests/catalog.test.ts
@@ -1,10 +1,16 @@
 // tests/catalog.test.ts
 import { describe, it, expect, vi } from 'vitest';
 import { MAX_MODEL_CATALOG } from '../src/constants.js';
-import { buildCatalogRoutes, localModelToRoute, makeRouteResolver } from '../src/catalog.js';
+import {
+  buildCatalogRoutes,
+  localModelToRoute,
+  makeRouteResolver,
+  resolveCatalogModelAliases,
+} from '../src/catalog.js';
 import * as env from '../src/env.js';
+import { modelAliasTarget } from '../src/model-aliases.js';
 import type { ModelInfo } from '../src/types.js';
-import type { FavoriteModel, LocalProvider } from '../src/types.js';
+import type { FavoriteModel, LocalProvider, ModelAlias } from '../src/types.js';
 
 const TEST_HELPER_REF = `helper:v1:${'a'.repeat(64)}:oauth:provider:openai-oauth`;
 
@@ -32,6 +38,52 @@ describe('buildCatalogRoutes', () => {
     expect(routes[0]).toEqual(starting);
     expect(routes).toHaveLength(2);
     expect(droppedFavorites).toEqual([{ providerId: 'zen', modelId: 'claude-sonnet-4' }]);
+  });
+});
+
+describe('resolveCatalogModelAliases', () => {
+  it('maps saved provider/model targets to the resolved catalog route id', () => {
+    const providers: LocalProvider[] = [{
+      id: 'test-provider',
+      name: 'Test Provider',
+      apiKey: 'test-key',
+      models: [{
+        id: 'model-v1',
+        name: 'Model V1',
+        family: 'test',
+        brand: 'Other',
+        modelFormat: 'openai',
+        upstreamModelId: 'model-v1',
+        npm: '@ai-sdk/openai-compatible',
+        contextWindow: 1_000_000,
+      }],
+    }];
+    const aliases: ModelAlias[] = [{
+      name: 'fast',
+      providerId: 'test-provider',
+      modelId: 'model-v1',
+    }];
+
+    const resolved = resolveCatalogModelAliases(aliases, makeRouteResolver(providers));
+
+    expect(resolved).toEqual([{
+      name: 'fast',
+      routeId: 'anthropic-test-provider__model-v1[1m]',
+    }]);
+    expect(resolved[0]?.routeId).not.toBe('clodex:test-provider:model-v1');
+  });
+
+  it('preserves unavailable saved aliases as reserved preference targets', () => {
+    const alias: ModelAlias = {
+      name: 'archived',
+      providerId: 'missing-provider',
+      modelId: 'missing-model',
+    };
+
+    expect(resolveCatalogModelAliases([alias], makeRouteResolver([]))).toEqual([{
+      name: 'archived',
+      routeId: modelAliasTarget(alias),
+    }]);
   });
 });
 

--- a/tests/context-model-id.test.ts
+++ b/tests/context-model-id.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   claudeCodeClientModelId,
+  normalizeRouteLookupId,
   routeLookupIds,
   stripOneMContextSuffix,
 } from '../src/context-model-id.js';
@@ -29,6 +30,11 @@ describe('routeLookupIds', () => {
     const ids = routeLookupIds('gemini-3.5-flash');
     expect(ids).toContain('gemini-3.5-flash[1m]');
     expect(ids).toContain('models/gemini-3.5-flash');
+  });
+
+  it('normalizes context suffix case and the Google models prefix to one key', () => {
+    expect(normalizeRouteLookupId('sol[1M]')).toBe('sol');
+    expect(normalizeRouteLookupId('models/sol[1m]')).toBe('sol');
   });
 });
 

--- a/tests/http-proxy-index.test.ts
+++ b/tests/http-proxy-index.test.ts
@@ -3,8 +3,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import {
+  buildConfiguredHttpProxyOptions,
+  formatHttpProxyEnvironmentLines,
   formatHttpProxyModelLines,
   runHttpProxyServerCommand,
+  type LoadedHttpProxyRoutes,
 } from '../src/http-proxy/index.js';
 import type { ProxyRoute } from '../src/proxy.js';
 import { getInferenceRequestLogPath } from '../src/trace-log.js';
@@ -83,4 +86,61 @@ describe('HTTP proxy startup model list', () => {
       rmSync(home, { recursive: true, force: true });
     }
   }, 20_000);
+  it('reserves unavailable configured aliases in the production server options', () => {
+    const loaded: LoadedHttpProxyRoutes = {
+      routes: [],
+      aliases: [],
+      unavailable: [],
+      unsupported: [],
+      unavailableAliases: [{
+        name: 'missing-route',
+        providerId: 'openai',
+        modelId: 'missing-model',
+      }],
+      favoriteCount: 0,
+    };
+
+    expect(buildConfiguredHttpProxyOptions(
+      loaded,
+      17645,
+      false,
+      '/tmp/inference.jsonl',
+    )).toMatchObject({
+      host: '127.0.0.1',
+      port: 17645,
+      routes: [],
+      modelAliases: [],
+      reservedModelIds: ['missing-route'],
+      inferenceLogPath: '/tmp/inference.jsonl',
+    });
+  });
+
+  it('prints proxy env values with the merged non-Anthropic bypass list', () => {
+    const lines = formatHttpProxyEnvironmentLines({
+      port: 17645,
+      caCertPath: '/tmp/clodex-ca.pem',
+    }, {
+      NO_PROXY: 'localhost,api.anthropic.com',
+      no_proxy: 'corp.internal,*',
+    });
+
+    expect(lines).toEqual([
+      '  HTTPS_PROXY=http://127.0.0.1:17645',
+      '  HTTP_PROXY=http://127.0.0.1:17645',
+      '  NODE_EXTRA_CA_CERTS=/tmp/clodex-ca.pem',
+      '  NO_PROXY=localhost,corp.internal',
+      '  no_proxy=localhost,corp.internal',
+    ]);
+
+    expect(formatHttpProxyEnvironmentLines({
+      port: 17645,
+      caCertPath: '/tmp/clodex-ca.pem',
+    }, { NO_PROXY: '*' })).toEqual([
+      '  HTTPS_PROXY=http://127.0.0.1:17645',
+      '  HTTP_PROXY=http://127.0.0.1:17645',
+      '  NODE_EXTRA_CA_CERTS=/tmp/clodex-ca.pem',
+      '  NO_PROXY=',
+      '  no_proxy=',
+    ]);
+  });
 });

--- a/tests/http-proxy-server.test.ts
+++ b/tests/http-proxy-server.test.ts
@@ -530,6 +530,7 @@ describe('selective HTTP proxy', () => {
         routeId: 'clodex:groq:llama-3.3-70b',
         displayName: 'Llama 3.3 70B (Groq)',
       }],
+      reservedModelIds: ['missing-route'],
       adapterHandle: {
         port: adapterPort,
         token: 'adapter-local-token',
@@ -641,7 +642,8 @@ describe('selective HTTP proxy', () => {
 
       const typoBody = JSON.stringify({ model: 'clodex:groq:typo', messages: [] });
       const typoSocket = await connectMitm(proxy.port, certificates.caCert);
-      typoSocket.resume();
+      let typoResponse = '';
+      typoSocket.on('data', chunk => { typoResponse += chunk.toString(); });
       typoSocket.write([
         'POST /v1/messages HTTP/1.1',
         'Host: api.anthropic.com',
@@ -653,14 +655,58 @@ describe('selective HTTP proxy', () => {
         '',
       ].join('\r\n') + typoBody);
       await once(typoSocket, 'close');
-      expect(anthropicRequests).toBe(1);
-      expect(fallbackAuth).toBe('Bearer subscription-oauth-token');
+      expect(typoResponse).toContain('400 Bad Request');
+      expect(typoResponse).toContain('Clodex model route is unavailable');
+      expect(anthropicRequests).toBe(0);
+      expect(fallbackAuth).toBeUndefined();
       const inferenceEntries = readFileSync(inferenceLogPath, 'utf8').trim().split('\n').map(line => JSON.parse(line));
       expect(inferenceEntries.find(entry => !entry.event && entry.modelId === 'clodex:groq:typo')).toMatchObject({
         modelId: 'clodex:groq:typo',
-        provider: 'anthropic',
-        route: 'passthrough',
+        provider: 'groq',
+        route: 'translated',
       });
+      expect(inferenceEntries).toContainEqual(expect.objectContaining({
+        event: 'upstream_error',
+        modelId: 'clodex:groq:typo',
+        provider: 'groq',
+        route: 'translated',
+        statusCode: 400,
+      }));
+
+      const unavailableAliasBody = JSON.stringify({ model: 'missing-route', messages: [] });
+      const unavailableAliasSocket = await connectMitm(proxy.port, certificates.caCert);
+      let unavailableAliasResponse = '';
+      unavailableAliasSocket.on('data', chunk => { unavailableAliasResponse += chunk.toString(); });
+      unavailableAliasSocket.write([
+        'POST /v1/messages HTTP/1.1',
+        'Host: api.anthropic.com',
+        'Authorization: Bearer subscription-oauth-token',
+        'Content-Type: application/json',
+        `Content-Length: ${Buffer.byteLength(unavailableAliasBody)}`,
+        'Connection: close',
+        '',
+        '',
+      ].join('\r\n') + unavailableAliasBody);
+      await once(unavailableAliasSocket, 'close');
+      expect(unavailableAliasResponse).toContain('400 Bad Request');
+      expect(unavailableAliasResponse).toContain('Clodex model route is unavailable');
+      expect(anthropicRequests).toBe(0);
+      expect(fallbackAuth).toBeUndefined();
+      const unavailableAliasEntries = readFileSync(inferenceLogPath, 'utf8')
+        .trim()
+        .split('\n')
+        .map(line => JSON.parse(line));
+      expect(unavailableAliasEntries.find(entry => !entry.event && entry.modelId === 'missing-route')).toMatchObject({
+        provider: 'unknown',
+        route: 'translated',
+      });
+      expect(unavailableAliasEntries).toContainEqual(expect.objectContaining({
+        event: 'upstream_error',
+        modelId: 'missing-route',
+        provider: 'unknown',
+        route: 'translated',
+        statusCode: 400,
+      }));
     } finally {
       await proxy.close();
       await new Promise<void>(resolve => origin.close(() => resolve()));

--- a/tests/http-proxy-server.test.ts
+++ b/tests/http-proxy-server.test.ts
@@ -698,7 +698,9 @@ describe('selective HTTP proxy', () => {
         { model: 'missing-route[1m]', path: '/v1/messages' },
         { model: 'missing-route[1M]', path: '/v1/messages' },
         { model: 'models/missing-route[1m]', path: '/v1/messages' },
+        { model: 'models/clodex:test:unavailable-model[1M]', path: '/v1/messages' },
         { model: 'missing-route', path: '/v1/messages/count_tokens' },
+        { model: 'models/clodex:test:unavailable-model[1M]', path: '/v1/messages/count_tokens' },
       ];
       for (const testCase of rejectedCases) {
         const response = await requestMitm(

--- a/tests/http-proxy-server.test.ts
+++ b/tests/http-proxy-server.test.ts
@@ -290,6 +290,54 @@ describe('selective HTTP proxy', () => {
     }
   }, 20_000);
 
+  it('preserves compressed first-party request bytes, encoding, and auth', async () => {
+    const certificates = ensureHttpProxyCertificates();
+    let receivedBody = Buffer.alloc(0);
+    let receivedEncoding: string | undefined;
+    let receivedAuth: string | undefined;
+    const origin = https.createServer({
+      key: certificates.serverKey,
+      cert: certificates.serverCert,
+    }, async (req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', chunk => chunks.push(Buffer.from(chunk)));
+      await once(req, 'end');
+      receivedBody = Buffer.concat(chunks);
+      receivedEncoding = req.headers['content-encoding'];
+      receivedAuth = req.headers.authorization;
+      res.writeHead(200, { 'Content-Type': 'application/json', 'Connection': 'close' });
+      res.end('{}');
+    });
+    const originPort = await listen(origin);
+    const proxy = await startHttpProxy({
+      routes: [],
+      anthropicOrigin: `https://127.0.0.1:${originPort}`,
+      anthropicRejectUnauthorized: false,
+    });
+
+    try {
+      const compressedBody = gzipSync(Buffer.from(JSON.stringify({
+        model: 'claude-synthetic-1',
+        messages: [{ role: 'user', content: 'test request' }],
+      })));
+      const response = await requestMitm(
+        proxy.port,
+        certificates.caCert,
+        '/v1/messages',
+        compressedBody,
+        { 'Content-Encoding': 'gzip' },
+      );
+
+      expect(response).toContain('200 OK');
+      expect(receivedBody.equals(compressedBody)).toBe(true);
+      expect(receivedEncoding).toBe('gzip');
+      expect(receivedAuth).toBe('Bearer subscription-oauth-token');
+    } finally {
+      await proxy.close();
+      await new Promise<void>(resolve => origin.close(() => resolve()));
+    }
+  });
+
   it('logs Haiku passthrough status, error body, and system fallback preview', async () => {
     const certificates = ensureHttpProxyCertificates();
     const inferenceLogPath = join(testHome, 'haiku-error-inference.jsonl');

--- a/tests/http-proxy-server.test.ts
+++ b/tests/http-proxy-server.test.ts
@@ -42,6 +42,33 @@ async function connectMitm(proxyPort: number, ca: string): Promise<tls.TLSSocket
   return secure;
 }
 
+async function requestMitm(
+  proxyPort: number,
+  ca: string,
+  path: string,
+  body: string | Buffer,
+  headers: Record<string, string> = {},
+): Promise<string> {
+  const socket = await connectMitm(proxyPort, ca);
+  let response = '';
+  socket.on('data', chunk => { response += chunk.toString(); });
+  const payload = Buffer.isBuffer(body) ? body : Buffer.from(body);
+  socket.write([
+    `POST ${path} HTTP/1.1`,
+    'Host: api.anthropic.com',
+    'Authorization: Bearer subscription-oauth-token',
+    'Content-Type: application/json',
+    `Content-Length: ${payload.length}`,
+    'Connection: close',
+    ...Object.entries(headers).map(([name, value]) => `${name}: ${value}`),
+    '',
+    '',
+  ].join('\r\n'));
+  socket.write(payload);
+  await once(socket, 'close');
+  return response;
+}
+
 function activeProxySockets(proxyPort: number): net.Socket[] {
   const getActiveHandles = (process as typeof process & {
     _getActiveHandles(): unknown[];
@@ -640,73 +667,95 @@ describe('selective HTTP proxy', () => {
         route: 'translated',
       });
 
-      const typoBody = JSON.stringify({ model: 'clodex:groq:typo', messages: [] });
-      const typoSocket = await connectMitm(proxy.port, certificates.caCert);
-      let typoResponse = '';
-      typoSocket.on('data', chunk => { typoResponse += chunk.toString(); });
-      typoSocket.write([
-        'POST /v1/messages HTTP/1.1',
-        'Host: api.anthropic.com',
-        'Authorization: Bearer subscription-oauth-token',
-        'Content-Type: application/json',
-        `Content-Length: ${Buffer.byteLength(typoBody)}`,
-        'Connection: close',
-        '',
-        '',
-      ].join('\r\n') + typoBody);
-      await once(typoSocket, 'close');
-      expect(typoResponse).toContain('400 Bad Request');
-      expect(typoResponse).toContain('Clodex model route is unavailable');
-      expect(anthropicRequests).toBe(0);
-      expect(fallbackAuth).toBeUndefined();
-      const inferenceEntries = readFileSync(inferenceLogPath, 'utf8').trim().split('\n').map(line => JSON.parse(line));
-      expect(inferenceEntries.find(entry => !entry.event && entry.modelId === 'clodex:groq:typo')).toMatchObject({
-        modelId: 'clodex:groq:typo',
-        provider: 'groq',
-        route: 'translated',
+      const normalizedRouteBody = JSON.stringify({
+        model: 'clodex:groq:llama-3.3-70b[1M]',
+        messages: [],
+        stream: true,
       });
-      expect(inferenceEntries).toContainEqual(expect.objectContaining({
-        event: 'upstream_error',
-        modelId: 'clodex:groq:typo',
-        provider: 'groq',
-        route: 'translated',
-        statusCode: 400,
-      }));
+      const normalizedRouteResponse = await requestMitm(
+        proxy.port,
+        certificates.caCert,
+        '/v1/messages',
+        normalizedRouteBody,
+      );
+      expect(normalizedRouteResponse).toContain('200 OK');
+      expect(JSON.parse(adapterBody).model).toBe('clodex:groq:llama-3.3-70b[1M]');
 
-      const unavailableAliasBody = JSON.stringify({ model: 'missing-route', messages: [] });
-      const unavailableAliasSocket = await connectMitm(proxy.port, certificates.caCert);
-      let unavailableAliasResponse = '';
-      unavailableAliasSocket.on('data', chunk => { unavailableAliasResponse += chunk.toString(); });
-      unavailableAliasSocket.write([
-        'POST /v1/messages HTTP/1.1',
-        'Host: api.anthropic.com',
-        'Authorization: Bearer subscription-oauth-token',
-        'Content-Type: application/json',
-        `Content-Length: ${Buffer.byteLength(unavailableAliasBody)}`,
-        'Connection: close',
-        '',
-        '',
-      ].join('\r\n') + unavailableAliasBody);
-      await once(unavailableAliasSocket, 'close');
-      expect(unavailableAliasResponse).toContain('400 Bad Request');
-      expect(unavailableAliasResponse).toContain('Clodex model route is unavailable');
+      const compressedRouteBody = JSON.stringify({ model: 'llama', messages: [], stream: true });
+      const compressedRouteResponse = await requestMitm(
+        proxy.port,
+        certificates.caCert,
+        '/v1/messages',
+        gzipSync(Buffer.from(compressedRouteBody)),
+        { 'Content-Encoding': 'gzip' },
+      );
+      expect(compressedRouteResponse).toContain('200 OK');
+      expect(JSON.parse(adapterBody).model).toBe('llama');
+
+      const rejectedCases = [
+        { model: 'clodex:groq:typo', path: '/v1/messages' },
+        { model: 'missing-route', path: '/v1/messages' },
+        { model: 'missing-route[1m]', path: '/v1/messages' },
+        { model: 'missing-route[1M]', path: '/v1/messages' },
+        { model: 'models/missing-route[1m]', path: '/v1/messages' },
+        { model: 'missing-route', path: '/v1/messages/count_tokens' },
+      ];
+      for (const testCase of rejectedCases) {
+        const response = await requestMitm(
+          proxy.port,
+          certificates.caCert,
+          testCase.path,
+          JSON.stringify({ model: testCase.model, messages: [] }),
+        );
+        expect(response, `${testCase.path} ${testCase.model}`).toContain('400 Bad Request');
+        expect(response).toContain('invalid_request_error');
+        expect(response).toContain('clodex models --list');
+        expect(response).toContain('clodex patch');
+      }
+
+      const compressedUnavailableBody = JSON.stringify({ model: 'missing-route', messages: [] });
+      const compressedUnavailableResponse = await requestMitm(
+        proxy.port,
+        certificates.caCert,
+        '/v1/messages',
+        gzipSync(Buffer.from(compressedUnavailableBody)),
+        { 'Content-Encoding': 'gzip' },
+      );
+      expect(compressedUnavailableResponse).toContain('400 Bad Request');
+      expect(compressedUnavailableResponse).toContain('invalid_request_error');
+
+      const unreadableCompressedResponse = await requestMitm(
+        proxy.port,
+        certificates.caCert,
+        '/v1/messages',
+        Buffer.from('not-a-gzip-stream'),
+        { 'Content-Encoding': 'gzip' },
+      );
+      expect(unreadableCompressedResponse).toContain('400 Bad Request');
+      expect(unreadableCompressedResponse).toContain('Unable to inspect compressed request body');
       expect(anthropicRequests).toBe(0);
       expect(fallbackAuth).toBeUndefined();
+
       const unavailableAliasEntries = readFileSync(inferenceLogPath, 'utf8')
         .trim()
         .split('\n')
         .map(line => JSON.parse(line));
-      expect(unavailableAliasEntries.find(entry => !entry.event && entry.modelId === 'missing-route')).toMatchObject({
-        provider: 'unknown',
-        route: 'translated',
-      });
       expect(unavailableAliasEntries).toContainEqual(expect.objectContaining({
-        event: 'upstream_error',
+        event: 'route_unavailable',
         modelId: 'missing-route',
-        provider: 'unknown',
-        route: 'translated',
         statusCode: 400,
       }));
+      expect(unavailableAliasEntries).not.toContainEqual(expect.objectContaining({
+        event: 'upstream_error',
+        modelId: 'missing-route',
+      }));
+      for (const testCase of rejectedCases.filter(item => item.path === '/v1/messages')) {
+        expect(unavailableAliasEntries).not.toContainEqual(expect.objectContaining({
+          modelId: testCase.model,
+          provider: expect.any(String),
+          route: expect.any(String),
+        }));
+      }
     } finally {
       await proxy.close();
       await new Promise<void>(resolve => origin.close(() => resolve()));

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -5,8 +5,10 @@ import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { aliasModelId, startProxy, startProxyCatalog, type ProxyRoute } from '../src/proxy.js';
+import { makeRouteResolver, resolveCatalogModelAliases } from '../src/catalog.js';
 import { getProxyDebugLogPath } from '../src/trace-log.js';
 import { anthropicMessagesEndpoint, estimateAnthropicInputTokens } from '../src/anthropic-endpoints.js';
+import type { LocalProvider, ModelAlias } from '../src/types.js';
 
 /** POST JSON to a local proxy via node:http (avoids vi.stubGlobal('fetch') interception). */
 function postToProxy(
@@ -345,7 +347,7 @@ describe('catalog model aliases', () => {
 
   it('routes alias names to their target route without rewriting the requested model id', async () => {
     const defaultRoute: ProxyRoute = {
-      aliasId: 'clodex:test:default-model',
+      aliasId: 'anthropic-test-provider__default-model',
       realModelId: 'default-model',
       displayName: 'Default Model',
       upstreamUrl: '',
@@ -354,29 +356,48 @@ describe('catalog model aliases', () => {
       npm: 'missing-sdk-provider-that-must-not-load',
       providerId: 'test-provider',
     };
-    const aliasTarget: ProxyRoute = {
-      aliasId: 'clodex:openai-oauth:gpt-5.6-sol[1m]',
-      realModelId: 'gpt-5.6-sol',
-      displayName: 'GPT-5.6 Sol',
-      upstreamUrl: 'https://upstream-sol.example',
+    const providers: LocalProvider[] = [{
+      id: 'test-provider',
+      name: 'Test Provider',
       apiKey: 'provider-key',
-      modelFormat: 'anthropic',
-      providerId: 'openai-oauth',
-    };
+      models: [{
+        id: 'solver-v1',
+        name: 'Solver V1',
+        family: 'test',
+        brand: 'Other',
+        modelFormat: 'anthropic',
+        upstreamModelId: 'solver-v1',
+        baseUrl: 'https://upstream-solver.example',
+        contextWindow: 1_000_000,
+      }],
+    }];
+    const savedAliases: ModelAlias[] = [{
+      name: 'sol',
+      providerId: 'test-provider',
+      modelId: 'solver-v1',
+    }];
+    const resolveRoute = makeRouteResolver(providers);
+    const aliasTarget = resolveRoute('test-provider', 'solver-v1');
+    const modelAliases = resolveCatalogModelAliases(savedAliases, resolveRoute);
+    expect(aliasTarget?.aliasId).toBe('anthropic-test-provider__solver-v1[1m]');
+    expect(modelAliases).toEqual([{
+      name: 'sol',
+      routeId: 'anthropic-test-provider__solver-v1[1m]',
+    }]);
     const fetchMock = vi.fn(async () => new Response(
-      JSON.stringify({ id: 'msg_1', type: 'message', role: 'assistant', model: 'gpt-5.6-sol', content: [], usage: { input_tokens: 1, output_tokens: 1 } }),
+      JSON.stringify({ id: 'msg_1', type: 'message', role: 'assistant', model: 'solver-v1', content: [], usage: { input_tokens: 1, output_tokens: 1 } }),
       { status: 200, headers: { 'Content-Type': 'application/json' } },
     ));
     vi.stubGlobal('fetch', fetchMock);
 
     const handle = await startProxyCatalog(
-      [defaultRoute, aliasTarget],
+      [defaultRoute, aliasTarget!],
       defaultRoute.aliasId,
       false,
       undefined,
       undefined,
       undefined,
-      [{ name: 'sol', routeId: 'clodex:openai-oauth:gpt-5.6-sol' }],
+      modelAliases,
     );
 
     try {
@@ -391,8 +412,8 @@ describe('catalog model aliases', () => {
       expect(res.status).toBe(200);
       expect(fetchMock).toHaveBeenCalledOnce();
       const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
-      expect(String(url)).toContain('upstream-sol.example');
-      expect(JSON.parse(init.body as string).model).toBe('gpt-5.6-sol');
+      expect(String(url)).toContain('upstream-solver.example');
+      expect(JSON.parse(init.body as string).model).toBe('solver-v1');
 
       // GET /v1/models/<alias> resolves too
       const modelLookup = await new Promise<number>((resolve, reject) => {

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -1,9 +1,11 @@
 // tests/proxy.test.ts
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import http from 'node:http';
+import { EventEmitter } from 'node:events';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { Readable } from 'node:stream';
 import { aliasModelId, startProxy, startProxyCatalog, type ProxyRoute } from '../src/proxy.js';
 import { getProxyDebugLogPath } from '../src/trace-log.js';
 import { anthropicMessagesEndpoint, estimateAnthropicInputTokens } from '../src/anthropic-endpoints.js';
@@ -250,6 +252,103 @@ describe('SDK anonymous route handling', () => {
 });
 
 describe('catalog model aliases', () => {
+  it('rejects unresolved configured model ids without using the default route', async () => {
+    let requestHandler: ((req: any, res: any) => Promise<void>) | undefined;
+    const fakeServer = Object.assign(new EventEmitter(), {
+      listen: (_port: number, _host: string, onListening: () => void) => {
+        queueMicrotask(onListening);
+        return fakeServer;
+      },
+      address: () => ({ address: '127.0.0.1', family: 'IPv4', port: 43001 }),
+      close: () => fakeServer,
+    });
+    vi.resetModules();
+    vi.doMock('node:http', async () => {
+      const actual = await vi.importActual<typeof import('node:http')>('node:http');
+      return {
+        ...actual,
+        createServer: (handler: typeof requestHandler) => {
+          requestHandler = handler;
+          return fakeServer;
+        },
+      };
+    });
+    const { startProxyCatalog: startIsolatedProxyCatalog } = await import('../src/proxy.js');
+    const route: ProxyRoute = {
+      aliasId: 'clodex:test:default-model',
+      realModelId: 'default-model',
+      displayName: 'Default Model',
+      upstreamUrl: 'https://default.example',
+      apiKey: 'provider-key',
+      modelFormat: 'anthropic',
+      providerId: 'test-provider',
+    };
+    const fetchMock = vi.fn(async () => new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const handle = await startIsolatedProxyCatalog(
+      [route],
+      route.aliasId,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      [{ name: 'missing-route', routeId: 'clodex:test:not-a-route' }],
+    );
+
+    try {
+      const invoke = async (model: string) => {
+        const payload = JSON.stringify({
+          model,
+          max_tokens: 100,
+          messages: [{ role: 'user', content: 'hi' }],
+          stream: false,
+        });
+        const req = Readable.from([Buffer.from(payload)]) as any;
+        req.method = 'POST';
+        req.url = '/v1/messages';
+        req.headers = { authorization: `Bearer ${handle.token}` };
+        const res = Object.assign(new EventEmitter(), {
+          statusCode: 0,
+          body: '',
+          headersSent: false,
+          writableFinished: false,
+          writeHead(status: number) {
+            this.statusCode = status;
+            this.headersSent = true;
+            return this;
+          },
+          end(chunk = '') {
+            this.body += String(chunk);
+            this.writableFinished = true;
+            return this;
+          },
+        });
+
+        expect(requestHandler).toBeDefined();
+        await requestHandler!(req, res);
+        return res;
+      };
+
+      const canonicalResponse = await invoke('clodex:test:unavailable-model');
+      expect(canonicalResponse.statusCode).toBe(400);
+      expect(fetchMock).not.toHaveBeenCalled();
+
+      const aliasResponse = await invoke('missing-route');
+      expect(aliasResponse.statusCode).toBe(400);
+      expect(fetchMock).not.toHaveBeenCalled();
+
+      const suffixedAliasResponse = await invoke('missing-route[1m]');
+      expect(suffixedAliasResponse.statusCode).toBe(400);
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      handle.close();
+      vi.unstubAllGlobals();
+      vi.doUnmock('node:http');
+      vi.resetModules();
+    }
+  });
+
   it('routes alias names to their target route without rewriting the requested model id', async () => {
     const defaultRoute: ProxyRoute = {
       aliasId: 'clodex:test:default-model',

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -250,6 +250,10 @@ describe('SDK anonymous route handling', () => {
 });
 
 describe('catalog model aliases', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('rejects unresolved configured model ids without using the default route', async () => {
     const route: ProxyRoute = {
       aliasId: 'clodex:test:default-model',

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -284,7 +284,9 @@ describe('catalog model aliases', () => {
         { model: 'missing-route[1m]', path: '/v1/messages' },
         { model: 'missing-route[1M]', path: '/v1/messages' },
         { model: 'models/missing-route[1m]', path: '/v1/messages' },
+        { model: 'models/clodex:test:unavailable-model[1M]', path: '/v1/messages' },
         { model: 'missing-route', path: '/v1/messages/count_tokens' },
+        { model: 'models/clodex:test:unavailable-model[1M]', path: '/v1/messages/count_tokens' },
       ]) {
         const response = await postToProxy(handle.port, handle.token, {
           model: testCase.model,

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -1,11 +1,9 @@
 // tests/proxy.test.ts
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import http from 'node:http';
-import { EventEmitter } from 'node:events';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { Readable } from 'node:stream';
 import { aliasModelId, startProxy, startProxyCatalog, type ProxyRoute } from '../src/proxy.js';
 import { getProxyDebugLogPath } from '../src/trace-log.js';
 import { anthropicMessagesEndpoint, estimateAnthropicInputTokens } from '../src/anthropic-endpoints.js';
@@ -253,27 +251,6 @@ describe('SDK anonymous route handling', () => {
 
 describe('catalog model aliases', () => {
   it('rejects unresolved configured model ids without using the default route', async () => {
-    let requestHandler: ((req: any, res: any) => Promise<void>) | undefined;
-    const fakeServer = Object.assign(new EventEmitter(), {
-      listen: (_port: number, _host: string, onListening: () => void) => {
-        queueMicrotask(onListening);
-        return fakeServer;
-      },
-      address: () => ({ address: '127.0.0.1', family: 'IPv4', port: 43001 }),
-      close: () => fakeServer,
-    });
-    vi.resetModules();
-    vi.doMock('node:http', async () => {
-      const actual = await vi.importActual<typeof import('node:http')>('node:http');
-      return {
-        ...actual,
-        createServer: (handler: typeof requestHandler) => {
-          requestHandler = handler;
-          return fakeServer;
-        },
-      };
-    });
-    const { startProxyCatalog: startIsolatedProxyCatalog } = await import('../src/proxy.js');
     const route: ProxyRoute = {
       aliasId: 'clodex:test:default-model',
       realModelId: 'default-model',
@@ -286,7 +263,7 @@ describe('catalog model aliases', () => {
     const fetchMock = vi.fn(async () => new Response('{}', { status: 200 }));
     vi.stubGlobal('fetch', fetchMock);
 
-    const handle = await startIsolatedProxyCatalog(
+    const handle = await startProxyCatalog(
       [route],
       route.aliasId,
       false,
@@ -297,55 +274,66 @@ describe('catalog model aliases', () => {
     );
 
     try {
-      const invoke = async (model: string) => {
-        const payload = JSON.stringify({
-          model,
+      for (const testCase of [
+        { model: 'clodex:test:unavailable-model', path: '/v1/messages' },
+        { model: 'missing-route', path: '/v1/messages' },
+        { model: 'missing-route[1m]', path: '/v1/messages' },
+        { model: 'missing-route[1M]', path: '/v1/messages' },
+        { model: 'models/missing-route[1m]', path: '/v1/messages' },
+        { model: 'missing-route', path: '/v1/messages/count_tokens' },
+      ]) {
+        const response = await postToProxy(handle.port, handle.token, {
+          model: testCase.model,
           max_tokens: 100,
           messages: [{ role: 'user', content: 'hi' }],
           stream: false,
-        });
-        const req = Readable.from([Buffer.from(payload)]) as any;
-        req.method = 'POST';
-        req.url = '/v1/messages';
-        req.headers = { authorization: `Bearer ${handle.token}` };
-        const res = Object.assign(new EventEmitter(), {
-          statusCode: 0,
-          body: '',
-          headersSent: false,
-          writableFinished: false,
-          writeHead(status: number) {
-            this.statusCode = status;
-            this.headersSent = true;
-            return this;
-          },
-          end(chunk = '') {
-            this.body += String(chunk);
-            this.writableFinished = true;
-            return this;
+        }, undefined, testCase.path);
+
+        expect(response.status, `${testCase.path} ${testCase.model}`).toBe(400);
+        expect(JSON.parse(response.body)).toEqual({
+          type: 'error',
+          error: {
+            type: 'invalid_request_error',
+            message: `Clodex model route '${testCase.model}' is unavailable. Run \`clodex models --list\` to see available routes, or \`clodex patch\` to refresh saved aliases.`,
           },
         });
-
-        expect(requestHandler).toBeDefined();
-        await requestHandler!(req, res);
-        return res;
-      };
-
-      const canonicalResponse = await invoke('clodex:test:unavailable-model');
-      expect(canonicalResponse.statusCode).toBe(400);
-      expect(fetchMock).not.toHaveBeenCalled();
-
-      const aliasResponse = await invoke('missing-route');
-      expect(aliasResponse.statusCode).toBe(400);
-      expect(fetchMock).not.toHaveBeenCalled();
-
-      const suffixedAliasResponse = await invoke('missing-route[1m]');
-      expect(suffixedAliasResponse.statusCode).toBe(400);
+      }
       expect(fetchMock).not.toHaveBeenCalled();
     } finally {
       handle.close();
       vi.unstubAllGlobals();
-      vi.doUnmock('node:http');
-      vi.resetModules();
+    }
+  });
+
+  it('rejects unresolved canonical ids when model aliases are not configured', async () => {
+    const route: ProxyRoute = {
+      aliasId: 'clodex:test:default-model',
+      realModelId: 'default-model',
+      displayName: 'Default Model',
+      upstreamUrl: 'https://default.example',
+      apiKey: 'provider-key',
+      modelFormat: 'anthropic',
+      providerId: 'test-provider',
+    };
+    const fetchMock = vi.fn(async () => new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const handle = await startProxyCatalog([route], route.aliasId, false);
+
+    try {
+      for (const path of ['/v1/messages', '/v1/messages/count_tokens']) {
+        const response = await postToProxy(handle.port, handle.token, {
+          model: 'clodex:test:unavailable-model',
+          max_tokens: 100,
+          messages: [{ role: 'user', content: 'hi' }],
+          stream: false,
+        }, undefined, path);
+        expect(response.status).toBe(400);
+        expect(JSON.parse(response.body).error.type).toBe('invalid_request_error');
+      }
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      handle.close();
+      vi.unstubAllGlobals();
     }
   });
 
@@ -361,7 +349,7 @@ describe('catalog model aliases', () => {
       providerId: 'test-provider',
     };
     const aliasTarget: ProxyRoute = {
-      aliasId: 'clodex:openai-oauth:gpt-5.6-sol',
+      aliasId: 'clodex:openai-oauth:gpt-5.6-sol[1m]',
       realModelId: 'gpt-5.6-sol',
       displayName: 'GPT-5.6 Sol',
       upstreamUrl: 'https://upstream-sol.example',
@@ -382,7 +370,7 @@ describe('catalog model aliases', () => {
       undefined,
       undefined,
       undefined,
-      [{ name: 'sol', routeId: aliasTarget.aliasId }],
+      [{ name: 'sol', routeId: 'clodex:openai-oauth:gpt-5.6-sol' }],
     );
 
     try {

--- a/tests/trace-log.test.ts
+++ b/tests/trace-log.test.ts
@@ -10,6 +10,7 @@ import {
   redactTraceLog,
   registerTraceSecret,
   writeInferenceRequestLog,
+  writeInferenceRouteUnavailableLog,
   writeInferenceResponseLifecycleLog,
   writeInferenceResponseErrorLog,
   writeProxyLifecycleLog,
@@ -282,6 +283,30 @@ describe('inference request log', () => {
     } finally {
       if (previous === undefined) delete process.env['CLODEX_LOG_REQUEST_PREVIEW'];
       else process.env['CLODEX_LOG_REQUEST_PREVIEW'] = previous;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('records local route rejection without upstream attribution', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'clodex-route-unavailable-'));
+    const path = join(dir, 'requests.jsonl');
+    try {
+      writeInferenceRouteUnavailableLog(path, {
+        requestId: 'request-1',
+        modelId: 'missing-route',
+        statusCode: 400,
+      });
+
+      const entry = JSON.parse(readFileSync(path, 'utf8').trim());
+      expect(entry).toMatchObject({
+        event: 'route_unavailable',
+        requestId: 'request-1',
+        modelId: 'missing-route',
+        statusCode: 400,
+      });
+      expect(entry).not.toHaveProperty('provider');
+      expect(entry).not.toHaveProperty('route');
+    } finally {
       rmSync(dir, { recursive: true, force: true });
     }
   });

--- a/tests/wrapper-env.test.ts
+++ b/tests/wrapper-env.test.ts
@@ -58,6 +58,24 @@ describe('computeWrapperEnv', () => {
     expect(env['no_proxy']).toBe('localhost,.internal.example');
   });
 
+  it('merges uppercase and lowercase bypass lists before filtering', () => {
+    const state: ServerRuntimeState = {
+      mode: 'proxy',
+      port: 17645,
+      pid: process.pid,
+      caPath: '/home/u/.clodex/http-proxy/clodex-ca.pem',
+      startedAt: '2026-07-20T00:00:00.000Z',
+    };
+    const env = computeWrapperEnv({
+      ...baseEnv,
+      NO_PROXY: 'localhost,api.anthropic.com',
+      no_proxy: 'corp.internal,.anthropic.com',
+    }, state);
+
+    expect(env['NO_PROXY']).toBe('localhost,corp.internal');
+    expect(env['no_proxy']).toBe('localhost,corp.internal');
+  });
+
   it('endpoint-mode server: points ANTHROPIC_BASE_URL at the gateway and clears proxy vars', () => {
     const state: ServerRuntimeState = {
       mode: 'endpoint',

--- a/tests/wrapper-env.test.ts
+++ b/tests/wrapper-env.test.ts
@@ -41,6 +41,23 @@ describe('computeWrapperEnv', () => {
     expect(env['PATH']).toBe('/usr/bin');
   });
 
+  it('proxy-mode server removes Anthropic bypasses while preserving unrelated hosts', () => {
+    const state: ServerRuntimeState = {
+      mode: 'proxy',
+      port: 17645,
+      pid: process.pid,
+      caPath: '/home/u/.clodex/http-proxy/clodex-ca.pem',
+      startedAt: '2026-07-20T00:00:00.000Z',
+    };
+    const env = computeWrapperEnv({
+      ...baseEnv,
+      NO_PROXY: 'localhost,api.anthropic.com,.anthropic.com,.internal.example,*',
+    }, state);
+
+    expect(env['NO_PROXY']).toBe('localhost,.internal.example');
+    expect(env['no_proxy']).toBe('localhost,.internal.example');
+  });
+
   it('endpoint-mode server: points ANTHROPIC_BASE_URL at the gateway and clears proxy vars', () => {
     const state: ServerRuntimeState = {
       mode: 'endpoint',


### PR DESCRIPTION
## Summary

- resolve saved endpoint aliases through the real catalog route identifier
- retain unavailable alias targets in the reserved namespace so they fail closed
- canonicalize configured and requested route identifiers across context suffixes and provider prefixes
- inspect supported compressed request bodies before selective routing and reject unreadable compressed input locally
- preserve compressed first-party payload bytes, encoding, and authentication during pass-through
- reject unavailable configured routes before default or first-party forwarding with one recovery message
- record local route rejection without upstream provider attribution
- merge uppercase and lowercase proxy bypass lists without dropping existing entries

## Routing guarantees

- available short aliases reach their configured catalog route
- unavailable aliases cannot fall through to the default route
- unavailable canonical identifiers cannot pass through with client credentials
- supported canonical variants resolve to the configured route
- messages and token-count endpoints enforce the same reservation boundary
- unrelated proxy bypass entries survive environment merging

## Test plan

- [x] production route-resolution wiring regression
- [x] compressed pass-through byte-equality regression
- [x] focused endpoint and selective-proxy regressions
- [x] complete suite: 79 files and 888 tests
- [x] type checking
- [x] production build
- [x] diff hygiene
- [x] secret scan
