### PR TITLE
feat(wrapper): add opt-in readiness enforcement

### DIFF
--- a/docs/background-agents.md
+++ b/docs/background-agents.md
@@ -12,6 +12,7 @@ This page explains how to bridge **every** Claude Code process on your machine �
   - **no live server: env untouched** — `claude` always launches normally, a stopped server never breaks anything.
 - Setting **`CLAUDE_CODE_PROCESS_WRAPPER`** to `clodex-claude` makes Claude Code invoke it as `clodex-claude <claude-binary-path> <args...>` for every process it spawns — agents view sessions and background agents are bridged automatically.
 - For your own terminal sessions, run **`clodex-claude`** instead of `claude` — same auto-discovery, no port or CA path to hardcode anywhere.
+- Set **`CLODEX_REQUIRE_SERVER=1`** in an isolated routed profile when bypassing Clodex must be impossible. `clodex-claude` then exits with an error if no advertised server passes its process and TCP checks. The default remains fail-open for ordinary installations.
 
 ## Setup steps
 
@@ -79,10 +80,14 @@ This page explains how to bridge **every** Claude Code process on your machine �
 
 Port and CA discovery are automatic via `~/.clodex/server-runtime.json` — do not hardcode `HTTPS_PROXY`, ports, or certificate paths in your profile.
 
+For service-manager readiness checks, `clodex-claude --check` exits `0` when an
+advertised server passes the process and TCP checks, and exits `1` otherwise.
+It does not launch Claude.
+
 ## Troubleshooting
 
 - **Is my session bridged?** In a session started via `clodex-claude` (or spawned by Claude Code with the wrapper set), `/model` accepts your `clodex:` model names and aliases (run `clodex models --list` to see them). If those models are rejected and you haven't run `clodex patch`, that's expected for unpatched binaries — but a bridged session still routes them; an unbridged one errors at the API instead.
-- **Server not running:** `clodex-claude` silently launches plain `claude`. Check `cat ~/.clodex/server-runtime.json` — a missing file (or records whose `pid` is no longer alive) means no server is advertised; start `clodex server --proxy`. If a server is running but absent from the file, make sure it was not started with `--no-discovery` / `CLODEX_NO_DISCOVERY=1`.
+- **Server not running:** `clodex-claude` launches plain `claude` by default. With `CLODEX_REQUIRE_SERVER=1`, it exits instead. Check `cat ~/.clodex/server-runtime.json` — a missing file (or records whose `pid` is no longer alive) means no server is advertised; start `clodex server --proxy`. If a server is running but absent from the file, make sure it was not started with `--no-discovery` / `CLODEX_NO_DISCOVERY=1`.
 - **Wrapper variable empty or stale:** run `echo "$CLAUDE_CODE_PROCESS_WRAPPER"` in a **new login shell**. If it is empty, a `$(command -v ...)` in your profile ran before your Node version manager initialized (see the warning in step 3) — switch to a literal path. If it points at a path that no longer exists (a Node upgrade moved the global bin, an fnm/nvm shim directory expired, or it still names an old hand-written script), spawned processes fail to start or silently skip bridging. Verify with `[ -x "$CLAUDE_CODE_PROCESS_WRAPPER" ] && echo OK`.
 - **Agents fail to spawn / `env: node: No such file or directory`:** the wrapper's `#!/usr/bin/env node` shebang could not find Node, typically because Claude Code was launched from a GUI (Spotlight, Raycast, an IDE) with a minimal PATH. Use the launcher script from step 3, which resolves Node by absolute path, and test it with `env -i HOME="$HOME" PATH=/usr/bin:/bin "$CLAUDE_CODE_PROCESS_WRAPPER" --version`.
 - **Port conflicts:** the server default is 17645; `clodex server --proxy --port <n>` picks another. `clodex-claude` reads the actual port from the runtime file, so no other change is needed.

--- a/src/claude-wrapper.ts
+++ b/src/claude-wrapper.ts
@@ -30,7 +30,7 @@ import {
   readLiveServerRuntimeStates,
   type ServerRuntimeState,
 } from './server-runtime.js';
-import { computeWrapperEnv } from './wrapper-env.js';
+import { computeWrapperEnv, wrapperRequiresServer } from './wrapper-env.js';
 import { findClaudeBinary } from './launch.js';
 
 const isWindows = process.platform === 'win32';
@@ -61,10 +61,13 @@ function portIsOpen(port: number, timeoutMs = 100): Promise<boolean> {
 
 async function main(): Promise<void> {
   const argv = process.argv.slice(2);
+  const checkOnly = argv[0] === '--check';
 
-  let claudePath: string | null;
-  let claudeArgs: string[];
-  if (argv[0] && isExecutableFile(argv[0])) {
+  let claudePath: string | null = null;
+  let claudeArgs: string[] = [];
+  if (checkOnly) {
+    // Readiness checks validate discovery and TCP state without launching Claude.
+  } else if (argv[0] && isExecutableFile(argv[0])) {
     // CLAUDE_CODE_PROCESS_WRAPPER shape: first arg is the claude binary path.
     claudePath = argv[0];
     claudeArgs = argv.slice(1);
@@ -73,7 +76,7 @@ async function main(): Promise<void> {
     claudeArgs = argv;
   }
 
-  if (!claudePath) {
+  if (!checkOnly && !claudePath) {
     process.stderr.write('clodex-claude: could not find the claude binary (set CLODEX_CLAUDE_PATH)\n');
     process.exit(127);
   }
@@ -90,9 +93,14 @@ async function main(): Promise<void> {
       break;
     }
   }
+  if (checkOnly) process.exit(state ? 0 : 1);
+  if (!state && wrapperRequiresServer(process.env)) {
+    process.stderr.write('clodex-claude: no live clodex server is available\n');
+    process.exit(1);
+  }
   const env = computeWrapperEnv(process.env, state);
 
-  const child = spawn(claudePath, claudeArgs, {
+  const child = spawn(claudePath!, claudeArgs, {
     stdio: 'inherit',
     env,
     shell: isWindows,

--- a/src/wrapper-env.ts
+++ b/src/wrapper-env.ts
@@ -8,12 +8,17 @@
 import type { ServerRuntimeState } from './server-runtime.js';
 
 const PROXY_ENV_VARS = ['HTTPS_PROXY', 'HTTP_PROXY', 'https_proxy', 'http_proxy'] as const;
+export const REQUIRE_SERVER_ENV = 'CLODEX_REQUIRE_SERVER';
 
 /**
  * Any non-empty key satisfies the local endpoint gateway (`isAuthorized`
  * accepts everything when no server password is set, i.e. local listen mode).
  */
 export const LOCAL_GATEWAY_API_KEY = 'clodex-local';
+
+export function wrapperRequiresServer(env: NodeJS.ProcessEnv): boolean {
+  return env[REQUIRE_SERVER_ENV] === '1';
+}
 
 export function computeWrapperEnv(
   baseEnv: NodeJS.ProcessEnv,

--- a/tests/claude-wrapper.test.ts
+++ b/tests/claude-wrapper.test.ts
@@ -1,0 +1,192 @@
+import { spawn } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer, type Server } from 'node:net';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { build } from 'tsup';
+
+interface WrapperResult {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+}
+
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+let buildRoot: string;
+let wrapperPath: string;
+let testRoot: string;
+let clodexHome: string;
+let helperPath: string;
+let launchMarker: string;
+
+async function runWrapper(
+  args: string[],
+  envOverrides: NodeJS.ProcessEnv = {},
+): Promise<WrapperResult> {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    CLODEX_HOME: clodexHome,
+    ...envOverrides,
+  };
+  if (!Object.hasOwn(envOverrides, 'CLODEX_REQUIRE_SERVER')) {
+    delete env['CLODEX_REQUIRE_SERVER'];
+  }
+
+  return new Promise((resolveResult, reject) => {
+    const child = spawn(process.execPath, [wrapperPath, ...args], {
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+
+    const timeout = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`wrapper timed out for arguments: ${args.join(' ')}`));
+    }, 5_000);
+    child.once('error', (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once('close', (code, signal) => {
+      clearTimeout(timeout);
+      resolveResult({ code, signal, stdout, stderr });
+    });
+  });
+}
+
+async function openLoopbackServer(): Promise<{ server: Server; port: number }> {
+  const server = createServer((socket) => socket.end());
+  await new Promise<void>((resolveListen, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolveListen());
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('expected a TCP address for the wrapper test server');
+  }
+  return { server, port: address.port };
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolveClose, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolveClose();
+    });
+  });
+}
+
+function advertiseEndpoint(port: number, pid = process.pid): void {
+  mkdirSync(clodexHome, { recursive: true });
+  writeFileSync(
+    join(clodexHome, 'server-runtime.json'),
+    `${JSON.stringify([
+      {
+        mode: 'endpoint',
+        port,
+        pid,
+        startedAt: new Date().toISOString(),
+      },
+    ])}\n`,
+  );
+}
+
+function claudeInvocation(exitCode = 0): string[] {
+  return [process.execPath, helperPath, launchMarker, String(exitCode)];
+}
+
+beforeAll(async () => {
+  buildRoot = mkdtempSync(join(tmpdir(), 'clodex-wrapper-build-'));
+  await build({
+    entry: [join(projectRoot, 'src', 'claude-wrapper.ts')],
+    format: ['esm'],
+    target: 'node22',
+    platform: 'node',
+    outDir: buildRoot,
+    outExtension: () => ({ js: '.mjs' }),
+    clean: true,
+    dts: false,
+    minify: false,
+    silent: true,
+    sourcemap: false,
+    splitting: false,
+  });
+  wrapperPath = join(buildRoot, 'claude-wrapper.mjs');
+  expect(existsSync(wrapperPath)).toBe(true);
+});
+
+afterAll(() => {
+  rmSync(buildRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  testRoot = mkdtempSync(join(tmpdir(), 'clodex-wrapper-test-'));
+  clodexHome = join(testRoot, 'clodex-home');
+  helperPath = join(testRoot, 'fake-claude.mjs');
+  launchMarker = join(testRoot, 'claude-launched');
+  writeFileSync(
+    helperPath,
+    [
+      "import { writeFileSync } from 'node:fs';",
+      "writeFileSync(process.argv[2], 'launched\\n');",
+      "process.stdout.write('fake-claude-launched\\n');",
+      'process.exit(Number(process.argv[3]));',
+      '',
+    ].join('\n'),
+  );
+});
+
+afterEach(() => {
+  rmSync(testRoot, { recursive: true, force: true });
+});
+
+describe('clodex-claude process wrapper', () => {
+  it('--check exits 0 only for an advertised server with a live TCP port', async () => {
+    const { server, port } = await openLoopbackServer();
+    try {
+      expect((await runWrapper(['--check'])).code).toBe(1);
+
+      advertiseEndpoint(port, Number.MAX_SAFE_INTEGER);
+      expect((await runWrapper(['--check'])).code).toBe(1);
+
+      advertiseEndpoint(port);
+      expect((await runWrapper(['--check'])).code).toBe(0);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('--check exits 1 without launching Claude when no server exists', async () => {
+    const result = await runWrapper(['--check', ...claudeInvocation()]);
+
+    expect(result).toMatchObject({ code: 1, signal: null });
+    expect(existsSync(launchMarker)).toBe(false);
+  });
+
+  it('CLODEX_REQUIRE_SERVER=1 fails closed without launching Claude', async () => {
+    const result = await runWrapper(claudeInvocation(), { CLODEX_REQUIRE_SERVER: '1' });
+
+    expect(result).toMatchObject({ code: 1, signal: null });
+    expect(result.stderr).toContain('no live clodex server is available');
+    expect(existsSync(launchMarker)).toBe(false);
+  });
+
+  it('default mode remains fail-open when no server exists', async () => {
+    const result = await runWrapper(claudeInvocation(23));
+
+    expect(result).toMatchObject({ code: 23, signal: null });
+    expect(result.stdout).toBe('fake-claude-launched\n');
+    expect(existsSync(launchMarker)).toBe(true);
+  });
+});

--- a/tests/wrapper-env.test.ts
+++ b/tests/wrapper-env.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { computeWrapperEnv, LOCAL_GATEWAY_API_KEY } from '../src/wrapper-env.js';
+import {
+  computeWrapperEnv,
+  LOCAL_GATEWAY_API_KEY,
+  wrapperRequiresServer,
+} from '../src/wrapper-env.js';
 import {
   readLiveServerRuntimeState,
   registerServerRuntimeState,
@@ -82,5 +86,11 @@ describe('computeWrapperEnv', () => {
     } finally {
       rmSync(tempHome, { recursive: true, force: true });
     }
+  });
+
+  it('requires a live server only when explicitly enabled', () => {
+    expect(wrapperRequiresServer({})).toBe(false);
+    expect(wrapperRequiresServer({ CLODEX_REQUIRE_SERVER: '0' })).toBe(false);
+    expect(wrapperRequiresServer({ CLODEX_REQUIRE_SERVER: '1' })).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Add a check-only command for service-manager readiness probes.
- Add an explicit fail-closed launch option when a live routed service is required.
- Preserve the existing fail-open launch behavior by default.

## Test plan

- [x] Focused wrapper tests: 9 passed.
- [x] Isolated non-listener suite: 574 passed.
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] Staged and committed secret scans

