### PR TITLE
fix(registry): serialize provider state changes

### DIFF
--- a/src/registry/add-template.ts
+++ b/src/registry/add-template.ts
@@ -6,6 +6,7 @@ import type { ProviderTemplate } from '../provider-templates.js';
 import { classifyFreeStatus, isFreeStatus } from '../free-models.js';
 import { fetchTemplateModels } from './fetch-template-models.js';
 import { loadRegistry, saveRegistry } from './io.js';
+import { withRegistryWriteLock } from './lock.js';
 import {
   buildPricingIndex,
   enrichModelsWithPricing,
@@ -65,15 +66,19 @@ export async function addProviderFromTemplate(
     return { added: false, error: 'API key cannot be empty.' };
   }
 
-  const registry = loadRegistry();
-  const existing = registry.providers.find(p => p.id === template.id);
-  if (existing && !opts?.replaceExisting) {
-    return {
-      added: false,
-      error: `${template.name} is already configured.`,
-      hint: `Remove it first with: clodex providers remove ${template.id}`,
-    };
-  }
+  const existingError = await withRegistryWriteLock(() => {
+    const registry = loadRegistry();
+    const existing = registry.providers.find(p => p.id === template.id);
+    if (existing && !opts?.replaceExisting) {
+      return {
+        added: false,
+        error: `${template.name} is already configured.`,
+        hint: `Remove it first with: clodex providers remove ${template.id}`,
+      };
+    }
+    return null;
+  });
+  if (existingError) return existingError;
 
   const fetched = await fetchTemplateModels(template, trimmedKey, opts?.baseUrl);
   if (fetched.error || fetched.models.length === 0) {
@@ -94,17 +99,6 @@ export async function addProviderFromTemplate(
     };
   }
 
-  const authRef = `keyring:provider:${template.id}`;
-  const saved = trimmedKey ? await saveProviderCredential(authRef, trimmedKey) : true;
-  if (!saved) {
-    return {
-      added: false,
-      error: 'Could not save API key to Keychain.',
-      hint: 'Grant Keychain access or try again.',
-    };
-  }
-
-  const now = new Date().toISOString();
   const pricingCache = loadPricingCache();
   const platform = pricingPlatformForProvider(template.id, template.id);
   const pricedModels = enrichModelsWithPricing(
@@ -112,33 +106,57 @@ export async function addProviderFromTemplate(
     buildPricingIndex(pricingCache),
     platform,
   );
-  const entry: RegistryProvider = {
-    id: template.id,
-    templateId: template.id,
-    name: template.name,
-    enabled: true,
-    authRef,
-    authType: template.authType,
-    api: {
-      npm: template.npm,
-      url: fetched.baseUrl,
-    },
-    addedAt: existing?.addedAt ?? now,
-    refreshedAt: now,
-    modelsCache: {
-      fetchedAt: now,
-      models: pricedModels,
-    },
-  };
+  const result = await withRegistryWriteLock(async () => {
+    const registry = loadRegistry();
+    const existing = registry.providers.find(p => p.id === template.id);
+    if (existing && !opts?.replaceExisting) {
+      return {
+        added: false,
+        error: `${template.name} is already configured.`,
+        hint: `Remove it first with: clodex providers remove ${template.id}`,
+      };
+    }
 
-  if (existing) {
-    const idx = registry.providers.findIndex(p => p.id === template.id);
-    registry.providers[idx] = entry;
-  } else {
-    registry.providers.push(entry);
-  }
-  saveRegistry(registry);
-  enrichPricingAsync();
+    const authRef = `keyring:provider:${template.id}`;
+    const saved = trimmedKey ? await saveProviderCredential(authRef, trimmedKey) : true;
+    if (!saved) {
+      return {
+        added: false,
+        error: 'Could not save API key to Keychain.',
+        hint: 'Grant Keychain access or try again.',
+      };
+    }
 
-  return { added: true, provider: entry, modelCount: pricedModels.length };
+    const now = new Date().toISOString();
+    const entry: RegistryProvider = {
+      id: template.id,
+      templateId: template.id,
+      name: template.name,
+      enabled: true,
+      authRef,
+      authType: template.authType,
+      api: {
+        npm: template.npm,
+        url: fetched.baseUrl,
+      },
+      addedAt: existing?.addedAt ?? now,
+      refreshedAt: now,
+      modelsCache: {
+        fetchedAt: now,
+        models: pricedModels,
+      },
+    };
+
+    if (existing) {
+      const idx = registry.providers.findIndex(p => p.id === template.id);
+      registry.providers[idx] = entry;
+    } else {
+      registry.providers.push(entry);
+    }
+    saveRegistry(registry);
+    return { added: true, provider: entry, modelCount: pricedModels.length };
+  });
+
+  if (result.added) enrichPricingAsync();
+  return result;
 }

--- a/src/registry/crud.ts
+++ b/src/registry/crud.ts
@@ -2,6 +2,7 @@
 
 import { parseAuthRef, deleteProviderCredential } from '../env.js';
 import { loadRegistry, saveRegistry } from './io.js';
+import { withRegistryWriteLock, withRegistryWriteLockSync } from './lock.js';
 import type { RegistryProvider } from './types.js';
 
 export interface RemoveProviderResult {
@@ -21,37 +22,41 @@ export async function removeProviderFromRegistry(
   id: string,
   opts?: { deleteCredential?: boolean },
 ): Promise<RemoveProviderResult> {
-  const registry = loadRegistry();
-  const index = registry.providers.findIndex(p => p.id === id);
-  if (index < 0) {
-    return { removed: false, id, credentialDeleted: false, error: `Provider not found: ${id}` };
-  }
-
-  const [removedProvider] = registry.providers.splice(index, 1);
-  saveRegistry(registry);
-
-  let credentialDeleted = false;
-  if (opts?.deleteCredential !== false) {
-    const parsed = parseAuthRef(removedProvider.authRef);
-    const shouldDelete = !credentialStillReferenced(removedProvider.authRef, registry.providers);
-    if (shouldDelete && parsed?.kind === 'keyring') {
-      credentialDeleted = await deleteProviderCredential(removedProvider.authRef);
+  return withRegistryWriteLock(async () => {
+    const registry = loadRegistry();
+    const index = registry.providers.findIndex(p => p.id === id);
+    if (index < 0) {
+      return { removed: false, id, credentialDeleted: false, error: `Provider not found: ${id}` };
     }
-  }
 
-  return {
-    removed: true,
-    id,
-    name: removedProvider.name,
-    credentialDeleted,
-  };
+    const [removedProvider] = registry.providers.splice(index, 1);
+    saveRegistry(registry);
+
+    let credentialDeleted = false;
+    if (opts?.deleteCredential !== false) {
+      const parsed = parseAuthRef(removedProvider.authRef);
+      const shouldDelete = !credentialStillReferenced(removedProvider.authRef, registry.providers);
+      if (shouldDelete && parsed?.kind === 'keyring') {
+        credentialDeleted = await deleteProviderCredential(removedProvider.authRef);
+      }
+    }
+
+    return {
+      removed: true,
+      id,
+      name: removedProvider.name,
+      credentialDeleted,
+    };
+  });
 }
 
 export function toggleProviderEnabled(id: string): { toggled: boolean; enabled?: boolean; error?: string } {
-  const registry = loadRegistry();
-  const provider = registry.providers.find(p => p.id === id);
-  if (!provider) return { toggled: false, error: `Provider not found: ${id}` };
-  provider.enabled = !provider.enabled;
-  saveRegistry(registry);
-  return { toggled: true, enabled: provider.enabled };
+  return withRegistryWriteLockSync(() => {
+    const registry = loadRegistry();
+    const provider = registry.providers.find(p => p.id === id);
+    if (!provider) return { toggled: false, error: `Provider not found: ${id}` };
+    provider.enabled = !provider.enabled;
+    saveRegistry(registry);
+    return { toggled: true, enabled: provider.enabled };
+  });
 }

--- a/src/registry/custom-endpoint.ts
+++ b/src/registry/custom-endpoint.ts
@@ -5,6 +5,7 @@ import { deriveBrand } from '../models.js';
 import { resolveContextWindow } from '../context-window.js';
 import { fetchTemplateModels } from './fetch-template-models.js';
 import { loadRegistry, saveRegistry } from './io.js';
+import { withRegistryWriteLock } from './lock.js';
 import type { CachedModel, RegistryProvider } from './types.js';
 import { customProviderId, isValidProviderId, slugifyProviderId } from './validate.js';
 import { validateCustomEndpointUrl } from './url-security.js';
@@ -146,8 +147,9 @@ export async function addCustomEndpointProvider(input: AddCustomEndpointInput): 
     return { added: false, error: urlCheck.error, hint: urlCheck.hint };
   }
 
-  const registry = loadRegistry();
-  const providerId = uniqueProviderId(input.displayName.trim(), registry);
+  const normalizedUrl = urlCheck.normalizedUrl;
+  const displayName = input.displayName.trim();
+  const probeProviderId = uniqueProviderId(displayName, { providers: [] });
   const npm = npmForKind(input.kind);
   const apiKey = input.apiKey.trim() || 'local';
 
@@ -155,20 +157,20 @@ export async function addCustomEndpointProvider(input: AddCustomEndpointInput): 
 
   let fetched: { models: CachedModel[]; baseUrl: string; error?: string; hint?: string };
   if (input.kind === 'anthropic') {
-    fetched = await fetchAnthropicModels(urlCheck.normalizedUrl, apiKey, headers);
+    fetched = await fetchAnthropicModels(normalizedUrl, apiKey, headers);
   } else {
     fetched = await fetchTemplateModels(
       {
-        id: providerId,
-        name: input.displayName,
+        id: probeProviderId,
+        name: displayName,
         authType: apiKey === 'local' ? 'none' : 'api',
         npm,
-        defaultBaseUrl: urlCheck.normalizedUrl,
+        defaultBaseUrl: normalizedUrl,
         modelSource: 'api-list',
         supported: true,
       },
       apiKey,
-      urlCheck.normalizedUrl,
+      normalizedUrl,
       headers,
     );
   }
@@ -177,40 +179,45 @@ export async function addCustomEndpointProvider(input: AddCustomEndpointInput): 
     return { added: false, error: fetched.error ?? 'No models returned.', hint: fetched.hint };
   }
 
-  if (apiKey !== 'local') {
-    const saved = await saveProviderCredential(`keyring:provider:${providerId}`, apiKey);
-    if (!saved) {
-      return { added: false, error: 'Could not save API key to Keychain.', hint: 'Grant Keychain access and try again.' };
+  return withRegistryWriteLock(async () => {
+    const registry = loadRegistry();
+    const providerId = uniqueProviderId(displayName, registry);
+    const authRef = `keyring:provider:${providerId}`;
+    if (apiKey !== 'local') {
+      const saved = await saveProviderCredential(authRef, apiKey);
+      if (!saved) {
+        return { added: false, error: 'Could not save API key to Keychain.', hint: 'Grant Keychain access and try again.' };
+      }
     }
-  }
 
-  const now = new Date().toISOString();
-  const entry: RegistryProvider = {
-    id: providerId,
-    templateId: input.kind === 'anthropic' ? 'custom-anthropic' : 'custom-openai',
-    name: input.displayName.trim(),
-    enabled: true,
-    authRef: apiKey === 'local' ? `keyring:provider:${providerId}` : `keyring:provider:${providerId}`,
-    api: { npm, url: fetched.baseUrl, ...(headers ? { headers } : {}) },
-    addedAt: now,
-    refreshedAt: now,
-    modelsCache: {
-      fetchedAt: now,
-      models: fetched.models.map(m => ({
-        ...m,
-        modelFormat: modelFormatForKind(input.kind),
-        npm,
-        apiUrl: fetched.baseUrl,
-      })),
-    },
-  };
+    const now = new Date().toISOString();
+    const entry: RegistryProvider = {
+      id: providerId,
+      templateId: input.kind === 'anthropic' ? 'custom-anthropic' : 'custom-openai',
+      name: displayName,
+      enabled: true,
+      authRef,
+      api: { npm, url: fetched.baseUrl, ...(headers ? { headers } : {}) },
+      addedAt: now,
+      refreshedAt: now,
+      modelsCache: {
+        fetchedAt: now,
+        models: fetched.models.map(m => ({
+          ...m,
+          modelFormat: modelFormatForKind(input.kind),
+          npm,
+          apiUrl: fetched.baseUrl,
+        })),
+      },
+    };
 
-  if (apiKey === 'local') {
-    await saveProviderCredential(entry.authRef, 'local');
-  }
+    if (apiKey === 'local') {
+      await saveProviderCredential(entry.authRef, 'local');
+    }
 
-  registry.providers.push(entry);
-  saveRegistry(registry);
+    registry.providers.push(entry);
+    saveRegistry(registry);
 
-  return { added: true, provider: entry, modelCount: fetched.models.length };
+    return { added: true, provider: entry, modelCount: fetched.models.length };
+  });
 }

--- a/src/registry/io.ts
+++ b/src/registry/io.ts
@@ -15,6 +15,7 @@ import { dirname } from 'node:path';
 import { ensureLegacyAppHomeMigrated, getAppHome, getProvidersPath } from '../paths.js';
 import type { ProviderRegistry, RegistryProvider } from './types.js';
 import { REGISTRY_SCHEMA_VERSION } from './types.js';
+import { withRegistryWriteLockSync } from './lock.js';
 import { migrateOAuthOpenAiProvider } from './migrate.js';
 import { isValidProviderId } from './validate.js';
 
@@ -122,7 +123,11 @@ export function loadRegistry(path = getProvidersPath()): ProviderRegistry {
     const migrated = migrateOAuthOpenAiProvider(registry);
     if (migrated) {
       try {
-        saveRegistry(registry, path);
+        withRegistryWriteLockSync(() => {
+          if (!existsSync(path)) return;
+          const current = parseRegistry(JSON.parse(readFileSync(path, 'utf8')));
+          if (migrateOAuthOpenAiProvider(current)) saveRegistry(current, path);
+        }, { lockPath: `${path}.lock` });
       } catch {
         // Parsed data remains usable even when migration persistence fails.
       }

--- a/src/registry/lock.ts
+++ b/src/registry/lock.ts
@@ -1,0 +1,335 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { randomUUID } from 'node:crypto';
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname } from 'node:path';
+import { getProvidersPath } from '../paths.js';
+
+const DEFAULT_WAIT_MS = 30_000;
+const DEFAULT_RETRY_MS = 25;
+const INVALID_LOCK_STALE_MS = 10 * 60 * 1000;
+
+interface RegistryLockOwner {
+  pid: number;
+  startedAt: number;
+  token: string;
+}
+
+interface RegistryLockSnapshot {
+  raw: string;
+  device: number;
+  inode: number;
+  modifiedAt: number;
+}
+
+interface RegistryLockOptions {
+  lockPath?: string;
+  waitMs?: number;
+  retryMs?: number;
+  now?: () => number;
+  isAlive?: (pid: number) => boolean;
+}
+
+interface RegistryLockContext {
+  leases: ReadonlyMap<string, RegistryLockLease>;
+}
+
+interface RegistryLockLease {
+  active: boolean;
+}
+
+const registryLockContext = new AsyncLocalStorage<RegistryLockContext>();
+
+export function getRegistryLockPath(): string {
+  return `${getProvidersPath()}.lock`;
+}
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+function parseLockOwner(raw: string): RegistryLockOwner | null {
+  try {
+    const parsed = JSON.parse(raw) as Partial<RegistryLockOwner>;
+    if (!Number.isInteger(parsed.pid) || (parsed.pid ?? 0) <= 0) return null;
+    if (
+      typeof parsed.startedAt !== 'number' ||
+      !Number.isFinite(parsed.startedAt)
+    )
+      return null;
+    if (typeof parsed.token !== 'string' || parsed.token.length === 0)
+      return null;
+    return parsed as RegistryLockOwner;
+  } catch {
+    return null;
+  }
+}
+
+function getStaleLockSnapshot(
+  lockPath: string,
+  now: number,
+  alive: (pid: number) => boolean,
+): RegistryLockSnapshot | null {
+  const raw = readFileSync(lockPath, 'utf8');
+  const stats = statSync(lockPath);
+  const snapshot: RegistryLockSnapshot = {
+    raw,
+    device: stats.dev,
+    inode: stats.ino,
+    modifiedAt: stats.mtimeMs,
+  };
+  const owner = parseLockOwner(raw);
+  if (owner) return alive(owner.pid) ? null : snapshot;
+
+  // A process can be between exclusive creation and writing its owner record.
+  // Only reap malformed locks after a long grace period.
+  return now - snapshot.modifiedAt >= INVALID_LOCK_STALE_MS ? snapshot : null;
+}
+
+function removeStaleLock(
+  lockPath: string,
+  expected?: RegistryLockSnapshot,
+): boolean {
+  try {
+    if (expected) {
+      const raw = readFileSync(lockPath, 'utf8');
+      const stats = statSync(lockPath);
+      if (
+        raw !== expected.raw ||
+        stats.dev !== expected.device ||
+        stats.ino !== expected.inode ||
+        stats.mtimeMs !== expected.modifiedAt
+      )
+        return false;
+    }
+    unlinkSync(lockPath);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    return false;
+  }
+}
+
+function tryAcquireReaperGuard(
+  lockPath: string,
+  now: number,
+  alive: (pid: number) => boolean,
+): (() => void) | null {
+  const guardPath = `${lockPath}.reap`;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const token = randomUUID();
+    let fd: number | undefined;
+    try {
+      fd = openSync(guardPath, 'wx', 0o600);
+      const owner: RegistryLockOwner = {
+        pid: process.pid,
+        startedAt: now,
+        token,
+      };
+      writeFileSync(fd, JSON.stringify(owner));
+      closeSync(fd);
+      fd = undefined;
+      return () => {
+        try {
+          const current = parseLockOwner(readFileSync(guardPath, 'utf8'));
+          if (current?.token === token) unlinkSync(guardPath);
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+        }
+      };
+    } catch (err) {
+      if (fd !== undefined) {
+        try {
+          closeSync(fd);
+        } catch {
+          // The original error remains authoritative.
+        }
+        removeStaleLock(guardPath);
+        throw err;
+      }
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+
+      let stale: RegistryLockSnapshot | null = null;
+      try {
+        stale = getStaleLockSnapshot(guardPath, now, alive);
+      } catch (readErr) {
+        if ((readErr as NodeJS.ErrnoException).code === 'ENOENT') continue;
+        throw readErr;
+      }
+      if (!stale) return null;
+      if (!removeStaleLock(guardPath, stale)) continue;
+    }
+  }
+  return null;
+}
+
+export function tryAcquireRegistryLock(
+  lockPath = getRegistryLockPath(),
+  options: Pick<RegistryLockOptions, 'now' | 'isAlive'> = {},
+): (() => void) | null {
+  const now = options.now?.() ?? Date.now();
+  const alive = options.isAlive ?? isPidAlive;
+  mkdirSync(dirname(lockPath), { recursive: true, mode: 0o700 });
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const token = randomUUID();
+    let fd: number | undefined;
+    try {
+      fd = openSync(lockPath, 'wx', 0o600);
+      const owner: RegistryLockOwner = {
+        pid: process.pid,
+        startedAt: now,
+        token,
+      };
+      writeFileSync(fd, JSON.stringify(owner));
+      closeSync(fd);
+      fd = undefined;
+      return () => {
+        try {
+          const current = parseLockOwner(readFileSync(lockPath, 'utf8'));
+          if (current?.token === token) unlinkSync(lockPath);
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+        }
+      };
+    } catch (err) {
+      if (fd !== undefined) {
+        try {
+          closeSync(fd);
+        } catch {
+          // The original error remains authoritative.
+        }
+        removeStaleLock(lockPath);
+        throw err;
+      }
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+
+      let stale: RegistryLockSnapshot | null = null;
+      try {
+        stale = getStaleLockSnapshot(lockPath, now, alive);
+      } catch (readErr) {
+        if ((readErr as NodeJS.ErrnoException).code === 'ENOENT') continue;
+        throw readErr;
+      }
+      if (!stale) return null;
+      const releaseReaper = tryAcquireReaperGuard(lockPath, now, alive);
+      if (!releaseReaper) return null;
+      try {
+        let currentStale: RegistryLockSnapshot | null = null;
+        try {
+          currentStale = getStaleLockSnapshot(lockPath, now, alive);
+        } catch (readErr) {
+          if ((readErr as NodeJS.ErrnoException).code === 'ENOENT') continue;
+          throw readErr;
+        }
+        if (!currentStale) return null;
+        if (!removeStaleLock(lockPath, currentStale)) continue;
+      } finally {
+        releaseReaper();
+      }
+    }
+  }
+  return null;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function lockTimeoutError(lockPath: string, waitMs: number): Error {
+  return new Error(
+    `Timed out after ${waitMs}ms waiting for provider registry lock: ${lockPath}`,
+  );
+}
+
+export async function withRegistryWriteLock<T>(
+  operation: () => Promise<T> | T,
+  options: RegistryLockOptions = {},
+): Promise<T> {
+  const lockPath = options.lockPath ?? getRegistryLockPath();
+  const inheritedLeases = registryLockContext.getStore()?.leases;
+  if (inheritedLeases?.get(lockPath)?.active) return operation();
+
+  const waitMs = options.waitMs ?? DEFAULT_WAIT_MS;
+  const retryMs = options.retryMs ?? DEFAULT_RETRY_MS;
+  const now = options.now ?? Date.now;
+  const deadline = now() + waitMs;
+  let release: (() => void) | null = null;
+
+  while (!release) {
+    release = tryAcquireRegistryLock(lockPath, {
+      now,
+      isAlive: options.isAlive,
+    });
+    if (release) break;
+    if (now() >= deadline) throw lockTimeoutError(lockPath, waitMs);
+    await sleep(retryMs);
+  }
+
+  const lease: RegistryLockLease = { active: true };
+  const leases = new Map(inheritedLeases);
+  leases.set(lockPath, lease);
+  const context: RegistryLockContext = { leases };
+  return registryLockContext.run(context, async () => {
+    try {
+      return await operation();
+    } finally {
+      lease.active = false;
+      release?.();
+    }
+  });
+}
+
+export function withRegistryWriteLockSync<T>(
+  operation: () => T,
+  options: RegistryLockOptions = {},
+): T {
+  const lockPath = options.lockPath ?? getRegistryLockPath();
+  const inheritedLeases = registryLockContext.getStore()?.leases;
+  if (inheritedLeases?.get(lockPath)?.active) return operation();
+
+  const waitMs = options.waitMs ?? DEFAULT_WAIT_MS;
+  const retryMs = options.retryMs ?? DEFAULT_RETRY_MS;
+  const now = options.now ?? Date.now;
+  const deadline = now() + waitMs;
+  let release: (() => void) | null = null;
+
+  while (!release) {
+    release = tryAcquireRegistryLock(lockPath, {
+      now,
+      isAlive: options.isAlive,
+    });
+    if (release) break;
+    if (now() >= deadline) throw lockTimeoutError(lockPath, waitMs);
+    sleepSync(retryMs);
+  }
+
+  const lease: RegistryLockLease = { active: true };
+  const leases = new Map(inheritedLeases);
+  leases.set(lockPath, lease);
+  const context: RegistryLockContext = { leases };
+  return registryLockContext.run(context, () => {
+    try {
+      return operation();
+    } finally {
+      lease.active = false;
+      release?.();
+    }
+  });
+}

--- a/src/registry/pricing.ts
+++ b/src/registry/pricing.ts
@@ -22,6 +22,7 @@ import bundledPricing from '../data/pricing-cache.json';
 import { getAppHome } from '../paths.js';
 import type { CachedModel } from './types.js';
 import { loadRegistry, saveRegistry } from './io.js';
+import { withRegistryWriteLock, withRegistryWriteLockSync } from './lock.js';
 import { classifyFreeStatus, isFreeStatus } from '../free-models.js';
 
 export const PRICING_API_URL = 'https://ai-model-pricing.com/api/v1/pricing.json';
@@ -243,11 +244,13 @@ export function applyPricingToRegistryProviders(
 
 /** Apply bundled or on-disk pricing cache synchronously (non-blocking enrich baseline). */
 export function applyCachedPricing(): boolean {
-  const registry = loadRegistry();
-  const cache = loadPricingCache();
-  const changed = applyPricingToRegistryProviders(registry, cache);
-  if (changed) saveRegistry(registry);
-  return changed;
+  return withRegistryWriteLockSync(() => {
+    const registry = loadRegistry();
+    const cache = loadPricingCache();
+    const changed = applyPricingToRegistryProviders(registry, cache);
+    if (changed) saveRegistry(registry);
+    return changed;
+  });
 }
 
 /** Fetch latest pricing in the background; updates registry when complete. */
@@ -255,11 +258,14 @@ export function enrichPricingAsync(onComplete?: (updated: boolean) => void): voi
   void (async () => {
     const fetched = await fetchPricingCache();
     const cache = fetched ?? loadPricingCache();
-    const registry = loadRegistry();
-    const changed = applyPricingToRegistryProviders(registry, cache);
-    if (changed) saveRegistry(registry);
+    const changed = await withRegistryWriteLock(() => {
+      const registry = loadRegistry();
+      const updated = applyPricingToRegistryProviders(registry, cache);
+      if (updated) saveRegistry(registry);
+      return updated;
+    });
     onComplete?.(changed);
-  })();
+  })().catch(() => onComplete?.(false));
 }
 
 export function pricingPlatformForProvider(templateId: string, providerId: string): string | undefined {

--- a/src/registry/provider-auth.ts
+++ b/src/registry/provider-auth.ts
@@ -16,6 +16,7 @@ import {
 import { getTemplateById } from '../provider-templates.js';
 import { oauthAuthRef, toOAuthRegistryId } from './import-build.js';
 import { loadRegistry, saveRegistry } from './io.js';
+import { withRegistryWriteLock } from './lock.js';
 import { refreshProviderModels } from './refresh-models.js';
 import type { RegistryProvider } from './types.js';
 
@@ -94,42 +95,44 @@ function oauthDisplayName(registryId: string, fallbackName: string): string {
 }
 
 async function upsertOAuthProvider(providerId: string, cred: StoredOAuthCredential): Promise<RegistryProvider> {
-  const registryId = toOAuthRegistryId(providerId);
-  const templateId = providerId.replace(/-oauth$/, '') || providerId;
+  return withRegistryWriteLock(() => {
+    const registryId = toOAuthRegistryId(providerId);
+    const templateId = providerId.replace(/-oauth$/, '') || providerId;
 
-  const registry = loadRegistry();
-  const authRef = oauthAuthRef(registryId);
-  const template = getTemplateById(templateId);
-  let entry: RegistryProvider | undefined = registry.providers.find(pr => pr.id === registryId);
+    const registry = loadRegistry();
+    const authRef = oauthAuthRef(registryId);
+    const template = getTemplateById(templateId);
+    let entry: RegistryProvider | undefined = registry.providers.find(pr => pr.id === registryId);
 
-  if (!entry) {
-    if (!template) {
-      throw new Error(`Provider "${providerId}" is not in your registry and has no template`);
+    if (!entry) {
+      if (!template) {
+        throw new Error(`Provider "${providerId}" is not in your registry and has no template`);
+      }
+      const displayName = oauthDisplayName(registryId, template.name);
+      entry = {
+        id: registryId,
+        templateId,
+        name: displayName,
+        enabled: true,
+        authRef,
+        authType: 'oauth',
+        api: {
+          npm: template.npm,
+          url: template.defaultBaseUrl ?? '',
+          ...(template.headers ? { headers: template.headers } : {}),
+        },
+        addedAt: new Date().toISOString(),
+      };
+    } else {
+      entry = { ...entry, authType: 'oauth', authRef, templateId };
     }
-    const displayName = oauthDisplayName(registryId, template.name);
-    entry = {
-      id: registryId,
-      templateId,
-      name: displayName,
-      enabled: true,
-      authRef,
-      authType: 'oauth',
-      api: {
-        npm: template.npm,
-        url: template.defaultBaseUrl ?? '',
-        ...(template.headers ? { headers: template.headers } : {}),
-      },
-      addedAt: new Date().toISOString(),
-    };
-  } else {
-    entry = { ...entry, authType: 'oauth', authRef, templateId };
-  }
 
-  const idx = registry.providers.findIndex(pr => pr.id === registryId);
-  if (idx >= 0) registry.providers[idx] = entry;
-  else registry.providers.push(entry);
-  saveRegistry(registry);
-  return entry;
+    const idx = registry.providers.findIndex(pr => pr.id === registryId);
+    if (idx >= 0) registry.providers[idx] = entry;
+    else registry.providers.push(entry);
+    saveRegistry(registry);
+    return entry;
+  });
 }
 
 export async function authenticateProvider(

--- a/src/registry/refresh-models.ts
+++ b/src/registry/refresh-models.ts
@@ -1,8 +1,10 @@
 // src/registry/refresh-models.ts — user-initiated model list refresh per modelSource
 
+import { isDeepStrictEqual } from 'node:util';
 import { fetchAnthropicModels } from './custom-endpoint.js';
 import { fetchTemplateModels } from './fetch-template-models.js';
 import { loadRegistry, saveRegistry } from './io.js';
+import { withRegistryWriteLock } from './lock.js';
 import { resolveModelSource } from './model-source.js';
 import { validateCustomEndpointUrl } from './url-security.js';
 import {
@@ -299,12 +301,23 @@ function updateProviderCache(
   };
 }
 
+function providerDiscoveryInputsMatch(
+  current: RegistryProvider,
+  started: RegistryProvider,
+): boolean {
+  return current.authRef === started.authRef
+    && current.authType === started.authType
+    && current.templateId === started.templateId
+    && isDeepStrictEqual(current.api, started.api);
+}
+
 export async function refreshProviderModels(
   providerId: string,
   apiKey: string | null,
-  registry = loadRegistry(),
+  registry?: ProviderRegistry,
 ): Promise<RefreshProviderResult> {
-  const provider = registry.providers.find(p => p.id === providerId);
+  const workingRegistry = registry ?? loadRegistry();
+  const provider = workingRegistry.providers.find(p => p.id === providerId);
   if (!provider) {
     return { id: providerId, name: providerId, ok: false, reason: 'Provider not found.' };
   }
@@ -410,8 +423,19 @@ export async function refreshProviderModels(
     const platform = pricingPlatformForProvider(provider.templateId, provider.id);
     const enriched = enrichModelsWithPricing(models, buildPricingIndex(pricingCache), platform);
 
-    updateProviderCache(registry, providerId, enriched, baseUrl);
-    saveRegistry(registry);
+    await withRegistryWriteLock(() => {
+      const currentRegistry = loadRegistry();
+      const currentProvider = currentRegistry.providers.find(candidate => candidate.id === providerId);
+      if (!currentProvider) throw new Error('Provider was removed while models were refreshing.');
+      if (currentProvider.authRef !== provider.authRef) {
+        throw new Error('Provider credentials changed while models were refreshing.');
+      }
+      if (!providerDiscoveryInputsMatch(currentProvider, provider)) {
+        throw new Error('Provider configuration changed while models were refreshing.');
+      }
+      updateProviderCache(currentRegistry, providerId, enriched, baseUrl);
+      saveRegistry(currentRegistry);
+    });
     enrichPricingAsync();
 
     return {
@@ -442,7 +466,7 @@ export async function refreshAllProviderModels(
 
   for (const provider of enabledProviders) {
     const key = await resolveRefreshCredential(provider, resolveKey);
-    refreshed.push(await refreshProviderModels(provider.id, key, registry));
+    refreshed.push(await refreshProviderModels(provider.id, key));
   }
 
   return { refreshed };

--- a/tests/custom-endpoint.test.ts
+++ b/tests/custom-endpoint.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProviderRegistry } from '../src/registry/types.js';
+
+const registryState = vi.hoisted(() => ({
+  current: { schemaVersion: 1, providers: [] } as ProviderRegistry,
+}));
+const lockState = vi.hoisted(() => ({
+  active: false,
+  entries: 0,
+}));
+
+vi.mock('../src/env.js', () => ({
+  saveProviderCredential: vi.fn(),
+}));
+vi.mock('../src/registry/fetch-template-models.js', () => ({
+  fetchTemplateModels: vi.fn(),
+}));
+vi.mock('../src/registry/io.js', () => ({
+  loadRegistry: vi.fn(() => structuredClone(registryState.current)),
+  saveRegistry: vi.fn((registry: ProviderRegistry) => {
+    registryState.current = structuredClone(registry);
+  }),
+}));
+vi.mock('../src/registry/lock.js', () => ({
+  withRegistryWriteLock: vi.fn(async <T>(operation: () => Promise<T> | T): Promise<T> => {
+    lockState.entries += 1;
+    if (lockState.active) throw new Error('registry lock re-entered');
+    lockState.active = true;
+    try {
+      return await operation();
+    } finally {
+      lockState.active = false;
+    }
+  }),
+}));
+vi.mock('../src/registry/url-security.js', () => ({
+  validateCustomEndpointUrl: vi.fn(),
+}));
+
+import { saveProviderCredential } from '../src/env.js';
+import { addCustomEndpointProvider } from '../src/registry/custom-endpoint.js';
+import { fetchTemplateModels } from '../src/registry/fetch-template-models.js';
+import { saveRegistry } from '../src/registry/io.js';
+import { validateCustomEndpointUrl } from '../src/registry/url-security.js';
+
+const endpointInput = {
+  displayName: 'Test Endpoint',
+  baseUrl: 'https://api.example.com/v1',
+  apiKey: 'test-key',
+  kind: 'openai' as const,
+};
+
+function successfulDiscovery() {
+  return {
+    models: [
+      {
+        id: 'model-1',
+        name: 'Model 1',
+        upstreamModelId: 'model-1',
+        family: 'test',
+        brand: 'test',
+        modelFormat: 'openai' as const,
+      },
+    ],
+    baseUrl: endpointInput.baseUrl,
+  };
+}
+
+describe('custom endpoint registry updates', () => {
+  beforeEach(() => {
+    registryState.current = { schemaVersion: 1, providers: [] };
+    lockState.active = false;
+    lockState.entries = 0;
+
+    vi.mocked(saveProviderCredential).mockReset().mockResolvedValue(true);
+    vi.mocked(fetchTemplateModels).mockReset().mockResolvedValue(successfulDiscovery());
+    vi.mocked(validateCustomEndpointUrl).mockReset().mockResolvedValue({
+      ok: true,
+      normalizedUrl: endpointInput.baseUrl,
+    });
+    vi.mocked(saveRegistry)
+      .mockReset()
+      .mockImplementation((registry) => {
+        registryState.current = structuredClone(registry);
+      });
+  });
+
+  it('discovers models before entering the registry write lock', async () => {
+    const observedLockStates: boolean[] = [];
+    vi.mocked(fetchTemplateModels).mockImplementation(async () => {
+      observedLockStates.push(lockState.active);
+      return successfulDiscovery();
+    });
+
+    const result = await addCustomEndpointProvider(endpointInput);
+
+    expect(result.added).toBe(true);
+    expect(observedLockStates).toEqual([false]);
+    expect(lockState.entries).toBe(1);
+    expect(lockState.active).toBe(false);
+  });
+
+  it('allocates the provider id from state reloaded after discovery', async () => {
+    vi.mocked(fetchTemplateModels).mockImplementation(async () => {
+      registryState.current.providers.push({
+        id: 'custom-test-endpoint',
+        templateId: 'custom-openai',
+        name: 'Concurrent endpoint',
+        enabled: true,
+        authRef: 'keyring:provider:custom-test-endpoint',
+        api: { npm: '@ai-sdk/openai-compatible', url: endpointInput.baseUrl },
+        addedAt: '2026-01-01T00:00:00.000Z',
+      });
+      return successfulDiscovery();
+    });
+
+    const result = await addCustomEndpointProvider(endpointInput);
+
+    expect(result).toMatchObject({
+      added: true,
+      provider: { id: 'custom-test-endpoint-2' },
+    });
+    expect(saveProviderCredential).toHaveBeenCalledWith(
+      'keyring:provider:custom-test-endpoint-2',
+      endpointInput.apiKey,
+    );
+    expect(registryState.current.providers.map((provider) => provider.id)).toEqual([
+      'custom-test-endpoint',
+      'custom-test-endpoint-2',
+    ]);
+  });
+});

--- a/tests/provider-auth.test.ts
+++ b/tests/provider-auth.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
+const lockState = vi.hoisted(() => ({ active: false }));
+
 vi.mock('../src/ui.js', () => ({
   printOAuthStepsPanel: vi.fn(),
 }));
@@ -19,6 +21,16 @@ vi.mock('../src/registry/io.js', () => ({
 vi.mock('../src/registry/refresh-models.js', () => ({
   refreshProviderModels: vi.fn(),
 }));
+vi.mock('../src/registry/lock.js', () => ({
+  withRegistryWriteLock: vi.fn(async (operation: () => unknown) => {
+    lockState.active = true;
+    try {
+      return await operation();
+    } finally {
+      lockState.active = false;
+    }
+  }),
+}));
 vi.mock('@clack/prompts', () => ({
   log: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), success: vi.fn() },
   spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
@@ -30,13 +42,16 @@ import { saveProviderCredential } from '../src/env.js';
 import { saveRegistry } from '../src/registry/io.js';
 import { authenticateProvider } from '../src/registry/provider-auth.js';
 import { runOpenAiDeviceCodeFlow } from '../src/oauth/openai.js';
+import { refreshProviderModels } from '../src/registry/refresh-models.js';
 import * as prompts from '@clack/prompts';
 
 describe('authenticateProvider', () => {
   beforeEach(() => {
+    lockState.active = false;
     vi.mocked(saveProviderCredential).mockClear();
     vi.mocked(saveRegistry).mockClear();
     vi.mocked(runOpenAiDeviceCodeFlow).mockClear();
+    vi.mocked(refreshProviderModels).mockClear();
     vi.mocked(prompts.select).mockClear();
   });
 
@@ -56,6 +71,32 @@ describe('authenticateProvider', () => {
     expect(saveProviderCredential).toHaveBeenCalled();
     expect(saveRegistry).toHaveBeenCalled();
     expect(result.providerId).toBe('openai-oauth');
+  });
+
+  it('holds the registry lock only while persisting the provider entry', async () => {
+    const observations: Array<[string, boolean]> = [];
+    vi.mocked(runOpenAiDeviceCodeFlow).mockImplementationOnce(async () => {
+      observations.push(['authorization', lockState.active]);
+      return {
+        tokens: { access_token: 'access-token', refresh_token: 'refresh-token', expires_in: 3600 },
+        accountId: 'account-id',
+      };
+    });
+    vi.mocked(saveRegistry).mockImplementationOnce(() => {
+      observations.push(['registry-write', lockState.active]);
+    });
+    vi.mocked(refreshProviderModels).mockImplementationOnce(async () => {
+      observations.push(['model-refresh', lockState.active]);
+      return { id: 'openai-oauth', name: 'OpenAI', ok: true };
+    });
+
+    await authenticateProvider('openai');
+
+    expect(observations).toEqual([
+      ['authorization', false],
+      ['registry-write', true],
+      ['model-refresh', false],
+    ]);
   });
 
   it('rejects non-OpenAI providers', async () => {

--- a/tests/refresh-models.test.ts
+++ b/tests/refresh-models.test.ts
@@ -12,14 +12,139 @@ vi.mock('../src/registry/io.js', () => ({
   loadRegistry: vi.fn(() => ({ version: 1, providers: [] })),
   saveRegistry: vi.fn(),
 }));
+vi.mock('../src/registry/lock.js', () => ({
+  withRegistryWriteLock: vi.fn(async (operation: () => unknown) => operation()),
+}));
 
 import { fetchTemplateModels } from '../src/registry/fetch-template-models.js';
-import { saveRegistry } from '../src/registry/io.js';
+import { loadRegistry, saveRegistry } from '../src/registry/io.js';
 
 describe('refreshProviderModels', () => {
   beforeEach(() => {
     vi.mocked(fetchTemplateModels).mockReset();
+    vi.mocked(loadRegistry).mockReset();
     vi.mocked(saveRegistry).mockClear();
+  });
+
+  it('reloads persisted state before saving discovery results', async () => {
+    const initialRegistry: ProviderRegistry = {
+      schemaVersion: 1,
+      providers: [{
+        id: 'groq',
+        templateId: 'groq',
+        name: 'Groq',
+        enabled: true,
+        authRef: 'keyring:provider:groq',
+        authType: 'api',
+        api: { npm: '@ai-sdk/groq', url: 'https://api.groq.com/openai/v1' },
+        addedAt: '2026-01-01T00:00:00.000Z',
+      }],
+    };
+    const persistedRegistry: ProviderRegistry = {
+      schemaVersion: 1,
+      providers: [{
+        ...initialRegistry.providers[0]!,
+        name: 'Renamed while discovery was running',
+      }],
+    };
+    vi.mocked(loadRegistry).mockReturnValue(persistedRegistry);
+    vi.mocked(fetchTemplateModels).mockResolvedValue({
+      baseUrl: 'https://api.groq.com/openai/v1',
+      models: [{
+        id: 'live-a',
+        name: 'Live A',
+        upstreamModelId: 'live-a',
+        modelFormat: 'openai',
+      }],
+    });
+
+    const result = await refreshProviderModels('groq', 'test-key', initialRegistry);
+
+    expect(result).toMatchObject({ ok: true, modelCount: 1 });
+    expect(loadRegistry).toHaveBeenCalledOnce();
+    expect(saveRegistry).toHaveBeenCalledWith(persistedRegistry);
+    expect(persistedRegistry.providers[0]?.name).toBe('Renamed while discovery was running');
+    expect(persistedRegistry.providers[0]?.modelsCache?.models[0]?.id).toBe('live-a');
+  });
+
+  it('does not apply discovery results after credentials change', async () => {
+    const initialRegistry: ProviderRegistry = {
+      schemaVersion: 1,
+      providers: [{
+        id: 'groq',
+        templateId: 'groq',
+        name: 'Groq',
+        enabled: true,
+        authRef: 'keyring:provider:groq',
+        authType: 'api',
+        api: { npm: '@ai-sdk/groq', url: 'https://api.groq.com/openai/v1' },
+        addedAt: '2026-01-01T00:00:00.000Z',
+      }],
+    };
+    vi.mocked(loadRegistry).mockReturnValue({
+      schemaVersion: 1,
+      providers: [{
+        ...initialRegistry.providers[0]!,
+        authRef: 'keyring:provider:groq-replacement',
+      }],
+    });
+    vi.mocked(fetchTemplateModels).mockResolvedValue({
+      baseUrl: 'https://api.groq.com/openai/v1',
+      models: [{
+        id: 'live-a',
+        name: 'Live A',
+        upstreamModelId: 'live-a',
+        modelFormat: 'openai',
+      }],
+    });
+
+    const result = await refreshProviderModels('groq', 'test-key', initialRegistry);
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: 'Provider credentials changed while models were refreshing.',
+    });
+    expect(saveRegistry).not.toHaveBeenCalled();
+  });
+
+  it('does not apply discovery results after endpoint configuration changes', async () => {
+    const initialRegistry: ProviderRegistry = {
+      schemaVersion: 1,
+      providers: [{
+        id: 'groq',
+        templateId: 'groq',
+        name: 'Groq',
+        enabled: true,
+        authRef: 'keyring:provider:groq',
+        authType: 'api',
+        api: { npm: '@ai-sdk/groq', url: 'https://api.groq.com/openai/v1' },
+        addedAt: '2026-01-01T00:00:00.000Z',
+      }],
+    };
+    vi.mocked(loadRegistry).mockReturnValue({
+      schemaVersion: 1,
+      providers: [{
+        ...initialRegistry.providers[0]!,
+        api: { npm: '@ai-sdk/groq', url: 'https://replacement.example/v1' },
+      }],
+    });
+    vi.mocked(fetchTemplateModels).mockResolvedValue({
+      baseUrl: 'https://api.groq.com/openai/v1',
+      models: [{
+        id: 'live-a',
+        name: 'Live A',
+        upstreamModelId: 'live-a',
+        modelFormat: 'openai',
+      }],
+    });
+
+    const result = await refreshProviderModels('groq', 'test-key', initialRegistry);
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: 'Provider configuration changed while models were refreshing.',
+    });
+    expect(saveRegistry).not.toHaveBeenCalled();
   });
 
   it('rejects restricted provider API URLs before refreshing models', async () => {
@@ -82,6 +207,7 @@ describe('refreshProviderModels', () => {
         modelFormat: 'openai',
       }],
     });
+    vi.mocked(loadRegistry).mockReturnValue(registry);
 
     const first = await refreshProviderModels('groq', 'gsk-real-key', registry);
     const second = await refreshProviderModels('groq', 'gsk-real-key', registry);

--- a/tests/registry-add-template.test.ts
+++ b/tests/registry-add-template.test.ts
@@ -8,6 +8,8 @@ import * as pricing from '../src/registry/pricing.js';
 import type { ProviderTemplate } from '../src/provider-templates.js';
 import type { ProviderRegistry } from '../src/registry/types.js';
 
+const lockState = vi.hoisted(() => ({ active: false }));
+
 vi.mock('../src/env.js', () => ({ saveProviderCredential: vi.fn() }));
 vi.mock('../src/provider-factory.js', () => ({ isSdkMigratedNpm: vi.fn() }));
 vi.mock('../src/registry/fetch-template-models.js', () => ({ fetchTemplateModels: vi.fn() }));
@@ -18,6 +20,17 @@ vi.mock('../src/registry/pricing.js', () => ({
   enrichPricingAsync: vi.fn(),
   pricingPlatformForProvider: vi.fn(),
   buildPricingIndex: vi.fn(),
+}));
+vi.mock('../src/registry/lock.js', () => ({
+  withRegistryWriteLock: vi.fn(async (operation: () => unknown) => {
+    if (lockState.active) return operation();
+    lockState.active = true;
+    try {
+      return await operation();
+    } finally {
+      lockState.active = false;
+    }
+  }),
 }));
 
 describe('registry/add-template', () => {
@@ -32,6 +45,7 @@ describe('registry/add-template', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    lockState.active = false;
 
     vi.mocked(providerFactory.isSdkMigratedNpm).mockReturnValue(true);
     vi.mocked(env.saveProviderCredential).mockResolvedValue(true);
@@ -93,6 +107,51 @@ describe('registry/add-template', () => {
     const res = await addProviderFromTemplate(dummyTemplate, 'key');
     expect(res.added).toBe(false);
     expect(res.error).toBe('Network failure');
+  });
+
+  it('keeps model discovery and background pricing outside the registry lock', async () => {
+    vi.mocked(fetchTemplate.fetchTemplateModels).mockImplementation(async () => {
+      expect(lockState.active).toBe(false);
+      return {
+        models: [{ id: 'model-1', name: 'Model 1', upstreamModelId: 'model-1', family: 'fam', brand: 'brand', modelFormat: 'openai' }],
+        baseUrl: 'https://api.example.com',
+      };
+    });
+    vi.mocked(pricing.enrichPricingAsync).mockImplementation(() => {
+      expect(lockState.active).toBe(false);
+    });
+
+    const res = await addProviderFromTemplate(dummyTemplate, 'key');
+
+    expect(res.added).toBe(true);
+    expect(fetchTemplate.fetchTemplateModels).toHaveBeenCalledOnce();
+    expect(pricing.enrichPricingAsync).toHaveBeenCalledOnce();
+  });
+
+  it('revalidates provider existence after model discovery', async () => {
+    vi.mocked(io.loadRegistry)
+      .mockReturnValueOnce({ schemaVersion: 1, providers: [] })
+      .mockReturnValueOnce({
+        schemaVersion: 1,
+        providers: [{
+          id: 'test-template',
+          templateId: 'test-template',
+          name: 'Concurrent provider',
+          enabled: true,
+          authType: 'api',
+          authRef: 'keyring:provider:test-template',
+          api: {},
+          addedAt: '2026-01-01T00:00:00.000Z',
+        }],
+      });
+
+    const res = await addProviderFromTemplate(dummyTemplate, 'key');
+
+    expect(res.added).toBe(false);
+    expect(res.error).toContain('is already configured');
+    expect(fetchTemplate.fetchTemplateModels).toHaveBeenCalledOnce();
+    expect(env.saveProviderCredential).not.toHaveBeenCalled();
+    expect(io.saveRegistry).not.toHaveBeenCalled();
   });
 
   it('fails if credential cannot be saved', async () => {

--- a/tests/registry-lock.test.ts
+++ b/tests/registry-lock.test.ts
@@ -1,0 +1,287 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  tryAcquireRegistryLock,
+  withRegistryWriteLock,
+  withRegistryWriteLockSync,
+} from '../src/registry/lock.js';
+
+const roots: string[] = [];
+
+function temporaryLockPath(): string {
+  const root = mkdtempSync(join(tmpdir(), 'registry-lock-'));
+  roots.push(root);
+  return join(root, 'providers.lock');
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0))
+    rmSync(root, { recursive: true, force: true });
+});
+
+describe('provider registry lock', () => {
+  it('allows only one owner until the matching release runs', () => {
+    const lockPath = temporaryLockPath();
+    const release = tryAcquireRegistryLock(lockPath);
+    expect(release).toBeTypeOf('function');
+    expect(tryAcquireRegistryLock(lockPath)).toBeNull();
+
+    release?.();
+    const nextRelease = tryAcquireRegistryLock(lockPath);
+    expect(nextRelease).toBeTypeOf('function');
+    nextRelease?.();
+  });
+
+  it('reaps a lock owned by a dead process but not an old live owner', () => {
+    const lockPath = temporaryLockPath();
+    const old = Date.now() - 24 * 60 * 60 * 1000;
+    writeFileSync(
+      lockPath,
+      JSON.stringify({ pid: 1234, startedAt: old, token: 'old-owner' }),
+    );
+
+    expect(
+      tryAcquireRegistryLock(lockPath, { isAlive: () => true }),
+    ).toBeNull();
+    const release = tryAcquireRegistryLock(lockPath, { isAlive: () => false });
+    expect(release).toBeTypeOf('function');
+    expect(JSON.parse(readFileSync(lockPath, 'utf8')).token).not.toBe(
+      'old-owner',
+    );
+    release?.();
+  });
+
+  it('does not remove a replacement created during stale-lock reclamation', () => {
+    const lockPath = temporaryLockPath();
+    const stalePid = 1234;
+    writeFileSync(
+      lockPath,
+      JSON.stringify({
+        pid: stalePid,
+        startedAt: Date.now() - 60_000,
+        token: 'stale-owner',
+      }),
+    );
+
+    let competingRelease: (() => void) | null = null;
+    let interleaved = false;
+    const release = tryAcquireRegistryLock(lockPath, {
+      isAlive: (pid) => {
+        if (pid === stalePid && !interleaved) {
+          interleaved = true;
+          competingRelease = tryAcquireRegistryLock(lockPath, {
+            isAlive: () => false,
+          });
+        }
+        return pid !== stalePid;
+      },
+    });
+
+    try {
+      expect(competingRelease).toBeTypeOf('function');
+      expect(release).toBeNull();
+    } finally {
+      release?.();
+      competingRelease?.();
+    }
+  });
+
+  it('serializes stale reclamation through a separate reaper guard', () => {
+    const lockPath = temporaryLockPath();
+    writeFileSync(
+      lockPath,
+      JSON.stringify({
+        pid: 1234,
+        startedAt: Date.now() - 60_000,
+        token: 'stale-owner',
+      }),
+    );
+    writeFileSync(
+      `${lockPath}.reap`,
+      JSON.stringify({
+        pid: process.pid,
+        startedAt: Date.now(),
+        token: 'active-reaper',
+      }),
+    );
+
+    expect(
+      tryAcquireRegistryLock(lockPath, {
+        isAlive: (pid) => pid === process.pid,
+      }),
+    ).toBeNull();
+    expect(JSON.parse(readFileSync(lockPath, 'utf8')).token).toBe(
+      'stale-owner',
+    );
+  });
+
+  it('recovers when a dead process leaves the reaper guard behind', () => {
+    const lockPath = temporaryLockPath();
+    const deadOwner = {
+      pid: 2_147_483_647,
+      startedAt: Date.now() - 60_000,
+      token: 'dead-owner',
+    };
+    writeFileSync(lockPath, JSON.stringify(deadOwner));
+    writeFileSync(`${lockPath}.reap`, JSON.stringify(deadOwner));
+
+    const release = tryAcquireRegistryLock(lockPath, { isAlive: () => false });
+
+    expect(release).toBeTypeOf('function');
+    expect(JSON.parse(readFileSync(lockPath, 'utf8')).token).not.toBe(
+      'dead-owner',
+    );
+    release?.();
+  });
+
+  it('acquires nested locks when their paths differ', async () => {
+    const firstPath = temporaryLockPath();
+    const secondPath = temporaryLockPath();
+
+    await withRegistryWriteLock(
+      async () => {
+        await withRegistryWriteLock(
+          () => {
+            expect(tryAcquireRegistryLock(secondPath)).toBeNull();
+          },
+          { lockPath: secondPath },
+        );
+      },
+      { lockPath: firstPath },
+    );
+
+    const release = tryAcquireRegistryLock(secondPath);
+    expect(release).toBeTypeOf('function');
+    release?.();
+  });
+
+  it('serializes independent asynchronous callers', async () => {
+    const lockPath = temporaryLockPath();
+    const events: string[] = [];
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const first = withRegistryWriteLock(
+      async () => {
+        events.push('first-enter');
+        await firstGate;
+        events.push('first-exit');
+      },
+      { lockPath, waitMs: 1_000, retryMs: 5 },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const second = withRegistryWriteLock(
+      () => {
+        events.push('second-enter');
+      },
+      { lockPath, waitMs: 1_000, retryMs: 5 },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(events).toEqual(['first-enter']);
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(events).toEqual(['first-enter', 'first-exit', 'second-enter']);
+  });
+
+  it('invalidates inherited asynchronous ownership after releasing the lock', async () => {
+    const lockPath = temporaryLockPath();
+    const events: string[] = [];
+    let startDetached!: () => void;
+    const detachedGate = new Promise<void>((resolve) => {
+      startDetached = resolve;
+    });
+    let detached: Promise<void> | undefined;
+
+    await withRegistryWriteLock(
+      () => {
+        detached = (async () => {
+          await detachedGate;
+          await withRegistryWriteLock(
+            () => {
+              events.push('detached-enter');
+            },
+            { lockPath, waitMs: 1_000, retryMs: 5 },
+          );
+        })();
+      },
+      { lockPath, waitMs: 1_000, retryMs: 5 },
+    );
+
+    let releaseSecond!: () => void;
+    const secondGate = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+    let markSecondEntered!: () => void;
+    const secondEntered = new Promise<void>((resolve) => {
+      markSecondEntered = resolve;
+    });
+    const second = withRegistryWriteLock(
+      async () => {
+        events.push('second-enter');
+        markSecondEntered();
+        await secondGate;
+        events.push('second-exit');
+      },
+      { lockPath, waitMs: 1_000, retryMs: 5 },
+    );
+
+    await secondEntered;
+    startDetached();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(events).toEqual(['second-enter']);
+
+    releaseSecond();
+    await Promise.all([second, detached]);
+    expect(events).toEqual(['second-enter', 'second-exit', 'detached-enter']);
+  });
+
+  it('invalidates inherited synchronous ownership after releasing the lock', async () => {
+    const lockPath = temporaryLockPath();
+    const events: string[] = [];
+    let detachedError: unknown;
+    let finishDetached!: () => void;
+    const detachedFinished = new Promise<void>((resolve) => {
+      finishDetached = resolve;
+    });
+
+    withRegistryWriteLockSync(
+      () => {
+        setImmediate(() => {
+          try {
+            withRegistryWriteLockSync(
+              () => {
+                events.push('detached-enter');
+              },
+              { lockPath, waitMs: 0 },
+            );
+          } catch (error) {
+            detachedError = error;
+          } finally {
+            finishDetached();
+          }
+        });
+      },
+      { lockPath },
+    );
+
+    const release = tryAcquireRegistryLock(lockPath);
+    expect(release).toBeTypeOf('function');
+    try {
+      await detachedFinished;
+    } finally {
+      release?.();
+    }
+
+    expect(events).toEqual([]);
+    expect(detachedError).toEqual(
+      expect.objectContaining({
+        message: expect.stringContaining('Timed out after 0ms'),
+      }),
+    );
+  });
+});

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -108,6 +108,38 @@ describe('registry io', () => {
     expect(loaded.providers[0]?.id).toBe('groq');
   });
 
+  it('serializes migration writes and reloads state after acquiring the lock', () => {
+    const path = join(home, 'providers.json');
+    const lockPath = `${path}.lock`;
+    const raw = {
+      schemaVersion: 1,
+      providers: [{
+        id: 'openai',
+        templateId: 'openai',
+        name: 'OpenAI',
+        enabled: true,
+        authRef: 'keyring:oauth:provider:openai',
+        authType: 'oauth',
+        api: { npm: '@ai-sdk/openai' },
+        addedAt: '2026-06-09T00:00:00.000Z',
+      }],
+    };
+    mkdirSync(home, { recursive: true });
+    writeFileSync(path, JSON.stringify(raw));
+    writeFileSync(lockPath, JSON.stringify({
+      pid: 2_147_483_647,
+      startedAt: Date.now() - 60_000,
+      token: 'dead-owner',
+    }));
+
+    const loaded = loadRegistry(path);
+    const persisted = JSON.parse(readFileSync(path, 'utf8'));
+
+    expect(loaded.providers[0]?.id).toBe('openai-oauth');
+    expect(persisted.providers[0]?.id).toBe('openai-oauth');
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
 });
 
 describe('materializeRegistry', () => {


### PR DESCRIPTION
## Summary

- Serialize registry write transactions across processes with stale-owner recovery.
- Keep network discovery outside the lock, then reload and revalidate state before committing.
- Reject refresh results when credentials or discovery configuration changed in flight.

## Test plan

- [x] Focused registry and lock tests: 58 passed.
- [x] Isolated non-listener suite: 587 passed.
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] Staged and committed secret scans

