### PR TITLE
fix(auth): represent anonymous access explicitly

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -147,10 +147,12 @@ const oauthRefreshInflight = new Map<string, Promise<string | null>>();
 
 export type ParsedAuthRef =
   | { kind: 'keyring'; account: string }
-  | { kind: 'env'; varName: string };
+  | { kind: 'env'; varName: string }
+  | { kind: 'none' };
 
-/** Parse registry authRef strings like `keyring:provider:openai` or `env:OPENAI_API_KEY`. */
+/** Parse registry credential references. */
 export function parseAuthRef(authRef: string): ParsedAuthRef | null {
+  if (authRef === 'none:anonymous') return { kind: 'none' };
   if (authRef.startsWith('keyring:')) {
     const account = authRef.slice('keyring:'.length);
     return account ? { kind: 'keyring', account } : null;
@@ -259,10 +261,11 @@ export async function resolveProviderCredential(
   authRef: string,
   diag?: (msg: string) => void,
 ): Promise<string | null> {
+  const parsed = parseAuthRef(authRef);
+  if (parsed?.kind === 'none') return null;
+
   const namespaced = readEnvCredential(clodexKeyEnvVar(providerId));
   if (namespaced) return namespaced;
-
-  const parsed = parseAuthRef(authRef);
   if (!parsed) return null;
 
   if (parsed.kind === 'env') {
@@ -373,5 +376,4 @@ export async function deleteProviderCredential(
   if (!parsed || parsed.kind !== 'keyring') return false;
   return deleteKeyringAccount(parsed.account, diag);
 }
-
 

--- a/src/provider-catalog.ts
+++ b/src/provider-catalog.ts
@@ -27,6 +27,8 @@ export function providersForPicker(providers: LocalProvider[]): LocalProvider[] 
 
 /** Resolve API key when provider.apiKey is empty (registry authRef or OAuth keyring). */
 export async function resolveLocalProviderApiKey(provider: LocalProvider): Promise<string | null> {
+  if (provider.authRef === 'none:anonymous') return 'anonymous';
+
   const direct = provider.apiKey?.trim();
   if (direct) return direct;
   
@@ -38,7 +40,7 @@ export async function resolveLocalProviderApiKey(provider: LocalProvider): Promi
   }
 
   const reg = loadRegistry().providers.find(p => p.id === provider.id);
-  const authRef = reg?.authRef ?? oauthAuthRef(provider.id);
+  const authRef = provider.authRef ?? reg?.authRef ?? oauthAuthRef(provider.id);
   return resolveProviderCredential(provider.id, authRef);
 }
 
@@ -50,6 +52,7 @@ export function formatRegistryAuthLabel(
     return 'keychain (OAuth)';
   }
   if (provider.authType === 'none') {
+    if (provider.authRef === 'none:anonymous') return 'anonymous';
     return 'gcloud / manual credentials';
   }
   if (provider.authRef.startsWith('keyring:')) {

--- a/src/registry/add-template.ts
+++ b/src/registry/add-template.ts
@@ -94,7 +94,9 @@ export async function addProviderFromTemplate(
     };
   }
 
-  const authRef = `keyring:provider:${template.id}`;
+  const authRef = trimmedKey
+    ? `keyring:provider:${template.id}`
+    : 'none:anonymous';
   const saved = trimmedKey ? await saveProviderCredential(authRef, trimmedKey) : true;
   if (!saved) {
     return {
@@ -118,7 +120,10 @@ export async function addProviderFromTemplate(
     name: template.name,
     enabled: true,
     authRef,
-    authType: template.authType,
+    authType: trimmedKey ? template.authType : 'none',
+    ...(!trimmedKey && template.anonymousFreeModels
+      ? { subscriptionFilter: 'free' as const }
+      : {}),
     api: {
       npm: template.npm,
       url: fetched.baseUrl,

--- a/src/registry/load.ts
+++ b/src/registry/load.ts
@@ -16,6 +16,7 @@ export async function loadRegistryProviders(
   const oauthAccountIds = new Map<string, string>();
   const oauthProviderData = new Map<string, Record<string, unknown>>();
   await Promise.all(registry.providers.map(async provider => {
+    if (provider.authRef === 'none:anonymous') return;
     try {
       const key = await resolveProviderCredential(provider.id, provider.authRef, diag);
       if (key) keys.set(provider.id, key);
@@ -47,5 +48,9 @@ export function loadRegistryProvidersSync(
   opts?: { agent?: CompatibilityAgent },
 ): LocalProvider[] {
   const registry = loadRegistry();
-  return materializeRegistry(registry, provider => resolveKey(provider.id, provider.authRef), opts);
+  return materializeRegistry(
+    registry,
+    provider => provider.authRef === 'none:anonymous' ? null : resolveKey(provider.id, provider.authRef),
+    opts,
+  );
 }

--- a/src/registry/materialize.ts
+++ b/src/registry/materialize.ts
@@ -8,7 +8,6 @@ import { normalizeGoogleDisplayName, normalizeGoogleModelId } from './google-mod
 import { findModelsDevModel } from './models-dev.js';
 import type { CachedModel, ProviderRegistry, RegistryProvider } from './types.js';
 import { isValidProviderId } from './validate.js';
-import { getTemplateById } from '../provider-templates.js';
 import { classifyFreeStatus, isFreeStatus } from '../free-models.js';
 
 export type CredentialResolver = (provider: RegistryProvider) => string | null;
@@ -83,11 +82,6 @@ export function cachedModelToLocal(
   };
 }
 
-function providerAllowsAnonymousFreeModels(provider: RegistryProvider): boolean {
-  const template = getTemplateById(provider.templateId) ?? getTemplateById(provider.id);
-  return template?.anonymousFreeModels === true;
-}
-
 function materializeOne(
   provider: RegistryProvider,
   resolveCredential: CredentialResolver,
@@ -97,8 +91,8 @@ function materializeOne(
   if (!isValidProviderId(provider.id)) return null;
 
   const freeOnly = provider.subscriptionFilter === 'free';
-  const apiKey = resolveCredential(provider) ?? '';
-  const anonymousFreeOnly = !apiKey.trim() && providerAllowsAnonymousFreeModels(provider);
+  const anonymous = provider.authRef === 'none:anonymous' && provider.authType === 'none';
+  const apiKey = anonymous ? '' : resolveCredential(provider) ?? '';
   const models: LocalProviderModel[] = [];
   for (const cached of provider.modelsCache?.models ?? []) {
     const freeStatus = classifyFreeStatus({
@@ -106,7 +100,7 @@ function materializeOne(
       providerId: provider.id,
       templateId: provider.templateId,
     });
-    if ((freeOnly || anonymousFreeOnly) && !isFreeStatus(freeStatus)) continue;
+    if (freeOnly && !isFreeStatus(freeStatus)) continue;
     const model = cachedModelToLocal(cached, provider);
     if (!model) continue;
     if (shouldHideModel({ providerId: provider.id, modelId: model.id, agent })) continue;
@@ -114,12 +108,13 @@ function materializeOne(
   }
   if (models.length === 0) return null;
 
-  if (!apiKey.trim() && !anonymousFreeOnly) return null;
+  if (!apiKey.trim() && !anonymous) return null;
 
   return {
     id: provider.id,
     name: provider.name,
     apiKey,
+    authRef: provider.authRef,
     authType: provider.authType,
     headers: provider.api.headers,
     models,

--- a/src/registry/refresh-credentials.ts
+++ b/src/registry/refresh-credentials.ts
@@ -55,6 +55,8 @@ export async function resolveRefreshCredential(
   provider: RegistryProvider,
   resolveKey: (provider: RegistryProvider) => Promise<string | null>,
 ): Promise<string | null> {
+  if (provider.authRef === 'none:anonymous') return null;
+
   // OAuth token refresh (e.g. an expired/revoked refresh token returning 401) throws
   // rather than resolving to null. Treat that the same as "no key" so callers fall
   // through to refreshProviderModels' existing friendly "sign in again" messaging

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,8 @@ export interface LocalProvider {
   id: string;
   name: string;
   apiKey: string;
+  /** Exact registry credential reference used to resolve this provider. */
+  authRef?: string;
   authType?: 'api' | 'oauth' | 'none';
   oauthAccountId?: string;
   providerData?: Record<string, unknown>;

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -89,6 +89,7 @@ describe('provider credentials', () => {
     expect(parseAuthRef('keyring:provider:openai')).toEqual({ kind: 'keyring', account: 'provider:openai' });
     expect(parseAuthRef('keyring:oauth:provider:openai-oauth')).toEqual({ kind: 'keyring', account: 'oauth:provider:openai-oauth' });
     expect(parseAuthRef('env:OPENAI_API_KEY')).toEqual({ kind: 'env', varName: 'OPENAI_API_KEY' });
+    expect(parseAuthRef('none:anonymous')).toEqual({ kind: 'none' });
     expect(parseAuthRef('bad')).toBeNull();
   });
 
@@ -101,6 +102,12 @@ describe('provider credentials', () => {
     process.env[clodexKeyEnvVar('openai')] = 'env-openai-key';
     const key = await resolveProviderCredential('openai', 'keyring:provider:openai');
     expect(key).toBe('env-openai-key');
+    delete process.env[clodexKeyEnvVar('openai')];
+  });
+
+  it('keeps explicit anonymous access authoritative over provider environment keys', async () => {
+    process.env[clodexKeyEnvVar('openai')] = 'stale-provider-key';
+    await expect(resolveProviderCredential('openai', 'none:anonymous')).resolves.toBeNull();
     delete process.env[clodexKeyEnvVar('openai')];
   });
 

--- a/tests/provider-catalog-display.test.ts
+++ b/tests/provider-catalog-display.test.ts
@@ -71,6 +71,18 @@ describe('provider-catalog-display', () => {
       expect(await resolveLocalProviderApiKey(provider)).toBe('anonymous');
     });
 
+    it('does not resurrect a direct key for an explicitly anonymous provider', async () => {
+      const provider = {
+        id: 'local',
+        name: 'Local',
+        apiKey: 'stale-key',
+        authRef: 'none:anonymous',
+        authType: 'none',
+        models: [],
+      } as any;
+      expect(await resolveLocalProviderApiKey(provider)).toBe('anonymous');
+    });
+
     it('falls back to the OAuth keyring ref when there is no registry authRef and no zen/go/anonymous special case', async () => {
       vi.spyOn(env, 'resolveProviderCredential').mockResolvedValue('oauth-key');
       const provider = { id: 'openai', name: 'OpenAI', apiKey: '', models: [] } as any;
@@ -92,6 +104,10 @@ describe('provider-catalog-display', () => {
       expect(formatRegistryAuthLabel({
         authRef: 'env:OPENAI_API_KEY',
       } as any)).toBe('env:OPENAI_API_KEY');
+      expect(formatRegistryAuthLabel({
+        authRef: 'none:anonymous',
+        authType: 'none',
+      } as any)).toBe('anonymous');
     });
   });
 
@@ -117,4 +133,3 @@ describe('provider-catalog-display', () => {
     });
   });
 });
-

--- a/tests/refresh-credentials.test.ts
+++ b/tests/refresh-credentials.test.ts
@@ -65,4 +65,24 @@ describe('resolveRefreshCredential', () => {
       else process.env['OPENAI_API_KEY'] = prev;
     }
   });
+
+  it('does not resolve credentials or environment fallbacks for explicit anonymous access', async () => {
+    const previous = process.env['OPENAI_API_KEY'];
+    process.env['OPENAI_API_KEY'] = 'sk-from-env';
+    let called = false;
+    try {
+      const key = await resolveRefreshCredential(
+        makeProvider({ authRef: 'none:anonymous', authType: 'none' }),
+        async () => {
+          called = true;
+          return 'stale-key';
+        },
+      );
+      expect(key).toBeNull();
+      expect(called).toBe(false);
+    } finally {
+      if (previous === undefined) delete process.env['OPENAI_API_KEY'];
+      else process.env['OPENAI_API_KEY'] = previous;
+    }
+  });
 });

--- a/tests/registry-add-template.test.ts
+++ b/tests/registry-add-template.test.ts
@@ -116,6 +116,51 @@ describe('registry/add-template', () => {
     expect(io.saveRegistry).toHaveBeenCalled();
   });
 
+  it('represents optional no-key access without a stored credential reference', async () => {
+    const anonymousTemplate = { ...dummyTemplate, apiKeyOptional: true };
+
+    const res = await addProviderFromTemplate(anonymousTemplate, '');
+
+    expect(res.added).toBe(true);
+    expect(res.provider).toMatchObject({
+      authRef: 'none:anonymous',
+      authType: 'none',
+    });
+    expect(env.saveProviderCredential).not.toHaveBeenCalled();
+    const savedRegistry = vi.mocked(io.saveRegistry).mock.calls.at(-1)?.[0] as ProviderRegistry;
+    expect(savedRegistry.providers[0]?.authRef).toBe('none:anonymous');
+  });
+
+  it('persists free-only filtering for anonymous free-model access', async () => {
+    const anonymousTemplate = {
+      ...dummyTemplate,
+      apiKeyOptional: true,
+      anonymousFreeModels: true,
+    };
+    vi.mocked(fetchTemplate.fetchTemplateModels).mockResolvedValue({
+      models: [{
+        id: 'free-model',
+        name: 'Free Model',
+        upstreamModelId: 'free-model',
+        family: 'fam',
+        brand: 'brand',
+        modelFormat: 'openai',
+        isFree: true,
+      }],
+      baseUrl: 'https://api.example.com',
+    });
+
+    const res = await addProviderFromTemplate(anonymousTemplate, '');
+
+    expect(res.added).toBe(true);
+    expect(res.provider).toMatchObject({
+      authRef: 'none:anonymous',
+      authType: 'none',
+      subscriptionFilter: 'free',
+    });
+    expect(res.modelCount).toBe(1);
+  });
+
   it('replaces existing provider if replaceExisting is true', async () => {
     vi.mocked(io.loadRegistry).mockReturnValue({
       version: 1,

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -164,6 +164,38 @@ describe('materializeRegistry', () => {
     expect(materializeRegistry(registry, () => null)).toHaveLength(0);
   });
 
+  it('materializes explicit anonymous access without consulting a credential resolver', () => {
+    const registry = emptyRegistry();
+    registry.providers.push({
+      id: 'anonymous-provider',
+      templateId: 'anonymous-provider',
+      name: 'Anonymous Provider',
+      enabled: true,
+      authRef: 'none:anonymous',
+      authType: 'none',
+      api: { npm: '@ai-sdk/openai-compatible', url: 'https://anonymous.example/v1' },
+      addedAt: '2026-06-09T00:00:00.000Z',
+      modelsCache: {
+        fetchedAt: '2026-06-09T00:00:00.000Z',
+        models: [{
+          id: 'free-model',
+          name: 'Free Model',
+          upstreamModelId: 'free-model',
+          modelFormat: 'openai',
+          npm: '@ai-sdk/openai-compatible',
+        }],
+      },
+    });
+
+    const locals = materializeRegistry(registry, () => {
+      throw new Error('anonymous access must not resolve a credential');
+    });
+
+    expect(locals).toHaveLength(1);
+    expect(locals[0]?.apiKey).toBe('');
+    expect(locals[0]?.authRef).toBe('none:anonymous');
+  });
+
   it('marks NVIDIA imported models as free provider access', () => {
     const registry = emptyRegistry();
     registry.providers.push({


### PR DESCRIPTION
## Summary

- Persist anonymous access as an explicit credential reference.
- Keep anonymous providers from consulting stale environment or stored credentials.
- Preserve free-only filtering and display anonymous access clearly.

## Test plan

- [x] Focused credential and registry tests: 64 passed.
- [x] Isolated non-listener suite: 575 passed.
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] Staged and committed secret scans

