### PR TITLE
fix(auth): make credential cleanup crash-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ clodex --version    # version
 - The config-home filesystem must support hard links because registry locks are
   published atomically. Keep `CLODEX_HOME` on a local filesystem rather than
   FAT, exFAT, or a network mount that rejects hard links. An abrupt process kill
-  during lock publication can leave a `providers.json.lock.*.tmp` file; it does
+  during lock publication can leave a `*.lock.*.tmp` file; it does
   not block later lock acquisition and can be removed when no Clodex process is
   running. A canonical `providers.json.lock` whose recorded PID is no longer
   running is reclaimed automatically on the next lock acquisition. If it remains

--- a/docs/credential-helpers.md
+++ b/docs/credential-helpers.md
@@ -32,6 +32,15 @@ diagnostic in the error instead of continuing with tokens that cannot be
 durably stored. Set `CLODEX_CREDENTIAL_HELPER` to the absolute path of an
 external helper, then run the authorization command again.
 
+Provider creation, replacement, and removal use a durable cleanup journal in
+`providers.json`. A new unreferenced credential is journaled before it is
+written, provider changes are saved before superseded credentials are deleted,
+and uncertain deletion outcomes remain queued. Per-credential cross-process
+locks serialize writes, activation, removal, and reconciliation for the same
+reference without blocking unrelated credentials. The next `clodex providers`
+command retries queued deletions idempotently and never deletes a credential
+that is referenced by an active provider.
+
 ## Protocol
 
 The helper receives one of these invocations:

--- a/docs/credential-helpers.md
+++ b/docs/credential-helpers.md
@@ -32,14 +32,18 @@ diagnostic in the error instead of continuing with tokens that cannot be
 durably stored. Set `CLODEX_CREDENTIAL_HELPER` to the absolute path of an
 external helper, then run the authorization command again.
 
-Provider creation, replacement, and removal use a durable cleanup journal in
-`providers.json`. A new unreferenced credential is journaled before it is
-written, provider changes are saved before superseded credentials are deleted,
-and uncertain deletion outcomes remain queued. Per-credential cross-process
-locks serialize writes, activation, removal, and reconciliation for the same
-reference without blocking unrelated credentials. The next `clodex providers`
-command retries queued deletions idempotently and never deletes a credential
-that is referenced by an active provider.
+Provider creation, replacement, and removal use the durable cleanup journal at
+`~/.clodex/credential-cleanup.json` (under `CLODEX_HOME` when set). Keeping the
+journal separate from `providers.json` prevents registry writers that only know
+schema 1 provider fields from dropping pending cleanup. A new unreferenced
+credential is journaled before it is written, provider changes are saved before
+superseded credentials are deleted, and uncertain deletion outcomes remain
+queued. Per-credential cross-process locks serialize writes, activation,
+removal, and reconciliation for the same reference without blocking unrelated
+credentials. Reconciliation is best-effort: one busy credential does not block
+unrelated cleanup or turn an already-saved provider into a failed creation. The
+next `clodex providers` command retries queued deletions idempotently and never
+deletes a credential that is referenced by an active provider.
 
 ## Protocol
 

--- a/docs/credential-helpers.md
+++ b/docs/credential-helpers.md
@@ -39,11 +39,19 @@ schema 1 provider fields from dropping pending cleanup. A new unreferenced
 credential is journaled before it is written, provider changes are saved before
 superseded credentials are deleted, and uncertain deletion outcomes remain
 queued. Per-credential cross-process locks serialize writes, activation,
-removal, and reconciliation for the same reference without blocking unrelated
-credentials. Reconciliation is best-effort: one busy credential does not block
-unrelated cleanup or turn an already-saved provider into a failed creation. The
-next `clodex providers` command retries queued deletions idempotently and never
-deletes a credential that is referenced by an active provider.
+removal, and reconciliation for the same reference. Reconciliation is
+best-effort and sequential: a contended credential can delay later entries
+until its lock attempt times out, but the timeout does not turn an already-saved
+provider into a failed creation. The next `clodex providers` command retries
+queued deletions idempotently and never deletes a credential that is referenced
+by an active provider. If the registry cannot be read and validated, cleanup
+stays queued instead of treating the registry as empty.
+
+The cleanup journal accepts only credential accounts generated for Clodex
+provider and OAuth records, including replacement, custom-provider, and scoped
+credential instances. It rejects symbolic links, foreign ownership, broad
+permissions on POSIX, files over 1 MiB, and more than 1,024 queued entries
+before attempting any credential-store deletion.
 
 ## Protocol
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -71,6 +71,10 @@ export function getProvidersPath(env: HomeEnv = process.env): string {
   return join(getAppHome(env), 'providers.json');
 }
 
+export function getCredentialCleanupPath(env: HomeEnv = process.env): string {
+  return join(getAppHome(env), 'credential-cleanup.json');
+}
+
 export function getLogsPath(env: HomeEnv = process.env): string {
   return join(getAppHome(env), 'logs');
 }

--- a/src/providers-command.ts
+++ b/src/providers-command.ts
@@ -263,6 +263,9 @@ async function runTemplateAddFlow(): Promise<number> {
   }
 
   logConnected(template.name, result.modelCount ?? 0);
+  if (result.credentialCleanupPending) {
+    p.log.warn('A previous credential is queued for cleanup and will be retried by the next provider command.');
+  }
   return 0;
 }
 
@@ -481,8 +484,14 @@ export async function runProvidersCommand(args: string[]): Promise<number> {
     return 0;
   }
 
-  const cleanup = await reconcilePendingCredentialDeletes();
-  if (cleanup.pending.length > 0 || cleanup.persistenceError) {
+  let cleanupPending = false;
+  try {
+    const cleanup = await reconcilePendingCredentialDeletes();
+    cleanupPending = cleanup.pending.length > 0 || cleanup.persistenceError !== undefined;
+  } catch {
+    cleanupPending = true;
+  }
+  if (cleanupPending) {
     p.log.warn('Some credential cleanup is still pending and will be retried later.');
   }
 

--- a/src/providers-command.ts
+++ b/src/providers-command.ts
@@ -18,6 +18,7 @@ import {
   removeProviderFromRegistry,
   toggleProviderEnabled,
 } from './registry/crud.js';
+import { reconcilePendingCredentialDeletes } from './registry/credential-lifecycle.js';
 import { loadRegistry } from './registry/io.js';
 import { refreshAllProviderModels, refreshProviderModels } from './registry/refresh-models.js';
 import { resolveRefreshCredential } from './registry/refresh-credentials.js';
@@ -115,6 +116,9 @@ export async function runProvidersAuth(providerId: string, method?: ProviderAuth
   try {
     const result = await authenticateProvider(providerId, { method });
     p.log.success(`Signed in to ${result.registryProvider.name} — credential saved to the credential store.`);
+    if (result.credentialCleanupPending) {
+      p.log.warn('A previous credential is queued for cleanup and will be retried by the next provider command.');
+    }
     return 0;
   } catch (err) {
     if (err instanceof Error && err.message === 'Cancelled') {
@@ -321,6 +325,9 @@ export async function runProvidersRemove(id: string, interactive = false): Promi
   if (result.credentialDeleted) {
     p.log.info('Provider API key removed from the credential store.');
   }
+  if (result.credentialCleanupPending) {
+    p.log.warn('Provider credential cleanup is queued for retry.');
+  }
   return 0;
 }
 
@@ -472,6 +479,11 @@ export async function runProvidersCommand(args: string[]): Promise<number> {
   if (parsed.showHelp && parsed.subcommand !== 'auth') {
     console.log(providersHelpText());
     return 0;
+  }
+
+  const cleanup = await reconcilePendingCredentialDeletes();
+  if (cleanup.pending.length > 0 || cleanup.persistenceError) {
+    p.log.warn('Some credential cleanup is still pending and will be retried later.');
   }
 
   if (parsed.subcommand === 'list') return runProvidersList();

--- a/src/providers-command.ts
+++ b/src/providers-command.ts
@@ -43,6 +43,52 @@ export type ProvidersSubcommand = 'hub' | 'add' | 'list' | 'remove' | 'refresh-m
 const CREDENTIAL_CLEANUP_PENDING_MESSAGE =
   'Credential cleanup is pending and will be retried by the next provider command.';
 
+interface ProviderCommandCleanupState {
+  reconciled: boolean;
+  pending: boolean;
+}
+
+function reportCredentialCleanup(
+  pending: boolean,
+  state?: ProviderCommandCleanupState,
+  reconciled = false,
+): void {
+  if (state) {
+    state.reconciled ||= reconciled;
+    state.pending ||= pending;
+    return;
+  }
+  if (pending) {
+    p.log.warn(CREDENTIAL_CLEANUP_PENDING_MESSAGE);
+  }
+}
+
+async function reconcileCredentialCleanup(): Promise<boolean> {
+  try {
+    const cleanup = await reconcilePendingCredentialDeletes();
+    return cleanup.pending.length > 0 || cleanup.persistenceError !== undefined;
+  } catch {
+    return true;
+  }
+}
+
+async function runWithCredentialCleanup(
+  run: (state: ProviderCommandCleanupState) => Promise<number>,
+): Promise<number> {
+  const state: ProviderCommandCleanupState = {
+    reconciled: false,
+    pending: false,
+  };
+  try {
+    return await run(state);
+  } finally {
+    if (!state.reconciled) {
+      state.pending = await reconcileCredentialCleanup();
+    }
+    reportCredentialCleanup(state.pending);
+  }
+}
+
 export function parseProvidersArgs(args: string[]): {
   subcommand: ProvidersSubcommand;
   showHelp: boolean;
@@ -115,13 +161,15 @@ function providerLabel(name: string, modelCount: number, enabled: boolean): stri
   return `${fmtEnabledStar(enabled)} ${fmtProvider(name)} ${pc.dim(`(${modelCount} model${modelCount === 1 ? '' : 's'})`)}`;
 }
 
-export async function runProvidersAuth(providerId: string, method?: ProviderAuthMethod): Promise<number> {
+async function runProvidersAuthWithCleanupState(
+  providerId: string,
+  method?: ProviderAuthMethod,
+  cleanupState?: ProviderCommandCleanupState,
+): Promise<number> {
   try {
     const result = await authenticateProvider(providerId, { method });
     p.log.success(`Signed in to ${result.registryProvider.name} — credential saved to the credential store.`);
-    if (result.credentialCleanupPending) {
-      p.log.warn(CREDENTIAL_CLEANUP_PENDING_MESSAGE);
-    }
+    reportCredentialCleanup(result.credentialCleanupPending, cleanupState, true);
     return 0;
   } catch (err) {
     if (err instanceof Error && err.message === 'Cancelled') {
@@ -131,6 +179,10 @@ export async function runProvidersAuth(providerId: string, method?: ProviderAuth
     p.log.error(err instanceof Error ? err.message : String(err));
     return 1;
   }
+}
+
+export async function runProvidersAuth(providerId: string, method?: ProviderAuthMethod): Promise<number> {
+  return runProvidersAuthWithCleanupState(providerId, method);
 }
 
 export async function runProvidersRefreshModels(providerId?: string): Promise<number> {
@@ -227,7 +279,7 @@ export async function runProvidersList(): Promise<number> {
 }
 
 /** Add the OpenAI API-key provider (the only addable template in clodex). */
-async function runTemplateAddFlow(): Promise<number> {
+async function runTemplateAddFlow(cleanupState?: ProviderCommandCleanupState): Promise<number> {
   const registry = loadRegistry();
   const configuredIds = registry.providers.map(p => p.id);
   const template = listAddableTemplates(configuredIds).find(t => t.id === 'openai')
@@ -258,6 +310,11 @@ async function runTemplateAddFlow(): Promise<number> {
   spinner.start(`Testing connection to ${template.name}...`);
   const result = await addProviderFromTemplate(template, apiKey);
   spinner.stop('');
+  reportCredentialCleanup(
+    result.credentialCleanupPending === true,
+    cleanupState,
+    result.credentialCleanupReconciled === true,
+  );
 
   if (!result.added) {
     p.log.error(result.error ?? 'Could not add provider.');
@@ -266,13 +323,12 @@ async function runTemplateAddFlow(): Promise<number> {
   }
 
   logConnected(template.name, result.modelCount ?? 0);
-  if (result.credentialCleanupPending) {
-    p.log.warn(CREDENTIAL_CLEANUP_PENDING_MESSAGE);
-  }
   return 0;
 }
 
-export async function runProvidersAdd(): Promise<number> {
+async function runProvidersAddWithCleanupState(
+  cleanupState?: ProviderCommandCleanupState,
+): Promise<number> {
   const choice = await p.select({
     message: 'Add a provider',
     options: [
@@ -293,12 +349,22 @@ export async function runProvidersAdd(): Promise<number> {
     return 0;
   }
 
-  if (choice === 'oauth') return runProvidersAuth('openai');
-  if (choice === 'apikey') return runTemplateAddFlow();
+  if (choice === 'oauth') {
+    return runProvidersAuthWithCleanupState('openai', undefined, cleanupState);
+  }
+  if (choice === 'apikey') return runTemplateAddFlow(cleanupState);
   return 0;
 }
 
-export async function runProvidersRemove(id: string, interactive = false): Promise<number> {
+export async function runProvidersAdd(): Promise<number> {
+  return runProvidersAddWithCleanupState();
+}
+
+async function runProvidersRemoveWithCleanupState(
+  id: string,
+  interactive = false,
+  cleanupState?: ProviderCommandCleanupState,
+): Promise<number> {
   const registry = loadRegistry();
   const provider = registry.providers.find(pr => pr.id === id);
   if (!provider) {
@@ -318,6 +384,11 @@ export async function runProvidersRemove(id: string, interactive = false): Promi
   }
 
   const result = await removeProviderFromRegistry(id);
+  reportCredentialCleanup(
+    result.credentialCleanupPending === true,
+    cleanupState,
+    result.credentialCleanupReconciled === true,
+  );
   if (!result.removed) {
     p.log.error(result.error ?? `Could not remove ${id}`);
     return 1;
@@ -331,10 +402,11 @@ export async function runProvidersRemove(id: string, interactive = false): Promi
   if (result.credentialDeleted) {
     p.log.info('Provider API key removed from the credential store.');
   }
-  if (result.credentialCleanupPending) {
-    p.log.warn(CREDENTIAL_CLEANUP_PENDING_MESSAGE);
-  }
   return 0;
+}
+
+export async function runProvidersRemove(id: string, interactive = false): Promise<number> {
+  return runProvidersRemoveWithCleanupState(id, interactive);
 }
 
 export function providerHubChoiceValue(entry: ProviderDisplayEntry): string {
@@ -496,28 +568,25 @@ export async function runProvidersCommand(args: string[]): Promise<number> {
       && parsed.removeId !== undefined
     );
   if (!reconcilesDuringMutation) {
-    let cleanupPending = false;
-    try {
-      const cleanup = await reconcilePendingCredentialDeletes();
-      cleanupPending = cleanup.pending.length > 0 || cleanup.persistenceError !== undefined;
-    } catch {
-      cleanupPending = true;
-    }
-    if (cleanupPending) {
-      p.log.warn(CREDENTIAL_CLEANUP_PENDING_MESSAGE);
-    }
+    reportCredentialCleanup(await reconcileCredentialCleanup());
   }
 
   if (parsed.subcommand === 'list') return runProvidersList();
-  if (parsed.subcommand === 'add') return runProvidersAdd();
-  if (parsed.subcommand === 'remove' && parsed.removeId) return runProvidersRemove(parsed.removeId);
+  if (parsed.subcommand === 'add') {
+    return runWithCredentialCleanup(state => runProvidersAddWithCleanupState(state));
+  }
+  if (parsed.subcommand === 'remove' && parsed.removeId) {
+    return runWithCredentialCleanup(state =>
+      runProvidersRemoveWithCleanupState(parsed.removeId!, false, state));
+  }
   if (parsed.subcommand === 'refresh-models') return runProvidersRefreshModels(parsed.removeId);
   if (parsed.subcommand === 'auth') {
     if (parsed.showHelp || !parsed.removeId) {
       console.log(providerAuthHelpText());
       return 0;
     }
-    return runProvidersAuth(parsed.removeId, parsed.authMethod);
+    return runWithCredentialCleanup(state =>
+      runProvidersAuthWithCleanupState(parsed.removeId!, parsed.authMethod, state));
   }
 
   relayIntro('Your OpenAI providers');

--- a/src/providers-command.ts
+++ b/src/providers-command.ts
@@ -40,6 +40,9 @@ import {
 
 export type ProvidersSubcommand = 'hub' | 'add' | 'list' | 'remove' | 'refresh-models' | 'auth' | 'help';
 
+const CREDENTIAL_CLEANUP_PENDING_MESSAGE =
+  'Credential cleanup is pending and will be retried by the next provider command.';
+
 export function parseProvidersArgs(args: string[]): {
   subcommand: ProvidersSubcommand;
   showHelp: boolean;
@@ -117,7 +120,7 @@ export async function runProvidersAuth(providerId: string, method?: ProviderAuth
     const result = await authenticateProvider(providerId, { method });
     p.log.success(`Signed in to ${result.registryProvider.name} — credential saved to the credential store.`);
     if (result.credentialCleanupPending) {
-      p.log.warn('A previous credential is queued for cleanup and will be retried by the next provider command.');
+      p.log.warn(CREDENTIAL_CLEANUP_PENDING_MESSAGE);
     }
     return 0;
   } catch (err) {
@@ -264,7 +267,7 @@ async function runTemplateAddFlow(): Promise<number> {
 
   logConnected(template.name, result.modelCount ?? 0);
   if (result.credentialCleanupPending) {
-    p.log.warn('A previous credential is queued for cleanup and will be retried by the next provider command.');
+    p.log.warn(CREDENTIAL_CLEANUP_PENDING_MESSAGE);
   }
   return 0;
 }
@@ -329,7 +332,7 @@ export async function runProvidersRemove(id: string, interactive = false): Promi
     p.log.info('Provider API key removed from the credential store.');
   }
   if (result.credentialCleanupPending) {
-    p.log.warn('Provider credential cleanup is queued for retry.');
+    p.log.warn(CREDENTIAL_CLEANUP_PENDING_MESSAGE);
   }
   return 0;
 }
@@ -484,15 +487,25 @@ export async function runProvidersCommand(args: string[]): Promise<number> {
     return 0;
   }
 
-  let cleanupPending = false;
-  try {
-    const cleanup = await reconcilePendingCredentialDeletes();
-    cleanupPending = cleanup.pending.length > 0 || cleanup.persistenceError !== undefined;
-  } catch {
-    cleanupPending = true;
-  }
-  if (cleanupPending) {
-    p.log.warn('Some credential cleanup is still pending and will be retried later.');
+  const reconcilesDuringMutation =
+    parsed.subcommand === 'add'
+    || parsed.subcommand === 'remove'
+    || (
+      parsed.subcommand === 'auth'
+      && !parsed.showHelp
+      && parsed.removeId !== undefined
+    );
+  if (!reconcilesDuringMutation) {
+    let cleanupPending = false;
+    try {
+      const cleanup = await reconcilePendingCredentialDeletes();
+      cleanupPending = cleanup.pending.length > 0 || cleanup.persistenceError !== undefined;
+    } catch {
+      cleanupPending = true;
+    }
+    if (cleanupPending) {
+      p.log.warn(CREDENTIAL_CLEANUP_PENDING_MESSAGE);
+    }
   }
 
   if (parsed.subcommand === 'list') return runProvidersList();

--- a/src/registry/add-template.ts
+++ b/src/registry/add-template.ts
@@ -1,10 +1,17 @@
 // src/registry/add-template.ts — add a provider from a builtin template
 
+import { randomUUID } from 'node:crypto';
 import { saveProviderCredential } from '../env.js';
 import { credentialAuthRef } from '../credential-helper.js';
 import { isSdkMigratedNpm } from '../provider-factory.js';
 import type { ProviderTemplate } from '../provider-templates.js';
 import { classifyFreeStatus, isFreeStatus } from '../free-models.js';
+import {
+  cancelCredentialDelete,
+  journalCredentialWriteLocked,
+  queueCredentialDelete,
+  reconcilePendingCredentialDeletes,
+} from './credential-lifecycle.js';
 import { fetchTemplateModels } from './fetch-template-models.js';
 import { loadRegistry, saveRegistry } from './io.js';
 import {
@@ -26,6 +33,7 @@ export interface AddTemplateResult {
   modelCount?: number;
   error?: string;
   hint?: string;
+  credentialCleanupPending?: boolean;
 }
 
 async function probeTemplatePackage(template: ProviderTemplate): Promise<string | null> {
@@ -70,19 +78,22 @@ export async function addProviderFromTemplate(
     return { added: false, error: 'API key cannot be empty.' };
   }
 
-  const existingError = await withRegistryWriteLock(() => {
+  const existingState = await withRegistryWriteLock(() => {
     const registry = loadRegistry();
     const existing = registry.providers.find(p => p.id === template.id);
     if (existing && !opts?.replaceExisting) {
       return {
-        added: false,
-        error: `${template.name} is already configured.`,
-        hint: `Remove it first with: clodex providers remove ${template.id}`,
+        existing: false,
+        error: {
+          added: false as const,
+          error: `${template.name} is already configured.`,
+          hint: `Remove it first with: clodex providers remove ${template.id}`,
+        },
       };
     }
-    return null;
+    return { existing: existing !== undefined, error: null };
   });
-  if (existingError) return existingError;
+  if (existingState.error) return existingState.error;
 
   const fetched = await fetchTemplateModels(template, trimmedKey, opts?.baseUrl);
   if (fetched.error || fetched.models.length === 0) {
@@ -111,7 +122,11 @@ export async function addProviderFromTemplate(
     platform,
   );
   const authRef = trimmedKey
-    ? credentialAuthRef(`provider:${template.id}`)
+    ? credentialAuthRef(
+      existingState.existing
+        ? `provider:${template.id}:replacement:${randomUUID()}`
+        : `provider:${template.id}`,
+    )
     : 'none:anonymous';
   const commitProvider = () => withRegistryWriteLock(() => {
     const registry = loadRegistry();
@@ -153,13 +168,21 @@ export async function addProviderFromTemplate(
     } else {
       registry.providers.push(entry);
     }
+    if (trimmedKey) cancelCredentialDelete(registry, authRef);
+    if (existing?.authRef && existing.authRef !== authRef) {
+      queueCredentialDelete(registry, existing.authRef);
+    }
     saveRegistry(registry);
-    return { added: true, provider: entry, modelCount: pricedModels.length };
+    return {
+      added: true,
+      provider: entry,
+      modelCount: pricedModels.length,
+    };
   });
 
-  const result = trimmedKey
+  const result: AddTemplateResult = trimmedKey
     ? await withCredentialMutationLock(authRef, async () => {
-      const commitError = await withRegistryWriteLock(() => {
+      const prepareError = await withRegistryWriteLock(() => {
         const registry = loadRegistry();
         const existing = registry.providers.find(p => p.id === template.id);
         if (existing && !opts?.replaceExisting) {
@@ -169,9 +192,10 @@ export async function addProviderFromTemplate(
             hint: `Remove it first with: clodex providers remove ${template.id}`,
           };
         }
+        journalCredentialWriteLocked(registry, authRef);
         return null;
       });
-      if (commitError) return commitError;
+      if (prepareError) return prepareError;
 
       const saved = await saveProviderCredential(authRef, trimmedKey);
       if (!saved) {
@@ -184,6 +208,12 @@ export async function addProviderFromTemplate(
       return commitProvider();
     })
     : await commitProvider();
+
+  const cleanup = await reconcilePendingCredentialDeletes();
+  if (result.added) {
+    result.credentialCleanupPending =
+      cleanup.pending.length > 0 || cleanup.persistenceError !== undefined;
+  }
 
   if (result.added) enrichPricingAsync();
   return result;

--- a/src/registry/add-template.ts
+++ b/src/registry/add-template.ts
@@ -8,7 +8,7 @@ import type { ProviderTemplate } from '../provider-templates.js';
 import { classifyFreeStatus, isFreeStatus } from '../free-models.js';
 import {
   cancelCredentialDelete,
-  journalCredentialWriteLocked,
+  journalCredentialWrite,
   queueCredentialDelete,
   reconcilePendingCredentialDeletes,
 } from './credential-lifecycle.js';
@@ -128,7 +128,7 @@ export async function addProviderFromTemplate(
         : `provider:${template.id}`,
     )
     : 'none:anonymous';
-  const commitProvider = () => withRegistryWriteLock(() => {
+  const commitProvider = () => withRegistryWriteLock(async () => {
     const registry = loadRegistry();
     const existing = registry.providers.find(p => p.id === template.id);
     if (existing && !opts?.replaceExisting) {
@@ -168,15 +168,23 @@ export async function addProviderFromTemplate(
     } else {
       registry.providers.push(entry);
     }
-    if (trimmedKey) cancelCredentialDelete(registry, authRef);
     if (existing?.authRef && existing.authRef !== authRef) {
-      queueCredentialDelete(registry, existing.authRef);
+      await queueCredentialDelete(existing.authRef);
     }
     saveRegistry(registry);
+    let credentialCleanupPending = false;
+    if (trimmedKey) {
+      try {
+        await cancelCredentialDelete(authRef);
+      } catch {
+        credentialCleanupPending = true;
+      }
+    }
     return {
       added: true,
       provider: entry,
       modelCount: pricedModels.length,
+      ...(credentialCleanupPending ? { credentialCleanupPending: true } : {}),
     };
   });
 
@@ -192,10 +200,11 @@ export async function addProviderFromTemplate(
             hint: `Remove it first with: clodex providers remove ${template.id}`,
           };
         }
-        journalCredentialWriteLocked(registry, authRef);
         return null;
       });
       if (prepareError) return prepareError;
+
+      await journalCredentialWrite(authRef);
 
       const saved = await saveProviderCredential(authRef, trimmedKey);
       if (!saved) {
@@ -209,10 +218,20 @@ export async function addProviderFromTemplate(
     })
     : await commitProvider();
 
-  const cleanup = await reconcilePendingCredentialDeletes();
   if (result.added) {
-    result.credentialCleanupPending =
-      cleanup.pending.length > 0 || cleanup.persistenceError !== undefined;
+    try {
+      const cleanup = await reconcilePendingCredentialDeletes();
+      result.credentialCleanupPending =
+        cleanup.pending.length > 0 || cleanup.persistenceError !== undefined;
+    } catch {
+      result.credentialCleanupPending = true;
+    }
+  } else {
+    try {
+      await reconcilePendingCredentialDeletes();
+    } catch {
+      // The failed credential remains journaled for a later retry.
+    }
   }
 
   if (result.added) enrichPricingAsync();

--- a/src/registry/add-template.ts
+++ b/src/registry/add-template.ts
@@ -13,7 +13,7 @@ import {
   reconcilePendingCredentialDeletes,
 } from './credential-lifecycle.js';
 import { fetchTemplateModels } from './fetch-template-models.js';
-import { loadRegistry, saveRegistry } from './io.js';
+import { loadRegistryStrict, saveRegistry } from './io.js';
 import {
   withCredentialMutationLock,
   withRegistryWriteLock,
@@ -79,7 +79,7 @@ export async function addProviderFromTemplate(
   }
 
   const existingState = await withRegistryWriteLock(() => {
-    const registry = loadRegistry();
+    const registry = loadRegistryStrict();
     const existing = registry.providers.find(p => p.id === template.id);
     if (existing && !opts?.replaceExisting) {
       return {
@@ -129,7 +129,7 @@ export async function addProviderFromTemplate(
     )
     : 'none:anonymous';
   const commitProvider = () => withRegistryWriteLock(async () => {
-    const registry = loadRegistry();
+    const registry = loadRegistryStrict();
     const existing = registry.providers.find(p => p.id === template.id);
     if (existing && !opts?.replaceExisting) {
       return {
@@ -191,7 +191,7 @@ export async function addProviderFromTemplate(
   const result: AddTemplateResult = trimmedKey
     ? await withCredentialMutationLock(authRef, async () => {
       const prepareError = await withRegistryWriteLock(() => {
-        const registry = loadRegistry();
+        const registry = loadRegistryStrict();
         const existing = registry.providers.find(p => p.id === template.id);
         if (existing && !opts?.replaceExisting) {
           return {

--- a/src/registry/add-template.ts
+++ b/src/registry/add-template.ts
@@ -34,6 +34,7 @@ export interface AddTemplateResult {
   error?: string;
   hint?: string;
   credentialCleanupPending?: boolean;
+  credentialCleanupReconciled?: boolean;
 }
 
 async function probeTemplatePackage(template: ProviderTemplate): Promise<string | null> {
@@ -228,11 +229,14 @@ export async function addProviderFromTemplate(
     }
   } else {
     try {
-      await reconcilePendingCredentialDeletes();
+      const cleanup = await reconcilePendingCredentialDeletes();
+      result.credentialCleanupPending =
+        cleanup.pending.length > 0 || cleanup.persistenceError !== undefined;
     } catch {
-      // The failed credential remains journaled for a later retry.
+      result.credentialCleanupPending = true;
     }
   }
+  result.credentialCleanupReconciled = true;
 
   if (result.added) enrichPricingAsync();
   return result;

--- a/src/registry/credential-cleanup-journal.ts
+++ b/src/registry/credential-cleanup-journal.ts
@@ -1,0 +1,168 @@
+import { randomUUID } from 'node:crypto';
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname } from 'node:path';
+import { parseAuthRef } from '../env.js';
+import {
+  ensureLegacyAppHomeMigrated,
+  getCredentialCleanupPath,
+} from '../paths.js';
+import { ensureSecureAppHome } from './io.js';
+import {
+  assertRegistryWriteOwnership,
+  withRegistryWriteLock,
+} from './lock.js';
+
+const JOURNAL_SCHEMA_VERSION = 1;
+const DIR_MODE = 0o700;
+const FILE_MODE = 0o600;
+
+interface CredentialCleanupJournal {
+  schemaVersion: typeof JOURNAL_SCHEMA_VERSION;
+  pendingCredentialDeletes: string[];
+}
+
+function emptyJournal(): CredentialCleanupJournal {
+  return {
+    schemaVersion: JOURNAL_SCHEMA_VERSION,
+    pendingCredentialDeletes: [],
+  };
+}
+
+export function isStoredCredentialRef(value: string): boolean {
+  const parsed = parseAuthRef(value);
+  return parsed?.kind === 'keyring' || parsed?.kind === 'helper';
+}
+
+function parseJournal(raw: unknown): CredentialCleanupJournal {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('Credential cleanup journal must be a JSON object.');
+  }
+  const data = raw as Record<string, unknown>;
+  if (data.schemaVersion !== JOURNAL_SCHEMA_VERSION) {
+    throw new Error('Unsupported credential cleanup journal schema.');
+  }
+  if (!Array.isArray(data.pendingCredentialDeletes)) {
+    throw new Error('Credential cleanup journal is missing its pending list.');
+  }
+  const pending = data.pendingCredentialDeletes.filter(
+    (value): value is string =>
+      typeof value === 'string' && isStoredCredentialRef(value),
+  );
+  return {
+    schemaVersion: JOURNAL_SCHEMA_VERSION,
+    pendingCredentialDeletes: [...new Set(pending)],
+  };
+}
+
+function readJournalUnlocked(path: string): CredentialCleanupJournal {
+  if (!existsSync(path)) return emptyJournal();
+  try {
+    return parseJournal(JSON.parse(readFileSync(path, 'utf8')));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Could not read credential cleanup journal: ${message}`);
+  }
+}
+
+function syncParentDirectory(path: string): void {
+  let fd: number | undefined;
+  try {
+    fd = openSync(dirname(path), 'r');
+    fsyncSync(fd);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== 'EINVAL' && code !== 'ENOTSUP' && code !== 'EPERM') throw error;
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+}
+
+function writeJournalUnlocked(
+  journal: CredentialCleanupJournal,
+  path: string,
+): void {
+  assertRegistryWriteOwnership(path);
+  ensureSecureAppHome();
+  mkdirSync(dirname(path), { recursive: true, mode: DIR_MODE });
+  const tmp = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  let fd: number | undefined;
+  try {
+    fd = openSync(tmp, 'wx', FILE_MODE);
+    writeFileSync(fd, `${JSON.stringify(journal, null, 2)}\n`);
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = undefined;
+    assertRegistryWriteOwnership(path);
+    renameSync(tmp, path);
+    syncParentDirectory(path);
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+    try {
+      unlinkSync(tmp);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+  }
+}
+
+function journalLockPath(path: string): string {
+  return `${path}.lock`;
+}
+
+export async function loadPendingCredentialDeletes(
+  path = getCredentialCleanupPath(),
+): Promise<string[]> {
+  ensureLegacyAppHomeMigrated();
+  return withRegistryWriteLock(
+    () => [...readJournalUnlocked(path).pendingCredentialDeletes],
+    { lockPath: journalLockPath(path) },
+  );
+}
+
+async function updatePendingCredentialDeletes(
+  update: (pending: string[]) => string[],
+  path = getCredentialCleanupPath(),
+): Promise<{ before: string[]; after: string[] }> {
+  ensureLegacyAppHomeMigrated();
+  return withRegistryWriteLock(() => {
+    const journal = readJournalUnlocked(path);
+    const before = [...journal.pendingCredentialDeletes];
+    const after = [...new Set(update(before))].filter(isStoredCredentialRef);
+    if (
+      after.length !== before.length ||
+      after.some((value, index) => value !== before[index])
+    ) {
+      writeJournalUnlocked(
+        {
+          schemaVersion: JOURNAL_SCHEMA_VERSION,
+          pendingCredentialDeletes: after,
+        },
+        path,
+      );
+    }
+    return { before, after };
+  }, { lockPath: journalLockPath(path) });
+}
+
+export async function queueCredentialDelete(authRef: string): Promise<boolean> {
+  if (!isStoredCredentialRef(authRef)) return false;
+  const result = await updatePendingCredentialDeletes(pending =>
+    pending.includes(authRef) ? pending : [...pending, authRef]);
+  return result.after.includes(authRef);
+}
+
+export async function cancelCredentialDelete(authRef: string): Promise<boolean> {
+  const result = await updatePendingCredentialDeletes(pending =>
+    pending.filter(candidate => candidate !== authRef));
+  return result.before.includes(authRef) && !result.after.includes(authRef);
+}

--- a/src/registry/credential-cleanup-journal.ts
+++ b/src/registry/credential-cleanup-journal.ts
@@ -2,7 +2,9 @@ import { randomUUID } from 'node:crypto';
 import {
   closeSync,
   existsSync,
+  fstatSync,
   fsyncSync,
+  lstatSync,
   mkdirSync,
   openSync,
   readFileSync,
@@ -21,10 +23,17 @@ import {
   assertRegistryWriteOwnership,
   withRegistryWriteLock,
 } from './lock.js';
+import { isValidProviderId } from './validate.js';
 
 const JOURNAL_SCHEMA_VERSION = 1;
 const DIR_MODE = 0o700;
 const FILE_MODE = 0o600;
+const MAX_JOURNAL_BYTES = 1024 * 1024;
+const MAX_PENDING_CREDENTIAL_DELETES = 1024;
+const MAX_CREDENTIAL_REF_BYTES = 4096;
+const CREDENTIAL_INSTANCE_SEPARATOR = '::credential::';
+const CREDENTIAL_INSTANCE_PATTERN = /^v1:[0-9a-f]{32}$/;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 interface CredentialCleanupJournal {
   schemaVersion: typeof JOURNAL_SCHEMA_VERSION;
@@ -40,7 +49,59 @@ function emptyJournal(): CredentialCleanupJournal {
 
 export function isStoredCredentialRef(value: string): boolean {
   const parsed = parseAuthRef(value);
-  return parsed?.kind === 'keyring' || parsed?.kind === 'helper';
+  return (
+    (parsed?.kind === 'keyring' || parsed?.kind === 'helper')
+    && isManagedCredentialAccount(parsed.account)
+  );
+}
+
+function credentialAccountBase(account: string): string | null {
+  const separatorIndex = account.lastIndexOf(CREDENTIAL_INSTANCE_SEPARATOR);
+  if (separatorIndex === -1) return account;
+  if (
+    separatorIndex === 0
+    || account.indexOf(CREDENTIAL_INSTANCE_SEPARATOR) !== separatorIndex
+    || !CREDENTIAL_INSTANCE_PATTERN.test(
+      account.slice(separatorIndex + CREDENTIAL_INSTANCE_SEPARATOR.length),
+    )
+  ) {
+    return null;
+  }
+  return account.slice(0, separatorIndex);
+}
+
+function isManagedCredentialAccount(account: string): boolean {
+  const base = credentialAccountBase(account);
+  if (!base) return false;
+
+  const oauth = /^oauth:provider:(.+)$/.exec(base);
+  if (oauth) return isValidProviderId(oauth[1]!);
+
+  const provider = /^provider:([^:]+)(?::(.+))?$/.exec(base);
+  if (!provider || !isValidProviderId(provider[1]!)) return false;
+  const suffix = provider[2];
+  if (!suffix) return true;
+  if (UUID_PATTERN.test(suffix)) return true;
+  return suffix.startsWith('replacement:')
+    && UUID_PATTERN.test(suffix.slice('replacement:'.length));
+}
+
+function normalizePendingCredentialDeletes(raw: unknown[]): string[] {
+  if (raw.length > MAX_PENDING_CREDENTIAL_DELETES) {
+    throw new Error('Credential cleanup journal contains too many pending entries.');
+  }
+  const pending: string[] = [];
+  for (const [index, value] of raw.entries()) {
+    if (
+      typeof value !== 'string'
+      || Buffer.byteLength(value) > MAX_CREDENTIAL_REF_BYTES
+      || !isStoredCredentialRef(value)
+    ) {
+      throw new Error(`Credential cleanup journal has an invalid entry at index ${index}.`);
+    }
+    if (!pending.includes(value)) pending.push(value);
+  }
+  return pending;
 }
 
 function parseJournal(raw: unknown): CredentialCleanupJournal {
@@ -54,23 +115,44 @@ function parseJournal(raw: unknown): CredentialCleanupJournal {
   if (!Array.isArray(data.pendingCredentialDeletes)) {
     throw new Error('Credential cleanup journal is missing its pending list.');
   }
-  const pending = data.pendingCredentialDeletes.filter(
-    (value): value is string =>
-      typeof value === 'string' && isStoredCredentialRef(value),
-  );
   return {
     schemaVersion: JOURNAL_SCHEMA_VERSION,
-    pendingCredentialDeletes: [...new Set(pending)],
+    pendingCredentialDeletes: normalizePendingCredentialDeletes(
+      data.pendingCredentialDeletes,
+    ),
   };
 }
 
 function readJournalUnlocked(path: string): CredentialCleanupJournal {
   if (!existsSync(path)) return emptyJournal();
+  let fd: number | undefined;
   try {
-    return parseJournal(JSON.parse(readFileSync(path, 'utf8')));
+    const before = lstatSync(path);
+    if (before.isSymbolicLink() || !before.isFile()) {
+      throw new Error('Credential cleanup journal must be a regular file.');
+    }
+    fd = openSync(path, 'r');
+    const opened = fstatSync(fd);
+    if (before.dev !== opened.dev || before.ino !== opened.ino) {
+      throw new Error('Credential cleanup journal changed while opening.');
+    }
+    if (typeof process.getuid === 'function') {
+      if (opened.uid !== process.getuid()) {
+        throw new Error('Credential cleanup journal is owned by another user.');
+      }
+      if ((opened.mode & 0o077) !== 0) {
+        throw new Error('Credential cleanup journal permissions are too broad.');
+      }
+    }
+    if (opened.size > MAX_JOURNAL_BYTES) {
+      throw new Error('Credential cleanup journal is too large.');
+    }
+    return parseJournal(JSON.parse(readFileSync(fd, 'utf8')));
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Could not read credential cleanup journal: ${message}`);
+  } finally {
+    if (fd !== undefined) closeSync(fd);
   }
 }
 
@@ -137,7 +219,7 @@ async function updatePendingCredentialDeletes(
   return withRegistryWriteLock(() => {
     const journal = readJournalUnlocked(path);
     const before = [...journal.pendingCredentialDeletes];
-    const after = [...new Set(update(before))].filter(isStoredCredentialRef);
+    const after = normalizePendingCredentialDeletes(update(before));
     if (
       after.length !== before.length ||
       after.some((value, index) => value !== before[index])

--- a/src/registry/credential-lifecycle.ts
+++ b/src/registry/credential-lifecycle.ts
@@ -1,0 +1,145 @@
+import { deleteProviderCredential, parseAuthRef } from '../env.js';
+import { loadRegistry, saveRegistry } from './io.js';
+import {
+  withCredentialMutationLock,
+  withRegistryWriteLock,
+} from './lock.js';
+import type { ProviderRegistry } from './types.js';
+
+export interface CredentialCleanupResult {
+  deleted: string[];
+  pending: string[];
+  persistenceError?: string;
+}
+
+function isStoredCredentialRef(authRef: string): boolean {
+  const parsed = parseAuthRef(authRef);
+  return parsed?.kind === 'keyring' || parsed?.kind === 'helper';
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function credentialIsReferenced(registry: ProviderRegistry, authRef: string): boolean {
+  return registry.providers.some(provider => provider.authRef === authRef);
+}
+
+/** Queue an unreferenced stored credential for idempotent cleanup. */
+export function queueCredentialDelete(registry: ProviderRegistry, authRef: string): boolean {
+  if (!isStoredCredentialRef(authRef) || credentialIsReferenced(registry, authRef)) return false;
+  const pending = registry.pendingCredentialDeletes ?? [];
+  if (pending.includes(authRef)) return false;
+  registry.pendingCredentialDeletes = [...pending, authRef];
+  return true;
+}
+
+/** Keep an active credential out of the cleanup queue. */
+export function cancelCredentialDelete(registry: ProviderRegistry, authRef: string): boolean {
+  const pending = registry.pendingCredentialDeletes;
+  if (!pending?.includes(authRef)) return false;
+  const next = pending.filter(candidate => candidate !== authRef);
+  if (next.length > 0) registry.pendingCredentialDeletes = next;
+  else delete registry.pendingCredentialDeletes;
+  return true;
+}
+
+/**
+ * Persist a cleanup marker before writing an unreferenced credential. The
+ * caller must hold that credential's mutation lock before entering the short
+ * registry-lock section that invokes this function.
+ */
+export function journalCredentialWriteLocked(registry: ProviderRegistry, authRef: string): void {
+  if (queueCredentialDelete(registry, authRef)) saveRegistry(registry);
+}
+
+interface SingleCleanupResult {
+  deleted: boolean;
+  persistenceError?: string;
+}
+
+async function discardInvalidPendingRef(authRef: string): Promise<SingleCleanupResult> {
+  try {
+    await withRegistryWriteLock(() => {
+      const registry = loadRegistry();
+      if (cancelCredentialDelete(registry, authRef)) saveRegistry(registry);
+    });
+    return { deleted: false };
+  } catch (error) {
+    return { deleted: false, persistenceError: errorMessage(error) };
+  }
+}
+
+/**
+ * Reconcile one queued reference without holding the registry lock during a
+ * credential-store operation. Every registry check happens inside the
+ * credential lock, so activation of the same reference is serialized with
+ * deletion while unrelated credentials remain independent.
+ */
+async function reconcilePendingCredentialDelete(authRef: string): Promise<SingleCleanupResult> {
+  if (!isStoredCredentialRef(authRef)) return discardInvalidPendingRef(authRef);
+
+  return withCredentialMutationLock(authRef, async () => {
+    let queuedForDelete = false;
+    try {
+      await withRegistryWriteLock(() => {
+        const registry = loadRegistry();
+        if (!registry.pendingCredentialDeletes?.includes(authRef)) return;
+        if (credentialIsReferenced(registry, authRef)) {
+          cancelCredentialDelete(registry, authRef);
+          saveRegistry(registry);
+          return;
+        }
+        queuedForDelete = true;
+      });
+    } catch (error) {
+      return { deleted: false, persistenceError: errorMessage(error) };
+    }
+    if (!queuedForDelete) return { deleted: false };
+
+    let deleted = false;
+    try {
+      deleted = await deleteProviderCredential(authRef);
+    } catch {
+      deleted = false;
+    }
+
+    try {
+      await withRegistryWriteLock(() => {
+        const registry = loadRegistry();
+        if (!registry.pendingCredentialDeletes?.includes(authRef)) return;
+        if (credentialIsReferenced(registry, authRef) || deleted) {
+          cancelCredentialDelete(registry, authRef);
+          saveRegistry(registry);
+        }
+      });
+    } catch (error) {
+      return { deleted, persistenceError: errorMessage(error) };
+    }
+    return { deleted };
+  });
+}
+
+/** Retry queued credential deletions sequentially and idempotently. */
+export async function reconcilePendingCredentialDeletes(): Promise<CredentialCleanupResult> {
+  const queued = await withRegistryWriteLock(() => [
+    ...(loadRegistry().pendingCredentialDeletes ?? []),
+  ]);
+  const deleted: string[] = [];
+  let persistenceError: string | undefined;
+
+  for (const authRef of queued) {
+    const result = await reconcilePendingCredentialDelete(authRef);
+    if (result.deleted) deleted.push(authRef);
+    persistenceError ??= result.persistenceError;
+  }
+
+  const pending = await withRegistryWriteLock(() => [
+    ...(loadRegistry().pendingCredentialDeletes ?? []),
+  ]);
+  return {
+    deleted,
+    pending,
+    ...(persistenceError ? { persistenceError } : {}),
+  };
+}

--- a/src/registry/credential-lifecycle.ts
+++ b/src/registry/credential-lifecycle.ts
@@ -1,10 +1,21 @@
-import { deleteProviderCredential, parseAuthRef } from '../env.js';
-import { loadRegistry, saveRegistry } from './io.js';
+import { deleteProviderCredential } from '../env.js';
+import {
+  cancelCredentialDelete,
+  isStoredCredentialRef,
+  loadPendingCredentialDeletes,
+  queueCredentialDelete,
+} from './credential-cleanup-journal.js';
+import { loadRegistry } from './io.js';
 import {
   withCredentialMutationLock,
   withRegistryWriteLock,
 } from './lock.js';
 import type { ProviderRegistry } from './types.js';
+
+export {
+  cancelCredentialDelete,
+  queueCredentialDelete,
+} from './credential-cleanup-journal.js';
 
 export interface CredentialCleanupResult {
   deleted: string[];
@@ -12,134 +23,145 @@ export interface CredentialCleanupResult {
   persistenceError?: string;
 }
 
-function isStoredCredentialRef(authRef: string): boolean {
-  const parsed = parseAuthRef(authRef);
-  return parsed?.kind === 'keyring' || parsed?.kind === 'helper';
-}
-
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-export function credentialIsReferenced(registry: ProviderRegistry, authRef: string): boolean {
+function appendError(errors: string[], context: string, error: unknown): void {
+  errors.push(`${context}: ${errorMessage(error)}`);
+}
+
+export function credentialIsReferenced(
+  registry: ProviderRegistry,
+  authRef: string,
+): boolean {
   return registry.providers.some(provider => provider.authRef === authRef);
 }
 
-/** Queue an unreferenced stored credential for idempotent cleanup. */
-export function queueCredentialDelete(registry: ProviderRegistry, authRef: string): boolean {
-  if (!isStoredCredentialRef(authRef) || credentialIsReferenced(registry, authRef)) return false;
-  const pending = registry.pendingCredentialDeletes ?? [];
-  if (pending.includes(authRef)) return false;
-  registry.pendingCredentialDeletes = [...pending, authRef];
-  return true;
-}
-
-/** Keep an active credential out of the cleanup queue. */
-export function cancelCredentialDelete(registry: ProviderRegistry, authRef: string): boolean {
-  const pending = registry.pendingCredentialDeletes;
-  if (!pending?.includes(authRef)) return false;
-  const next = pending.filter(candidate => candidate !== authRef);
-  if (next.length > 0) registry.pendingCredentialDeletes = next;
-  else delete registry.pendingCredentialDeletes;
-  return true;
-}
-
-/**
- * Persist a cleanup marker before writing an unreferenced credential. The
- * caller must hold that credential's mutation lock before entering the short
- * registry-lock section that invokes this function.
- */
-export function journalCredentialWriteLocked(registry: ProviderRegistry, authRef: string): void {
-  if (queueCredentialDelete(registry, authRef)) saveRegistry(registry);
+/** Persist cleanup intent before a credential can become unreferenced. */
+export async function journalCredentialWrite(authRef: string): Promise<void> {
+  await queueCredentialDelete(authRef);
 }
 
 interface SingleCleanupResult {
   deleted: boolean;
+  cleared: boolean;
   persistenceError?: string;
-}
-
-async function discardInvalidPendingRef(authRef: string): Promise<SingleCleanupResult> {
-  try {
-    await withRegistryWriteLock(() => {
-      const registry = loadRegistry();
-      if (cancelCredentialDelete(registry, authRef)) saveRegistry(registry);
-    });
-    return { deleted: false };
-  } catch (error) {
-    return { deleted: false, persistenceError: errorMessage(error) };
-  }
 }
 
 /**
  * Reconcile one queued reference without holding the registry lock during a
- * credential-store operation. Every registry check happens inside the
- * credential lock, so activation of the same reference is serialized with
- * deletion while unrelated credentials remain independent.
+ * credential-store operation. The credential lock serializes activation and
+ * deletion for this reference without blocking unrelated credentials.
  */
-async function reconcilePendingCredentialDelete(authRef: string): Promise<SingleCleanupResult> {
-  if (!isStoredCredentialRef(authRef)) return discardInvalidPendingRef(authRef);
-
-  return withCredentialMutationLock(authRef, async () => {
-    let queuedForDelete = false;
+async function reconcilePendingCredentialDelete(
+  authRef: string,
+): Promise<SingleCleanupResult> {
+  if (!isStoredCredentialRef(authRef)) {
     try {
-      await withRegistryWriteLock(() => {
-        const registry = loadRegistry();
-        if (!registry.pendingCredentialDeletes?.includes(authRef)) return;
-        if (credentialIsReferenced(registry, authRef)) {
-          cancelCredentialDelete(registry, authRef);
-          saveRegistry(registry);
-          return;
-        }
-        queuedForDelete = true;
-      });
+      await cancelCredentialDelete(authRef);
+      return { deleted: false, cleared: true };
     } catch (error) {
-      return { deleted: false, persistenceError: errorMessage(error) };
+      return {
+        deleted: false,
+        cleared: false,
+        persistenceError: errorMessage(error),
+      };
     }
-    if (!queuedForDelete) return { deleted: false };
+  }
 
-    let deleted = false;
-    try {
-      deleted = await deleteProviderCredential(authRef);
-    } catch {
-      deleted = false;
-    }
-
-    try {
-      await withRegistryWriteLock(() => {
-        const registry = loadRegistry();
-        if (!registry.pendingCredentialDeletes?.includes(authRef)) return;
-        if (credentialIsReferenced(registry, authRef) || deleted) {
-          cancelCredentialDelete(registry, authRef);
-          saveRegistry(registry);
+  try {
+    return await withCredentialMutationLock(authRef, async () => {
+      try {
+        const clearedReferencedMarker = await withRegistryWriteLock(async () => {
+          if (!credentialIsReferenced(loadRegistry(), authRef)) return false;
+          await cancelCredentialDelete(authRef);
+          return true;
+        });
+        if (clearedReferencedMarker) {
+          return { deleted: false, cleared: true };
         }
-      });
-    } catch (error) {
-      return { deleted, persistenceError: errorMessage(error) };
-    }
-    return { deleted };
-  });
+      } catch (error) {
+        return {
+          deleted: false,
+          cleared: false,
+          persistenceError: errorMessage(error),
+        };
+      }
+
+      let deleted = false;
+      try {
+        deleted = await deleteProviderCredential(authRef);
+      } catch {
+        deleted = false;
+      }
+      if (!deleted) return { deleted: false, cleared: false };
+
+      try {
+        await cancelCredentialDelete(authRef);
+        return { deleted: true, cleared: true };
+      } catch (error) {
+        return {
+          deleted: true,
+          cleared: false,
+          persistenceError: errorMessage(error),
+        };
+      }
+    });
+  } catch (error) {
+    return {
+      deleted: false,
+      cleared: false,
+      persistenceError: errorMessage(error),
+    };
+  }
 }
 
 /** Retry queued credential deletions sequentially and idempotently. */
 export async function reconcilePendingCredentialDeletes(): Promise<CredentialCleanupResult> {
-  const queued = await withRegistryWriteLock(() => [
-    ...(loadRegistry().pendingCredentialDeletes ?? []),
-  ]);
-  const deleted: string[] = [];
-  let persistenceError: string | undefined;
-
-  for (const authRef of queued) {
-    const result = await reconcilePendingCredentialDelete(authRef);
-    if (result.deleted) deleted.push(authRef);
-    persistenceError ??= result.persistenceError;
+  let queued: string[];
+  try {
+    queued = await loadPendingCredentialDeletes();
+  } catch (error) {
+    return {
+      deleted: [],
+      pending: [],
+      persistenceError: `Could not read pending credential cleanup: ${errorMessage(error)}`,
+    };
   }
 
-  const pending = await withRegistryWriteLock(() => [
-    ...(loadRegistry().pendingCredentialDeletes ?? []),
-  ]);
+  const knownPending = new Set(queued);
+  const deleted: string[] = [];
+  const errors: string[] = [];
+
+  for (const authRef of queued) {
+    let result: SingleCleanupResult;
+    try {
+      result = await reconcilePendingCredentialDelete(authRef);
+    } catch (error) {
+      result = {
+        deleted: false,
+        cleared: false,
+        persistenceError: errorMessage(error),
+      };
+    }
+    if (result.deleted) deleted.push(authRef);
+    if (result.cleared) knownPending.delete(authRef);
+    if (result.persistenceError) {
+      appendError(errors, `Cleanup for ${authRef}`, result.persistenceError);
+    }
+  }
+
+  let pending = [...knownPending];
+  try {
+    pending = await loadPendingCredentialDeletes();
+  } catch (error) {
+    appendError(errors, 'Could not confirm pending credential cleanup', error);
+  }
+
   return {
     deleted,
     pending,
-    ...(persistenceError ? { persistenceError } : {}),
+    ...(errors.length > 0 ? { persistenceError: errors.join('; ') } : {}),
   };
 }

--- a/src/registry/credential-lifecycle.ts
+++ b/src/registry/credential-lifecycle.ts
@@ -5,7 +5,7 @@ import {
   loadPendingCredentialDeletes,
   queueCredentialDelete,
 } from './credential-cleanup-journal.js';
-import { loadRegistry } from './io.js';
+import { loadRegistryStrict } from './io.js';
 import {
   withCredentialMutationLock,
   withRegistryWriteLock,
@@ -40,7 +40,9 @@ export function credentialIsReferenced(
 
 /** Persist cleanup intent before a credential can become unreferenced. */
 export async function journalCredentialWrite(authRef: string): Promise<void> {
-  await queueCredentialDelete(authRef);
+  if (!await queueCredentialDelete(authRef)) {
+    throw new Error('Credential reference is not managed by Clodex.');
+  }
 }
 
 interface SingleCleanupResult {
@@ -74,7 +76,7 @@ async function reconcilePendingCredentialDelete(
     return await withCredentialMutationLock(authRef, async () => {
       try {
         const clearedReferencedMarker = await withRegistryWriteLock(async () => {
-          if (!credentialIsReferenced(loadRegistry(), authRef)) return false;
+          if (!credentialIsReferenced(loadRegistryStrict(), authRef)) return false;
           await cancelCredentialDelete(authRef);
           return true;
         });

--- a/src/registry/crud.ts
+++ b/src/registry/crud.ts
@@ -1,36 +1,30 @@
 // src/registry/crud.ts — add/remove providers in the native registry
 
-import { deleteProviderCredential } from '../env.js';
+import {
+  queueCredentialDelete,
+  reconcilePendingCredentialDeletes,
+} from './credential-lifecycle.js';
 import { loadRegistry, saveRegistry } from './io.js';
 import {
-  withCredentialMutationLock,
   withRegistryWriteLock,
   withRegistryWriteLockSync,
 } from './lock.js';
-import type { RegistryProvider } from './types.js';
 
 export interface RemoveProviderResult {
   removed: boolean;
   id: string;
   name?: string;
   credentialDeleted: boolean;
+  credentialCleanupPending?: boolean;
   error?: string;
 }
 
 interface PendingProviderRemoval {
   result: RemoveProviderResult;
-  authRefToDelete: string | null;
+  authRef: string | null;
 }
 
-function credentialStillReferenced(authRef: string, remaining: RegistryProvider[]): boolean {
-  return remaining.some(p => p.authRef === authRef);
-}
-
-function isStoredCredentialRef(authRef: string): boolean {
-  return authRef.startsWith('keyring:') || authRef.startsWith('helper:');
-}
-
-/** Remove a provider from the registry; delete per-provider keychain entry when safe. */
+/** Remove a provider from the registry; delete its stored credential when safe. */
 export async function removeProviderFromRegistry(
   id: string,
   opts?: { deleteCredential?: boolean },
@@ -46,11 +40,16 @@ export async function removeProviderFromRegistry(
           credentialDeleted: false,
           error: `Provider not found: ${id}`,
         },
-        authRefToDelete: null,
+        authRef: null,
       };
     }
 
     const [removedProvider] = registry.providers.splice(index, 1);
+    if (opts?.deleteCredential !== false) {
+      queueCredentialDelete(registry, removedProvider.authRef);
+    }
+    const cleanupQueued = opts?.deleteCredential !== false
+      && registry.pendingCredentialDeletes?.includes(removedProvider.authRef) === true;
     saveRegistry(registry);
 
     return {
@@ -60,34 +59,15 @@ export async function removeProviderFromRegistry(
         name: removedProvider.name,
         credentialDeleted: false,
       },
-      authRefToDelete:
-        opts?.deleteCredential !== false &&
-        isStoredCredentialRef(removedProvider.authRef) &&
-        !credentialStillReferenced(removedProvider.authRef, registry.providers)
-          ? removedProvider.authRef
-          : null,
+      authRef: cleanupQueued ? removedProvider.authRef : null,
     };
   });
 
-  const authRefToDelete = removal.authRefToDelete;
-  if (authRefToDelete) {
-    await withCredentialMutationLock(authRefToDelete, async () => {
-      const referencedAgain = await withRegistryWriteLock(() =>
-        credentialStillReferenced(
-          authRefToDelete,
-          loadRegistry().providers,
-        ));
-      if (referencedAgain) return;
-      removal.result.credentialDeleted = await deleteProviderCredential(
-        authRefToDelete,
-      );
-      if (!removal.result.credentialDeleted) {
-        removal.result.error =
-          `Provider ${removal.result.name ?? id} was removed, but credential ` +
-          `cleanup failed for ${authRefToDelete}. The credential remains in ` +
-          'the configured store and must be removed manually.';
-      }
-    });
+  if (removal.authRef) {
+    const cleanup = await reconcilePendingCredentialDeletes();
+    removal.result.credentialDeleted = cleanup.deleted.includes(removal.authRef);
+    removal.result.credentialCleanupPending =
+      cleanup.pending.includes(removal.authRef) || cleanup.persistenceError !== undefined;
   }
   return removal.result;
 }

--- a/src/registry/crud.ts
+++ b/src/registry/crud.ts
@@ -16,6 +16,7 @@ export interface RemoveProviderResult {
   name?: string;
   credentialDeleted: boolean;
   credentialCleanupPending?: boolean;
+  credentialCleanupReconciled?: boolean;
   error?: string;
 }
 
@@ -70,6 +71,7 @@ export async function removeProviderFromRegistry(
     } catch {
       removal.result.credentialCleanupPending = true;
     }
+    removal.result.credentialCleanupReconciled = true;
   }
   return removal.result;
 }

--- a/src/registry/crud.ts
+++ b/src/registry/crud.ts
@@ -4,7 +4,7 @@ import {
   queueCredentialDelete,
   reconcilePendingCredentialDeletes,
 } from './credential-lifecycle.js';
-import { loadRegistry, saveRegistry } from './io.js';
+import { loadRegistryStrict, saveRegistry } from './io.js';
 import {
   withRegistryWriteLock,
   withRegistryWriteLockSync,
@@ -30,7 +30,7 @@ export async function removeProviderFromRegistry(
   opts?: { deleteCredential?: boolean },
 ): Promise<RemoveProviderResult> {
   const removal = await withRegistryWriteLock<PendingProviderRemoval>(async () => {
-    const registry = loadRegistry();
+    const registry = loadRegistryStrict();
     const index = registry.providers.findIndex(p => p.id === id);
     if (index < 0) {
       return {
@@ -76,7 +76,7 @@ export async function removeProviderFromRegistry(
 
 export function toggleProviderEnabled(id: string): { toggled: boolean; enabled?: boolean; error?: string } {
   return withRegistryWriteLockSync(() => {
-    const registry = loadRegistry();
+    const registry = loadRegistryStrict();
     const provider = registry.providers.find(p => p.id === id);
     if (!provider) return { toggled: false, error: `Provider not found: ${id}` };
     provider.enabled = !provider.enabled;

--- a/src/registry/crud.ts
+++ b/src/registry/crud.ts
@@ -29,7 +29,7 @@ export async function removeProviderFromRegistry(
   id: string,
   opts?: { deleteCredential?: boolean },
 ): Promise<RemoveProviderResult> {
-  const removal = await withRegistryWriteLock<PendingProviderRemoval>(() => {
+  const removal = await withRegistryWriteLock<PendingProviderRemoval>(async () => {
     const registry = loadRegistry();
     const index = registry.providers.findIndex(p => p.id === id);
     if (index < 0) {
@@ -45,11 +45,9 @@ export async function removeProviderFromRegistry(
     }
 
     const [removedProvider] = registry.providers.splice(index, 1);
-    if (opts?.deleteCredential !== false) {
-      queueCredentialDelete(registry, removedProvider.authRef);
-    }
     const cleanupQueued = opts?.deleteCredential !== false
-      && registry.pendingCredentialDeletes?.includes(removedProvider.authRef) === true;
+      ? await queueCredentialDelete(removedProvider.authRef)
+      : false;
     saveRegistry(registry);
 
     return {
@@ -64,10 +62,14 @@ export async function removeProviderFromRegistry(
   });
 
   if (removal.authRef) {
-    const cleanup = await reconcilePendingCredentialDeletes();
-    removal.result.credentialDeleted = cleanup.deleted.includes(removal.authRef);
-    removal.result.credentialCleanupPending =
-      cleanup.pending.includes(removal.authRef) || cleanup.persistenceError !== undefined;
+    try {
+      const cleanup = await reconcilePendingCredentialDeletes();
+      removal.result.credentialDeleted = cleanup.deleted.includes(removal.authRef);
+      removal.result.credentialCleanupPending =
+        cleanup.pending.includes(removal.authRef) || cleanup.persistenceError !== undefined;
+    } catch {
+      removal.result.credentialCleanupPending = true;
+    }
   }
   return removal.result;
 }

--- a/src/registry/custom-endpoint.ts
+++ b/src/registry/custom-endpoint.ts
@@ -11,7 +11,7 @@ import {
   reconcilePendingCredentialDeletes,
 } from './credential-lifecycle.js';
 import { fetchTemplateModels } from './fetch-template-models.js';
-import { loadRegistry, saveRegistry } from './io.js';
+import { loadRegistryStrict, saveRegistry } from './io.js';
 import {
   withCredentialMutationLock,
   withRegistryWriteLock,
@@ -195,7 +195,7 @@ export async function addCustomEndpointProvider(input: AddCustomEndpointInput): 
     ? 'none:anonymous'
     : credentialAuthRef(`provider:${probeProviderId}:${randomUUID()}`);
   const commitProvider = () => withRegistryWriteLock(async () => {
-    const registry = loadRegistry();
+    const registry = loadRegistryStrict();
     const providerId = uniqueProviderId(displayName, registry);
 
     const now = new Date().toISOString();

--- a/src/registry/custom-endpoint.ts
+++ b/src/registry/custom-endpoint.ts
@@ -7,7 +7,7 @@ import { deriveBrand } from '../models.js';
 import { resolveContextWindow } from '../context-window.js';
 import {
   cancelCredentialDelete,
-  journalCredentialWriteLocked,
+  journalCredentialWrite,
   reconcilePendingCredentialDeletes,
 } from './credential-lifecycle.js';
 import { fetchTemplateModels } from './fetch-template-models.js';
@@ -194,7 +194,7 @@ export async function addCustomEndpointProvider(input: AddCustomEndpointInput): 
   const authRef = anonymous
     ? 'none:anonymous'
     : credentialAuthRef(`provider:${probeProviderId}:${randomUUID()}`);
-  const commitProvider = () => withRegistryWriteLock(() => {
+  const commitProvider = () => withRegistryWriteLock(async () => {
     const registry = loadRegistry();
     const providerId = uniqueProviderId(displayName, registry);
 
@@ -221,23 +221,28 @@ export async function addCustomEndpointProvider(input: AddCustomEndpointInput): 
     };
 
     registry.providers.push(entry);
-    if (!anonymous) cancelCredentialDelete(registry, authRef);
     saveRegistry(registry);
+    let credentialCleanupPending = false;
+    if (!anonymous) {
+      try {
+        await cancelCredentialDelete(authRef);
+      } catch {
+        credentialCleanupPending = true;
+      }
+    }
 
     return {
       added: true,
       provider: entry,
       modelCount: fetched.models.length,
+      ...(credentialCleanupPending ? { credentialCleanupPending: true } : {}),
     };
   });
 
   const result: AddCustomEndpointResult = anonymous
     ? await commitProvider()
     : await withCredentialMutationLock(authRef, async () => {
-      await withRegistryWriteLock(() => {
-        const registry = loadRegistry();
-        journalCredentialWriteLocked(registry, authRef);
-      });
+      await journalCredentialWrite(authRef);
       const saved = await saveProviderCredential(authRef, apiKey);
       if (!saved) {
         return {
@@ -249,10 +254,20 @@ export async function addCustomEndpointProvider(input: AddCustomEndpointInput): 
       return commitProvider();
     });
 
-  const cleanup = await reconcilePendingCredentialDeletes();
   if (result.added) {
-    result.credentialCleanupPending =
-      cleanup.pending.length > 0 || cleanup.persistenceError !== undefined;
+    try {
+      const cleanup = await reconcilePendingCredentialDeletes();
+      result.credentialCleanupPending =
+        cleanup.pending.length > 0 || cleanup.persistenceError !== undefined;
+    } catch {
+      result.credentialCleanupPending = true;
+    }
+  } else {
+    try {
+      await reconcilePendingCredentialDeletes();
+    } catch {
+      // The failed credential remains journaled for a later retry.
+    }
   }
   return result;
 }

--- a/src/registry/custom-endpoint.ts
+++ b/src/registry/custom-endpoint.ts
@@ -5,6 +5,11 @@ import { saveProviderCredential } from '../env.js';
 import { credentialAuthRef } from '../credential-helper.js';
 import { deriveBrand } from '../models.js';
 import { resolveContextWindow } from '../context-window.js';
+import {
+  cancelCredentialDelete,
+  journalCredentialWriteLocked,
+  reconcilePendingCredentialDeletes,
+} from './credential-lifecycle.js';
 import { fetchTemplateModels } from './fetch-template-models.js';
 import { loadRegistry, saveRegistry } from './io.js';
 import {
@@ -34,6 +39,7 @@ export interface AddCustomEndpointResult {
   modelCount?: number;
   error?: string;
   hint?: string;
+  credentialCleanupPending?: boolean;
 }
 
 function npmForKind(kind: CustomEndpointKind): string {
@@ -215,21 +221,38 @@ export async function addCustomEndpointProvider(input: AddCustomEndpointInput): 
     };
 
     registry.providers.push(entry);
+    if (!anonymous) cancelCredentialDelete(registry, authRef);
     saveRegistry(registry);
 
-    return { added: true, provider: entry, modelCount: fetched.models.length };
+    return {
+      added: true,
+      provider: entry,
+      modelCount: fetched.models.length,
+    };
   });
 
-  if (anonymous) return commitProvider();
-  return withCredentialMutationLock(authRef, async () => {
-    const saved = await saveProviderCredential(authRef, apiKey);
-    if (!saved) {
-      return {
-        added: false,
-        error: 'Could not save API key to the credential store.',
-        hint: 'Check credential-store access and try again.',
-      };
-    }
-    return commitProvider();
-  });
+  const result: AddCustomEndpointResult = anonymous
+    ? await commitProvider()
+    : await withCredentialMutationLock(authRef, async () => {
+      await withRegistryWriteLock(() => {
+        const registry = loadRegistry();
+        journalCredentialWriteLocked(registry, authRef);
+      });
+      const saved = await saveProviderCredential(authRef, apiKey);
+      if (!saved) {
+        return {
+          added: false,
+          error: 'Could not save API key to the credential store.',
+          hint: 'Check credential-store access and try again.',
+        };
+      }
+      return commitProvider();
+    });
+
+  const cleanup = await reconcilePendingCredentialDeletes();
+  if (result.added) {
+    result.credentialCleanupPending =
+      cleanup.pending.length > 0 || cleanup.persistenceError !== undefined;
+  }
+  return result;
 }

--- a/src/registry/io.ts
+++ b/src/registry/io.ts
@@ -119,6 +119,41 @@ function parseProvider(raw: unknown): RegistryProvider | null {
   return provider;
 }
 
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function hasValidStrictProviderFields(raw: unknown): boolean {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return false;
+  const provider = raw as Record<string, unknown>;
+  if (hasOwn(provider, 'subscriptionFilter') && provider.subscriptionFilter !== 'free') {
+    return false;
+  }
+  if (
+    hasOwn(provider, 'authType')
+    && provider.authType !== 'api'
+    && provider.authType !== 'oauth'
+    && provider.authType !== 'none'
+  ) {
+    return false;
+  }
+  if (hasOwn(provider, 'refreshedAt') && typeof provider.refreshedAt !== 'string') {
+    return false;
+  }
+  if (hasOwn(provider, 'modelsCache')) {
+    const cache = provider.modelsCache;
+    if (!cache || typeof cache !== 'object' || Array.isArray(cache)) return false;
+    const fields = cache as Record<string, unknown>;
+    if (typeof fields.fetchedAt !== 'string' || !Array.isArray(fields.models)) {
+      return false;
+    }
+    if (fields.models.some(model => !model || typeof model !== 'object' || Array.isArray(model))) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function parseRegistry(raw: unknown): ProviderRegistry {
   const empty: ProviderRegistry = { schemaVersion: REGISTRY_SCHEMA_VERSION, providers: [] };
   if (!raw || typeof raw !== 'object') return empty;
@@ -152,7 +187,7 @@ function parseRegistryStrict(raw: unknown): ProviderRegistry {
     throw new Error('Provider registry is missing its providers list.');
   }
   for (const entry of data.providers) {
-    if (!parseProvider(entry)) {
+    if (!parseProvider(entry) || !hasValidStrictProviderFields(entry)) {
       throw new Error('Provider registry contains an invalid provider entry.');
     }
   }

--- a/src/registry/io.ts
+++ b/src/registry/io.ts
@@ -43,7 +43,15 @@ function writeSecureFile(path: string, content: string): void {
   mkdirSync(dirname(path), { recursive: true, mode: DIR_MODE });
   const fd = openSync(path, 'wx', FILE_MODE);
   try {
-    writeSync(fd, content);
+    const payload = Buffer.from(content);
+    let offset = 0;
+    while (offset < payload.length) {
+      const written = writeSync(fd, payload, offset, payload.length - offset);
+      if (written <= 0) {
+        throw new Error(`Could not complete secure file write: ${path}`);
+      }
+      offset += written;
+    }
     fsyncSync(fd);
   } finally {
     closeSync(fd);
@@ -132,6 +140,29 @@ function parseRegistry(raw: unknown): ProviderRegistry {
   return registry;
 }
 
+function parseRegistryStrict(raw: unknown): ProviderRegistry {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('Provider registry must be a JSON object.');
+  }
+  const data = raw as Record<string, unknown>;
+  if (data.schemaVersion !== REGISTRY_SCHEMA_VERSION) {
+    throw new Error('Provider registry has an unsupported schema version.');
+  }
+  if (!Array.isArray(data.providers)) {
+    throw new Error('Provider registry is missing its providers list.');
+  }
+  for (const entry of data.providers) {
+    if (!parseProvider(entry)) {
+      throw new Error('Provider registry contains an invalid provider entry.');
+    }
+  }
+  return parseRegistry(raw);
+}
+
+function readRegistryStrict(path: string): ProviderRegistry {
+  return parseRegistryStrict(JSON.parse(readFileSync(path, 'utf8')));
+}
+
 export function loadRegistry(path = getProvidersPath()): ProviderRegistry {
   ensureLegacyAppHomeMigrated();
   if (!existsSync(path)) {
@@ -156,6 +187,19 @@ export function loadRegistry(path = getProvidersPath()): ProviderRegistry {
   } catch {
     return { schemaVersion: REGISTRY_SCHEMA_VERSION, providers: [] };
   }
+}
+
+/**
+ * Load a registry for destructive decisions. Unlike `loadRegistry`, read,
+ * parse, and provider-shape errors propagate so callers cannot confuse an
+ * unreadable registry with an empty one.
+ */
+export function loadRegistryStrict(path = getProvidersPath()): ProviderRegistry {
+  ensureLegacyAppHomeMigrated();
+  if (!existsSync(path)) {
+    return { schemaVersion: REGISTRY_SCHEMA_VERSION, providers: [] };
+  }
+  return readRegistryStrict(path);
 }
 
 export function saveRegistry(registry: ProviderRegistry, path = getProvidersPath()): void {

--- a/src/registry/io.ts
+++ b/src/registry/io.ts
@@ -27,6 +27,11 @@ import { isValidProviderId } from './validate.js';
 const DIR_MODE = 0o700;
 const FILE_MODE = 0o600;
 
+function isStoredCredentialRef(value: string): boolean {
+  if (value.startsWith('keyring:')) return value.length > 'keyring:'.length;
+  return /^helper:v1:[0-9a-f]{64}:.+$/s.test(value);
+}
+
 export function ensureSecureAppHome(): void {
   const home = getAppHome();
   mkdirSync(home, { recursive: true, mode: DIR_MODE });
@@ -112,6 +117,16 @@ function parseRegistry(raw: unknown): ProviderRegistry {
       typeof data.schemaVersion === 'number' ? data.schemaVersion : REGISTRY_SCHEMA_VERSION,
     providers,
   };
+  if (Array.isArray(data.pendingCredentialDeletes)) {
+    const pendingCredentialDeletes = data.pendingCredentialDeletes.filter(
+      (value): value is string => {
+        return typeof value === 'string' && isStoredCredentialRef(value);
+      },
+    );
+    if (pendingCredentialDeletes.length > 0) {
+      registry.pendingCredentialDeletes = [...new Set(pendingCredentialDeletes)];
+    }
+  }
   if (typeof data.importedAt === 'string') registry.importedAt = data.importedAt;
   if (typeof data.pricingCacheAt === 'string') registry.pricingCacheAt = data.pricingCacheAt;
   return registry;

--- a/src/registry/io.ts
+++ b/src/registry/io.ts
@@ -6,6 +6,7 @@ import {
   closeSync,
   copyFileSync,
   existsSync,
+  fsyncSync,
   mkdirSync,
   openSync,
   readFileSync,
@@ -27,11 +28,6 @@ import { isValidProviderId } from './validate.js';
 const DIR_MODE = 0o700;
 const FILE_MODE = 0o600;
 
-function isStoredCredentialRef(value: string): boolean {
-  if (value.startsWith('keyring:')) return value.length > 'keyring:'.length;
-  return /^helper:v1:[0-9a-f]{64}:.+$/s.test(value);
-}
-
 export function ensureSecureAppHome(): void {
   const home = getAppHome();
   mkdirSync(home, { recursive: true, mode: DIR_MODE });
@@ -45,9 +41,10 @@ export function ensureSecureAppHome(): void {
 function writeSecureFile(path: string, content: string): void {
   ensureSecureAppHome();
   mkdirSync(dirname(path), { recursive: true, mode: DIR_MODE });
-  const fd = openSync(path, 'w', FILE_MODE);
+  const fd = openSync(path, 'wx', FILE_MODE);
   try {
     writeSync(fd, content);
+    fsyncSync(fd);
   } finally {
     closeSync(fd);
   }
@@ -55,6 +52,19 @@ function writeSecureFile(path: string, content: string): void {
     chmodSync(path, FILE_MODE);
   } catch {
     // best-effort
+  }
+}
+
+function syncParentDirectory(path: string): void {
+  let fd: number | undefined;
+  try {
+    fd = openSync(dirname(path), 'r');
+    fsyncSync(fd);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== 'EINVAL' && code !== 'ENOTSUP' && code !== 'EPERM') throw error;
+  } finally {
+    if (fd !== undefined) closeSync(fd);
   }
 }
 
@@ -117,16 +127,6 @@ function parseRegistry(raw: unknown): ProviderRegistry {
       typeof data.schemaVersion === 'number' ? data.schemaVersion : REGISTRY_SCHEMA_VERSION,
     providers,
   };
-  if (Array.isArray(data.pendingCredentialDeletes)) {
-    const pendingCredentialDeletes = data.pendingCredentialDeletes.filter(
-      (value): value is string => {
-        return typeof value === 'string' && isStoredCredentialRef(value);
-      },
-    );
-    if (pendingCredentialDeletes.length > 0) {
-      registry.pendingCredentialDeletes = [...new Set(pendingCredentialDeletes)];
-    }
-  }
   if (typeof data.importedAt === 'string') registry.importedAt = data.importedAt;
   if (typeof data.pricingCacheAt === 'string') registry.pricingCacheAt = data.pricingCacheAt;
   return registry;
@@ -174,6 +174,7 @@ export function saveRegistry(registry: ProviderRegistry, path = getProvidersPath
     writeSecureFile(tmp, payload);
     assertRegistryWriteOwnership(path);
     renameSync(tmp, path);
+    syncParentDirectory(path);
   } finally {
     try {
       unlinkSync(tmp);

--- a/src/registry/io.ts
+++ b/src/registry/io.ts
@@ -176,7 +176,7 @@ export function loadRegistry(path = getProvidersPath()): ProviderRegistry {
       try {
         withRegistryWriteLockSync(() => {
           if (!existsSync(path)) return;
-          const current = parseRegistry(JSON.parse(readFileSync(path, 'utf8')));
+          const current = readRegistryStrict(path);
           if (migrateOAuthOpenAiProvider(current)) saveRegistry(current, path);
         }, { lockPath: `${path}.lock` });
       } catch {
@@ -199,7 +199,9 @@ export function loadRegistryStrict(path = getProvidersPath()): ProviderRegistry 
   if (!existsSync(path)) {
     return { schemaVersion: REGISTRY_SCHEMA_VERSION, providers: [] };
   }
-  return readRegistryStrict(path);
+  const registry = readRegistryStrict(path);
+  migrateOAuthOpenAiProvider(registry);
+  return registry;
 }
 
 export function saveRegistry(registry: ProviderRegistry, path = getProvidersPath()): void {

--- a/src/registry/pricing.ts
+++ b/src/registry/pricing.ts
@@ -21,7 +21,7 @@ import { dirname, join } from 'node:path';
 import bundledPricing from '../data/pricing-cache.json';
 import { getAppHome } from '../paths.js';
 import type { CachedModel } from './types.js';
-import { loadRegistry, saveRegistry } from './io.js';
+import { loadRegistryStrict, saveRegistry } from './io.js';
 import { withRegistryWriteLock, withRegistryWriteLockSync } from './lock.js';
 import { classifyFreeStatus, isFreeStatus } from '../free-models.js';
 
@@ -245,7 +245,7 @@ export function applyPricingToRegistryProviders(
 /** Apply bundled or on-disk pricing cache synchronously (non-blocking enrich baseline). */
 export function applyCachedPricing(): boolean {
   return withRegistryWriteLockSync(() => {
-    const registry = loadRegistry();
+    const registry = loadRegistryStrict();
     const cache = loadPricingCache();
     const changed = applyPricingToRegistryProviders(registry, cache);
     if (changed) saveRegistry(registry);
@@ -259,7 +259,7 @@ export function enrichPricingAsync(onComplete?: (updated: boolean) => void): voi
     const fetched = await fetchPricingCache();
     const cache = fetched ?? loadPricingCache();
     const changed = await withRegistryWriteLock(() => {
-      const registry = loadRegistry();
+      const registry = loadRegistryStrict();
       const updated = applyPricingToRegistryProviders(registry, cache);
       if (updated) saveRegistry(registry);
       return updated;

--- a/src/registry/provider-auth.ts
+++ b/src/registry/provider-auth.ts
@@ -24,7 +24,7 @@ import {
   queueCredentialDelete,
   reconcilePendingCredentialDeletes,
 } from './credential-lifecycle.js';
-import { loadRegistry, saveRegistry } from './io.js';
+import { loadRegistryStrict, saveRegistry } from './io.js';
 import {
   withCredentialMutationLock,
   withRegistryWriteLock,
@@ -110,7 +110,7 @@ async function persistOAuthProvider(
     const registryId = toOAuthRegistryId(providerId);
     const templateId = providerId.replace(/-oauth$/, '') || providerId;
     await withRegistryWriteLock(() => {
-      const registry = loadRegistry();
+      const registry = loadRegistryStrict();
       const previousEntry = registry.providers.find(provider => provider.id === registryId);
       if (!previousEntry && !getTemplateById(templateId)) {
         throw new Error(`Provider "${providerId}" is not in your registry and has no template`);
@@ -129,7 +129,7 @@ async function persistOAuthProvider(
     }
 
     const committed = await withRegistryWriteLock(async () => {
-      const registry = loadRegistry();
+      const registry = loadRegistryStrict();
       const template = getTemplateById(templateId);
       const previousEntry = registry.providers.find(provider => provider.id === registryId);
       if (!previousEntry && !template) {

--- a/src/registry/provider-auth.ts
+++ b/src/registry/provider-auth.ts
@@ -18,6 +18,12 @@ import {
 } from '../oauth/types.js';
 import { getTemplateById } from '../provider-templates.js';
 import { oauthAuthRef, toOAuthRegistryId } from './import-build.js';
+import {
+  cancelCredentialDelete,
+  journalCredentialWriteLocked,
+  queueCredentialDelete,
+  reconcilePendingCredentialDeletes,
+} from './credential-lifecycle.js';
 import { loadRegistry, saveRegistry } from './io.js';
 import {
   withCredentialMutationLock,
@@ -38,6 +44,7 @@ export interface ProviderAuthResult {
   providerId: string;
   credential: StoredOAuthCredential;
   registryProvider: RegistryProvider;
+  credentialCleanupPending: boolean;
 }
 
 const OPENAI_DISPLAY = 'OpenAI ChatGPT Plus/Pro';
@@ -82,16 +89,7 @@ export async function saveNativeOAuthCredential(
   const cred = tokensToStoredCredential(tokens, undefined, accountId, providerData);
   const registryId = toOAuthRegistryId(providerId);
   const authRef = oauthAuthRef(registryId);
-  await withCredentialMutationLock(authRef, async () => {
-    let diagMsg = '';
-    const saved = await saveProviderCredential(
-      authRef,
-      oauthCredentialToKeychainJson(cred),
-      (msg) => { diagMsg = msg; },
-    );
-    if (!saved) throw new Error(`Could not save OAuth tokens to the credential store${diagMsg ? ` — ${diagMsg}` : ' — check access and try again'}`);
-    await upsertOAuthProvider(providerId, cred, authRef);
-  });
+  await persistOAuthProvider(providerId, cred, authRef);
 }
 
 /**
@@ -103,48 +101,81 @@ function oauthDisplayName(registryId: string, fallbackName: string): string {
   return fallbackName;
 }
 
-async function upsertOAuthProvider(
+async function persistOAuthProvider(
   providerId: string,
   cred: StoredOAuthCredential,
   authRef: string,
-): Promise<RegistryProvider> {
-  return withRegistryWriteLock(() => {
+): Promise<{ registryProvider: RegistryProvider; credentialCleanupPending: boolean }> {
+  const registryProvider = await withCredentialMutationLock(authRef, async () => {
     const registryId = toOAuthRegistryId(providerId);
     const templateId = providerId.replace(/-oauth$/, '') || providerId;
-
-    const registry = loadRegistry();
-    const template = getTemplateById(templateId);
-    let entry: RegistryProvider | undefined = registry.providers.find(pr => pr.id === registryId);
-
-    if (!entry) {
-      if (!template) {
+    await withRegistryWriteLock(() => {
+      const registry = loadRegistry();
+      const previousEntry = registry.providers.find(provider => provider.id === registryId);
+      if (!previousEntry && !getTemplateById(templateId)) {
         throw new Error(`Provider "${providerId}" is not in your registry and has no template`);
       }
-      const displayName = oauthDisplayName(registryId, template.name);
-      entry = {
-        id: registryId,
-        templateId,
-        name: displayName,
-        enabled: true,
-        authRef,
-        authType: 'oauth',
-        api: {
-          npm: template.npm,
-          url: template.defaultBaseUrl ?? '',
-          ...(template.headers ? { headers: template.headers } : {}),
-        },
-        addedAt: new Date().toISOString(),
-      };
-    } else {
-      entry = { ...entry, authType: 'oauth', authRef, templateId };
+      journalCredentialWriteLocked(registry, authRef);
+    });
+
+    let diagMsg = '';
+    const saved = await saveProviderCredential(
+      authRef,
+      oauthCredentialToKeychainJson(cred),
+      (msg) => { diagMsg = msg; },
+    );
+    if (!saved) {
+      throw new Error(`Could not save OAuth tokens to the credential store${diagMsg ? ` — ${diagMsg}` : ' — check access and try again'}`);
     }
 
-    const idx = registry.providers.findIndex(pr => pr.id === registryId);
-    if (idx >= 0) registry.providers[idx] = entry;
-    else registry.providers.push(entry);
-    saveRegistry(registry);
-    return entry;
+    return withRegistryWriteLock(() => {
+      const registry = loadRegistry();
+      const template = getTemplateById(templateId);
+      const previousEntry = registry.providers.find(provider => provider.id === registryId);
+      if (!previousEntry && !template) {
+        throw new Error(`Provider "${providerId}" is not in your registry and has no template`);
+      }
+
+      let entry: RegistryProvider;
+      if (!previousEntry) {
+        if (!template) throw new Error(`Provider "${providerId}" has no template`);
+        const displayName = oauthDisplayName(registryId, template.name);
+        entry = {
+          id: registryId,
+          templateId,
+          name: displayName,
+          enabled: true,
+          authRef,
+          authType: 'oauth',
+          api: {
+            npm: template.npm,
+            url: template.defaultBaseUrl ?? '',
+            ...(template.headers ? { headers: template.headers } : {}),
+          },
+          addedAt: new Date().toISOString(),
+        };
+      } else {
+        entry = { ...previousEntry, authType: 'oauth', authRef, templateId };
+      }
+
+      const idx = registry.providers.findIndex(provider => provider.id === registryId);
+      if (idx >= 0) registry.providers[idx] = entry;
+      else registry.providers.push(entry);
+      cancelCredentialDelete(registry, authRef);
+      if (previousEntry?.authRef && previousEntry.authRef !== authRef) {
+        queueCredentialDelete(registry, previousEntry.authRef);
+      }
+      saveRegistry(registry);
+      return entry;
+    });
   });
+
+  const cleanup = await reconcilePendingCredentialDeletes();
+  return {
+    registryProvider,
+    credentialCleanupPending:
+      cleanup.pending.length > 0 || cleanup.persistenceError !== undefined,
+  };
 }
 
 export async function authenticateProvider(
@@ -168,27 +199,7 @@ export async function authenticateProvider(
   }
 
   const cred = await runNativeDeviceCode(providerId);
-
-  const persisted = await withCredentialMutationLock(authRef, async () => {
-    let nativeDiagMsg = '';
-    const saved = await saveProviderCredential(
-      authRef,
-      oauthCredentialToKeychainJson(cred),
-      (msg) => { nativeDiagMsg = msg; },
-    );
-    if (!saved) {
-      throw new Error(
-        `Could not save OAuth tokens to the credential store${nativeDiagMsg ? ` — ${nativeDiagMsg}` : ' — check access and try again'}`,
-      );
-    }
-    const registryProvider = await upsertOAuthProvider(
-      providerId,
-      cred,
-      authRef,
-    );
-    return { registryProvider };
-  });
-  const { registryProvider } = persisted;
+  const persisted = await persistOAuthProvider(providerId, cred, authRef);
 
   const refreshSpinner = p.spinner();
   refreshSpinner.start('Refreshing model list...');
@@ -199,7 +210,12 @@ export async function authenticateProvider(
     refreshSpinner.stop('Could not refresh models — run clodex providers refresh-models later');
   }
 
-  return { providerId: registryId, credential: cred, registryProvider };
+  return {
+    providerId: registryId,
+    credential: cred,
+    registryProvider: persisted.registryProvider,
+    credentialCleanupPending: persisted.credentialCleanupPending,
+  };
 }
 
 export function providerAuthHelpText(): string {

--- a/src/registry/provider-auth.ts
+++ b/src/registry/provider-auth.ts
@@ -20,7 +20,7 @@ import { getTemplateById } from '../provider-templates.js';
 import { oauthAuthRef, toOAuthRegistryId } from './import-build.js';
 import {
   cancelCredentialDelete,
-  journalCredentialWriteLocked,
+  journalCredentialWrite,
   queueCredentialDelete,
   reconcilePendingCredentialDeletes,
 } from './credential-lifecycle.js';
@@ -115,8 +115,8 @@ async function persistOAuthProvider(
       if (!previousEntry && !getTemplateById(templateId)) {
         throw new Error(`Provider "${providerId}" is not in your registry and has no template`);
       }
-      journalCredentialWriteLocked(registry, authRef);
     });
+    await journalCredentialWrite(authRef);
 
     let diagMsg = '';
     const saved = await saveProviderCredential(
@@ -128,7 +128,7 @@ async function persistOAuthProvider(
       throw new Error(`Could not save OAuth tokens to the credential store${diagMsg ? ` — ${diagMsg}` : ' — check access and try again'}`);
     }
 
-    return withRegistryWriteLock(() => {
+    const committed = await withRegistryWriteLock(async () => {
       const registry = loadRegistry();
       const template = getTemplateById(templateId);
       const previousEntry = registry.providers.find(provider => provider.id === registryId);
@@ -161,20 +161,31 @@ async function persistOAuthProvider(
       const idx = registry.providers.findIndex(provider => provider.id === registryId);
       if (idx >= 0) registry.providers[idx] = entry;
       else registry.providers.push(entry);
-      cancelCredentialDelete(registry, authRef);
       if (previousEntry?.authRef && previousEntry.authRef !== authRef) {
-        queueCredentialDelete(registry, previousEntry.authRef);
+        await queueCredentialDelete(previousEntry.authRef);
       }
       saveRegistry(registry);
+      try {
+        await cancelCredentialDelete(authRef);
+      } catch {
+        // Reconciliation below reports and retries the committed marker.
+      }
       return entry;
     });
+    return committed;
   });
 
-  const cleanup = await reconcilePendingCredentialDeletes();
+  let credentialCleanupPending = true;
+  try {
+    const cleanup = await reconcilePendingCredentialDeletes();
+    credentialCleanupPending =
+      cleanup.pending.length > 0 || cleanup.persistenceError !== undefined;
+  } catch {
+    credentialCleanupPending = true;
+  }
   return {
     registryProvider,
-    credentialCleanupPending:
-      cleanup.pending.length > 0 || cleanup.persistenceError !== undefined,
+    credentialCleanupPending,
   };
 }
 

--- a/src/registry/refresh-models.ts
+++ b/src/registry/refresh-models.ts
@@ -3,7 +3,7 @@
 import { isDeepStrictEqual } from 'node:util';
 import { fetchAnthropicModels } from './custom-endpoint.js';
 import { fetchTemplateModels } from './fetch-template-models.js';
-import { loadRegistry, saveRegistry } from './io.js';
+import { loadRegistryStrict, saveRegistry } from './io.js';
 import { withRegistryWriteLock } from './lock.js';
 import { resolveModelSource } from './model-source.js';
 import { validateCustomEndpointUrl } from './url-security.js';
@@ -316,7 +316,7 @@ export async function refreshProviderModels(
   apiKey: string | null,
   registry?: ProviderRegistry,
 ): Promise<RefreshProviderResult> {
-  const workingRegistry = registry ?? loadRegistry();
+  const workingRegistry = registry ?? loadRegistryStrict();
   const provider = workingRegistry.providers.find(p => p.id === providerId);
   if (!provider) {
     return { id: providerId, name: providerId, ok: false, reason: 'Provider not found.' };
@@ -424,7 +424,7 @@ export async function refreshProviderModels(
     const enriched = enrichModelsWithPricing(models, buildPricingIndex(pricingCache), platform);
 
     await withRegistryWriteLock(() => {
-      const currentRegistry = loadRegistry();
+      const currentRegistry = loadRegistryStrict();
       const currentProvider = currentRegistry.providers.find(candidate => candidate.id === providerId);
       if (!currentProvider) throw new Error('Provider was removed while models were refreshing.');
       if (currentProvider.authRef !== provider.authRef) {
@@ -460,7 +460,7 @@ export async function refreshAllProviderModels(
   resolveKey: (provider: RegistryProvider) => Promise<string | null>,
 ): Promise<RefreshModelsResult> {
   const refreshed: RefreshProviderResult[] = [];
-  const registry = loadRegistry();
+  const registry = loadRegistryStrict();
 
   const enabledProviders = registry.providers.filter(p => p.enabled);
 

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -60,6 +60,8 @@ export interface RegistryProvider {
 export interface ProviderRegistry {
   schemaVersion: number;
   providers: RegistryProvider[];
+  /** Credential references durably queued for idempotent cleanup. */
+  pendingCredentialDeletes?: string[];
   importedAt?: string;
   pricingCacheAt?: string;
 }

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -60,8 +60,6 @@ export interface RegistryProvider {
 export interface ProviderRegistry {
   schemaVersion: number;
   providers: RegistryProvider[];
-  /** Credential references durably queued for idempotent cleanup. */
-  pendingCredentialDeletes?: string[];
   importedAt?: string;
   pricingCacheAt?: string;
 }

--- a/tests/credential-cleanup-journal-durability.test.ts
+++ b/tests/credential-cleanup-journal-durability.test.ts
@@ -1,0 +1,134 @@
+import type { PathLike } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fsState = vi.hoisted(() => ({
+  journalPath: '',
+  openPaths: new Map<number, string>(),
+  tempOpenFlags: [] as Array<string | number>,
+  events: [] as string[],
+  failTempFsync: false,
+  failParentFsync: false,
+}));
+
+function ioError(message: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(message), { code: 'EIO' });
+}
+
+vi.mock('node:fs', async importOriginal => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  const isJournalTemp = (path: string | undefined): boolean =>
+    path?.startsWith(`${fsState.journalPath}.`) === true
+    && path.endsWith('.tmp')
+    && !path.startsWith(`${fsState.journalPath}.lock.`);
+
+  return {
+    ...actual,
+    openSync: vi.fn((path: PathLike, flags: string | number, mode?: string | number) => {
+      const fd = actual.openSync(path, flags, mode);
+      const stringPath = String(path);
+      fsState.openPaths.set(fd, stringPath);
+      if (isJournalTemp(stringPath)) fsState.tempOpenFlags.push(flags);
+      return fd;
+    }),
+    closeSync: vi.fn((fd: number) => {
+      actual.closeSync(fd);
+      fsState.openPaths.delete(fd);
+    }),
+    fsyncSync: vi.fn((fd: number) => {
+      const path = fsState.openPaths.get(fd);
+      if (isJournalTemp(path)) {
+        fsState.events.push('temp-fsync');
+        if (fsState.failTempFsync) throw ioError('journal temp fsync failed');
+        actual.fsyncSync(fd);
+        return;
+      }
+      if (path === dirname(fsState.journalPath)) {
+        fsState.events.push('parent-fsync');
+        if (fsState.failParentFsync) throw ioError('journal parent fsync failed');
+      }
+      actual.fsyncSync(fd);
+    }),
+    renameSync: vi.fn((oldPath: PathLike, newPath: PathLike) => {
+      if (String(newPath) === fsState.journalPath) {
+        fsState.events.push('rename');
+      }
+      actual.renameSync(oldPath, newPath);
+    }),
+  };
+});
+
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from 'node:fs';
+import { queueCredentialDelete } from '../src/registry/credential-cleanup-journal.js';
+import { getCredentialCleanupPath, resetLegacyMigrationForTests } from '../src/paths.js';
+
+describe('credential cleanup journal durability', () => {
+  const previousHome = process.env.CLODEX_HOME;
+  let home = '';
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'clodex-journal-durability-'));
+    process.env.CLODEX_HOME = home;
+    resetLegacyMigrationForTests();
+    fsState.journalPath = getCredentialCleanupPath();
+    fsState.openPaths.clear();
+    fsState.tempOpenFlags = [];
+    fsState.events = [];
+    fsState.failTempFsync = false;
+    fsState.failParentFsync = false;
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) delete process.env.CLODEX_HOME;
+    else process.env.CLODEX_HOME = previousHome;
+    resetLegacyMigrationForTests();
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('exclusively creates and syncs the completed temp before publication', async () => {
+    await queueCredentialDelete('keyring:provider:openai');
+
+    expect(fsState.tempOpenFlags).toEqual(['wx']);
+    expect(fsState.events).toEqual([
+      'temp-fsync',
+      'rename',
+      'parent-fsync',
+    ]);
+    expect(JSON.parse(readFileSync(fsState.journalPath, 'utf8'))).toEqual({
+      schemaVersion: 1,
+      pendingCredentialDeletes: ['keyring:provider:openai'],
+    });
+  });
+
+  it('does not publish when syncing the completed temp fails', async () => {
+    fsState.failTempFsync = true;
+
+    await expect(
+      queueCredentialDelete('keyring:provider:openai'),
+    ).rejects.toThrow('journal temp fsync failed');
+
+    expect(fsState.events).toEqual(['temp-fsync']);
+    expect(existsSync(fsState.journalPath)).toBe(false);
+  });
+
+  it('reports a parent sync failure after the journal rename committed', async () => {
+    fsState.failParentFsync = true;
+
+    await expect(
+      queueCredentialDelete('keyring:provider:openai'),
+    ).rejects.toThrow('journal parent fsync failed');
+
+    expect(fsState.events).toEqual([
+      'temp-fsync',
+      'rename',
+      'parent-fsync',
+    ]);
+    expect(existsSync(fsState.journalPath)).toBe(true);
+  });
+});

--- a/tests/credential-cleanup-journal.test.ts
+++ b/tests/credential-cleanup-journal.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  chmodSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
   statSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -92,7 +94,7 @@ describe('credential cleanup journal', () => {
     expect(await loadPendingCredentialDeletes()).toEqual([authRef]);
   });
 
-  it('sanitizes stored references and persists cancellation atomically', async () => {
+  it('deduplicates managed references and persists cancellation atomically', async () => {
     const authRef = helperRef('provider:stale');
     writeFileSync(getCredentialCleanupPath(), JSON.stringify({
       schemaVersion: 1,
@@ -100,10 +102,8 @@ describe('credential cleanup journal', () => {
         authRef,
         authRef,
         'keyring:provider:stale',
-        'env:OPENAI_API_KEY',
-        42,
       ],
-    }));
+    }), { mode: 0o600 });
 
     expect(await loadPendingCredentialDeletes()).toEqual([
       authRef,
@@ -116,4 +116,107 @@ describe('credential cleanup journal', () => {
       'keyring:provider:stale',
     ]);
   });
+
+  it.each([
+    ['malformed JSON', '{'],
+    ['wrong schema', JSON.stringify({ schemaVersion: 2, pendingCredentialDeletes: [] })],
+    ['non-object root', JSON.stringify([])],
+    ['missing pending list', JSON.stringify({ schemaVersion: 1 })],
+    ['non-array pending list', JSON.stringify({
+      schemaVersion: 1,
+      pendingCredentialDeletes: 'keyring:provider:stale',
+    })],
+  ])('rejects %s without processing cleanup entries', async (_label, content) => {
+    writeFileSync(getCredentialCleanupPath(), content, { mode: 0o600 });
+
+    await expect(loadPendingCredentialDeletes()).rejects.toThrow(
+      'Could not read credential cleanup journal',
+    );
+  });
+
+  it('rejects unmanaged or malformed credential references', async () => {
+    writeFileSync(getCredentialCleanupPath(), JSON.stringify({
+      schemaVersion: 1,
+      pendingCredentialDeletes: [
+        'keyring:arbitrary-account',
+        'env:OPENAI_API_KEY',
+        42,
+      ],
+    }), { mode: 0o600 });
+
+    await expect(loadPendingCredentialDeletes()).rejects.toThrow(
+      'invalid entry at index 0',
+    );
+    expect(await queueCredentialDelete('keyring:arbitrary-account')).toBe(false);
+  });
+
+  it('accepts generated replacement, custom, OAuth, and scoped account shapes', async () => {
+    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    const refs = [
+      'keyring:provider:openai',
+      `keyring:provider:openai:replacement:${uuid}`,
+      `keyring:provider:custom-openai:${uuid}`,
+      'keyring:oauth:provider:openai-oauth',
+      `keyring:provider:openai::credential::v1:${'a'.repeat(32)}`,
+      helperRef(`oauth:provider:openai-oauth::credential::v1:${'b'.repeat(32)}`),
+    ];
+
+    for (const authRef of refs) {
+      expect(await queueCredentialDelete(authRef)).toBe(true);
+    }
+
+    expect(await loadPendingCredentialDeletes()).toEqual(refs);
+  });
+
+  it('bounds the persisted journal before parsing entries', async () => {
+    writeFileSync(getCredentialCleanupPath(), 'x'.repeat(1024 * 1024 + 1), {
+      mode: 0o600,
+    });
+
+    await expect(loadPendingCredentialDeletes()).rejects.toThrow(
+      'Credential cleanup journal is too large',
+    );
+  });
+
+  it('bounds the number of pending entries', async () => {
+    writeFileSync(getCredentialCleanupPath(), JSON.stringify({
+      schemaVersion: 1,
+      pendingCredentialDeletes: Array.from(
+        { length: 1025 },
+        () => 'keyring:provider:openai',
+      ),
+    }), { mode: 0o600 });
+
+    await expect(loadPendingCredentialDeletes()).rejects.toThrow(
+      'too many pending entries',
+    );
+  });
+
+  it('rejects a symlinked journal', async () => {
+    const target = join(home, 'journal-target.json');
+    writeFileSync(target, JSON.stringify({
+      schemaVersion: 1,
+      pendingCredentialDeletes: ['keyring:provider:openai'],
+    }), { mode: 0o600 });
+    symlinkSync(target, getCredentialCleanupPath());
+
+    await expect(loadPendingCredentialDeletes()).rejects.toThrow(
+      'must be a regular file',
+    );
+  });
+
+  it.runIf(typeof process.getuid === 'function')(
+    'rejects a journal with group or other permissions',
+    async () => {
+      writeFileSync(getCredentialCleanupPath(), JSON.stringify({
+        schemaVersion: 1,
+        pendingCredentialDeletes: ['keyring:provider:openai'],
+      }), { mode: 0o600 });
+      chmodSync(getCredentialCleanupPath(), 0o644);
+
+      await expect(loadPendingCredentialDeletes()).rejects.toThrow(
+        'permissions are too broad',
+      );
+    },
+  );
 });

--- a/tests/credential-cleanup-journal.test.ts
+++ b/tests/credential-cleanup-journal.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  cancelCredentialDelete,
+  loadPendingCredentialDeletes,
+  queueCredentialDelete,
+} from '../src/registry/credential-cleanup-journal.js';
+import { emptyRegistry, saveRegistry } from '../src/registry/io.js';
+import { withRegistryWriteLockSync } from '../src/registry/lock.js';
+import {
+  getCredentialCleanupPath,
+  getProvidersPath,
+  resetLegacyMigrationForTests,
+} from '../src/paths.js';
+
+const TEST_HELPER_ID = 'a'.repeat(64);
+const helperRef = (account: string): string => `helper:v1:${TEST_HELPER_ID}:${account}`;
+
+describe('credential cleanup journal', () => {
+  const previousHome = process.env.CLODEX_HOME;
+  const previousUserHome = process.env.HOME;
+  let home = '';
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'clodex-cleanup-journal-'));
+    process.env.CLODEX_HOME = home;
+    resetLegacyMigrationForTests();
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) delete process.env.CLODEX_HOME;
+    else process.env.CLODEX_HOME = previousHome;
+    if (previousUserHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousUserHome;
+    resetLegacyMigrationForTests();
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('migrates the legacy app home before publishing its first journal lock', async () => {
+    const appHome = join(home, '.clodex');
+    const legacyHome = join(home, '.relay-ai');
+    const legacyRegistry = `${JSON.stringify({
+      schemaVersion: 1,
+      providers: [{ id: 'legacy-provider' }],
+    })}\n`;
+    process.env.HOME = home;
+    process.env.CLODEX_HOME = appHome;
+    mkdirSync(legacyHome, { recursive: true });
+    writeFileSync(join(legacyHome, 'providers.json'), legacyRegistry);
+    resetLegacyMigrationForTests();
+
+    expect(await loadPendingCredentialDeletes()).toEqual([]);
+
+    expect(readFileSync(join(appHome, 'providers.json'), 'utf8')).toBe(
+      legacyRegistry,
+    );
+  });
+
+  it('serializes concurrent updates without dropping references', async () => {
+    const refs = [
+      helperRef('provider:first'),
+      helperRef('provider:second'),
+      'keyring:provider:third',
+    ];
+
+    await Promise.all(refs.map(authRef => queueCredentialDelete(authRef)));
+
+    expect(await loadPendingCredentialDeletes()).toEqual(refs);
+    expect(statSync(getCredentialCleanupPath()).mode.toString(8).slice(-3)).toBe('600');
+  });
+
+  it('survives a schema-1 registry rewrite by an older writer', async () => {
+    const authRef = helperRef('provider:orphaned-write');
+    await queueCredentialDelete(authRef);
+
+    const registry = emptyRegistry();
+    withRegistryWriteLockSync(() => saveRegistry(registry));
+    const persistedRegistry = JSON.parse(
+      readFileSync(getProvidersPath(), 'utf8'),
+    ) as Record<string, unknown>;
+
+    expect(persistedRegistry).toEqual({ schemaVersion: 1, providers: [] });
+    expect(await loadPendingCredentialDeletes()).toEqual([authRef]);
+  });
+
+  it('sanitizes stored references and persists cancellation atomically', async () => {
+    const authRef = helperRef('provider:stale');
+    writeFileSync(getCredentialCleanupPath(), JSON.stringify({
+      schemaVersion: 1,
+      pendingCredentialDeletes: [
+        authRef,
+        authRef,
+        'keyring:provider:stale',
+        'env:OPENAI_API_KEY',
+        42,
+      ],
+    }));
+
+    expect(await loadPendingCredentialDeletes()).toEqual([
+      authRef,
+      'keyring:provider:stale',
+    ]);
+
+    await cancelCredentialDelete(authRef);
+
+    expect(await loadPendingCredentialDeletes()).toEqual([
+      'keyring:provider:stale',
+    ]);
+  });
+});

--- a/tests/credential-lifecycle-persistence.test.ts
+++ b/tests/credential-lifecycle-persistence.test.ts
@@ -1,0 +1,112 @@
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { credentialAuthRef } from '../src/credential-helper.js';
+import {
+  resolveProviderCredential,
+  saveProviderCredential,
+} from '../src/env.js';
+import {
+  journalCredentialWrite,
+  reconcilePendingCredentialDeletes,
+} from '../src/registry/credential-lifecycle.js';
+import { emptyRegistry, saveRegistry } from '../src/registry/io.js';
+import { withRegistryWriteLockSync } from '../src/registry/lock.js';
+import {
+  getProvidersPath,
+  resetLegacyMigrationForTests,
+} from '../src/paths.js';
+
+const helperPath = fileURLToPath(
+  new URL('./fixtures/credential-helper.mjs', import.meta.url),
+);
+
+describe('persisted credential cleanup recovery', () => {
+  const previousHome = process.env.CLODEX_HOME;
+  const previousHelper = process.env.CLODEX_CREDENTIAL_HELPER;
+  const previousStore = process.env.CLODEX_TEST_CREDENTIAL_HELPER_STORE;
+  let home = '';
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'clodex-cleanup-persistence-'));
+    process.env.CLODEX_HOME = home;
+    process.env.CLODEX_CREDENTIAL_HELPER = helperPath;
+    process.env.CLODEX_TEST_CREDENTIAL_HELPER_STORE = join(home, 'helper-store.json');
+    resetLegacyMigrationForTests();
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) delete process.env.CLODEX_HOME;
+    else process.env.CLODEX_HOME = previousHome;
+    if (previousHelper === undefined) delete process.env.CLODEX_CREDENTIAL_HELPER;
+    else process.env.CLODEX_CREDENTIAL_HELPER = previousHelper;
+    if (previousStore === undefined) delete process.env.CLODEX_TEST_CREDENTIAL_HELPER_STORE;
+    else process.env.CLODEX_TEST_CREDENTIAL_HELPER_STORE = previousStore;
+    resetLegacyMigrationForTests();
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('deletes a persisted credential when interruption precedes registry commit', async () => {
+    const authRef = credentialAuthRef('provider:interrupted-write');
+    await journalCredentialWrite(authRef);
+    expect(await saveProviderCredential(authRef, 'persisted-secret')).toBe(true);
+    expect(await resolveProviderCredential('interrupted-write', authRef)).toBe(
+      'persisted-secret',
+    );
+
+    const cleanup = await reconcilePendingCredentialDeletes();
+
+    expect(cleanup.deleted).toEqual([authRef]);
+    expect(cleanup.pending).toEqual([]);
+    expect(await resolveProviderCredential('interrupted-write', authRef)).toBeNull();
+  });
+
+  it('retains a persisted credential when interruption follows registry commit', async () => {
+    const authRef = credentialAuthRef('provider:committed-write');
+    await journalCredentialWrite(authRef);
+    expect(await saveProviderCredential(authRef, 'persisted-secret')).toBe(true);
+    const registry = emptyRegistry();
+    registry.providers.push({
+      id: 'committed-write',
+      templateId: 'committed-write',
+      name: 'Committed Write',
+      enabled: true,
+      authRef,
+      authType: 'api',
+      api: {},
+      addedAt: '2026-01-01T00:00:00.000Z',
+    });
+    withRegistryWriteLockSync(() => saveRegistry(registry));
+
+    const cleanup = await reconcilePendingCredentialDeletes();
+
+    expect(cleanup.deleted).toEqual([]);
+    expect(cleanup.pending).toEqual([]);
+    expect(await resolveProviderCredential('committed-write', authRef)).toBe(
+      'persisted-secret',
+    );
+  });
+
+  it('retains a persisted credential when the registry is malformed', async () => {
+    const authRef = credentialAuthRef('provider:unreadable-registry');
+    await journalCredentialWrite(authRef);
+    expect(await saveProviderCredential(authRef, 'persisted-secret')).toBe(true);
+    writeFileSync(getProvidersPath(), '{', { mode: 0o600 });
+
+    const cleanup = await reconcilePendingCredentialDeletes();
+
+    expect(cleanup.deleted).toEqual([]);
+    expect(cleanup.pending).toEqual([authRef]);
+    expect(cleanup.persistenceError).toContain(authRef);
+    expect(cleanup.persistenceError).toContain('JSON');
+    expect(await resolveProviderCredential('unreadable-registry', authRef)).toBe(
+      'persisted-secret',
+    );
+  });
+});

--- a/tests/credential-lifecycle.test.ts
+++ b/tests/credential-lifecycle.test.ts
@@ -22,7 +22,7 @@ vi.mock('../src/env.js', async importOriginal => ({
   deleteProviderCredential: vi.fn(),
 }));
 vi.mock('../src/registry/io.js', () => ({
-  loadRegistry: vi.fn(() => structuredClone(registryState.current)),
+  loadRegistryStrict: vi.fn(() => structuredClone(registryState.current)),
 }));
 vi.mock('../src/registry/credential-cleanup-journal.js', () => ({
   isStoredCredentialRef: vi.fn((authRef: string) =>
@@ -77,6 +77,7 @@ vi.mock('../src/registry/lock.js', () => ({
 import { deleteProviderCredential } from '../src/env.js';
 import * as cleanupJournal from '../src/registry/credential-cleanup-journal.js';
 import { reconcilePendingCredentialDeletes } from '../src/registry/credential-lifecycle.js';
+import { loadRegistryStrict } from '../src/registry/io.js';
 
 const TEST_HELPER_ID = 'a'.repeat(64);
 const helperRef = (account: string): string => `helper:v1:${TEST_HELPER_ID}:${account}`;
@@ -93,6 +94,8 @@ describe('credential cleanup lifecycle', () => {
     lockState.events = [];
     lockState.afterRegistryUnlock = null;
     vi.mocked(deleteProviderCredential).mockReset().mockResolvedValue(true);
+    vi.mocked(loadRegistryStrict).mockReset()
+      .mockImplementation(() => structuredClone(registryState.current));
     vi.mocked(cleanupJournal.loadPendingCredentialDeletes).mockReset()
       .mockImplementation(async () => [...journalState.pending]);
     vi.mocked(cleanupJournal.cancelCredentialDelete).mockReset()
@@ -212,6 +215,20 @@ describe('credential cleanup lifecycle', () => {
     expect(result.persistenceError).toContain('registry lock timed out');
   });
 
+  it('keeps cleanup queued when the provider registry cannot be read', async () => {
+    const authRef = helperRef('provider:registry-unreadable');
+    journalState.pending.add(authRef);
+    vi.mocked(loadRegistryStrict).mockImplementationOnce(() => {
+      throw new Error('provider registry is unreadable');
+    });
+
+    const result = await reconcilePendingCredentialDeletes();
+
+    expect(deleteProviderCredential).not.toHaveBeenCalled();
+    expect(result.pending).toEqual([authRef]);
+    expect(result.persistenceError).toContain('provider registry is unreadable');
+  });
+
   it('reports a snapshot read failure without rejecting', async () => {
     vi.mocked(cleanupJournal.loadPendingCredentialDeletes).mockRejectedValueOnce(
       new Error('journal lock timed out'),
@@ -251,5 +268,21 @@ describe('credential cleanup lifecycle', () => {
     expect(result.deleted).toEqual([authRef]);
     expect(result.pending).toEqual([authRef]);
     expect(result.persistenceError).toContain('journal write failed');
+  });
+
+  it('retries an already-deleted credential when marker clearing previously failed', async () => {
+    const authRef = helperRef('provider:already-deleted');
+    journalState.pending.add(authRef);
+    journalState.cancelFailures.add(authRef);
+
+    const first = await reconcilePendingCredentialDeletes();
+    journalState.cancelFailures.delete(authRef);
+    const second = await reconcilePendingCredentialDeletes();
+
+    expect(first.deleted).toEqual([authRef]);
+    expect(first.pending).toEqual([authRef]);
+    expect(second.deleted).toEqual([authRef]);
+    expect(second.pending).toEqual([]);
+    expect(deleteProviderCredential).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/credential-lifecycle.test.ts
+++ b/tests/credential-lifecycle.test.ts
@@ -4,51 +4,64 @@ import type { ProviderRegistry } from '../src/registry/types.js';
 const registryState = vi.hoisted(() => ({
   current: { schemaVersion: 1, providers: [] } as ProviderRegistry,
 }));
+const journalState = vi.hoisted(() => ({
+  pending: new Set<string>(),
+  cancelFailures: new Set<string>(),
+}));
 const lockState = vi.hoisted(() => ({
   registryActive: false,
   credentialActive: null as string | null,
-  credentialTails: new Map<string, Promise<void>>(),
+  credentialFailures: new Set<string>(),
+  registryFailures: new Set<string>(),
   events: [] as string[],
+  afterRegistryUnlock: null as null | (() => void),
 }));
 
-vi.mock('../src/env.js', async importOriginal => {
-  const actual = await importOriginal<typeof import('../src/env.js')>();
-  return {
-    ...actual,
-    deleteProviderCredential: vi.fn(),
-  };
-});
+vi.mock('../src/env.js', async importOriginal => ({
+  ...await importOriginal<typeof import('../src/env.js')>(),
+  deleteProviderCredential: vi.fn(),
+}));
 vi.mock('../src/registry/io.js', () => ({
   loadRegistry: vi.fn(() => structuredClone(registryState.current)),
-  saveRegistry: vi.fn((registry: ProviderRegistry) => {
-    if (!lockState.registryActive) throw new Error('registry write escaped its lock');
-    registryState.current = structuredClone(registry);
+}));
+vi.mock('../src/registry/credential-cleanup-journal.js', () => ({
+  isStoredCredentialRef: vi.fn((authRef: string) =>
+    authRef.startsWith('keyring:') || authRef.startsWith('helper:v1:')),
+  loadPendingCredentialDeletes: vi.fn(async () => [...journalState.pending]),
+  queueCredentialDelete: vi.fn(async (authRef: string) => {
+    journalState.pending.add(authRef);
+    return true;
+  }),
+  cancelCredentialDelete: vi.fn(async (authRef: string) => {
+    if (journalState.cancelFailures.has(authRef)) {
+      throw new Error('journal write failed');
+    }
+    return journalState.pending.delete(authRef);
   }),
 }));
 vi.mock('../src/registry/lock.js', () => ({
   withRegistryWriteLock: vi.fn(async <T>(operation: () => Promise<T> | T): Promise<T> => {
+    const authRef = lockState.credentialActive;
+    if (authRef && lockState.registryFailures.has(authRef)) {
+      throw new Error(`registry lock timed out for ${authRef}`);
+    }
     if (lockState.registryActive) throw new Error('registry lock re-entered');
-    lockState.events.push('registry:enter');
     lockState.registryActive = true;
     try {
       return await operation();
     } finally {
       lockState.registryActive = false;
-      lockState.events.push('registry:exit');
+      const afterUnlock = lockState.afterRegistryUnlock;
+      lockState.afterRegistryUnlock = null;
+      afterUnlock?.();
     }
   }),
   withCredentialMutationLock: vi.fn(async <T>(
     authRef: string,
     operation: () => Promise<T> | T,
   ): Promise<T> => {
-    const previous = lockState.credentialTails.get(authRef) ?? Promise.resolve();
-    let release!: () => void;
-    const gate = new Promise<void>(resolve => { release = resolve; });
-    const tail = previous.then(() => gate);
-    lockState.credentialTails.set(authRef, tail);
-    await previous;
-    if (lockState.credentialActive !== null) {
-      throw new Error(`nested credential lock: ${lockState.credentialActive} -> ${authRef}`);
+    if (lockState.credentialFailures.has(authRef)) {
+      throw new Error(`credential lock timed out for ${authRef}`);
     }
     lockState.credentialActive = authRef;
     lockState.events.push(`credential:enter:${authRef}`);
@@ -57,21 +70,13 @@ vi.mock('../src/registry/lock.js', () => ({
     } finally {
       lockState.events.push(`credential:exit:${authRef}`);
       lockState.credentialActive = null;
-      release();
-      if (lockState.credentialTails.get(authRef) === tail) {
-        lockState.credentialTails.delete(authRef);
-      }
     }
   }),
 }));
 
 import { deleteProviderCredential } from '../src/env.js';
-import {
-  cancelCredentialDelete,
-  queueCredentialDelete,
-  reconcilePendingCredentialDeletes,
-} from '../src/registry/credential-lifecycle.js';
-import { saveRegistry } from '../src/registry/io.js';
+import * as cleanupJournal from '../src/registry/credential-cleanup-journal.js';
+import { reconcilePendingCredentialDeletes } from '../src/registry/credential-lifecycle.js';
 
 const TEST_HELPER_ID = 'a'.repeat(64);
 const helperRef = (account: string): string => `helper:v1:${TEST_HELPER_ID}:${account}`;
@@ -79,124 +84,172 @@ const helperRef = (account: string): string => `helper:v1:${TEST_HELPER_ID}:${ac
 describe('credential cleanup lifecycle', () => {
   beforeEach(() => {
     registryState.current = { schemaVersion: 1, providers: [] };
+    journalState.pending.clear();
+    journalState.cancelFailures.clear();
     lockState.registryActive = false;
     lockState.credentialActive = null;
-    lockState.credentialTails.clear();
+    lockState.credentialFailures.clear();
+    lockState.registryFailures.clear();
     lockState.events = [];
+    lockState.afterRegistryUnlock = null;
     vi.mocked(deleteProviderCredential).mockReset().mockResolvedValue(true);
-    vi.mocked(saveRegistry).mockReset().mockImplementation(registry => {
-      if (!lockState.registryActive) throw new Error('registry write escaped its lock');
-      registryState.current = structuredClone(registry);
-    });
-  });
-
-  it('queues only unreferenced stored credentials', () => {
-    registryState.current.providers.push({
-      id: 'active',
-      templateId: 'active',
-      name: 'Active',
-      enabled: true,
-      authRef: helperRef('provider:active'),
-      api: {},
-      addedAt: '2026-01-01T00:00:00.000Z',
-    });
-
-    expect(queueCredentialDelete(registryState.current, helperRef('provider:active'))).toBe(false);
-    expect(queueCredentialDelete(registryState.current, 'env:OPENAI_API_KEY')).toBe(false);
-    expect(queueCredentialDelete(registryState.current, helperRef('provider:stale'))).toBe(true);
-    expect(queueCredentialDelete(registryState.current, helperRef('provider:stale'))).toBe(false);
-    expect(registryState.current.pendingCredentialDeletes).toEqual([helperRef('provider:stale')]);
+    vi.mocked(cleanupJournal.loadPendingCredentialDeletes).mockReset()
+      .mockImplementation(async () => [...journalState.pending]);
+    vi.mocked(cleanupJournal.cancelCredentialDelete).mockReset()
+      .mockImplementation(async (authRef: string) => {
+        if (journalState.cancelFailures.has(authRef)) {
+          throw new Error('journal write failed');
+        }
+        return journalState.pending.delete(authRef);
+      });
   });
 
   it('clears successful deletions while retaining failed and thrown deletions', async () => {
-    registryState.current.pendingCredentialDeletes = [
-      helperRef('provider:deleted'),
-      helperRef('provider:failed'),
-      'keyring:provider:thrown',
-    ];
+    const deletedRef = helperRef('provider:deleted');
+    const failedRef = helperRef('provider:failed');
+    const thrownRef = 'keyring:provider:thrown';
+    journalState.pending = new Set([deletedRef, failedRef, thrownRef]);
     vi.mocked(deleteProviderCredential).mockImplementation(async authRef => {
       expect(lockState.registryActive).toBe(false);
       expect(lockState.credentialActive).toBe(authRef);
       lockState.events.push(`delete:${authRef}`);
-      if (authRef.endsWith(':deleted')) return true;
-      if (authRef.endsWith(':thrown')) throw new Error('response lost');
+      if (authRef === deletedRef) return true;
+      if (authRef === thrownRef) throw new Error('response lost');
       return false;
     });
 
     const result = await reconcilePendingCredentialDeletes();
 
-    expect(result.deleted).toEqual([helperRef('provider:deleted')]);
-    expect(result.pending).toEqual([
-      helperRef('provider:failed'),
-      'keyring:provider:thrown',
-    ]);
-    expect(registryState.current.pendingCredentialDeletes).toEqual(result.pending);
-    for (const authRef of [
-      helperRef('provider:deleted'),
-      helperRef('provider:failed'),
-      'keyring:provider:thrown',
-    ]) {
-      const entered = lockState.events.indexOf(`credential:enter:${authRef}`);
-      const deletedAt = lockState.events.indexOf(`delete:${authRef}`);
-      const exited = lockState.events.indexOf(`credential:exit:${authRef}`);
-      expect(entered).toBeGreaterThanOrEqual(0);
-      expect(deletedAt).toBeGreaterThan(entered);
-      expect(exited).toBeGreaterThan(deletedAt);
-    }
+    expect(result.deleted).toEqual([deletedRef]);
+    expect(result.pending).toEqual([failedRef, thrownRef]);
+    expect([...journalState.pending]).toEqual(result.pending);
   });
 
   it('never deletes a credential that became active again', async () => {
+    const authRef = helperRef('provider:active');
     registryState.current.providers.push({
       id: 'active',
       templateId: 'active',
       name: 'Active',
       enabled: true,
-      authRef: helperRef('provider:active'),
+      authRef,
       api: {},
       addedAt: '2026-01-01T00:00:00.000Z',
     });
-    registryState.current.pendingCredentialDeletes = [helperRef('provider:active')];
+    journalState.pending.add(authRef);
 
     const result = await reconcilePendingCredentialDeletes();
 
     expect(deleteProviderCredential).not.toHaveBeenCalled();
     expect(result.pending).toEqual([]);
-    expect(registryState.current.pendingCredentialDeletes).toBeUndefined();
+    expect(journalState.pending.size).toBe(0);
   });
 
-  it('keeps the durable marker when clearing it cannot be saved', async () => {
-    registryState.current.pendingCredentialDeletes = [helperRef('provider:stale')];
-    vi.mocked(saveRegistry).mockImplementationOnce(() => {
-      throw new Error('disk full');
+  it('does not cancel a removal marker queued after an active-reference decision', async () => {
+    const authRef = helperRef('provider:removed-after-check');
+    registryState.current.providers.push({
+      id: 'active',
+      templateId: 'active',
+      name: 'Active',
+      enabled: true,
+      authRef,
+      api: {},
+      addedAt: '2026-01-01T00:00:00.000Z',
     });
-
-    const failed = await reconcilePendingCredentialDeletes();
-    expect(failed.persistenceError).toContain('disk full');
-    expect(failed.pending).toEqual([helperRef('provider:stale')]);
-    expect(registryState.current.pendingCredentialDeletes).toEqual([helperRef('provider:stale')]);
-
-    vi.mocked(saveRegistry).mockImplementation(registry => {
-      registryState.current = structuredClone(registry);
-    });
-    const retried = await reconcilePendingCredentialDeletes();
-    expect(retried.pending).toEqual([]);
-    expect(registryState.current.pendingCredentialDeletes).toBeUndefined();
-  });
-
-  it('can cancel a pending deletion when a credential becomes active', () => {
-    registryState.current.pendingCredentialDeletes = [helperRef('provider:new')];
-    expect(cancelCredentialDelete(registryState.current, helperRef('provider:new'))).toBe(true);
-    expect(registryState.current.pendingCredentialDeletes).toBeUndefined();
-  });
-
-  it('drops an anonymous cleanup marker without invoking credential deletion', async () => {
-    registryState.current.pendingCredentialDeletes = ['none:anonymous'];
+    journalState.pending.add(authRef);
+    vi.mocked(cleanupJournal.cancelCredentialDelete).mockImplementation(
+      async candidate => {
+        lockState.events.push(`cancel:${lockState.registryActive}`);
+        return journalState.pending.delete(candidate);
+      },
+    );
+    lockState.afterRegistryUnlock = () => {
+      registryState.current.providers = [];
+      journalState.pending.add(authRef);
+      lockState.events.push('provider-removed');
+    };
 
     const result = await reconcilePendingCredentialDeletes();
 
-    expect(result).toEqual({ deleted: [], pending: [] });
+    expect(lockState.events).toEqual([
+      `credential:enter:${authRef}`,
+      'cancel:true',
+      'provider-removed',
+      `credential:exit:${authRef}`,
+    ]);
     expect(deleteProviderCredential).not.toHaveBeenCalled();
-    expect(lockState.events.some(event => event.startsWith('credential:enter:'))).toBe(false);
-    expect(registryState.current.pendingCredentialDeletes).toBeUndefined();
+    expect(result.pending).toEqual([authRef]);
+    expect(journalState.pending).toEqual(new Set([authRef]));
+  });
+
+  it('isolates credential-lock failures and continues unrelated references', async () => {
+    const lockedRef = helperRef('provider:locked');
+    const deletableRef = helperRef('provider:deletable');
+    journalState.pending = new Set([lockedRef, deletableRef]);
+    lockState.credentialFailures.add(lockedRef);
+
+    const result = await reconcilePendingCredentialDeletes();
+
+    expect(deleteProviderCredential).toHaveBeenCalledWith(deletableRef);
+    expect(result.deleted).toEqual([deletableRef]);
+    expect(result.pending).toEqual([lockedRef]);
+    expect(result.persistenceError).toContain(lockedRef);
+    expect(result.persistenceError).toContain('credential lock timed out');
+  });
+
+  it('isolates registry-lock failures and continues unrelated references', async () => {
+    const lockedRef = helperRef('provider:registry-locked');
+    const deletableRef = helperRef('provider:deletable');
+    journalState.pending = new Set([lockedRef, deletableRef]);
+    lockState.registryFailures.add(lockedRef);
+
+    const result = await reconcilePendingCredentialDeletes();
+
+    expect(deleteProviderCredential).toHaveBeenCalledWith(deletableRef);
+    expect(result.deleted).toEqual([deletableRef]);
+    expect(result.pending).toEqual([lockedRef]);
+    expect(result.persistenceError).toContain(lockedRef);
+    expect(result.persistenceError).toContain('registry lock timed out');
+  });
+
+  it('reports a snapshot read failure without rejecting', async () => {
+    vi.mocked(cleanupJournal.loadPendingCredentialDeletes).mockRejectedValueOnce(
+      new Error('journal lock timed out'),
+    );
+
+    const result = await reconcilePendingCredentialDeletes();
+
+    expect(result).toEqual({
+      deleted: [],
+      pending: [],
+      persistenceError: expect.stringContaining('journal lock timed out'),
+    });
+    expect(deleteProviderCredential).not.toHaveBeenCalled();
+  });
+
+  it('retains known pending state when the final journal read fails', async () => {
+    const authRef = helperRef('provider:failed');
+    journalState.pending.add(authRef);
+    vi.mocked(deleteProviderCredential).mockResolvedValue(false);
+    vi.mocked(cleanupJournal.loadPendingCredentialDeletes)
+      .mockResolvedValueOnce([authRef])
+      .mockRejectedValueOnce(new Error('final journal read failed'));
+
+    const result = await reconcilePendingCredentialDeletes();
+
+    expect(result.pending).toEqual([authRef]);
+    expect(result.persistenceError).toContain('final journal read failed');
+  });
+
+  it('keeps a deleted reference journaled when clearing it fails', async () => {
+    const authRef = helperRef('provider:stale');
+    journalState.pending.add(authRef);
+    journalState.cancelFailures.add(authRef);
+
+    const result = await reconcilePendingCredentialDeletes();
+
+    expect(result.deleted).toEqual([authRef]);
+    expect(result.pending).toEqual([authRef]);
+    expect(result.persistenceError).toContain('journal write failed');
   });
 });

--- a/tests/credential-lifecycle.test.ts
+++ b/tests/credential-lifecycle.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProviderRegistry } from '../src/registry/types.js';
+
+const registryState = vi.hoisted(() => ({
+  current: { schemaVersion: 1, providers: [] } as ProviderRegistry,
+}));
+const lockState = vi.hoisted(() => ({
+  registryActive: false,
+  credentialActive: null as string | null,
+  credentialTails: new Map<string, Promise<void>>(),
+  events: [] as string[],
+}));
+
+vi.mock('../src/env.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/env.js')>();
+  return {
+    ...actual,
+    deleteProviderCredential: vi.fn(),
+  };
+});
+vi.mock('../src/registry/io.js', () => ({
+  loadRegistry: vi.fn(() => structuredClone(registryState.current)),
+  saveRegistry: vi.fn((registry: ProviderRegistry) => {
+    if (!lockState.registryActive) throw new Error('registry write escaped its lock');
+    registryState.current = structuredClone(registry);
+  }),
+}));
+vi.mock('../src/registry/lock.js', () => ({
+  withRegistryWriteLock: vi.fn(async <T>(operation: () => Promise<T> | T): Promise<T> => {
+    if (lockState.registryActive) throw new Error('registry lock re-entered');
+    lockState.events.push('registry:enter');
+    lockState.registryActive = true;
+    try {
+      return await operation();
+    } finally {
+      lockState.registryActive = false;
+      lockState.events.push('registry:exit');
+    }
+  }),
+  withCredentialMutationLock: vi.fn(async <T>(
+    authRef: string,
+    operation: () => Promise<T> | T,
+  ): Promise<T> => {
+    const previous = lockState.credentialTails.get(authRef) ?? Promise.resolve();
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => { release = resolve; });
+    const tail = previous.then(() => gate);
+    lockState.credentialTails.set(authRef, tail);
+    await previous;
+    if (lockState.credentialActive !== null) {
+      throw new Error(`nested credential lock: ${lockState.credentialActive} -> ${authRef}`);
+    }
+    lockState.credentialActive = authRef;
+    lockState.events.push(`credential:enter:${authRef}`);
+    try {
+      return await operation();
+    } finally {
+      lockState.events.push(`credential:exit:${authRef}`);
+      lockState.credentialActive = null;
+      release();
+      if (lockState.credentialTails.get(authRef) === tail) {
+        lockState.credentialTails.delete(authRef);
+      }
+    }
+  }),
+}));
+
+import { deleteProviderCredential } from '../src/env.js';
+import {
+  cancelCredentialDelete,
+  queueCredentialDelete,
+  reconcilePendingCredentialDeletes,
+} from '../src/registry/credential-lifecycle.js';
+import { saveRegistry } from '../src/registry/io.js';
+
+const TEST_HELPER_ID = 'a'.repeat(64);
+const helperRef = (account: string): string => `helper:v1:${TEST_HELPER_ID}:${account}`;
+
+describe('credential cleanup lifecycle', () => {
+  beforeEach(() => {
+    registryState.current = { schemaVersion: 1, providers: [] };
+    lockState.registryActive = false;
+    lockState.credentialActive = null;
+    lockState.credentialTails.clear();
+    lockState.events = [];
+    vi.mocked(deleteProviderCredential).mockReset().mockResolvedValue(true);
+    vi.mocked(saveRegistry).mockReset().mockImplementation(registry => {
+      if (!lockState.registryActive) throw new Error('registry write escaped its lock');
+      registryState.current = structuredClone(registry);
+    });
+  });
+
+  it('queues only unreferenced stored credentials', () => {
+    registryState.current.providers.push({
+      id: 'active',
+      templateId: 'active',
+      name: 'Active',
+      enabled: true,
+      authRef: helperRef('provider:active'),
+      api: {},
+      addedAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    expect(queueCredentialDelete(registryState.current, helperRef('provider:active'))).toBe(false);
+    expect(queueCredentialDelete(registryState.current, 'env:OPENAI_API_KEY')).toBe(false);
+    expect(queueCredentialDelete(registryState.current, helperRef('provider:stale'))).toBe(true);
+    expect(queueCredentialDelete(registryState.current, helperRef('provider:stale'))).toBe(false);
+    expect(registryState.current.pendingCredentialDeletes).toEqual([helperRef('provider:stale')]);
+  });
+
+  it('clears successful deletions while retaining failed and thrown deletions', async () => {
+    registryState.current.pendingCredentialDeletes = [
+      helperRef('provider:deleted'),
+      helperRef('provider:failed'),
+      'keyring:provider:thrown',
+    ];
+    vi.mocked(deleteProviderCredential).mockImplementation(async authRef => {
+      expect(lockState.registryActive).toBe(false);
+      expect(lockState.credentialActive).toBe(authRef);
+      lockState.events.push(`delete:${authRef}`);
+      if (authRef.endsWith(':deleted')) return true;
+      if (authRef.endsWith(':thrown')) throw new Error('response lost');
+      return false;
+    });
+
+    const result = await reconcilePendingCredentialDeletes();
+
+    expect(result.deleted).toEqual([helperRef('provider:deleted')]);
+    expect(result.pending).toEqual([
+      helperRef('provider:failed'),
+      'keyring:provider:thrown',
+    ]);
+    expect(registryState.current.pendingCredentialDeletes).toEqual(result.pending);
+    for (const authRef of [
+      helperRef('provider:deleted'),
+      helperRef('provider:failed'),
+      'keyring:provider:thrown',
+    ]) {
+      const entered = lockState.events.indexOf(`credential:enter:${authRef}`);
+      const deletedAt = lockState.events.indexOf(`delete:${authRef}`);
+      const exited = lockState.events.indexOf(`credential:exit:${authRef}`);
+      expect(entered).toBeGreaterThanOrEqual(0);
+      expect(deletedAt).toBeGreaterThan(entered);
+      expect(exited).toBeGreaterThan(deletedAt);
+    }
+  });
+
+  it('never deletes a credential that became active again', async () => {
+    registryState.current.providers.push({
+      id: 'active',
+      templateId: 'active',
+      name: 'Active',
+      enabled: true,
+      authRef: helperRef('provider:active'),
+      api: {},
+      addedAt: '2026-01-01T00:00:00.000Z',
+    });
+    registryState.current.pendingCredentialDeletes = [helperRef('provider:active')];
+
+    const result = await reconcilePendingCredentialDeletes();
+
+    expect(deleteProviderCredential).not.toHaveBeenCalled();
+    expect(result.pending).toEqual([]);
+    expect(registryState.current.pendingCredentialDeletes).toBeUndefined();
+  });
+
+  it('keeps the durable marker when clearing it cannot be saved', async () => {
+    registryState.current.pendingCredentialDeletes = [helperRef('provider:stale')];
+    vi.mocked(saveRegistry).mockImplementationOnce(() => {
+      throw new Error('disk full');
+    });
+
+    const failed = await reconcilePendingCredentialDeletes();
+    expect(failed.persistenceError).toContain('disk full');
+    expect(failed.pending).toEqual([helperRef('provider:stale')]);
+    expect(registryState.current.pendingCredentialDeletes).toEqual([helperRef('provider:stale')]);
+
+    vi.mocked(saveRegistry).mockImplementation(registry => {
+      registryState.current = structuredClone(registry);
+    });
+    const retried = await reconcilePendingCredentialDeletes();
+    expect(retried.pending).toEqual([]);
+    expect(registryState.current.pendingCredentialDeletes).toBeUndefined();
+  });
+
+  it('can cancel a pending deletion when a credential becomes active', () => {
+    registryState.current.pendingCredentialDeletes = [helperRef('provider:new')];
+    expect(cancelCredentialDelete(registryState.current, helperRef('provider:new'))).toBe(true);
+    expect(registryState.current.pendingCredentialDeletes).toBeUndefined();
+  });
+
+  it('drops an anonymous cleanup marker without invoking credential deletion', async () => {
+    registryState.current.pendingCredentialDeletes = ['none:anonymous'];
+
+    const result = await reconcilePendingCredentialDeletes();
+
+    expect(result).toEqual({ deleted: [], pending: [] });
+    expect(deleteProviderCredential).not.toHaveBeenCalled();
+    expect(lockState.events.some(event => event.startsWith('credential:enter:'))).toBe(false);
+    expect(registryState.current.pendingCredentialDeletes).toBeUndefined();
+  });
+});

--- a/tests/custom-endpoint.test.ts
+++ b/tests/custom-endpoint.test.ts
@@ -25,6 +25,7 @@ vi.mock('../src/registry/fetch-template-models.js', () => ({
 }));
 vi.mock('../src/registry/io.js', () => ({
   loadRegistry: vi.fn(() => structuredClone(registryState.current)),
+  loadRegistryStrict: vi.fn(() => structuredClone(registryState.current)),
   saveRegistry: vi.fn((registry: ProviderRegistry) => {
     if (!lockState.active) throw new Error('registry write escaped its lock');
     registryState.current = structuredClone(registry);

--- a/tests/custom-endpoint.test.ts
+++ b/tests/custom-endpoint.test.ts
@@ -9,6 +9,10 @@ const lockState = vi.hoisted(() => ({
   active: false,
   credentialActive: false,
   entries: 0,
+  afterRegistryUnlock: null as null | (() => void),
+}));
+const journalState = vi.hoisted(() => ({
+  pending: new Set<string>(),
 }));
 
 vi.mock('../src/env.js', async importOriginal => ({
@@ -27,6 +31,18 @@ vi.mock('../src/registry/io.js', () => ({
     registryState.persisted.push(structuredClone(registry));
   }),
 }));
+vi.mock('../src/registry/credential-cleanup-journal.js', () => ({
+  isStoredCredentialRef: vi.fn((authRef: string) =>
+    authRef.startsWith('keyring:') || authRef.startsWith('helper:v1:')),
+  loadPendingCredentialDeletes: vi.fn(async () => [...journalState.pending]),
+  queueCredentialDelete: vi.fn(async (authRef: string) => {
+    if (!authRef.startsWith('keyring:') && !authRef.startsWith('helper:v1:')) return false;
+    journalState.pending.add(authRef);
+    return true;
+  }),
+  cancelCredentialDelete: vi.fn(async (authRef: string) =>
+    journalState.pending.delete(authRef)),
+}));
 vi.mock('../src/registry/lock.js', () => ({
   withRegistryWriteLock: vi.fn(async <T>(operation: () => Promise<T> | T): Promise<T> => {
     lockState.entries += 1;
@@ -36,6 +52,9 @@ vi.mock('../src/registry/lock.js', () => ({
       return await operation();
     } finally {
       lockState.active = false;
+      const afterUnlock = lockState.afterRegistryUnlock;
+      lockState.afterRegistryUnlock = null;
+      afterUnlock?.();
     }
   }),
   withCredentialMutationLock: vi.fn(async <T>(
@@ -68,6 +87,7 @@ import {
   fetchAnthropicModels,
 } from '../src/registry/custom-endpoint.js';
 import { fetchTemplateModels } from '../src/registry/fetch-template-models.js';
+import * as cleanupJournal from '../src/registry/credential-cleanup-journal.js';
 import { saveRegistry } from '../src/registry/io.js';
 import { validateCustomEndpointUrl } from '../src/registry/url-security.js';
 
@@ -104,9 +124,15 @@ describe('custom endpoint credential lifecycle', () => {
     lockState.active = false;
     lockState.credentialActive = false;
     lockState.entries = 0;
+    lockState.afterRegistryUnlock = null;
+    journalState.pending.clear();
 
     vi.mocked(deleteProviderCredential).mockReset().mockResolvedValue(true);
     vi.mocked(saveProviderCredential).mockReset().mockResolvedValue(true);
+    vi.mocked(cleanupJournal.loadPendingCredentialDeletes).mockReset()
+      .mockImplementation(async () => [...journalState.pending]);
+    vi.mocked(cleanupJournal.queueCredentialDelete).mockClear();
+    vi.mocked(cleanupJournal.cancelCredentialDelete).mockClear();
     vi.mocked(fetchTemplateModels).mockReset().mockResolvedValue(successfulDiscovery());
     vi.mocked(validateCustomEndpointUrl).mockReset().mockResolvedValue({
       ok: true,
@@ -144,7 +170,7 @@ describe('custom endpoint credential lifecycle', () => {
 
     expect(result.added).toBe(true);
     expect(observedLockStates).toEqual([false, false]);
-    expect(lockState.entries).toBeGreaterThanOrEqual(2);
+    expect(lockState.entries).toBeGreaterThanOrEqual(1);
     expect(lockState.active).toBe(false);
   });
 
@@ -260,25 +286,17 @@ describe('custom endpoint credential lifecycle', () => {
       added: false,
       error: 'Could not save API key to the credential store.',
     });
-    expect(registryState.persisted[0]).toMatchObject({
-      providers: [],
-      pendingCredentialDeletes: [authRef],
-    });
+    expect(cleanupJournal.queueCredentialDelete).toHaveBeenCalledWith(authRef);
     expect(saveProviderCredential).toHaveBeenCalledWith(authRef!, endpointInput.apiKey);
     expect(deleteProviderCredential).toHaveBeenCalledWith(authRef!);
     expect(registryState.current.providers).toEqual([]);
-    expect(registryState.current.pendingCredentialDeletes).toBeUndefined();
+    expect(journalState.pending.size).toBe(0);
   });
 
   it('leaves the written credential journaled when provider activation cannot be saved', async () => {
-    vi.mocked(saveRegistry)
-      .mockImplementationOnce(registry => {
-        registryState.current = structuredClone(registry);
-        registryState.persisted.push(structuredClone(registry));
-      })
-      .mockImplementationOnce(() => {
-        throw new Error('activation failed');
-      });
+    vi.mocked(saveRegistry).mockImplementationOnce(() => {
+      throw new Error('activation failed');
+    });
 
     await expect(addCustomEndpointProvider(endpointInput)).rejects.toThrow('activation failed');
 
@@ -287,23 +305,21 @@ describe('custom endpoint credential lifecycle', () => {
       /^keyring:provider:custom-test-endpoint:[0-9a-f-]{36}$/,
     );
     expect(saveProviderCredential).toHaveBeenCalledWith(authRef!, endpointInput.apiKey);
-    expect(registryState.current).toMatchObject({
-      providers: [],
-      pendingCredentialDeletes: [authRef],
-    });
+    expect(registryState.current.providers).toEqual([]);
+    expect(journalState.pending).toEqual(new Set([authRef]));
     expect(deleteProviderCredential).not.toHaveBeenCalled();
   });
 
   it('retries pending cleanup on the next successful custom endpoint addition', async () => {
     const staleAuthRef = 'keyring:provider:stale-endpoint';
-    registryState.current.pendingCredentialDeletes = [staleAuthRef];
+    journalState.pending.add(staleAuthRef);
     vi.mocked(deleteProviderCredential).mockResolvedValueOnce(false).mockResolvedValueOnce(true);
 
     const first = await addCustomEndpointProvider(endpointInput);
 
     expect(first.added).toBe(true);
     expect(first.credentialCleanupPending).toBe(true);
-    expect(registryState.current.pendingCredentialDeletes).toEqual([staleAuthRef]);
+    expect([...journalState.pending]).toEqual([staleAuthRef]);
 
     const second = await addCustomEndpointProvider({
       ...endpointInput,
@@ -315,6 +331,49 @@ describe('custom endpoint credential lifecycle', () => {
     expect(deleteProviderCredential).toHaveBeenNthCalledWith(1, staleAuthRef);
     expect(deleteProviderCredential).toHaveBeenNthCalledWith(2, staleAuthRef);
     expect(registryState.current.providers).toHaveLength(2);
-    expect(registryState.current.pendingCredentialDeletes).toBeUndefined();
+    expect(journalState.pending.size).toBe(0);
+  });
+
+  it('retains a removal marker queued immediately after endpoint commit', async () => {
+    const cancellationLockStates: boolean[] = [];
+    vi.mocked(cleanupJournal.cancelCredentialDelete).mockImplementationOnce(
+      async authRef => {
+        cancellationLockStates.push(lockState.active);
+        return journalState.pending.delete(authRef);
+      },
+    );
+    vi.mocked(deleteProviderCredential).mockResolvedValue(false);
+    vi.mocked(saveRegistry).mockImplementationOnce(registry => {
+      if (!lockState.active) throw new Error('registry write escaped its lock');
+      registryState.current = structuredClone(registry);
+      registryState.persisted.push(structuredClone(registry));
+      const authRef = registry.providers[0]?.authRef;
+      lockState.afterRegistryUnlock = () => {
+        registryState.current.providers = [];
+        if (authRef) journalState.pending.add(authRef);
+      };
+    });
+
+    const result = await addCustomEndpointProvider(endpointInput);
+    const authRef = result.provider?.authRef;
+
+    expect(cancellationLockStates).toEqual([true]);
+    expect(authRef).toMatch(
+      /^keyring:provider:custom-test-endpoint:[0-9a-f-]{36}$/,
+    );
+    expect(journalState.pending).toContain(authRef);
+    expect(result.credentialCleanupPending).toBe(true);
+  });
+
+  it('reports cleanup pending instead of rejecting after endpoint commit', async () => {
+    vi.mocked(cleanupJournal.loadPendingCredentialDeletes).mockRejectedValue(
+      new Error('cleanup journal lock timed out'),
+    );
+
+    const result = await addCustomEndpointProvider(endpointInput);
+
+    expect(result.added).toBe(true);
+    expect(result.credentialCleanupPending).toBe(true);
+    expect(registryState.current.providers).toHaveLength(1);
   });
 });

--- a/tests/custom-endpoint.test.ts
+++ b/tests/custom-endpoint.test.ts
@@ -3,6 +3,7 @@ import type { ProviderRegistry } from '../src/registry/types.js';
 
 const registryState = vi.hoisted(() => ({
   current: { schemaVersion: 1, providers: [] } as ProviderRegistry,
+  persisted: [] as ProviderRegistry[],
 }));
 const lockState = vi.hoisted(() => ({
   active: false,
@@ -12,6 +13,7 @@ const lockState = vi.hoisted(() => ({
 
 vi.mock('../src/env.js', async importOriginal => ({
   ...await importOriginal<typeof import('../src/env.js')>(),
+  deleteProviderCredential: vi.fn(),
   saveProviderCredential: vi.fn(),
 }));
 vi.mock('../src/registry/fetch-template-models.js', () => ({
@@ -20,7 +22,9 @@ vi.mock('../src/registry/fetch-template-models.js', () => ({
 vi.mock('../src/registry/io.js', () => ({
   loadRegistry: vi.fn(() => structuredClone(registryState.current)),
   saveRegistry: vi.fn((registry: ProviderRegistry) => {
+    if (!lockState.active) throw new Error('registry write escaped its lock');
     registryState.current = structuredClone(registry);
+    registryState.persisted.push(structuredClone(registry));
   }),
 }));
 vi.mock('../src/registry/lock.js', () => ({
@@ -55,6 +59,7 @@ vi.mock('../src/registry/url-security.js', () => ({
 
 import {
   clodexKeyEnvVar,
+  deleteProviderCredential,
   resolveProviderCredential,
   saveProviderCredential,
 } from '../src/env.js';
@@ -89,13 +94,18 @@ function successfulDiscovery() {
   };
 }
 
-describe('custom endpoint registry updates', () => {
+describe('custom endpoint credential lifecycle', () => {
+  const previousHelper = process.env.CLODEX_CREDENTIAL_HELPER;
+
   beforeEach(() => {
+    delete process.env.CLODEX_CREDENTIAL_HELPER;
     registryState.current = { schemaVersion: 1, providers: [] };
+    registryState.persisted = [];
     lockState.active = false;
     lockState.credentialActive = false;
     lockState.entries = 0;
 
+    vi.mocked(deleteProviderCredential).mockReset().mockResolvedValue(true);
     vi.mocked(saveProviderCredential).mockReset().mockResolvedValue(true);
     vi.mocked(fetchTemplateModels).mockReset().mockResolvedValue(successfulDiscovery());
     vi.mocked(validateCustomEndpointUrl).mockReset().mockResolvedValue({
@@ -105,13 +115,17 @@ describe('custom endpoint registry updates', () => {
     vi.mocked(saveRegistry)
       .mockReset()
       .mockImplementation((registry) => {
+        if (!lockState.active) throw new Error('registry write escaped its lock');
         registryState.current = structuredClone(registry);
+        registryState.persisted.push(structuredClone(registry));
       });
   });
 
   afterEach(() => {
     delete process.env[clodexKeyEnvVar('custom-test-endpoint')];
     vi.unstubAllGlobals();
+    if (previousHelper === undefined) delete process.env.CLODEX_CREDENTIAL_HELPER;
+    else process.env.CLODEX_CREDENTIAL_HELPER = previousHelper;
   });
 
   it('discovers models before entering the registry write lock', async () => {
@@ -130,7 +144,7 @@ describe('custom endpoint registry updates', () => {
 
     expect(result.added).toBe(true);
     expect(observedLockStates).toEqual([false, false]);
-    expect(lockState.entries).toBe(1);
+    expect(lockState.entries).toBeGreaterThanOrEqual(2);
     expect(lockState.active).toBe(false);
   });
 
@@ -209,5 +223,98 @@ describe('custom endpoint registry updates', () => {
       'custom-test-endpoint',
       'custom-test-endpoint-2',
     ]);
+  });
+
+  it('does not persist registry or credential state when model discovery fails', async () => {
+    vi.mocked(fetchTemplateModels).mockResolvedValue({
+      models: [],
+      error: 'Network discovery failed.',
+      hint: 'Check the endpoint.',
+    });
+    const initialRegistry = structuredClone(registryState.current);
+
+    const result = await addCustomEndpointProvider(endpointInput);
+
+    expect(result).toMatchObject({
+      added: false,
+      error: 'Network discovery failed.',
+      hint: 'Check the endpoint.',
+    });
+    expect(saveProviderCredential).not.toHaveBeenCalled();
+    expect(deleteProviderCredential).not.toHaveBeenCalled();
+    expect(saveRegistry).not.toHaveBeenCalled();
+    expect(lockState.entries).toBe(0);
+    expect(registryState.current).toEqual(initialRegistry);
+  });
+
+  it('cleans the journal without activating a provider when credential writing fails', async () => {
+    vi.mocked(saveProviderCredential).mockResolvedValue(false);
+
+    const result = await addCustomEndpointProvider(endpointInput);
+
+    const authRef = vi.mocked(saveProviderCredential).mock.calls[0]?.[0];
+    expect(authRef).toMatch(
+      /^keyring:provider:custom-test-endpoint:[0-9a-f-]{36}$/,
+    );
+    expect(result).toMatchObject({
+      added: false,
+      error: 'Could not save API key to the credential store.',
+    });
+    expect(registryState.persisted[0]).toMatchObject({
+      providers: [],
+      pendingCredentialDeletes: [authRef],
+    });
+    expect(saveProviderCredential).toHaveBeenCalledWith(authRef!, endpointInput.apiKey);
+    expect(deleteProviderCredential).toHaveBeenCalledWith(authRef!);
+    expect(registryState.current.providers).toEqual([]);
+    expect(registryState.current.pendingCredentialDeletes).toBeUndefined();
+  });
+
+  it('leaves the written credential journaled when provider activation cannot be saved', async () => {
+    vi.mocked(saveRegistry)
+      .mockImplementationOnce(registry => {
+        registryState.current = structuredClone(registry);
+        registryState.persisted.push(structuredClone(registry));
+      })
+      .mockImplementationOnce(() => {
+        throw new Error('activation failed');
+      });
+
+    await expect(addCustomEndpointProvider(endpointInput)).rejects.toThrow('activation failed');
+
+    const authRef = vi.mocked(saveProviderCredential).mock.calls[0]?.[0];
+    expect(authRef).toMatch(
+      /^keyring:provider:custom-test-endpoint:[0-9a-f-]{36}$/,
+    );
+    expect(saveProviderCredential).toHaveBeenCalledWith(authRef!, endpointInput.apiKey);
+    expect(registryState.current).toMatchObject({
+      providers: [],
+      pendingCredentialDeletes: [authRef],
+    });
+    expect(deleteProviderCredential).not.toHaveBeenCalled();
+  });
+
+  it('retries pending cleanup on the next successful custom endpoint addition', async () => {
+    const staleAuthRef = 'keyring:provider:stale-endpoint';
+    registryState.current.pendingCredentialDeletes = [staleAuthRef];
+    vi.mocked(deleteProviderCredential).mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    const first = await addCustomEndpointProvider(endpointInput);
+
+    expect(first.added).toBe(true);
+    expect(first.credentialCleanupPending).toBe(true);
+    expect(registryState.current.pendingCredentialDeletes).toEqual([staleAuthRef]);
+
+    const second = await addCustomEndpointProvider({
+      ...endpointInput,
+      displayName: 'Second Endpoint',
+    });
+
+    expect(second.added).toBe(true);
+    expect(second.credentialCleanupPending).toBe(false);
+    expect(deleteProviderCredential).toHaveBeenNthCalledWith(1, staleAuthRef);
+    expect(deleteProviderCredential).toHaveBeenNthCalledWith(2, staleAuthRef);
+    expect(registryState.current.providers).toHaveLength(2);
+    expect(registryState.current.pendingCredentialDeletes).toBeUndefined();
   });
 });

--- a/tests/provider-auth.test.ts
+++ b/tests/provider-auth.test.ts
@@ -35,6 +35,7 @@ vi.mock('../src/env.js', async importOriginal => {
 });
 vi.mock('../src/registry/io.js', () => ({
   loadRegistry: vi.fn(() => structuredClone(registryState.current)),
+  loadRegistryStrict: vi.fn(() => structuredClone(registryState.current)),
   saveRegistry: vi.fn((registry: ProviderRegistry) => {
     if (!lockState.active) throw new Error('registry write escaped its lock');
     registryState.current = structuredClone(registry);
@@ -273,6 +274,31 @@ describe('authenticateProvider', () => {
     expect(registryState.current.providers[0]?.authRef).toBe(helperAuthRef);
   });
 
+  it('reauthorizes the same OAuth reference without deleting the active credential', async () => {
+    const authRef = 'keyring:oauth:provider:openai-oauth';
+    registryState.current.providers.push({
+      id: 'openai-oauth',
+      templateId: 'openai',
+      name: 'OpenAI (ChatGPT)',
+      enabled: true,
+      authRef,
+      authType: 'oauth',
+      api: { npm: '@ai-sdk/openai', url: 'https://api.openai.com/v1' },
+      addedAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    const result = await authenticateProvider('openai');
+
+    expect(saveProviderCredential).toHaveBeenCalledWith(
+      authRef,
+      expect.any(String),
+      expect.any(Function),
+    );
+    expect(result.registryProvider.authRef).toBe(authRef);
+    expect(deleteProviderCredential).not.toHaveBeenCalled();
+    expect(journalState.pending.size).toBe(0);
+  });
+
   it('keeps the new provider active and queues the prior credential when cleanup is uncertain', async () => {
     registryState.current.providers.push({
       id: 'openai-oauth',
@@ -350,7 +376,7 @@ describe('authenticateProvider', () => {
       templateId: 'openai',
       name: 'OpenAI (ChatGPT)',
       enabled: true,
-      authRef: 'keyring:oauth:provider:openai-oauth:previous',
+      authRef: `helper:v1:${'b'.repeat(64)}:oauth:provider:openai-oauth`,
       authType: 'oauth',
       api: { npm: '@ai-sdk/openai', url: 'https://api.openai.com/v1' },
       addedAt: '2026-01-01T00:00:00.000Z',

--- a/tests/provider-auth.test.ts
+++ b/tests/provider-auth.test.ts
@@ -1,48 +1,78 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ProviderRegistry } from '../src/registry/types.js';
 
 const lockState = vi.hoisted(() => ({
   active: false,
+  registryTail: Promise.resolve(),
   credentialActive: false,
+  credentialTails: new Map<string, Promise<void>>(),
+}));
+const registryState = vi.hoisted(() => ({
+  current: { schemaVersion: 1, providers: [] } as ProviderRegistry,
 }));
 
 vi.mock('../src/ui.js', () => ({
   printOAuthStepsPanel: vi.fn(),
 }));
 vi.mock('../src/oauth/openai.js', () => ({
-  runOpenAiDeviceCodeFlow: vi.fn(async () => ({
-    tokens: { access_token: 'openai-access', refresh_token: 'openai-refresh', expires_in: 3600 },
-    accountId: 'acct-123',
-  })),
+  runOpenAiDeviceCodeFlow: vi.fn(),
 }));
-vi.mock('../src/env.js', () => ({
-  probeProviderCredentialStore: vi.fn(async () => true),
-  saveProviderCredential: vi.fn(async () => false),
-}));
+vi.mock('../src/env.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/env.js')>();
+  return {
+    ...actual,
+    deleteProviderCredential: vi.fn(),
+    probeProviderCredentialStore: vi.fn(),
+    saveProviderCredential: vi.fn(),
+  };
+});
 vi.mock('../src/registry/io.js', () => ({
-  loadRegistry: vi.fn(() => ({ version: 1, providers: [] })),
-  saveRegistry: vi.fn(),
+  loadRegistry: vi.fn(() => structuredClone(registryState.current)),
+  saveRegistry: vi.fn((registry: ProviderRegistry) => {
+    if (!lockState.active) throw new Error('registry write escaped its lock');
+    registryState.current = structuredClone(registry);
+  }),
 }));
 vi.mock('../src/registry/refresh-models.js', () => ({
   refreshProviderModels: vi.fn(),
 }));
 vi.mock('../src/registry/lock.js', () => ({
-  withRegistryWriteLock: vi.fn(async (operation: () => unknown) => {
+  withRegistryWriteLock: vi.fn(async <T>(operation: () => Promise<T> | T): Promise<T> => {
+    const previous = lockState.registryTail;
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => { release = resolve; });
+    lockState.registryTail = previous.then(() => gate);
+    await previous;
     lockState.active = true;
     try {
       return await operation();
     } finally {
       lockState.active = false;
+      release();
     }
   }),
-  withCredentialMutationLock: vi.fn(async (
-    _authRef: string,
-    operation: () => unknown,
-  ) => {
+  withCredentialMutationLock: vi.fn(async <T>(
+    authRef: string,
+    operation: () => Promise<T> | T,
+  ): Promise<T> => {
+    const previous = lockState.credentialTails.get(authRef) ?? Promise.resolve();
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => { release = resolve; });
+    const tail = previous.then(() => gate);
+    lockState.credentialTails.set(authRef, tail);
+    await previous;
     lockState.credentialActive = true;
     try {
       return await operation();
     } finally {
       lockState.credentialActive = false;
+      release();
+      if (lockState.credentialTails.get(authRef) === tail) {
+        lockState.credentialTails.delete(authRef);
+      }
     }
   }),
 }));
@@ -53,23 +83,58 @@ vi.mock('@clack/prompts', () => ({
   isCancel: vi.fn(() => false),
 }));
 
-import { probeProviderCredentialStore, saveProviderCredential } from '../src/env.js';
+import {
+  deleteProviderCredential,
+  probeProviderCredentialStore,
+  saveProviderCredential,
+} from '../src/env.js';
+import { credentialAuthRef } from '../src/credential-helper.js';
+import { runOpenAiDeviceCodeFlow } from '../src/oauth/openai.js';
+import { reconcilePendingCredentialDeletes } from '../src/registry/credential-lifecycle.js';
 import { saveRegistry } from '../src/registry/io.js';
 import { authenticateProvider } from '../src/registry/provider-auth.js';
-import { runOpenAiDeviceCodeFlow } from '../src/oauth/openai.js';
 import { refreshProviderModels } from '../src/registry/refresh-models.js';
 import * as prompts from '@clack/prompts';
 
 describe('authenticateProvider', () => {
+  const previousHelper = process.env.CLODEX_CREDENTIAL_HELPER;
+  const previousHome = process.env.CLODEX_HOME;
+  let home = '';
+
   beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'clodex-provider-auth-'));
+    process.env.CLODEX_HOME = home;
+    registryState.current = { schemaVersion: 1, providers: [] };
+    delete process.env.CLODEX_CREDENTIAL_HELPER;
+    vi.mocked(deleteProviderCredential).mockReset().mockResolvedValue(true);
     vi.mocked(probeProviderCredentialStore).mockReset().mockResolvedValue(true);
     lockState.active = false;
+    lockState.registryTail = Promise.resolve();
     lockState.credentialActive = false;
-    vi.mocked(saveProviderCredential).mockReset().mockResolvedValue(false);
-    vi.mocked(saveRegistry).mockClear();
-    vi.mocked(runOpenAiDeviceCodeFlow).mockClear();
-    vi.mocked(refreshProviderModels).mockClear();
+    lockState.credentialTails.clear();
+    vi.mocked(saveProviderCredential).mockReset().mockResolvedValue(true);
+    vi.mocked(saveRegistry).mockReset().mockImplementation(registry => {
+      if (!lockState.active) throw new Error('registry write escaped its lock');
+      registryState.current = structuredClone(registry) as typeof registryState.current;
+    });
+    vi.mocked(runOpenAiDeviceCodeFlow).mockReset().mockResolvedValue({
+      tokens: { access_token: 'openai-access', refresh_token: 'openai-refresh', expires_in: 3600 },
+      accountId: 'acct-123',
+    });
+    vi.mocked(refreshProviderModels).mockReset().mockResolvedValue({
+      id: 'openai-oauth',
+      name: 'OpenAI',
+      ok: true,
+    });
     vi.mocked(prompts.select).mockClear();
+  });
+
+  afterEach(() => {
+    if (previousHelper === undefined) delete process.env.CLODEX_CREDENTIAL_HELPER;
+    else process.env.CLODEX_CREDENTIAL_HELPER = previousHelper;
+    if (previousHome === undefined) delete process.env.CLODEX_HOME;
+    else process.env.CLODEX_HOME = previousHome;
+    rmSync(home, { recursive: true, force: true });
   });
 
   it('runs the OpenAI device-code flow and stores the openai-oauth registry entry', async () => {
@@ -116,35 +181,139 @@ describe('authenticateProvider', () => {
       'Could not save OAuth tokens to the credential store',
     );
     expect(saveProviderCredential).toHaveBeenCalled();
-    expect(saveRegistry).not.toHaveBeenCalled();
+    expect(registryState.current.providers).toHaveLength(0);
+    expect(registryState.current.pendingCredentialDeletes).toEqual([
+      'keyring:oauth:provider:openai-oauth',
+    ]);
+    expect(deleteProviderCredential).not.toHaveBeenCalled();
     expect(refreshProviderModels).not.toHaveBeenCalled();
   });
 
-  it('holds the registry lock only while persisting the provider entry', async () => {
-    const observations: Array<[string, boolean]> = [];
-    vi.mocked(saveProviderCredential).mockResolvedValueOnce(true);
+  it('keeps authorization and model refresh outside the credential transaction lock', async () => {
+    const observations: Array<[string, boolean, boolean]> = [];
     vi.mocked(runOpenAiDeviceCodeFlow).mockImplementationOnce(async () => {
-      observations.push(['authorization', lockState.active]);
+      observations.push(['authorization', lockState.active, lockState.credentialActive]);
       return {
         tokens: { access_token: 'access-token', refresh_token: 'refresh-token', expires_in: 3600 },
         accountId: 'account-id',
       };
     });
-    vi.mocked(saveRegistry).mockImplementationOnce(() => {
-      observations.push(['registry-write', lockState.active]);
+    vi.mocked(saveProviderCredential).mockImplementationOnce(async () => {
+      observations.push(['credential-write', lockState.active, lockState.credentialActive]);
+      return true;
     });
     vi.mocked(refreshProviderModels).mockImplementationOnce(async () => {
-      observations.push(['model-refresh', lockState.active]);
+      observations.push(['model-refresh', lockState.active, lockState.credentialActive]);
       return { id: 'openai-oauth', name: 'OpenAI', ok: true };
     });
 
     await authenticateProvider('openai');
 
     expect(observations).toEqual([
-      ['authorization', false],
-      ['registry-write', true],
-      ['model-refresh', false],
+      ['authorization', false, false],
+      ['credential-write', false, true],
+      ['model-refresh', false, false],
     ]);
+  });
+
+  it('removes an unshared prior credential after migrating stores', async () => {
+    registryState.current.providers.push({
+      id: 'openai-oauth',
+      templateId: 'openai',
+      name: 'OpenAI (ChatGPT)',
+      enabled: true,
+      authRef: 'keyring:oauth:provider:openai-oauth',
+      authType: 'oauth',
+      api: { npm: '@ai-sdk/openai', url: 'https://api.openai.com/v1' },
+      addedAt: '2026-01-01T00:00:00.000Z',
+    });
+    process.env.CLODEX_CREDENTIAL_HELPER = process.execPath;
+    const helperAuthRef = credentialAuthRef('oauth:provider:openai-oauth');
+
+    await authenticateProvider('openai');
+
+    expect(saveProviderCredential).toHaveBeenCalledWith(
+      helperAuthRef,
+      expect.any(String),
+      expect.any(Function),
+    );
+    expect(deleteProviderCredential).toHaveBeenCalledWith('keyring:oauth:provider:openai-oauth');
+    expect(registryState.current.providers[0]?.authRef).toBe(helperAuthRef);
+  });
+
+  it('keeps the new provider active and queues the prior credential when cleanup is uncertain', async () => {
+    registryState.current.providers.push({
+      id: 'openai-oauth',
+      templateId: 'openai',
+      name: 'OpenAI (ChatGPT)',
+      enabled: true,
+      authRef: 'keyring:oauth:provider:openai-oauth',
+      authType: 'oauth',
+      api: { npm: '@ai-sdk/openai', url: 'https://api.openai.com/v1' },
+      addedAt: '2026-01-01T00:00:00.000Z',
+    });
+    process.env.CLODEX_CREDENTIAL_HELPER = process.execPath;
+    const helperAuthRef = credentialAuthRef('oauth:provider:openai-oauth');
+    vi.mocked(deleteProviderCredential).mockResolvedValue(false);
+
+    const result = await authenticateProvider('openai');
+    expect(result.credentialCleanupPending).toBe(true);
+    expect(registryState.current.providers[0]?.authRef).toBe(helperAuthRef);
+    expect(registryState.current.pendingCredentialDeletes).toEqual([
+      'keyring:oauth:provider:openai-oauth',
+    ]);
+    expect(deleteProviderCredential).toHaveBeenCalledWith('keyring:oauth:provider:openai-oauth');
+    expect(deleteProviderCredential).not.toHaveBeenCalledWith(helperAuthRef);
+  });
+
+  it('does not write a credential when the durable pending marker cannot be saved', async () => {
+    vi.mocked(saveRegistry).mockImplementationOnce(() => {
+      throw new Error('registry unavailable');
+    });
+
+    await expect(authenticateProvider('openai')).rejects.toThrow('registry unavailable');
+    expect(saveProviderCredential).not.toHaveBeenCalled();
+    expect(registryState.current.providers).toHaveLength(0);
+  });
+
+  it('leaves a newly written credential journaled when provider activation cannot be saved', async () => {
+    vi.mocked(saveRegistry)
+      .mockImplementationOnce(registry => {
+        registryState.current = structuredClone(registry) as typeof registryState.current;
+      })
+      .mockImplementationOnce(() => {
+        throw new Error('activation failed');
+      });
+
+    await expect(authenticateProvider('openai')).rejects.toThrow('activation failed');
+    expect(saveProviderCredential).toHaveBeenCalled();
+    expect(registryState.current.providers).toHaveLength(0);
+    expect(registryState.current.pendingCredentialDeletes).toEqual([
+      'keyring:oauth:provider:openai-oauth',
+    ]);
+    expect(deleteProviderCredential).not.toHaveBeenCalled();
+  });
+
+  it('does not let concurrent reconciliation delete a credential during activation', async () => {
+    let releaseWrite!: () => void;
+    const writeGate = new Promise<void>(resolve => { releaseWrite = resolve; });
+    vi.mocked(saveProviderCredential).mockImplementation(async () => {
+      await writeGate;
+      return true;
+    });
+
+    const authentication = authenticateProvider('openai');
+    await vi.waitFor(() => expect(saveProviderCredential).toHaveBeenCalledTimes(1));
+    const reconciliation = reconcilePendingCredentialDeletes();
+    await new Promise(resolve => setTimeout(resolve, 25));
+
+    expect(deleteProviderCredential).not.toHaveBeenCalled();
+    releaseWrite();
+    const [result, cleanup] = await Promise.all([authentication, reconciliation]);
+    expect(result.registryProvider.authRef).toBe('keyring:oauth:provider:openai-oauth');
+    expect(cleanup.deleted).toEqual([]);
+    expect(deleteProviderCredential).not.toHaveBeenCalled();
+    expect(registryState.current.pendingCredentialDeletes).toBeUndefined();
   });
 
   it('rejects non-OpenAI providers', async () => {

--- a/tests/provider-auth.test.ts
+++ b/tests/provider-auth.test.ts
@@ -9,9 +9,13 @@ const lockState = vi.hoisted(() => ({
   registryTail: Promise.resolve(),
   credentialActive: false,
   credentialTails: new Map<string, Promise<void>>(),
+  afterRegistryUnlock: null as null | (() => void),
 }));
 const registryState = vi.hoisted(() => ({
   current: { schemaVersion: 1, providers: [] } as ProviderRegistry,
+}));
+const journalState = vi.hoisted(() => ({
+  pending: new Set<string>(),
 }));
 
 vi.mock('../src/ui.js', () => ({
@@ -36,6 +40,18 @@ vi.mock('../src/registry/io.js', () => ({
     registryState.current = structuredClone(registry);
   }),
 }));
+vi.mock('../src/registry/credential-cleanup-journal.js', () => ({
+  isStoredCredentialRef: vi.fn((authRef: string) =>
+    authRef.startsWith('keyring:') || authRef.startsWith('helper:v1:')),
+  loadPendingCredentialDeletes: vi.fn(async () => [...journalState.pending]),
+  queueCredentialDelete: vi.fn(async (authRef: string) => {
+    if (!authRef.startsWith('keyring:') && !authRef.startsWith('helper:v1:')) return false;
+    journalState.pending.add(authRef);
+    return true;
+  }),
+  cancelCredentialDelete: vi.fn(async (authRef: string) =>
+    journalState.pending.delete(authRef)),
+}));
 vi.mock('../src/registry/refresh-models.js', () => ({
   refreshProviderModels: vi.fn(),
 }));
@@ -52,6 +68,9 @@ vi.mock('../src/registry/lock.js', () => ({
     } finally {
       lockState.active = false;
       release();
+      const afterUnlock = lockState.afterRegistryUnlock;
+      lockState.afterRegistryUnlock = null;
+      afterUnlock?.();
     }
   }),
   withCredentialMutationLock: vi.fn(async <T>(
@@ -91,6 +110,7 @@ import {
 import { credentialAuthRef } from '../src/credential-helper.js';
 import { runOpenAiDeviceCodeFlow } from '../src/oauth/openai.js';
 import { reconcilePendingCredentialDeletes } from '../src/registry/credential-lifecycle.js';
+import * as cleanupJournal from '../src/registry/credential-cleanup-journal.js';
 import { saveRegistry } from '../src/registry/io.js';
 import { authenticateProvider } from '../src/registry/provider-auth.js';
 import { refreshProviderModels } from '../src/registry/refresh-models.js';
@@ -105,6 +125,7 @@ describe('authenticateProvider', () => {
     home = mkdtempSync(join(tmpdir(), 'clodex-provider-auth-'));
     process.env.CLODEX_HOME = home;
     registryState.current = { schemaVersion: 1, providers: [] };
+    journalState.pending.clear();
     delete process.env.CLODEX_CREDENTIAL_HELPER;
     vi.mocked(deleteProviderCredential).mockReset().mockResolvedValue(true);
     vi.mocked(probeProviderCredentialStore).mockReset().mockResolvedValue(true);
@@ -112,7 +133,18 @@ describe('authenticateProvider', () => {
     lockState.registryTail = Promise.resolve();
     lockState.credentialActive = false;
     lockState.credentialTails.clear();
+    lockState.afterRegistryUnlock = null;
     vi.mocked(saveProviderCredential).mockReset().mockResolvedValue(true);
+    vi.mocked(cleanupJournal.loadPendingCredentialDeletes).mockReset()
+      .mockImplementation(async () => [...journalState.pending]);
+    vi.mocked(cleanupJournal.queueCredentialDelete).mockReset()
+      .mockImplementation(async (authRef: string) => {
+        if (!authRef.startsWith('keyring:') && !authRef.startsWith('helper:v1:')) return false;
+        journalState.pending.add(authRef);
+        return true;
+      });
+    vi.mocked(cleanupJournal.cancelCredentialDelete).mockReset()
+      .mockImplementation(async (authRef: string) => journalState.pending.delete(authRef));
     vi.mocked(saveRegistry).mockReset().mockImplementation(registry => {
       if (!lockState.active) throw new Error('registry write escaped its lock');
       registryState.current = structuredClone(registry) as typeof registryState.current;
@@ -182,7 +214,7 @@ describe('authenticateProvider', () => {
     );
     expect(saveProviderCredential).toHaveBeenCalled();
     expect(registryState.current.providers).toHaveLength(0);
-    expect(registryState.current.pendingCredentialDeletes).toEqual([
+    expect([...journalState.pending]).toEqual([
       'keyring:oauth:provider:openai-oauth',
     ]);
     expect(deleteProviderCredential).not.toHaveBeenCalled();
@@ -259,7 +291,7 @@ describe('authenticateProvider', () => {
     const result = await authenticateProvider('openai');
     expect(result.credentialCleanupPending).toBe(true);
     expect(registryState.current.providers[0]?.authRef).toBe(helperAuthRef);
-    expect(registryState.current.pendingCredentialDeletes).toEqual([
+    expect([...journalState.pending]).toEqual([
       'keyring:oauth:provider:openai-oauth',
     ]);
     expect(deleteProviderCredential).toHaveBeenCalledWith('keyring:oauth:provider:openai-oauth');
@@ -267,28 +299,24 @@ describe('authenticateProvider', () => {
   });
 
   it('does not write a credential when the durable pending marker cannot be saved', async () => {
-    vi.mocked(saveRegistry).mockImplementationOnce(() => {
-      throw new Error('registry unavailable');
-    });
+    vi.mocked(cleanupJournal.queueCredentialDelete).mockRejectedValueOnce(
+      new Error('journal unavailable'),
+    );
 
-    await expect(authenticateProvider('openai')).rejects.toThrow('registry unavailable');
+    await expect(authenticateProvider('openai')).rejects.toThrow('journal unavailable');
     expect(saveProviderCredential).not.toHaveBeenCalled();
     expect(registryState.current.providers).toHaveLength(0);
   });
 
   it('leaves a newly written credential journaled when provider activation cannot be saved', async () => {
-    vi.mocked(saveRegistry)
-      .mockImplementationOnce(registry => {
-        registryState.current = structuredClone(registry) as typeof registryState.current;
-      })
-      .mockImplementationOnce(() => {
-        throw new Error('activation failed');
-      });
+    vi.mocked(saveRegistry).mockImplementationOnce(() => {
+      throw new Error('activation failed');
+    });
 
     await expect(authenticateProvider('openai')).rejects.toThrow('activation failed');
     expect(saveProviderCredential).toHaveBeenCalled();
     expect(registryState.current.providers).toHaveLength(0);
-    expect(registryState.current.pendingCredentialDeletes).toEqual([
+    expect([...journalState.pending]).toEqual([
       'keyring:oauth:provider:openai-oauth',
     ]);
     expect(deleteProviderCredential).not.toHaveBeenCalled();
@@ -313,7 +341,57 @@ describe('authenticateProvider', () => {
     expect(result.registryProvider.authRef).toBe('keyring:oauth:provider:openai-oauth');
     expect(cleanup.deleted).toEqual([]);
     expect(deleteProviderCredential).not.toHaveBeenCalled();
-    expect(registryState.current.pendingCredentialDeletes).toBeUndefined();
+    expect(journalState.pending.size).toBe(0);
+  });
+
+  it('retains a removal marker queued immediately after OAuth replacement commit', async () => {
+    registryState.current.providers.push({
+      id: 'openai-oauth',
+      templateId: 'openai',
+      name: 'OpenAI (ChatGPT)',
+      enabled: true,
+      authRef: 'keyring:oauth:provider:openai-oauth:previous',
+      authType: 'oauth',
+      api: { npm: '@ai-sdk/openai', url: 'https://api.openai.com/v1' },
+      addedAt: '2026-01-01T00:00:00.000Z',
+    });
+    const cancellationLockStates: boolean[] = [];
+    vi.mocked(cleanupJournal.cancelCredentialDelete).mockImplementationOnce(
+      async authRef => {
+        cancellationLockStates.push(lockState.active);
+        return journalState.pending.delete(authRef);
+      },
+    );
+    vi.mocked(deleteProviderCredential).mockResolvedValue(false);
+    vi.mocked(saveRegistry).mockImplementationOnce(registry => {
+      if (!lockState.active) throw new Error('registry write escaped its lock');
+      registryState.current = structuredClone(registry);
+      const replacementRef = registry.providers[0]?.authRef;
+      lockState.afterRegistryUnlock = () => {
+        registryState.current.providers = [];
+        if (replacementRef) journalState.pending.add(replacementRef);
+      };
+    });
+
+    const result = await authenticateProvider('openai');
+    const replacementRef = result.registryProvider.authRef;
+
+    expect(cancellationLockStates).toEqual([true]);
+    expect(replacementRef).toBe('keyring:oauth:provider:openai-oauth');
+    expect(journalState.pending).toContain(replacementRef);
+    expect(result.credentialCleanupPending).toBe(true);
+  });
+
+  it('reports cleanup pending instead of rejecting after OAuth provider commit', async () => {
+    vi.mocked(cleanupJournal.loadPendingCredentialDeletes).mockRejectedValue(
+      new Error('cleanup journal lock timed out'),
+    );
+
+    const result = await authenticateProvider('openai');
+
+    expect(result.registryProvider.id).toBe('openai-oauth');
+    expect(result.credentialCleanupPending).toBe(true);
+    expect(registryState.current.providers).toHaveLength(1);
   });
 
   it('rejects non-OpenAI providers', async () => {

--- a/tests/provider-auth.test.ts
+++ b/tests/provider-auth.test.ts
@@ -112,7 +112,7 @@ import { credentialAuthRef } from '../src/credential-helper.js';
 import { runOpenAiDeviceCodeFlow } from '../src/oauth/openai.js';
 import { reconcilePendingCredentialDeletes } from '../src/registry/credential-lifecycle.js';
 import * as cleanupJournal from '../src/registry/credential-cleanup-journal.js';
-import { saveRegistry } from '../src/registry/io.js';
+import { loadRegistryStrict, saveRegistry } from '../src/registry/io.js';
 import { authenticateProvider } from '../src/registry/provider-auth.js';
 import { refreshProviderModels } from '../src/registry/refresh-models.js';
 import * as prompts from '@clack/prompts';
@@ -136,6 +136,9 @@ describe('authenticateProvider', () => {
     lockState.credentialTails.clear();
     lockState.afterRegistryUnlock = null;
     vi.mocked(saveProviderCredential).mockReset().mockResolvedValue(true);
+    vi.mocked(loadRegistryStrict).mockReset().mockImplementation(
+      () => structuredClone(registryState.current),
+    );
     vi.mocked(cleanupJournal.loadPendingCredentialDeletes).mockReset()
       .mockImplementation(async () => [...journalState.pending]);
     vi.mocked(cleanupJournal.queueCredentialDelete).mockReset()
@@ -219,6 +222,21 @@ describe('authenticateProvider', () => {
       'keyring:oauth:provider:openai-oauth',
     ]);
     expect(deleteProviderCredential).not.toHaveBeenCalled();
+    expect(refreshProviderModels).not.toHaveBeenCalled();
+  });
+
+  it('does not persist credentials when the registry cannot be validated', async () => {
+    vi.mocked(loadRegistryStrict).mockImplementationOnce(() => {
+      throw new Error('Provider registry contains an invalid provider entry.');
+    });
+
+    await expect(authenticateProvider('openai')).rejects.toThrow(
+      'Provider registry contains an invalid provider entry.',
+    );
+
+    expect(saveProviderCredential).not.toHaveBeenCalled();
+    expect(saveRegistry).not.toHaveBeenCalled();
+    expect(cleanupJournal.loadPendingCredentialDeletes).not.toHaveBeenCalled();
     expect(refreshProviderModels).not.toHaveBeenCalled();
   });
 

--- a/tests/providers-command.test.ts
+++ b/tests/providers-command.test.ts
@@ -17,11 +17,19 @@ import {
 } from '../src/registry/crud.js';
 import { emptyRegistry, loadRegistry, saveRegistry } from '../src/registry/io.js';
 import { withRegistryWriteLockSync } from '../src/registry/lock.js';
+import {
+  loadPendingCredentialDeletes,
+  queueCredentialDelete,
+} from '../src/registry/credential-cleanup-journal.js';
 import { providerAuthHelpText } from '../src/registry/provider-auth.js';
 import type { RegistryProvider } from '../src/registry/types.js';
 import * as env from '../src/env.js';
 
 const selectMock = vi.hoisted(() => vi.fn());
+const passwordMock = vi.hoisted(() => vi.fn());
+const spinnerStartMock = vi.hoisted(() => vi.fn());
+const spinnerStopMock = vi.hoisted(() => vi.fn());
+const addTemplateMock = vi.hoisted(() => vi.fn());
 const logErrorMock = vi.hoisted(() => vi.fn());
 const logSuccessMock = vi.hoisted(() => vi.fn());
 const authenticateProviderMock = vi.hoisted(() => vi.fn());
@@ -34,6 +42,11 @@ vi.mock('@clack/prompts', async importOriginal => {
   return {
     ...actual,
     select: selectMock,
+    password: passwordMock,
+    spinner: () => ({
+      start: spinnerStartMock,
+      stop: spinnerStopMock,
+    }),
     log: {
       ...actual.log,
       error: logErrorMock,
@@ -48,6 +61,14 @@ vi.mock('../src/registry/provider-auth.js', async importOriginal => {
   return {
     ...actual,
     authenticateProvider: authenticateProviderMock,
+  };
+});
+
+vi.mock('../src/registry/add-template.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/registry/add-template.js')>();
+  return {
+    ...actual,
+    addProviderFromTemplate: addTemplateMock,
   };
 });
 
@@ -181,7 +202,7 @@ describe('registry crud', () => {
     expect(code).toBe(0);
     expect(loadRegistry().providers).toHaveLength(0);
     expect(deleteSpy).toHaveBeenCalledWith(authRef);
-    expect(loadRegistry().pendingCredentialDeletes).toEqual([authRef]);
+    await expect(loadPendingCredentialDeletes()).resolves.toEqual([authRef]);
     expect(logErrorMock).not.toHaveBeenCalled();
     expect(logSuccessMock).toHaveBeenCalledWith('Removed OpenAI.');
     expect(warnMock).toHaveBeenCalledWith(
@@ -254,7 +275,9 @@ describe('provider removal cleanup', () => {
     const deleteSpy = vi.spyOn(env, 'deleteProviderCredential').mockImplementation(async () => {
       const duringDelete = loadRegistry();
       expect(duringDelete.providers).toHaveLength(0);
-      expect(duringDelete.pendingCredentialDeletes).toEqual([helperRef('provider:openai')]);
+      await expect(loadPendingCredentialDeletes()).resolves.toEqual([
+        helperRef('provider:openai'),
+      ]);
       return false;
     });
     const result = await removeProviderFromRegistry('openai');
@@ -264,7 +287,9 @@ describe('provider removal cleanup', () => {
     expect(result.error).toBeUndefined();
     expect(deleteSpy).toHaveBeenCalledWith(helperRef('provider:openai'));
     expect(loadRegistry().providers).toHaveLength(0);
-    expect(loadRegistry().pendingCredentialDeletes).toEqual([helperRef('provider:openai')]);
+    await expect(loadPendingCredentialDeletes()).resolves.toEqual([
+      helperRef('provider:openai'),
+    ]);
   });
 });
 
@@ -287,9 +312,7 @@ describe('provider command cleanup reconciliation', () => {
 
   it('persists uncertain cleanup for retry after a process restart', async () => {
     const authRef = helperRef('provider:stale');
-    const registry = emptyRegistry();
-    registry.pendingCredentialDeletes = [authRef];
-    withRegistryWriteLockSync(() => saveRegistry(registry));
+    await queueCredentialDelete(authRef);
     const deleteSpy = vi.spyOn(env, 'deleteProviderCredential')
       .mockResolvedValueOnce(false)
       .mockResolvedValueOnce(true);
@@ -298,19 +321,19 @@ describe('provider command cleanup reconciliation', () => {
     await runProvidersCommand(['auth']);
 
     expect(deleteSpy).toHaveBeenNthCalledWith(1, authRef);
-    expect(loadRegistry().pendingCredentialDeletes).toEqual([authRef]);
+    await expect(loadPendingCredentialDeletes()).resolves.toEqual([authRef]);
     expect(warnMock).toHaveBeenCalledWith(
       'Some credential cleanup is still pending and will be retried later.',
     );
     const persisted = JSON.parse(
-      readFileSync(join(home, 'providers.json'), 'utf8'),
+      readFileSync(join(home, 'credential-cleanup.json'), 'utf8'),
     ) as { pendingCredentialDeletes?: string[] };
     expect(persisted.pendingCredentialDeletes).toEqual([authRef]);
 
     await runProvidersCommand(['auth']);
 
     expect(deleteSpy).toHaveBeenNthCalledWith(2, authRef);
-    expect(loadRegistry().pendingCredentialDeletes).toBeUndefined();
+    await expect(loadPendingCredentialDeletes()).resolves.toEqual([]);
     expect(warnMock).toHaveBeenCalledTimes(1);
   });
 });
@@ -323,6 +346,11 @@ describe('providers add menu', () => {
     home = mkdtempSync(join(tmpdir(), 'clodex-providers-add-'));
     process.env.CLODEX_HOME = home;
     selectMock.mockReset();
+    passwordMock.mockReset();
+    spinnerStartMock.mockReset();
+    spinnerStopMock.mockReset();
+    addTemplateMock.mockReset();
+    warnMock.mockReset();
   });
 
   afterEach(() => {
@@ -339,5 +367,21 @@ describe('providers add menu', () => {
 
     const options = selectMock.mock.calls[0]?.[0].options.map((option: { value: string }) => option.value);
     expect(options).toEqual(['oauth', 'apikey']);
+  });
+
+  it('reports pending cleanup after an API-key provider is committed', async () => {
+    selectMock.mockResolvedValue('apikey');
+    passwordMock.mockResolvedValue('api-key');
+    addTemplateMock.mockResolvedValue({
+      added: true,
+      modelCount: 3,
+      credentialCleanupPending: true,
+    });
+
+    await expect(runProvidersAdd()).resolves.toBe(0);
+
+    expect(warnMock).toHaveBeenCalledWith(
+      'A previous credential is queued for cleanup and will be retried by the next provider command.',
+    );
   });
 });

--- a/tests/providers-command.test.ts
+++ b/tests/providers-command.test.ts
@@ -33,7 +33,6 @@ const addTemplateMock = vi.hoisted(() => vi.fn());
 const authenticateProviderMock = vi.hoisted(() => vi.fn());
 const logErrorMock = vi.hoisted(() => vi.fn());
 const logSuccessMock = vi.hoisted(() => vi.fn());
-const authenticateProviderMock = vi.hoisted(() => vi.fn());
 const warnMock = vi.hoisted(() => vi.fn());
 const TEST_HELPER_ID = 'a'.repeat(64);
 const helperRef = (account: string): string => `helper:v1:${TEST_HELPER_ID}:${account}`;

--- a/tests/providers-command.test.ts
+++ b/tests/providers-command.test.ts
@@ -206,7 +206,7 @@ describe('registry crud', () => {
     expect(logErrorMock).not.toHaveBeenCalled();
     expect(logSuccessMock).toHaveBeenCalledWith('Removed OpenAI.');
     expect(warnMock).toHaveBeenCalledWith(
-      'Provider credential cleanup is queued for retry.',
+      'Credential cleanup is pending and will be retried by the next provider command.',
     );
   });
 
@@ -323,7 +323,7 @@ describe('provider command cleanup reconciliation', () => {
     expect(deleteSpy).toHaveBeenNthCalledWith(1, authRef);
     await expect(loadPendingCredentialDeletes()).resolves.toEqual([authRef]);
     expect(warnMock).toHaveBeenCalledWith(
-      'Some credential cleanup is still pending and will be retried later.',
+      'Credential cleanup is pending and will be retried by the next provider command.',
     );
     const persisted = JSON.parse(
       readFileSync(join(home, 'credential-cleanup.json'), 'utf8'),
@@ -335,6 +335,22 @@ describe('provider command cleanup reconciliation', () => {
     expect(deleteSpy).toHaveBeenNthCalledWith(2, authRef);
     await expect(loadPendingCredentialDeletes()).resolves.toEqual([]);
     expect(warnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns once when a mutating command leaves cleanup pending', async () => {
+    const authRef = helperRef('provider:openai');
+    const registry = emptyRegistry();
+    registry.providers.push(openaiEntry({ authRef }));
+    withRegistryWriteLockSync(() => saveRegistry(registry));
+    vi.spyOn(env, 'deleteProviderCredential').mockResolvedValue(false);
+
+    await expect(runProvidersCommand(['remove', 'openai'])).resolves.toBe(0);
+
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(warnMock).toHaveBeenCalledWith(
+      'Credential cleanup is pending and will be retried by the next provider command.',
+    );
+    await expect(loadPendingCredentialDeletes()).resolves.toEqual([authRef]);
   });
 });
 
@@ -381,7 +397,7 @@ describe('providers add menu', () => {
     await expect(runProvidersAdd()).resolves.toBe(0);
 
     expect(warnMock).toHaveBeenCalledWith(
-      'A previous credential is queued for cleanup and will be retried by the next provider command.',
+      'Credential cleanup is pending and will be retried by the next provider command.',
     );
   });
 });

--- a/tests/providers-command.test.ts
+++ b/tests/providers-command.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -9,6 +9,7 @@ import {
   runProvidersAdd,
   runProvidersAuth,
   runProvidersRemove,
+  runProvidersCommand,
 } from '../src/providers-command.js';
 import {
   removeProviderFromRegistry,
@@ -24,6 +25,9 @@ const selectMock = vi.hoisted(() => vi.fn());
 const logErrorMock = vi.hoisted(() => vi.fn());
 const logSuccessMock = vi.hoisted(() => vi.fn());
 const authenticateProviderMock = vi.hoisted(() => vi.fn());
+const warnMock = vi.hoisted(() => vi.fn());
+const TEST_HELPER_ID = 'a'.repeat(64);
+const helperRef = (account: string): string => `helper:v1:${TEST_HELPER_ID}:${account}`;
 
 vi.mock('@clack/prompts', async importOriginal => {
   const actual = await importOriginal<typeof import('@clack/prompts')>();
@@ -34,6 +38,7 @@ vi.mock('@clack/prompts', async importOriginal => {
       ...actual.log,
       error: logErrorMock,
       success: logSuccessMock,
+      warn: warnMock,
     },
   };
 });
@@ -132,6 +137,7 @@ describe('registry crud', () => {
     process.env.CLODEX_HOME = home;
     logErrorMock.mockReset();
     logSuccessMock.mockReset();
+    warnMock.mockReset();
   });
 
   afterEach(() => {
@@ -163,7 +169,7 @@ describe('registry crud', () => {
     expect(deleteSpy).toHaveBeenCalledWith('keyring:provider:openai');
   });
 
-  it('returns failure and avoids success output when credential cleanup fails', async () => {
+  it('keeps uncertain credential cleanup queued without failing provider removal', async () => {
     const authRef = 'keyring:provider:openai';
     const registry = emptyRegistry();
     registry.providers.push(openaiEntry({ authRef }));
@@ -172,17 +178,15 @@ describe('registry crud', () => {
     const deleteSpy = vi.spyOn(env, 'deleteProviderCredential').mockResolvedValue(false);
     const code = await runProvidersRemove('openai');
 
-    expect(code).toBe(1);
+    expect(code).toBe(0);
     expect(loadRegistry().providers).toHaveLength(0);
     expect(deleteSpy).toHaveBeenCalledWith(authRef);
-    expect(logErrorMock).toHaveBeenCalledWith(expect.stringContaining(authRef));
-    expect(logErrorMock.mock.calls[0]?.[0]).toMatch(
-      /credential.*(?:cleanup|deletion).*failed/i,
+    expect(loadRegistry().pendingCredentialDeletes).toEqual([authRef]);
+    expect(logErrorMock).not.toHaveBeenCalled();
+    expect(logSuccessMock).toHaveBeenCalledWith('Removed OpenAI.');
+    expect(warnMock).toHaveBeenCalledWith(
+      'Provider credential cleanup is queued for retry.',
     );
-    expect(logErrorMock.mock.calls[0]?.[0]).toContain(
-      'must be removed manually',
-    );
-    expect(logSuccessMock).not.toHaveBeenCalled();
   });
 
   it('keeps a shared credential when another provider still references it', async () => {
@@ -238,6 +242,76 @@ describe('providers auth command', () => {
       'Could not save OAuth tokens to the credential store: credential write failed',
     );
     expect(logSuccessMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('provider removal cleanup', () => {
+  it('removes the provider and queues cleanup when deletion has an unknown outcome', async () => {
+    const registry = emptyRegistry();
+    registry.providers.push(openaiEntry({ authRef: helperRef('provider:openai') }));
+    withRegistryWriteLockSync(() => saveRegistry(registry));
+
+    const deleteSpy = vi.spyOn(env, 'deleteProviderCredential').mockImplementation(async () => {
+      const duringDelete = loadRegistry();
+      expect(duringDelete.providers).toHaveLength(0);
+      expect(duringDelete.pendingCredentialDeletes).toEqual([helperRef('provider:openai')]);
+      return false;
+    });
+    const result = await removeProviderFromRegistry('openai');
+
+    expect(result.removed).toBe(true);
+    expect(result.credentialCleanupPending).toBe(true);
+    expect(result.error).toBeUndefined();
+    expect(deleteSpy).toHaveBeenCalledWith(helperRef('provider:openai'));
+    expect(loadRegistry().providers).toHaveLength(0);
+    expect(loadRegistry().pendingCredentialDeletes).toEqual([helperRef('provider:openai')]);
+  });
+});
+
+describe('provider command cleanup reconciliation', () => {
+  let home: string;
+  const prevHome = process.env.CLODEX_HOME;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'clodex-provider-cleanup-'));
+    process.env.CLODEX_HOME = home;
+    warnMock.mockReset();
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.CLODEX_HOME;
+    else process.env.CLODEX_HOME = prevHome;
+    rmSync(home, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('persists uncertain cleanup for retry after a process restart', async () => {
+    const authRef = helperRef('provider:stale');
+    const registry = emptyRegistry();
+    registry.pendingCredentialDeletes = [authRef];
+    withRegistryWriteLockSync(() => saveRegistry(registry));
+    const deleteSpy = vi.spyOn(env, 'deleteProviderCredential')
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runProvidersCommand(['auth']);
+
+    expect(deleteSpy).toHaveBeenNthCalledWith(1, authRef);
+    expect(loadRegistry().pendingCredentialDeletes).toEqual([authRef]);
+    expect(warnMock).toHaveBeenCalledWith(
+      'Some credential cleanup is still pending and will be retried later.',
+    );
+    const persisted = JSON.parse(
+      readFileSync(join(home, 'providers.json'), 'utf8'),
+    ) as { pendingCredentialDeletes?: string[] };
+    expect(persisted.pendingCredentialDeletes).toEqual([authRef]);
+
+    await runProvidersCommand(['auth']);
+
+    expect(deleteSpy).toHaveBeenNthCalledWith(2, authRef);
+    expect(loadRegistry().pendingCredentialDeletes).toBeUndefined();
+    expect(warnMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/tests/providers-command.test.ts
+++ b/tests/providers-command.test.ts
@@ -30,6 +30,7 @@ const passwordMock = vi.hoisted(() => vi.fn());
 const spinnerStartMock = vi.hoisted(() => vi.fn());
 const spinnerStopMock = vi.hoisted(() => vi.fn());
 const addTemplateMock = vi.hoisted(() => vi.fn());
+const authenticateProviderMock = vi.hoisted(() => vi.fn());
 const logErrorMock = vi.hoisted(() => vi.fn());
 const logSuccessMock = vi.hoisted(() => vi.fn());
 const authenticateProviderMock = vi.hoisted(() => vi.fn());
@@ -69,6 +70,14 @@ vi.mock('../src/registry/add-template.js', async importOriginal => {
   return {
     ...actual,
     addProviderFromTemplate: addTemplateMock,
+  };
+});
+
+vi.mock('../src/registry/provider-auth.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/registry/provider-auth.js')>();
+  return {
+    ...actual,
+    authenticateProvider: authenticateProviderMock,
   };
 });
 
@@ -300,6 +309,11 @@ describe('provider command cleanup reconciliation', () => {
   beforeEach(() => {
     home = mkdtempSync(join(tmpdir(), 'clodex-provider-cleanup-'));
     process.env.CLODEX_HOME = home;
+    selectMock.mockReset();
+    passwordMock.mockReset();
+    addTemplateMock.mockReset();
+    authenticateProviderMock.mockReset();
+    logErrorMock.mockReset();
     warnMock.mockReset();
   });
 
@@ -342,7 +356,7 @@ describe('provider command cleanup reconciliation', () => {
     const registry = emptyRegistry();
     registry.providers.push(openaiEntry({ authRef }));
     withRegistryWriteLockSync(() => saveRegistry(registry));
-    vi.spyOn(env, 'deleteProviderCredential').mockResolvedValue(false);
+    const deleteSpy = vi.spyOn(env, 'deleteProviderCredential').mockResolvedValue(false);
 
     await expect(runProvidersCommand(['remove', 'openai'])).resolves.toBe(0);
 
@@ -350,7 +364,85 @@ describe('provider command cleanup reconciliation', () => {
     expect(warnMock).toHaveBeenCalledWith(
       'Credential cleanup is pending and will be retried by the next provider command.',
     );
+    expect(deleteSpy).toHaveBeenCalledTimes(1);
     await expect(loadPendingCredentialDeletes()).resolves.toEqual([authRef]);
+  });
+
+  it('retries queued cleanup when the add picker is cancelled', async () => {
+    const authRef = helperRef('provider:retired');
+    await queueCredentialDelete(authRef);
+    const deleteSpy = vi.spyOn(env, 'deleteProviderCredential').mockResolvedValue(true);
+    selectMock.mockResolvedValue(Symbol('cancel'));
+
+    await expect(runProvidersCommand(['add'])).resolves.toBe(0);
+
+    expect(deleteSpy).toHaveBeenCalledOnce();
+    expect(deleteSpy).toHaveBeenCalledWith(authRef);
+    await expect(loadPendingCredentialDeletes()).resolves.toEqual([]);
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it('retries queued cleanup when an add flow returns before mutation', async () => {
+    const authRef = helperRef('provider:retired');
+    await queueCredentialDelete(authRef);
+    const deleteSpy = vi.spyOn(env, 'deleteProviderCredential').mockResolvedValue(true);
+    selectMock.mockResolvedValue('apikey');
+    passwordMock.mockResolvedValue('test-key');
+    addTemplateMock.mockResolvedValue({
+      added: false,
+      error: 'Provider package is unavailable.',
+    });
+
+    await expect(runProvidersCommand(['add'])).resolves.toBe(1);
+
+    expect(deleteSpy).toHaveBeenCalledOnce();
+    expect(deleteSpy).toHaveBeenCalledWith(authRef);
+    await expect(loadPendingCredentialDeletes()).resolves.toEqual([]);
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it('retries queued cleanup when remove returns before mutation', async () => {
+    const authRef = helperRef('provider:retired');
+    await queueCredentialDelete(authRef);
+    const deleteSpy = vi.spyOn(env, 'deleteProviderCredential').mockResolvedValue(true);
+
+    await expect(runProvidersCommand(['remove', 'missing-provider'])).resolves.toBe(1);
+
+    expect(deleteSpy).toHaveBeenCalledOnce();
+    expect(deleteSpy).toHaveBeenCalledWith(authRef);
+    await expect(loadPendingCredentialDeletes()).resolves.toEqual([]);
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it('retries queued cleanup when authorization is cancelled', async () => {
+    const authRef = helperRef('provider:retired');
+    await queueCredentialDelete(authRef);
+    const deleteSpy = vi.spyOn(env, 'deleteProviderCredential').mockResolvedValue(true);
+    authenticateProviderMock.mockRejectedValue(new Error('Cancelled'));
+
+    await expect(runProvidersCommand(['auth', 'openai'])).resolves.toBe(0);
+
+    expect(deleteSpy).toHaveBeenCalledOnce();
+    expect(deleteSpy).toHaveBeenCalledWith(authRef);
+    await expect(loadPendingCredentialDeletes()).resolves.toEqual([]);
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it('warns once when authorization fails and queued cleanup remains', async () => {
+    const authRef = helperRef('provider:retired');
+    await queueCredentialDelete(authRef);
+    const deleteSpy = vi.spyOn(env, 'deleteProviderCredential').mockResolvedValue(false);
+    authenticateProviderMock.mockRejectedValue(new Error('Authorization failed.'));
+
+    await expect(runProvidersCommand(['auth', 'openai'])).resolves.toBe(1);
+
+    expect(deleteSpy).toHaveBeenCalledOnce();
+    expect(deleteSpy).toHaveBeenCalledWith(authRef);
+    await expect(loadPendingCredentialDeletes()).resolves.toEqual([authRef]);
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(warnMock).toHaveBeenCalledWith(
+      'Credential cleanup is pending and will be retried by the next provider command.',
+    );
   });
 });
 

--- a/tests/refresh-models.test.ts
+++ b/tests/refresh-models.test.ts
@@ -9,7 +9,7 @@ vi.mock('../src/registry/custom-endpoint.js', () => ({
   fetchAnthropicModels: vi.fn(),
 }));
 vi.mock('../src/registry/io.js', () => ({
-  loadRegistry: vi.fn(() => ({ version: 1, providers: [] })),
+  loadRegistryStrict: vi.fn(() => ({ schemaVersion: 1, providers: [] })),
   saveRegistry: vi.fn(),
 }));
 vi.mock('../src/registry/lock.js', () => ({
@@ -18,12 +18,12 @@ vi.mock('../src/registry/lock.js', () => ({
 }));
 
 import { fetchTemplateModels } from '../src/registry/fetch-template-models.js';
-import { loadRegistry, saveRegistry } from '../src/registry/io.js';
+import { loadRegistryStrict, saveRegistry } from '../src/registry/io.js';
 
 describe('refreshProviderModels', () => {
   beforeEach(() => {
     vi.mocked(fetchTemplateModels).mockReset();
-    vi.mocked(loadRegistry).mockReset();
+    vi.mocked(loadRegistryStrict).mockReset();
     vi.mocked(saveRegistry).mockClear();
   });
 
@@ -48,7 +48,7 @@ describe('refreshProviderModels', () => {
         name: 'Renamed while discovery was running',
       }],
     };
-    vi.mocked(loadRegistry).mockReturnValue(persistedRegistry);
+    vi.mocked(loadRegistryStrict).mockReturnValue(persistedRegistry);
     vi.mocked(fetchTemplateModels).mockResolvedValue({
       baseUrl: 'https://api.groq.com/openai/v1',
       models: [{
@@ -62,7 +62,7 @@ describe('refreshProviderModels', () => {
     const result = await refreshProviderModels('groq', 'test-key', initialRegistry);
 
     expect(result).toMatchObject({ ok: true, modelCount: 1 });
-    expect(loadRegistry).toHaveBeenCalledOnce();
+    expect(loadRegistryStrict).toHaveBeenCalledOnce();
     expect(saveRegistry).toHaveBeenCalledWith(persistedRegistry);
     expect(persistedRegistry.providers[0]?.name).toBe('Renamed while discovery was running');
     expect(persistedRegistry.providers[0]?.modelsCache?.models[0]?.id).toBe('live-a');
@@ -82,7 +82,7 @@ describe('refreshProviderModels', () => {
         addedAt: '2026-01-01T00:00:00.000Z',
       }],
     };
-    vi.mocked(loadRegistry).mockReturnValue({
+    vi.mocked(loadRegistryStrict).mockReturnValue({
       schemaVersion: 1,
       providers: [{
         ...initialRegistry.providers[0]!,
@@ -122,7 +122,7 @@ describe('refreshProviderModels', () => {
         addedAt: '2026-01-01T00:00:00.000Z',
       }],
     };
-    vi.mocked(loadRegistry).mockReturnValue({
+    vi.mocked(loadRegistryStrict).mockReturnValue({
       schemaVersion: 1,
       providers: [{
         ...initialRegistry.providers[0]!,
@@ -208,7 +208,7 @@ describe('refreshProviderModels', () => {
         modelFormat: 'openai',
       }],
     });
-    vi.mocked(loadRegistry).mockReturnValue(registry);
+    vi.mocked(loadRegistryStrict).mockReturnValue(registry);
 
     const first = await refreshProviderModels('groq', 'gsk-real-key', registry);
     const second = await refreshProviderModels('groq', 'gsk-real-key', registry);

--- a/tests/registry-add-template.test.ts
+++ b/tests/registry-add-template.test.ts
@@ -31,7 +31,11 @@ vi.mock('../src/env.js', async importOriginal => {
 });
 vi.mock('../src/provider-factory.js', () => ({ isSdkMigratedNpm: vi.fn() }));
 vi.mock('../src/registry/fetch-template-models.js', () => ({ fetchTemplateModels: vi.fn() }));
-vi.mock('../src/registry/io.js', () => ({ loadRegistry: vi.fn(), saveRegistry: vi.fn() }));
+vi.mock('../src/registry/io.js', () => ({
+  loadRegistry: vi.fn(),
+  loadRegistryStrict: vi.fn(),
+  saveRegistry: vi.fn(),
+}));
 vi.mock('../src/registry/credential-cleanup-journal.js', () => ({
   isStoredCredentialRef: vi.fn((authRef: string) =>
     authRef.startsWith('keyring:') || authRef.startsWith('helper:v1:')),
@@ -125,6 +129,8 @@ describe('registry/add-template', () => {
       providers: [],
     };
     vi.mocked(io.loadRegistry).mockReset().mockImplementation(() =>
+      structuredClone(registryState));
+    vi.mocked(io.loadRegistryStrict).mockReset().mockImplementation(() =>
       structuredClone(registryState));
     vi.mocked(io.saveRegistry).mockReset().mockImplementation((registry) => {
       if (!lockState.active) throw new Error('registry write escaped its lock');

--- a/tests/registry-add-template.test.ts
+++ b/tests/registry-add-template.test.ts
@@ -10,11 +10,20 @@ import type { ProviderRegistry } from '../src/registry/types.js';
 
 const lockState = vi.hoisted(() => ({
   active: false,
+  registryTail: Promise.resolve(),
   credentialActive: false,
   credentialTails: new Map<string, Promise<void>>(),
 }));
+let registryState: ProviderRegistry;
 
-vi.mock('../src/env.js', () => ({ saveProviderCredential: vi.fn() }));
+vi.mock('../src/env.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/env.js')>();
+  return {
+    ...actual,
+    deleteProviderCredential: vi.fn(),
+    saveProviderCredential: vi.fn(),
+  };
+});
 vi.mock('../src/provider-factory.js', () => ({ isSdkMigratedNpm: vi.fn() }));
 vi.mock('../src/registry/fetch-template-models.js', () => ({ fetchTemplateModels: vi.fn() }));
 vi.mock('../src/registry/io.js', () => ({ loadRegistry: vi.fn(), saveRegistry: vi.fn() }));
@@ -27,12 +36,17 @@ vi.mock('../src/registry/pricing.js', () => ({
 }));
 vi.mock('../src/registry/lock.js', () => ({
   withRegistryWriteLock: vi.fn(async (operation: () => unknown) => {
-    if (lockState.active) return operation();
+    const previous = lockState.registryTail;
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => { release = resolve; });
+    lockState.registryTail = previous.then(() => gate);
+    await previous;
     lockState.active = true;
     try {
       return await operation();
     } finally {
       lockState.active = false;
+      release();
     }
   }),
   withCredentialMutationLock: vi.fn(async (
@@ -73,15 +87,22 @@ describe('registry/add-template', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     lockState.active = false;
+    lockState.registryTail = Promise.resolve();
     lockState.credentialActive = false;
     lockState.credentialTails.clear();
 
     vi.mocked(providerFactory.isSdkMigratedNpm).mockReturnValue(true);
+    vi.mocked(env.deleteProviderCredential).mockResolvedValue(true);
     vi.mocked(env.saveProviderCredential).mockResolvedValue(true);
-    
-    vi.mocked(io.loadRegistry).mockReturnValue({
-      version: 1,
+    registryState = {
+      schemaVersion: 1,
       providers: [],
+    };
+    vi.mocked(io.loadRegistry).mockReset().mockImplementation(() =>
+      structuredClone(registryState));
+    vi.mocked(io.saveRegistry).mockReset().mockImplementation((registry) => {
+      if (!lockState.active) throw new Error('registry write escaped its lock');
+      registryState = structuredClone(registry);
     });
     
     vi.mocked(fetchTemplate.fetchTemplateModels).mockResolvedValue({
@@ -118,8 +139,17 @@ describe('registry/add-template', () => {
 
   it('fails if provider already exists and replaceExisting is not set', async () => {
     vi.mocked(io.loadRegistry).mockReturnValue({
-      version: 1,
-      providers: [{ id: 'test-template', templateId: 'test-template', name: 'Existing', enabled: true, authType: 'keyring', authRef: 'k', api: {} }],
+      schemaVersion: 1,
+      providers: [{
+        id: 'test-template',
+        templateId: 'test-template',
+        name: 'Existing',
+        enabled: true,
+        authType: 'api',
+        authRef: 'keyring:provider:test-template',
+        api: {},
+        addedAt: '2026-01-01T00:00:00.000Z',
+      }],
     });
 
     const res = await addProviderFromTemplate(dummyTemplate, 'key');
@@ -211,11 +241,21 @@ describe('registry/add-template', () => {
   });
 
   it('fails if credential cannot be saved', async () => {
+    const persisted: ProviderRegistry[] = [];
+    vi.mocked(io.saveRegistry).mockImplementation(registry => {
+      registryState = structuredClone(registry);
+      persisted.push(structuredClone(registry));
+    });
     vi.mocked(env.saveProviderCredential).mockResolvedValue(false);
 
     const res = await addProviderFromTemplate(dummyTemplate, 'key');
     expect(res.added).toBe(false);
     expect(res.error).toContain('Could not save API key');
+    expect(persisted[0]?.pendingCredentialDeletes).toEqual([
+      'keyring:provider:test-template',
+    ]);
+    expect(env.deleteProviderCredential).toHaveBeenCalledWith('keyring:provider:test-template');
+    expect(persisted.at(-1)?.pendingCredentialDeletes).toBeUndefined();
   });
 
   it('successfully adds provider', async () => {
@@ -244,6 +284,16 @@ describe('registry/add-template', () => {
     expect(env.saveProviderCredential).not.toHaveBeenCalled();
     const savedRegistry = vi.mocked(io.saveRegistry).mock.calls.at(-1)?.[0] as ProviderRegistry;
     expect(savedRegistry.providers[0]?.authRef).toBe('none:anonymous');
+  });
+
+  it('never sends an anonymous reference to credential deletion', async () => {
+    const anonymousTemplate = { ...dummyTemplate, apiKeyOptional: true };
+
+    const res = await addProviderFromTemplate(anonymousTemplate, '');
+
+    expect(res.added).toBe(true);
+    expect(res.provider?.authRef).toBe('none:anonymous');
+    expect(env.deleteProviderCredential).not.toHaveBeenCalled();
   });
 
   it('persists free-only filtering for anonymous free-model access', async () => {
@@ -278,16 +328,65 @@ describe('registry/add-template', () => {
 
   it('replaces existing provider if replaceExisting is true', async () => {
     vi.mocked(io.loadRegistry).mockReturnValue({
-      version: 1,
-      providers: [{ id: 'test-template', templateId: 'test-template', name: 'Existing', enabled: true, authType: 'keyring', authRef: 'k', api: {} }],
+      schemaVersion: 1,
+      providers: [{
+        id: 'test-template',
+        templateId: 'test-template',
+        name: 'Existing',
+        enabled: true,
+        authType: 'api',
+        authRef: 'keyring:provider:test-template',
+        api: {},
+        addedAt: '2026-01-01T00:00:00.000Z',
+      }],
     });
 
     const res = await addProviderFromTemplate(dummyTemplate, 'key_123', { replaceExisting: true });
 
     expect(res.added).toBe(true);
     
-    const savedRegistry = vi.mocked(io.saveRegistry).mock.calls[0]?.[0] as ProviderRegistry;
+    const savedRegistry = vi.mocked(io.saveRegistry).mock.calls.at(-1)?.[0] as ProviderRegistry;
     expect(savedRegistry.providers).toHaveLength(1); // Replaced, not duplicated
     expect(savedRegistry.providers[0]?.name).toBe('Test Provider');
+    expect(savedRegistry.providers[0]?.authRef).toMatch(
+      /^keyring:provider:test-template:replacement:/,
+    );
+    expect(env.deleteProviderCredential).toHaveBeenCalledWith('keyring:provider:test-template');
+  });
+
+  it('keeps a failed replacement journaled without changing the active provider', async () => {
+    vi.mocked(io.loadRegistry).mockReturnValue({
+      schemaVersion: 1,
+      providers: [{
+        id: 'test-template',
+        templateId: 'test-template',
+        name: 'Existing',
+        enabled: true,
+        authType: 'api',
+        authRef: 'keyring:provider:test-template',
+        api: {},
+        addedAt: '2026-01-01T00:00:00.000Z',
+      }],
+    });
+    let durableJournal: ProviderRegistry | undefined;
+    vi.mocked(io.saveRegistry)
+      .mockImplementationOnce(registry => {
+        durableJournal = structuredClone(registry);
+      })
+      .mockImplementationOnce(() => {
+        throw new Error('activation failed');
+      });
+
+    await expect(
+      addProviderFromTemplate(dummyTemplate, 'replacement-key', {
+        replaceExisting: true,
+      }),
+    ).rejects.toThrow('activation failed');
+
+    expect(durableJournal?.providers[0]?.authRef).toBe('keyring:provider:test-template');
+    expect(durableJournal?.pendingCredentialDeletes?.[0]).toMatch(
+      /^keyring:provider:test-template:replacement:/,
+    );
+    expect(env.deleteProviderCredential).not.toHaveBeenCalled();
   });
 });

--- a/tests/registry-add-template.test.ts
+++ b/tests/registry-add-template.test.ts
@@ -4,6 +4,7 @@ import * as env from '../src/env.js';
 import * as providerFactory from '../src/provider-factory.js';
 import * as fetchTemplate from '../src/registry/fetch-template-models.js';
 import * as io from '../src/registry/io.js';
+import * as cleanupJournal from '../src/registry/credential-cleanup-journal.js';
 import * as pricing from '../src/registry/pricing.js';
 import type { ProviderTemplate } from '../src/provider-templates.js';
 import type { ProviderRegistry } from '../src/registry/types.js';
@@ -13,6 +14,10 @@ const lockState = vi.hoisted(() => ({
   registryTail: Promise.resolve(),
   credentialActive: false,
   credentialTails: new Map<string, Promise<void>>(),
+  afterRegistryUnlock: null as null | (() => void),
+}));
+const journalState = vi.hoisted(() => ({
+  pending: new Set<string>(),
 }));
 let registryState: ProviderRegistry;
 
@@ -27,6 +32,18 @@ vi.mock('../src/env.js', async importOriginal => {
 vi.mock('../src/provider-factory.js', () => ({ isSdkMigratedNpm: vi.fn() }));
 vi.mock('../src/registry/fetch-template-models.js', () => ({ fetchTemplateModels: vi.fn() }));
 vi.mock('../src/registry/io.js', () => ({ loadRegistry: vi.fn(), saveRegistry: vi.fn() }));
+vi.mock('../src/registry/credential-cleanup-journal.js', () => ({
+  isStoredCredentialRef: vi.fn((authRef: string) =>
+    authRef.startsWith('keyring:') || authRef.startsWith('helper:v1:')),
+  loadPendingCredentialDeletes: vi.fn(async () => [...journalState.pending]),
+  queueCredentialDelete: vi.fn(async (authRef: string) => {
+    if (!authRef.startsWith('keyring:') && !authRef.startsWith('helper:v1:')) return false;
+    journalState.pending.add(authRef);
+    return true;
+  }),
+  cancelCredentialDelete: vi.fn(async (authRef: string) =>
+    journalState.pending.delete(authRef)),
+}));
 vi.mock('../src/registry/pricing.js', () => ({
   loadPricingCache: vi.fn(),
   enrichModelsWithPricing: vi.fn(),
@@ -47,6 +64,9 @@ vi.mock('../src/registry/lock.js', () => ({
     } finally {
       lockState.active = false;
       release();
+      const afterUnlock = lockState.afterRegistryUnlock;
+      lockState.afterRegistryUnlock = null;
+      afterUnlock?.();
     }
   }),
   withCredentialMutationLock: vi.fn(async (
@@ -90,10 +110,16 @@ describe('registry/add-template', () => {
     lockState.registryTail = Promise.resolve();
     lockState.credentialActive = false;
     lockState.credentialTails.clear();
+    lockState.afterRegistryUnlock = null;
+    journalState.pending.clear();
 
     vi.mocked(providerFactory.isSdkMigratedNpm).mockReturnValue(true);
     vi.mocked(env.deleteProviderCredential).mockResolvedValue(true);
     vi.mocked(env.saveProviderCredential).mockResolvedValue(true);
+    vi.mocked(cleanupJournal.loadPendingCredentialDeletes).mockReset()
+      .mockImplementation(async () => [...journalState.pending]);
+    vi.mocked(cleanupJournal.queueCredentialDelete).mockClear();
+    vi.mocked(cleanupJournal.cancelCredentialDelete).mockClear();
     registryState = {
       schemaVersion: 1,
       providers: [],
@@ -241,21 +267,16 @@ describe('registry/add-template', () => {
   });
 
   it('fails if credential cannot be saved', async () => {
-    const persisted: ProviderRegistry[] = [];
-    vi.mocked(io.saveRegistry).mockImplementation(registry => {
-      registryState = structuredClone(registry);
-      persisted.push(structuredClone(registry));
-    });
     vi.mocked(env.saveProviderCredential).mockResolvedValue(false);
 
     const res = await addProviderFromTemplate(dummyTemplate, 'key');
     expect(res.added).toBe(false);
     expect(res.error).toContain('Could not save API key');
-    expect(persisted[0]?.pendingCredentialDeletes).toEqual([
+    expect(cleanupJournal.queueCredentialDelete).toHaveBeenCalledWith(
       'keyring:provider:test-template',
-    ]);
+    );
     expect(env.deleteProviderCredential).toHaveBeenCalledWith('keyring:provider:test-template');
-    expect(persisted.at(-1)?.pendingCredentialDeletes).toBeUndefined();
+    expect(journalState.pending.size).toBe(0);
   });
 
   it('successfully adds provider', async () => {
@@ -327,7 +348,7 @@ describe('registry/add-template', () => {
   });
 
   it('replaces existing provider if replaceExisting is true', async () => {
-    vi.mocked(io.loadRegistry).mockReturnValue({
+    registryState = {
       schemaVersion: 1,
       providers: [{
         id: 'test-template',
@@ -339,7 +360,7 @@ describe('registry/add-template', () => {
         api: {},
         addedAt: '2026-01-01T00:00:00.000Z',
       }],
-    });
+    };
 
     const res = await addProviderFromTemplate(dummyTemplate, 'key_123', { replaceExisting: true });
 
@@ -354,8 +375,8 @@ describe('registry/add-template', () => {
     expect(env.deleteProviderCredential).toHaveBeenCalledWith('keyring:provider:test-template');
   });
 
-  it('keeps a failed replacement journaled without changing the active provider', async () => {
-    vi.mocked(io.loadRegistry).mockReturnValue({
+  it('retains a removal marker queued immediately after replacement commit', async () => {
+    registryState = {
       schemaVersion: 1,
       providers: [{
         id: 'test-template',
@@ -367,15 +388,55 @@ describe('registry/add-template', () => {
         api: {},
         addedAt: '2026-01-01T00:00:00.000Z',
       }],
+    };
+    const cancellationLockStates: boolean[] = [];
+    vi.mocked(cleanupJournal.cancelCredentialDelete).mockImplementationOnce(
+      async authRef => {
+        cancellationLockStates.push(lockState.active);
+        return journalState.pending.delete(authRef);
+      },
+    );
+    vi.mocked(env.deleteProviderCredential).mockResolvedValue(false);
+    vi.mocked(io.saveRegistry).mockImplementationOnce(registry => {
+      if (!lockState.active) throw new Error('registry write escaped its lock');
+      registryState = structuredClone(registry);
+      const replacementRef = registry.providers[0]?.authRef;
+      lockState.afterRegistryUnlock = () => {
+        registryState.providers = [];
+        if (replacementRef) journalState.pending.add(replacementRef);
+      };
     });
-    let durableJournal: ProviderRegistry | undefined;
-    vi.mocked(io.saveRegistry)
-      .mockImplementationOnce(registry => {
-        durableJournal = structuredClone(registry);
-      })
-      .mockImplementationOnce(() => {
-        throw new Error('activation failed');
-      });
+
+    const result = await addProviderFromTemplate(dummyTemplate, 'replacement-key', {
+      replaceExisting: true,
+    });
+    const replacementRef = result.provider?.authRef;
+
+    expect(cancellationLockStates).toEqual([true]);
+    expect(replacementRef).toMatch(
+      /^keyring:provider:test-template:replacement:/,
+    );
+    expect(journalState.pending).toContain(replacementRef);
+    expect(result.credentialCleanupPending).toBe(true);
+  });
+
+  it('keeps a failed replacement journaled without changing the active provider', async () => {
+    registryState = {
+      schemaVersion: 1,
+      providers: [{
+        id: 'test-template',
+        templateId: 'test-template',
+        name: 'Existing',
+        enabled: true,
+        authType: 'api',
+        authRef: 'keyring:provider:test-template',
+        api: {},
+        addedAt: '2026-01-01T00:00:00.000Z',
+      }],
+    };
+    vi.mocked(io.saveRegistry).mockImplementationOnce(() => {
+      throw new Error('activation failed');
+    });
 
     await expect(
       addProviderFromTemplate(dummyTemplate, 'replacement-key', {
@@ -383,10 +444,23 @@ describe('registry/add-template', () => {
       }),
     ).rejects.toThrow('activation failed');
 
-    expect(durableJournal?.providers[0]?.authRef).toBe('keyring:provider:test-template');
-    expect(durableJournal?.pendingCredentialDeletes?.[0]).toMatch(
-      /^keyring:provider:test-template:replacement:/,
-    );
+    expect(registryState.providers[0]?.authRef).toBe('keyring:provider:test-template');
+    expect([...journalState.pending]).toEqual([
+      expect.stringMatching(/^keyring:provider:test-template:replacement:/),
+      'keyring:provider:test-template',
+    ]);
     expect(env.deleteProviderCredential).not.toHaveBeenCalled();
+  });
+
+  it('reports cleanup pending instead of failing after provider commit', async () => {
+    vi.mocked(cleanupJournal.loadPendingCredentialDeletes).mockRejectedValue(
+      new Error('cleanup journal lock timed out'),
+    );
+
+    const result = await addProviderFromTemplate(dummyTemplate, 'key');
+
+    expect(result.added).toBe(true);
+    expect(result.credentialCleanupPending).toBe(true);
+    expect(registryState.providers).toHaveLength(1);
   });
 });

--- a/tests/registry-add-template.test.ts
+++ b/tests/registry-add-template.test.ts
@@ -170,7 +170,7 @@ describe('registry/add-template', () => {
   });
 
   it('fails if provider already exists and replaceExisting is not set', async () => {
-    vi.mocked(io.loadRegistry).mockReturnValue({
+    vi.mocked(io.loadRegistryStrict).mockReturnValue({
       schemaVersion: 1,
       providers: [{
         id: 'test-template',
@@ -226,7 +226,7 @@ describe('registry/add-template', () => {
 
   it('serializes concurrent writes to the same provider credential', async () => {
     let registry: ProviderRegistry = { schemaVersion: 1, providers: [] };
-    vi.mocked(io.loadRegistry).mockImplementation(() =>
+    vi.mocked(io.loadRegistryStrict).mockImplementation(() =>
       structuredClone(registry));
     vi.mocked(io.saveRegistry).mockImplementation((next) => {
       registry = structuredClone(next);
@@ -247,7 +247,7 @@ describe('registry/add-template', () => {
   });
 
   it('revalidates provider existence after model discovery', async () => {
-    vi.mocked(io.loadRegistry)
+    vi.mocked(io.loadRegistryStrict)
       .mockReturnValueOnce({ schemaVersion: 1, providers: [] })
       .mockReturnValueOnce({
         schemaVersion: 1,

--- a/tests/registry-crud.test.ts
+++ b/tests/registry-crud.test.ts
@@ -6,11 +6,13 @@ const registryState = vi.hoisted(() => ({
 }));
 const lockState = vi.hoisted(() => ({
   active: false,
+  registryTail: Promise.resolve(),
   credentialActive: false,
   credentialTails: new Map<string, Promise<void>>(),
 }));
 
-vi.mock('../src/env.js', () => ({
+vi.mock('../src/env.js', async importOriginal => ({
+  ...await importOriginal<typeof import('../src/env.js')>(),
   deleteProviderCredential: vi.fn(),
 }));
 vi.mock('../src/registry/io.js', () => ({
@@ -23,12 +25,17 @@ vi.mock('../src/registry/io.js', () => ({
 vi.mock('../src/registry/lock.js', () => ({
   withRegistryWriteLock: vi.fn(
     async <T>(operation: () => Promise<T> | T): Promise<T> => {
-      if (lockState.active) throw new Error('registry lock re-entered');
+      const previous = lockState.registryTail;
+      let release!: () => void;
+      const gate = new Promise<void>(resolve => { release = resolve; });
+      lockState.registryTail = previous.then(() => gate);
+      await previous;
       lockState.active = true;
       try {
         return await operation();
       } finally {
         lockState.active = false;
+        release();
       }
     },
   ),
@@ -68,6 +75,7 @@ import {
 describe('registry provider removal', () => {
   beforeEach(() => {
     lockState.active = false;
+    lockState.registryTail = Promise.resolve();
     lockState.credentialActive = false;
     lockState.credentialTails.clear();
     registryState.current = {
@@ -108,7 +116,7 @@ describe('registry provider removal', () => {
     expect(lockState.active).toBe(false);
   });
 
-  it('reports a credential cleanup failure with the credential reference', async () => {
+  it('keeps a failed credential deletion queued for retry', async () => {
     vi.mocked(deleteProviderCredential).mockImplementation(async () => {
       expect(lockState.active).toBe(false);
       expect(lockState.credentialActive).toBe(true);
@@ -120,11 +128,13 @@ describe('registry provider removal', () => {
     expect(result).toMatchObject({
       removed: true,
       credentialDeleted: false,
-      error: expect.stringContaining('keyring:provider:openai'),
+      credentialCleanupPending: true,
     });
-    expect(result.error).toMatch(/credential.*(?:cleanup|deletion).*failed/i);
-    expect(result.error).toContain('must be removed manually');
+    expect(result.error).toBeUndefined();
     expect(registryState.current.providers).toHaveLength(0);
+    expect(registryState.current.pendingCredentialDeletes).toEqual([
+      'keyring:provider:openai',
+    ]);
     expect(deleteProviderCredential).toHaveBeenCalledWith(
       'keyring:provider:openai',
     );

--- a/tests/registry-crud.test.ts
+++ b/tests/registry-crud.test.ts
@@ -20,6 +20,7 @@ vi.mock('../src/env.js', async importOriginal => ({
 }));
 vi.mock('../src/registry/io.js', () => ({
   loadRegistry: vi.fn(() => structuredClone(registryState.current)),
+  loadRegistryStrict: vi.fn(() => structuredClone(registryState.current)),
   saveRegistry: vi.fn((registry: ProviderRegistry) => {
     if (!lockState.active) throw new Error('registry write escaped its lock');
     registryState.current = structuredClone(registry);

--- a/tests/registry-crud.test.ts
+++ b/tests/registry-crud.test.ts
@@ -10,6 +10,9 @@ const lockState = vi.hoisted(() => ({
   credentialActive: false,
   credentialTails: new Map<string, Promise<void>>(),
 }));
+const journalState = vi.hoisted(() => ({
+  pending: new Set<string>(),
+}));
 
 vi.mock('../src/env.js', async importOriginal => ({
   ...await importOriginal<typeof import('../src/env.js')>(),
@@ -21,6 +24,18 @@ vi.mock('../src/registry/io.js', () => ({
     if (!lockState.active) throw new Error('registry write escaped its lock');
     registryState.current = structuredClone(registry);
   }),
+}));
+vi.mock('../src/registry/credential-cleanup-journal.js', () => ({
+  isStoredCredentialRef: vi.fn((authRef: string) =>
+    authRef.startsWith('keyring:') || authRef.startsWith('helper:v1:')),
+  loadPendingCredentialDeletes: vi.fn(async () => [...journalState.pending]),
+  queueCredentialDelete: vi.fn(async (authRef: string) => {
+    if (!authRef.startsWith('keyring:') && !authRef.startsWith('helper:v1:')) return false;
+    journalState.pending.add(authRef);
+    return true;
+  }),
+  cancelCredentialDelete: vi.fn(async (authRef: string) =>
+    journalState.pending.delete(authRef)),
 }));
 vi.mock('../src/registry/lock.js', () => ({
   withRegistryWriteLock: vi.fn(
@@ -78,6 +93,7 @@ describe('registry provider removal', () => {
     lockState.registryTail = Promise.resolve();
     lockState.credentialActive = false;
     lockState.credentialTails.clear();
+    journalState.pending.clear();
     registryState.current = {
       schemaVersion: 1,
       providers: [
@@ -132,7 +148,7 @@ describe('registry provider removal', () => {
     });
     expect(result.error).toBeUndefined();
     expect(registryState.current.providers).toHaveLength(0);
-    expect(registryState.current.pendingCredentialDeletes).toEqual([
+    expect([...journalState.pending]).toEqual([
       'keyring:provider:openai',
     ]);
     expect(deleteProviderCredential).toHaveBeenCalledWith(

--- a/tests/registry-io-durability.test.ts
+++ b/tests/registry-io-durability.test.ts
@@ -10,6 +10,8 @@ const fsState = vi.hoisted(() => ({
   failTempFsync: false,
   failParentFsync: false,
   dropLockAfterTempFsync: false,
+  maxWriteBytes: Number.POSITIVE_INFINITY,
+  tempWriteSizes: [] as number[],
 }));
 
 function ioError(message: string): NodeJS.ErrnoException {
@@ -33,6 +35,21 @@ vi.mock('node:fs', async importOriginal => {
     closeSync: vi.fn((fd: number) => {
       actual.closeSync(fd);
       fsState.openPaths.delete(fd);
+    }),
+    writeSync: vi.fn((
+      fd: number,
+      buffer: Uint8Array,
+      offset: number,
+      length: number,
+    ) => {
+      const path = fsState.openPaths.get(fd);
+      if (isRegistryTemp(path)) {
+        const bytes = Math.min(length, fsState.maxWriteBytes);
+        fsState.tempWriteSizes.push(bytes);
+        if (bytes === 0) return 0;
+        return actual.writeSync(fd, buffer, offset, bytes);
+      }
+      return actual.writeSync(fd, buffer, offset, length);
     }),
     fsyncSync: vi.fn((fd: number) => {
       const path = fsState.openPaths.get(fd);
@@ -85,6 +102,8 @@ describe('registry publication durability', () => {
     fsState.failTempFsync = false;
     fsState.failParentFsync = false;
     fsState.dropLockAfterTempFsync = false;
+    fsState.maxWriteBytes = Number.POSITIVE_INFINITY;
+    fsState.tempWriteSizes = [];
   });
 
   afterEach(() => {
@@ -141,6 +160,27 @@ describe('registry publication durability', () => {
     expect(publishRegistry).toThrow(RegistryLockLostError);
 
     expect(fsState.events).toEqual(['temp-fsync']);
+    expect(existsSync(fsState.registryPath)).toBe(false);
+  });
+
+  it('retries short writes until the complete registry payload is stored', () => {
+    fsState.maxWriteBytes = 5;
+
+    publishRegistry();
+
+    expect(fsState.tempWriteSizes.length).toBeGreaterThan(1);
+    expect(fsState.tempWriteSizes.every(size => size > 0 && size <= 5)).toBe(true);
+    expect(JSON.parse(readFileSync(fsState.registryPath, 'utf8'))).toEqual(
+      emptyRegistry(),
+    );
+  });
+
+  it('does not publish when a secure write makes no progress', () => {
+    fsState.maxWriteBytes = 0;
+
+    expect(publishRegistry).toThrow('Could not complete secure file write');
+
+    expect(fsState.events).toEqual([]);
     expect(existsSync(fsState.registryPath)).toBe(false);
   });
 });

--- a/tests/registry-io-durability.test.ts
+++ b/tests/registry-io-durability.test.ts
@@ -1,0 +1,146 @@
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import type { PathLike } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fsState = vi.hoisted(() => ({
+  registryPath: '',
+  openPaths: new Map<number, string>(),
+  events: [] as string[],
+  failTempFsync: false,
+  failParentFsync: false,
+  dropLockAfterTempFsync: false,
+}));
+
+function ioError(message: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(message), { code: 'EIO' });
+}
+
+vi.mock('node:fs', async importOriginal => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  const isRegistryTemp = (path: string | undefined): boolean =>
+    path?.startsWith(`${fsState.registryPath}.`) === true
+    && path.endsWith('.tmp')
+    && !path.startsWith(`${fsState.registryPath}.lock.`);
+
+  return {
+    ...actual,
+    openSync: vi.fn((path: PathLike, flags: string | number, mode?: string | number) => {
+      const fd = actual.openSync(path, flags, mode);
+      fsState.openPaths.set(fd, String(path));
+      return fd;
+    }),
+    closeSync: vi.fn((fd: number) => {
+      actual.closeSync(fd);
+      fsState.openPaths.delete(fd);
+    }),
+    fsyncSync: vi.fn((fd: number) => {
+      const path = fsState.openPaths.get(fd);
+      if (isRegistryTemp(path)) {
+        fsState.events.push('temp-fsync');
+        if (fsState.failTempFsync) throw ioError('temp fsync failed');
+        actual.fsyncSync(fd);
+        if (fsState.dropLockAfterTempFsync) {
+          actual.unlinkSync(`${fsState.registryPath}.lock`);
+        }
+        return;
+      }
+      if (path === dirname(fsState.registryPath)) {
+        fsState.events.push('parent-fsync');
+        if (fsState.failParentFsync) throw ioError('parent fsync failed');
+      }
+      actual.fsyncSync(fd);
+    }),
+    renameSync: vi.fn((oldPath: PathLike, newPath: PathLike) => {
+      if (String(newPath) === fsState.registryPath) {
+        fsState.events.push('rename');
+      }
+      actual.renameSync(oldPath, newPath);
+    }),
+  };
+});
+
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from 'node:fs';
+import { emptyRegistry, saveRegistry } from '../src/registry/io.js';
+import {
+  RegistryLockLostError,
+  withRegistryWriteLockSync,
+} from '../src/registry/lock.js';
+
+describe('registry publication durability', () => {
+  const previousHome = process.env.CLODEX_HOME;
+  let home = '';
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'clodex-registry-durability-'));
+    process.env.CLODEX_HOME = home;
+    fsState.registryPath = join(home, 'providers.json');
+    fsState.openPaths.clear();
+    fsState.events = [];
+    fsState.failTempFsync = false;
+    fsState.failParentFsync = false;
+    fsState.dropLockAfterTempFsync = false;
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) delete process.env.CLODEX_HOME;
+    else process.env.CLODEX_HOME = previousHome;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  function publishRegistry(): void {
+    withRegistryWriteLockSync(
+      () => saveRegistry(emptyRegistry(), fsState.registryPath),
+      { lockPath: `${fsState.registryPath}.lock` },
+    );
+  }
+
+  it('syncs the completed temp before rename and the parent after rename', () => {
+    publishRegistry();
+
+    expect(fsState.events).toEqual([
+      'temp-fsync',
+      'rename',
+      'parent-fsync',
+    ]);
+    expect(JSON.parse(readFileSync(fsState.registryPath, 'utf8'))).toEqual(
+      emptyRegistry(),
+    );
+  });
+
+  it('does not publish when syncing the completed temp fails', () => {
+    fsState.failTempFsync = true;
+
+    expect(publishRegistry).toThrow('temp fsync failed');
+
+    expect(fsState.events).toEqual(['temp-fsync']);
+    expect(existsSync(fsState.registryPath)).toBe(false);
+  });
+
+  it('reports a parent sync failure only after the rename has committed', () => {
+    fsState.failParentFsync = true;
+
+    expect(publishRegistry).toThrow('parent fsync failed');
+
+    expect(fsState.events).toEqual([
+      'temp-fsync',
+      'rename',
+      'parent-fsync',
+    ]);
+    expect(existsSync(fsState.registryPath)).toBe(true);
+  });
+
+  it('still fences publication when the lease is lost after temp sync', () => {
+    fsState.dropLockAfterTempFsync = true;
+
+    expect(publishRegistry).toThrow(RegistryLockLostError);
+
+    expect(fsState.events).toEqual(['temp-fsync']);
+    expect(existsSync(fsState.registryPath)).toBe(false);
+  });
+});

--- a/tests/registry-refresh-models.test.ts
+++ b/tests/registry-refresh-models.test.ts
@@ -5,6 +5,7 @@ import type { ProviderRegistry } from '../src/registry/types.js';
 
 vi.mock('../src/registry/io.js', () => ({
   loadRegistry: vi.fn(),
+  loadRegistryStrict: vi.fn(),
   saveRegistry: vi.fn(),
 }));
 
@@ -43,7 +44,7 @@ describe('registry/refresh-models', () => {
           api: {},
         }],
       };
-      vi.mocked(io.loadRegistry).mockReturnValue(mockRegistry);
+      vi.mocked(io.loadRegistryStrict).mockReturnValue(mockRegistry);
 
       // Codex endpoint returns valid models
       vi.mocked(global.fetch).mockResolvedValueOnce({
@@ -79,7 +80,7 @@ describe('registry/refresh-models', () => {
           api: {},
         }],
       };
-      vi.mocked(io.loadRegistry).mockReturnValue(mockRegistry);
+      vi.mocked(io.loadRegistryStrict).mockReturnValue(mockRegistry);
 
       // 1. Codex endpoint 404s
       vi.mocked(global.fetch).mockResolvedValueOnce({
@@ -125,7 +126,7 @@ describe('registry/refresh-models', () => {
           api: {},
         }],
       };
-      vi.mocked(io.loadRegistry).mockReturnValue(mockRegistry);
+      vi.mocked(io.loadRegistryStrict).mockReturnValue(mockRegistry);
 
       // Both endpoints fail
       vi.mocked(global.fetch).mockResolvedValue({
@@ -167,7 +168,7 @@ describe('registry/refresh-models', () => {
           },
         }],
       };
-      vi.mocked(io.loadRegistry).mockReturnValue(mockRegistry);
+      vi.mocked(io.loadRegistryStrict).mockReturnValue(mockRegistry);
 
       // Both live endpoints fail — would normally fall back to the static seed.
       vi.mocked(global.fetch).mockResolvedValue({
@@ -199,7 +200,7 @@ describe('registry/refresh-models', () => {
           api: {},
         }],
       };
-      vi.mocked(io.loadRegistry).mockReturnValue(mockRegistry);
+      vi.mocked(io.loadRegistryStrict).mockReturnValue(mockRegistry);
 
       vi.mocked(global.fetch).mockResolvedValueOnce({
         ok: true,
@@ -239,7 +240,7 @@ describe('registry/refresh-models', () => {
           api: {},
         }],
       };
-      vi.mocked(io.loadRegistry).mockReturnValue(mockRegistry);
+      vi.mocked(io.loadRegistryStrict).mockReturnValue(mockRegistry);
 
       // Both live endpoints fail → static seed.
       vi.mocked(global.fetch).mockResolvedValue({ ok: false, status: 500 } as Response);

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -141,6 +141,36 @@ describe('registry io', () => {
     expect(existsSync(lockPath)).toBe(false);
   });
 
+  it('round-trips and sanitizes pending credential cleanup references', () => {
+    const path = join(home, 'providers.json');
+    const helperRef = `helper:v1:${'a'.repeat(64)}:provider:stale`;
+    mkdirSync(home, { recursive: true });
+    writeFileSync(path, JSON.stringify({
+      schemaVersion: 1,
+      providers: [],
+      pendingCredentialDeletes: [
+        helperRef,
+        'keyring:provider:stale',
+        helperRef,
+        'env:OPENAI_API_KEY',
+        'helper:',
+        'helper:provider:stale',
+        42,
+      ],
+    }));
+
+    const loaded = loadRegistry(path);
+    expect(loaded.pendingCredentialDeletes).toEqual([
+      helperRef,
+      'keyring:provider:stale',
+    ]);
+    withRegistryWriteLockSync(
+      () => saveRegistry(loaded, path),
+      { lockPath: `${path}.lock` },
+    );
+    expect(loadRegistry(path).pendingCredentialDeletes).toEqual(loaded.pendingCredentialDeletes);
+  });
+
 });
 
 describe('materializeRegistry', () => {

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -9,7 +9,9 @@ import {
   materializeRegistry,
   saveRegistry,
   slugifyProviderId,
+  toggleProviderEnabled,
 } from '../src/registry/index.js';
+import { loadRegistryStrict } from '../src/registry/io.js';
 import { withRegistryWriteLockSync } from '../src/registry/lock.js';
 
 describe('provider id validation', () => {
@@ -107,6 +109,69 @@ describe('registry io', () => {
     const loaded = loadRegistry(path);
     expect(loaded.providers).toHaveLength(1);
     expect(loaded.providers[0]?.id).toBe('groq');
+  });
+
+  it('does not publish a migration from partially invalid registry data', () => {
+    const path = join(home, 'providers.json');
+    const raw = {
+      schemaVersion: 1,
+      providers: [
+        {
+          id: 'openai',
+          templateId: 'openai',
+          name: 'OpenAI',
+          enabled: true,
+          authRef: 'keyring:oauth:provider:openai',
+          authType: 'oauth',
+          api: { npm: '@ai-sdk/openai' },
+          addedAt: '2026-06-09T00:00:00.000Z',
+        },
+        {
+          id: 'BAD ID',
+          templateId: 'invalid',
+          name: 'Invalid',
+          enabled: true,
+          authRef: 'keyring:provider:invalid',
+          api: {},
+          addedAt: '2026-06-09T00:00:00.000Z',
+        },
+      ],
+    };
+    const serialized = JSON.stringify(raw);
+    mkdirSync(home, { recursive: true });
+    writeFileSync(path, serialized);
+
+    expect(loadRegistry(path).providers[0]?.id).toBe('openai-oauth');
+    expect(() => loadRegistryStrict(path)).toThrow(
+      'Provider registry contains an invalid provider entry.',
+    );
+    expect(() => toggleProviderEnabled('openai-oauth')).toThrow(
+      'Provider registry contains an invalid provider entry.',
+    );
+    expect(readFileSync(path, 'utf8')).toBe(serialized);
+  });
+
+  it('applies supported migrations only after strict validation', () => {
+    const path = join(home, 'providers.json');
+    const raw = {
+      schemaVersion: 1,
+      providers: [{
+        id: 'openai',
+        templateId: 'openai',
+        name: 'OpenAI',
+        enabled: true,
+        authRef: 'keyring:oauth:provider:openai',
+        authType: 'oauth',
+        api: { npm: '@ai-sdk/openai' },
+        addedAt: '2026-06-09T00:00:00.000Z',
+      }],
+    };
+    const serialized = JSON.stringify(raw);
+    mkdirSync(home, { recursive: true });
+    writeFileSync(path, serialized);
+
+    expect(loadRegistryStrict(path).providers[0]?.id).toBe('openai-oauth');
+    expect(readFileSync(path, 'utf8')).toBe(serialized);
   });
 
   it('serializes migration writes and reloads state after acquiring the lock', () => {

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -141,36 +141,6 @@ describe('registry io', () => {
     expect(existsSync(lockPath)).toBe(false);
   });
 
-  it('round-trips and sanitizes pending credential cleanup references', () => {
-    const path = join(home, 'providers.json');
-    const helperRef = `helper:v1:${'a'.repeat(64)}:provider:stale`;
-    mkdirSync(home, { recursive: true });
-    writeFileSync(path, JSON.stringify({
-      schemaVersion: 1,
-      providers: [],
-      pendingCredentialDeletes: [
-        helperRef,
-        'keyring:provider:stale',
-        helperRef,
-        'env:OPENAI_API_KEY',
-        'helper:',
-        'helper:provider:stale',
-        42,
-      ],
-    }));
-
-    const loaded = loadRegistry(path);
-    expect(loaded.pendingCredentialDeletes).toEqual([
-      helperRef,
-      'keyring:provider:stale',
-    ]);
-    withRegistryWriteLockSync(
-      () => saveRegistry(loaded, path),
-      { lockPath: `${path}.lock` },
-    );
-    expect(loadRegistry(path).pendingCredentialDeletes).toEqual(loaded.pendingCredentialDeletes);
-  });
-
 });
 
 describe('materializeRegistry', () => {

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -151,6 +151,74 @@ describe('registry io', () => {
     expect(readFileSync(path, 'utf8')).toBe(serialized);
   });
 
+  it.each([
+    ['subscriptionFilter', { subscriptionFilter: 'paid' }],
+    ['authType', { authType: 'token' }],
+    ['refreshedAt', { refreshedAt: 42 }],
+    ['modelsCache metadata', { modelsCache: { fetchedAt: 42, models: [] } }],
+    ['modelsCache entries', { modelsCache: {
+      fetchedAt: '2026-06-09T00:00:00.000Z',
+      models: [{ id: 'model-a' }, null],
+    } }],
+  ])('rejects malformed present %s without rewriting the registry', (_field, malformed) => {
+    const path = join(home, 'providers.json');
+    const raw = {
+      schemaVersion: 1,
+      providers: [{
+        id: 'example',
+        templateId: 'example',
+        name: 'Example',
+        enabled: true,
+        authRef: 'keyring:provider:example',
+        api: { npm: '@example/sdk' },
+        addedAt: '2026-06-09T00:00:00.000Z',
+        ...malformed,
+      }],
+    };
+    const serialized = JSON.stringify(raw);
+    mkdirSync(home, { recursive: true });
+    writeFileSync(path, serialized);
+
+    expect(() => loadRegistryStrict(path)).toThrow(
+      'Provider registry contains an invalid provider entry.',
+    );
+    expect(() => toggleProviderEnabled('example')).toThrow(
+      'Provider registry contains an invalid provider entry.',
+    );
+    expect(readFileSync(path, 'utf8')).toBe(serialized);
+  });
+
+  it('accepts unknown provider and model fields during strict loading', () => {
+    const path = join(home, 'providers.json');
+    const raw = {
+      schemaVersion: 1,
+      providers: [{
+        id: 'example',
+        templateId: 'example',
+        name: 'Example',
+        enabled: true,
+        authRef: 'keyring:provider:example',
+        api: { npm: '@example/sdk' },
+        addedAt: '2026-06-09T00:00:00.000Z',
+        futureProviderField: { revision: 2 },
+        modelsCache: {
+          fetchedAt: '2026-06-09T00:00:00.000Z',
+          models: [{
+            id: 'model-a',
+            name: 'Model A',
+            upstreamModelId: 'model-a',
+            modelFormat: 'openai',
+            futureModelField: 'supported',
+          }],
+        },
+      }],
+    };
+    mkdirSync(home, { recursive: true });
+    writeFileSync(path, JSON.stringify(raw));
+
+    expect(loadRegistryStrict(path).providers[0]?.id).toBe('example');
+  });
+
   it('applies supported migrations only after strict validation', () => {
     const path = join(home, 'providers.json');
     const raw = {


### PR DESCRIPTION
## Summary

- persist cleanup intent before writing a stored credential
- fail closed when the provider registry or cleanup journal cannot be read and validated
- publish complete registry and journal payloads with file and parent-directory durability
- constrain cleanup entries to generated provider references and bound queued work
- reconcile from a command-scoped finalizer so cancellation and early errors still retry pending cleanup
- emit one consistent cleanup warning without repeating successful-path reconciliation
- reject malformed present registry fields while retaining unknown forward-compatible fields
- retain the exported custom-endpoint lifecycle under the same credential safety contract

## Recovery guarantees

- a credential saved before registry commit remains journaled and is removed during reconciliation
- a credential referenced by a committed provider is retained even if marker cancellation was interrupted
- malformed or unreadable registry state never authorizes credential deletion
- uncertain deletion and journal-persistence outcomes remain queued for an idempotent retry
- add, remove, and authorization commands retry queued cleanup even when they exit before mutation
- unrelated registry mutations never persist a lossy projection of malformed known fields

## Test plan

- [x] focused lifecycle, registry, and provider-command regressions
- [x] complete suite: 75 files and 798 tests
- [x] type checking
- [x] production build
- [x] diff hygiene
- [x] secret and personal-identifier scans

## Related work

- #17 owns chunked credential publication, recovery, and deletion, including interruption before the base chunk record exists.
- #16 owns rejected access-token refresh and one-time request recovery.
