### PR TITLE
fix(transport): terminate rejected connection upgrades

### DIFF
--- a/src/oauth/responses-websocket.ts
+++ b/src/oauth/responses-websocket.ts
@@ -12,6 +12,7 @@ import type { FetchFunction } from '@ai-sdk/provider-utils';
 import type { RawData, WebSocket as WsWebSocket } from 'ws';
 import { CODEX_RESPONSES_WEBSOCKETS_BETA } from '../constants.js';
 import { outboundWsProxyAgent } from '../outbound-proxy.js';
+import { anthropicErrorType } from '../upstream-error.js';
 
 const RESPONSES_LITE_HEADER = 'x-openai-internal-codex-responses-lite';
 const TERMINAL_EVENT_TYPES = new Set(['response.completed', 'response.failed', 'response.incomplete']);
@@ -801,6 +802,7 @@ function failContext(
   ctx: RequestContext,
   message: string,
   diagnosticDetails: Record<string, unknown>,
+  statusCode?: number,
 ): void {
   if (ctx.closed || entry.current !== ctx) return;
   entry.debug(`fail: ${message}`);
@@ -809,7 +811,16 @@ function failContext(
     ...diagnosticTextFingerprint('errorMessage', message),
   });
   flushPending(ctx);
-  encodeSse(ctx, { type: 'error', error: { message } });
+  encodeSse(ctx, {
+    type: 'error',
+    sequence_number: ctx.frameCount,
+    error: {
+      type: statusCode === undefined ? 'transport_error' : anthropicErrorType(statusCode),
+      code: statusCode === undefined ? 'websocket_transport_error' : String(statusCode),
+      message,
+      param: null,
+    },
+  });
   deleteEntry(entry);
   closeContext(ctx);
 }
@@ -1039,13 +1050,17 @@ function createConnection(
     if (ctx && !ctx.closed) sendContext(entry, ctx);
   });
   socket.on('unexpected-response', (_request, response) => {
-    debug(`unexpected-response status=${response.statusCode}`);
+    const statusCode = response.statusCode ?? 502;
+    debug(`unexpected-response status=${statusCode}`);
+    response.resume();
     const ctx = entry.current;
     if (ctx && !ctx.closed) {
-      emitResponseErrorDiagnostic(entry, ctx, {
+      failContext(entry, ctx, `WebSocket upgrade failed (HTTP ${statusCode})`, {
         source: 'unexpected_response',
-        httpStatusCode: response.statusCode,
-      });
+        httpStatusCode: statusCode,
+      }, statusCode);
+    } else {
+      deleteEntry(entry);
     }
   });
   socket.on('message', (data: RawData) => handleSocketMessage(entry, data));

--- a/src/sdk-adapter.ts
+++ b/src/sdk-adapter.ts
@@ -930,6 +930,11 @@ export async function generateAnthropicResponse(
         if (abortSignal.aborted || part.type === 'abort') {
           throw streamAbortError(abortSignal);
         }
+        if (part.type === 'error') {
+          throw part.error instanceof Error || (part.error && typeof part.error === 'object')
+            ? part.error
+            : new Error(typeof part.error === 'string' ? part.error : 'Upstream stream failed');
+        }
         if (part.type === 'text-delta') streamedText.push(part.text ?? '');
         else if (part.type === 'tool-call') {
           streamedToolCalls.push({

--- a/tests/responses-websocket.test.ts
+++ b/tests/responses-websocket.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EventEmitter } from 'node:events';
+import { createOpenAI } from '@ai-sdk/openai';
+import { streamText } from 'ai';
 
 // Fake `ws` WebSocket that records constructor args and lets tests drive events.
 const { fakeSockets } = vi.hoisted(() => ({ fakeSockets: [] as FakeWebSocket[] }));
@@ -27,6 +29,7 @@ import {
   withResponsesWebSocketDiagnosticContext,
   type ResponsesWebSocketDiagnosticEvent,
 } from '../src/oauth/responses-websocket.js';
+import { sdkUpstreamErrorDetails } from '../src/upstream-error.js';
 
 const WS_URL = 'wss://chatgpt.com/backend-api/codex/responses';
 
@@ -219,8 +222,16 @@ describe('createResponsesWebSocketFetch', () => {
     const error = Object.assign(new Error('secret socket failure'), { code: 'ECONNRESET' });
     socket.emit('error', error);
     const body = await readAll(res);
-    expect(body).toContain('"type":"error"');
-    expect(body).toContain('secret socket failure');
+    expect(JSON.parse(body.replace(/^data: /, '').trim())).toEqual({
+      type: 'error',
+      sequence_number: 0,
+      error: {
+        type: 'transport_error',
+        code: 'websocket_transport_error',
+        message: 'secret socket failure',
+        param: null,
+      },
+    });
     expect(diagnostics).toContainEqual(expect.objectContaining({
       event: 'ws_response_error',
       requestId: 'req-socket-error',
@@ -234,6 +245,104 @@ describe('createResponsesWebSocketFetch', () => {
       errorMessageHash: expect.stringMatching(/^[a-f0-9]{16}$/),
     }));
     expect(JSON.stringify(diagnostics)).not.toContain('secret socket failure');
+  });
+
+  it('terminates an unexpected HTTP upgrade response with a schema-valid stream error', async () => {
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
+      onDiagnostic: event => diagnostics.push(event),
+    });
+    const res = await withResponsesWebSocketDiagnosticContext(
+      { requestId: 'req-upgrade-401' },
+      () => wsFetch('https://x', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer private-rejected-token' },
+        body: JSON.stringify(
+          sessionPayload([
+            {
+              role: 'user',
+              content: [{ type: 'input_text', text: 'private request body' }],
+            },
+          ]),
+        ),
+      }),
+    );
+    const socket = lastSocket();
+    const resume = vi.fn();
+    socket.emit(
+      'unexpected-response',
+      {},
+      {
+        statusCode: 401,
+        statusMessage: 'private response status',
+        headers: { 'x-private': 'private response header' },
+        resume,
+      },
+    );
+
+    const body = await readAll(res);
+    const frame = JSON.parse(body.replace(/^data: /, '').trim());
+    expect(frame).toEqual({
+      type: 'error',
+      sequence_number: 0,
+      error: {
+        type: 'authentication_error',
+        code: '401',
+        message: 'WebSocket upgrade failed (HTTP 401)',
+        param: null,
+      },
+    });
+    const provider = createOpenAI({
+      apiKey: 'test-only',
+      fetch: async () => new Response(body, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      }),
+    });
+    const streamed = streamText({
+      model: provider.responses('gpt-5.6-sol'),
+      prompt: 'test',
+      onError: () => {},
+    });
+    let upstreamError: unknown;
+    for await (const part of streamed.stream) {
+      if (part.type === 'error') upstreamError = part.error;
+    }
+    expect(sdkUpstreamErrorDetails(upstreamError)?.statusCode).toBe(401);
+    expect(resume).toHaveBeenCalledOnce();
+    expect(socket.close).toHaveBeenCalledOnce();
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({
+        event: 'ws_response_error',
+        requestId: 'req-upgrade-401',
+        source: 'unexpected_response',
+        httpStatusCode: 401,
+        emittedModelData: false,
+      }),
+    );
+    const serialized = JSON.stringify(diagnostics);
+    expect(serialized).not.toContain('private-rejected-token');
+    expect(serialized).not.toContain('private request body');
+    expect(serialized).not.toContain('private response status');
+    expect(serialized).not.toContain('private response header');
+
+    const next = await wsFetch('https://x', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer private-rejected-token' },
+      body: JSON.stringify(
+        sessionPayload([
+          {
+            role: 'user',
+            content: [{ type: 'input_text', text: 'replacement request' }],
+          },
+        ]),
+      ),
+    });
+    expect(fakeSockets).toHaveLength(2);
+    const replacement = lastSocket();
+    replacement.emit('open');
+    emitTextResponse(replacement, 'resp_after_401', 'recovered');
+    await readAll(next);
   });
 
   it('logs sanitized upstream response failure details after partial output', async () => {

--- a/tests/sdk-adapter.test.ts
+++ b/tests/sdk-adapter.test.ts
@@ -532,6 +532,34 @@ describe('generateAnthropicResponse', () => {
     vi.resetModules();
   });
 
+  it('forceStream propagates an SDK error part with its upstream status', async () => {
+    vi.resetModules();
+    const upstreamError = { statusCode: 401, message: 'Unauthorized' };
+    async function* stream() {
+      yield { type: 'start' };
+      yield { type: 'text-delta', text: 'partial' };
+      yield { type: 'error', error: upstreamError };
+    }
+    const streamText = vi.fn(() => ({ stream: stream() }));
+    vi.doMock('ai', () => ({
+      generateText: vi.fn(),
+      streamText,
+      tool: vi.fn((spec: unknown) => spec),
+      jsonSchema: vi.fn((schema: unknown) => schema),
+    }));
+
+    const { generateAnthropicResponse } = await import('../src/sdk-adapter.js');
+    await expect(generateAnthropicResponse(
+      {} as never,
+      { messages: [] },
+      'gpt-5.6-sol',
+      { forceStream: true },
+    )).rejects.toBe(upstreamError);
+
+    vi.doUnmock('ai');
+    vi.resetModules();
+  });
+
   it('forceStream propagates an SDK abort even when lifecycle observation is disabled', async () => {
     vi.resetModules();
     const abort = new AbortController();


### PR DESCRIPTION
## Summary

- Convert rejected connection upgrades into status-aware terminal stream errors.
- Drain rejected responses and discard failed connections so clients do not hang or reuse them.
- Preserve structured upstream errors through forced streaming.

## Test plan

- [x] Focused transport and stream tests: 89 passed.
- [x] Isolated non-listener suite: 571 passed.
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] Staged and committed secret scans

