### PR TITLE
fix(auth): recover once from rejected access tokens

### DIFF
--- a/docs/credential-helpers.md
+++ b/docs/credential-helpers.md
@@ -24,7 +24,10 @@ previous store; remove that credential with the previous backend's tooling.
 
 Clodex verifies the selected store with a disposable write, read, and delete
 before starting device authorization. It also reads back real credential
-writes.
+writes. OAuth refresh returns the new access token only after the rotated
+credential has been stored and verified. An environment override rejected by
+the upstream service remains bypassed until its value changes or the process
+restarts, preventing the same stale value from causing a 401 on every request.
 
 Credential storage is fail-closed. If the selected credential store fails its
 probe, Clodex stops before device authorization and includes the backend
@@ -58,7 +61,9 @@ are bounded.
 
 ## Security responsibilities
 
-The helper owns storage and its security properties. A helper should:
+Clodex owns OAuth parsing, refresh decisions, replacement-token serialization,
+and in-process refresh deduplication. The helper owns storage and its security
+properties. A helper should:
 
 - encrypt credentials at rest using a system or user trust root;
 - serialize concurrent updates when its backend requires it;

--- a/docs/credential-helpers.md
+++ b/docs/credential-helpers.md
@@ -62,8 +62,8 @@ are bounded.
 ## Security responsibilities
 
 Clodex owns OAuth parsing, refresh decisions, replacement-token serialization,
-and in-process refresh deduplication. The helper owns storage and its security
-properties. A helper should:
+and in-process refresh deduplication per provider and credential reference. The
+helper owns storage and its security properties. A helper should:
 
 - encrypt credentials at rest using a system or user trust root;
 - serialize concurrent updates when its backend requires it;

--- a/docs/credential-helpers.md
+++ b/docs/credential-helpers.md
@@ -28,6 +28,9 @@ writes. OAuth refresh returns the new access token only after the rotated
 credential has been stored and verified. An environment override rejected by
 the upstream service remains bypassed until its value changes or the process
 restarts, preventing the same stale value from causing a 401 on every request.
+For stored OAuth credentials, a rejected-access marker is cleared when refresh
+returns a different access token. If the identity provider keeps returning the
+same rejected token, run `clodex providers auth <provider>` to reauthenticate.
 
 Credential storage is fail-closed. If the selected credential store fails its
 probe, Clodex stops before device authorization and includes the backend
@@ -58,6 +61,11 @@ The service and account arguments are identifiers, not secrets. Credential
 contents are never passed in arguments or environment variables. Helper
 standard error is not copied into Clodex diagnostics, and output and runtime
 are bounded.
+
+The helper protocol transports credential bytes without interpreting them.
+For non-OAuth provider references, Clodex preserves valid opaque JSON secrets.
+OAuth references accept only complete OAuth records or well-known token
+records; malformed or unknown JSON is never used as a bearer token.
 
 ## Security responsibilities
 

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -1,6 +1,7 @@
 // Route map + catalog assembly for the mid-session /model switch menu.
 import { MAX_MODEL_CATALOG } from './constants.js';
 import { claudeCodeClientModelId } from './context-model-id.js';
+import { resolveProviderCredential } from './env.js';
 import { isSdkMigratedNpm } from './provider-factory.js';
 import { aliasModelId } from './proxy.js';
 import type { ProxyRoute } from './proxy.js';
@@ -22,6 +23,16 @@ export function localModelToRoute(lp: LocalProvider, model: LocalProviderModel):
     baseURL: model.apiBaseUrl,
     providerId: lp.id,
     authType: lp.authType,
+    refreshToken: lp.authType === 'oauth' && lp.authRef
+      ? rejectedAccessToken => rejectedAccessToken === undefined
+        ? resolveProviderCredential(lp.id, lp.authRef!)
+        : resolveProviderCredential(
+            lp.id,
+            lp.authRef!,
+            undefined,
+            { rejectedAccessToken },
+          )
+      : undefined,
     oauthAccountId: lp.oauthAccountId,
     providerData: lp.providerData,
     headers: lp.headers,

--- a/src/env.ts
+++ b/src/env.ts
@@ -152,7 +152,18 @@ function oauthProviderIdFromAccount(account: string): string | null {
 }
 
 const oauthRefreshInflight = new Map<string, Promise<string | null>>();
-const oauthCredentialCache = new Map<string, StoredOAuthCredential>();
+interface CachedOAuthCredential {
+  access: string;
+  expires: number;
+  accessRejected?: true;
+  checkedAt: number;
+}
+
+// Another process can replace the shared credential without invalidating this
+// process. Keep only access-token metadata and bound that stale view to 30 seconds;
+// rejection and expiration bypass it immediately.
+const OAUTH_CREDENTIAL_CACHE_MAX_AGE_MS = 30_000;
+const oauthCredentialCache = new Map<string, CachedOAuthCredential>();
 const rejectedEnvCredentialFingerprints = new Map<string, string>();
 const OAUTH_REFRESH_LOCK_WAIT_MS = 150_000;
 const OAUTH_STATE_KEY_SEPARATOR = '\0';
@@ -453,6 +464,32 @@ function clearOAuthCredentialCache(authRef: string): void {
   }
 }
 
+function cacheOAuthCredential(
+  stateKey: string,
+  credential: StoredOAuthCredential,
+): void {
+  oauthCredentialCache.set(stateKey, {
+    access: credential.access,
+    expires: credential.expires,
+    ...(credential.accessRejected === true ? { accessRejected: true as const } : {}),
+    checkedAt: Date.now(),
+  });
+}
+
+function cachedOAuthCredentialIsUsable(
+  credential: CachedOAuthCredential | undefined,
+  providerId: string,
+  rejectedAccessToken?: string,
+): boolean {
+  if (!credential) return false;
+  const age = Date.now() - credential.checkedAt;
+  return age >= 0
+    && age < OAUTH_CREDENTIAL_CACHE_MAX_AGE_MS
+    && credential.access !== rejectedAccessToken
+    && credential.accessRejected !== true
+    && !oauthCredentialShouldRefresh(credential, providerId);
+}
+
 async function readOAuthProviderSecret(
   ref: StoredCredentialRef,
   providerId: string,
@@ -469,12 +506,7 @@ async function readOAuthProviderSecret(
   }
 
   const cached = oauthCredentialCache.get(stateKey);
-  if (
-    cached
-    && cached.access !== rejectedAccessToken
-    && cached.accessRejected !== true
-    && !oauthCredentialShouldRefresh(cached, providerId)
-  ) {
+  if (cached && cachedOAuthCredentialIsUsable(cached, providerId, rejectedAccessToken)) {
     return cached.access;
   }
   if (cached?.access === rejectedAccessToken) oauthCredentialCache.delete(stateKey);
@@ -483,9 +515,7 @@ async function readOAuthProviderSecret(
     const latestCached = oauthCredentialCache.get(stateKey);
     if (
       latestCached
-      && latestCached.access !== rejectedAccessToken
-      && latestCached.accessRejected !== true
-      && !oauthCredentialShouldRefresh(latestCached, providerId)
+      && cachedOAuthCredentialIsUsable(latestCached, providerId, rejectedAccessToken)
     ) {
       return latestCached.access;
     }
@@ -499,7 +529,7 @@ async function readOAuthProviderSecret(
         const decoded = decodeProviderSecret(raw);
         return decoded === rejectedAccessToken ? null : decoded;
       }
-      oauthCredentialCache.set(stateKey, cred);
+      cacheOAuthCredential(stateKey, cred);
 
       const forceRefresh = cred.access === rejectedAccessToken || cred.accessRejected === true;
       if (!forceRefresh && !oauthCredentialShouldRefresh(cred, providerId)) {
@@ -590,7 +620,7 @@ export async function saveProviderCredential(
       const oauth = parseStoredOAuthCredential(key);
       const oauthProviderId = oauthProviderIdFromAccount(parsed.account);
       if (oauth && oauthProviderId) {
-        oauthCredentialCache.set(oauthCredentialStateKey(oauthProviderId, cacheKey), oauth);
+        cacheOAuthCredential(oauthCredentialStateKey(oauthProviderId, cacheKey), oauth);
       }
       return true;
     }

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,6 +1,6 @@
 // src/env.ts
 import { CONFLICTING_ENV_VARS } from './constants.js';
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import {
   deleteCredentialHelperAccount,
   readCredentialHelperAccount,
@@ -11,6 +11,7 @@ import { resolveContextWindow } from './context-window.js';
 import {
   oauthCredentialToKeychainJson,
   parseStoredOAuthCredential,
+  type StoredOAuthCredential,
 } from './oauth/types.js';
 import { refreshStoredOAuthCredential, oauthCredentialShouldRefresh } from './oauth/refresh.js';
 import { withCredentialMutationLock } from './registry/lock.js';
@@ -151,12 +152,19 @@ function oauthProviderIdFromAccount(account: string): string | null {
 }
 
 const oauthRefreshInflight = new Map<string, Promise<string | null>>();
+const oauthCredentialCache = new Map<string, StoredOAuthCredential>();
+const rejectedEnvCredentialFingerprints = new Map<string, string>();
+const OAUTH_REFRESH_LOCK_WAIT_MS = 150_000;
 
 export type ParsedAuthRef =
   | { kind: 'keyring'; account: string }
   | { kind: 'helper'; helperId: string; account: string }
   | { kind: 'env'; varName: string }
   | { kind: 'none' };
+
+export interface ResolveCredentialOptions {
+  rejectedAccessToken?: string;
+}
 
 /** Parse registry credential references. */
 export function parseAuthRef(authRef: string): ParsedAuthRef | null {
@@ -183,6 +191,37 @@ function readEnvCredential(varName: string): string | null {
   const raw = process.env[varName];
   if (!raw?.trim()) return null;
   return raw.trim().split(/\r?\n/)[0]?.trim() || null;
+}
+
+function credentialFingerprint(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function usableEnvCredential(
+  source: string,
+  value: string | null,
+  rejectedAccessToken?: string,
+): string | null {
+  if (!value) {
+    rejectedEnvCredentialFingerprints.delete(source);
+    return null;
+  }
+
+  const fingerprint = credentialFingerprint(value);
+  if (
+    rejectedAccessToken !== undefined
+    && fingerprint === credentialFingerprint(rejectedAccessToken)
+  ) {
+    rejectedEnvCredentialFingerprints.set(source, fingerprint);
+    return null;
+  }
+
+  const rejectedFingerprint = rejectedEnvCredentialFingerprints.get(source);
+  if (rejectedFingerprint === fingerprint) return null;
+  if (rejectedFingerprint !== undefined) {
+    rejectedEnvCredentialFingerprints.delete(source);
+  }
+  return value;
 }
 
 function readKeyringAccountFromService(
@@ -321,20 +360,30 @@ export async function resolveProviderCredential(
   providerId: string,
   authRef: string,
   diag?: (msg: string) => void,
+  options: ResolveCredentialOptions = {},
 ): Promise<string | null> {
   const parsed = parseAuthRef(authRef);
   if (parsed?.kind === 'none') return null;
 
-  const namespaced = readEnvCredential(clodexKeyEnvVar(providerId));
+  const namespacedVar = clodexKeyEnvVar(providerId);
+  const namespaced = usableEnvCredential(
+    `provider:${providerId}`,
+    readEnvCredential(namespacedVar),
+    options.rejectedAccessToken,
+  );
   if (namespaced) return namespaced;
 
   if (!parsed) return null;
 
   if (parsed.kind === 'env') {
-    return readEnvCredential(parsed.varName);
+    return usableEnvCredential(
+      `env:${parsed.varName}`,
+      readEnvCredential(parsed.varName),
+      options.rejectedAccessToken,
+    );
   }
 
-  return readProviderSecret(parsed, diag);
+  return readProviderSecret(parsed, diag, options.rejectedAccessToken);
 }
 
 /** Read OAuth metadata retained alongside the access token. */
@@ -375,61 +424,135 @@ function decodeProviderSecret(raw: string | null): string | null {
   const oauth = parseStoredOAuthCredential(trimmed);
   if (oauth) return oauth.access;
   try {
-    const parsed = JSON.parse(trimmed) as { type?: string; access?: string; token?: string };
-    if (parsed.type === 'oauth' && typeof parsed.access === 'string') return parsed.access;
-    if (parsed.type === 'wellknown' && typeof parsed.token === 'string') return parsed.token;
+    const parsed = JSON.parse(trimmed) as { type?: string; token?: string };
+    if (parsed.type === 'wellknown') {
+      return typeof parsed.token === 'string' && parsed.token.trim()
+        ? parsed.token.trim()
+        : null;
+    }
   } catch {
-    // fall through
+    return null;
   }
-  return trimmed;
+  return null;
 }
 
-async function refreshOAuthStoredCredential(
+async function readOAuthProviderSecret(
   ref: StoredCredentialRef,
   providerId: string,
   diag?: (msg: string) => void,
+  rejectedAccessToken?: string,
 ): Promise<string | null> {
-  const authRef = storedCredentialAuthRef(ref);
-  const existing = oauthRefreshInflight.get(authRef);
-  if (existing) return existing;
+  const inflightKey = storedCredentialAuthRef(ref);
+  const cached = oauthCredentialCache.get(inflightKey);
+  if (
+    cached
+    && cached.access !== rejectedAccessToken
+    && cached.accessRejected !== true
+    && !oauthCredentialShouldRefresh(cached, providerId)
+  ) {
+    return cached.access;
+  }
+  if (cached?.access === rejectedAccessToken) oauthCredentialCache.delete(inflightKey);
 
-  const work = withCredentialMutationLock(authRef, async (): Promise<string | null> => {
-    const currentRaw = await readStoredCredential(ref, diag);
-    if (!currentRaw) return null;
-    const cred = parseStoredOAuthCredential(currentRaw);
-    if (!cred || !oauthCredentialShouldRefresh(cred, providerId)) {
-      return decodeProviderSecret(currentRaw);
+  const existing = oauthRefreshInflight.get(inflightKey);
+  if (existing) {
+    const resolved = await existing;
+    if (resolved !== rejectedAccessToken) return resolved;
+    return readOAuthProviderSecret(ref, providerId, diag, rejectedAccessToken);
+  }
+
+  const work = withCredentialMutationLock(inflightKey, async (): Promise<string | null> => {
+    const latestCached = oauthCredentialCache.get(inflightKey);
+    if (
+      latestCached
+      && latestCached.access !== rejectedAccessToken
+      && latestCached.accessRejected !== true
+      && !oauthCredentialShouldRefresh(latestCached, providerId)
+    ) {
+      return latestCached.access;
     }
-    try {
-      const refreshed = await refreshStoredOAuthCredential(providerId, cred);
-      const json = oauthCredentialToKeychainJson(refreshed);
-      const saved = await saveProviderCredential(authRef, json, diag);
-      if (!saved) throw new Error('Could not persist refreshed OAuth credential');
+
+    for (let generation = 0; generation < 3; generation += 1) {
+      const raw = await readStoredCredential(ref, diag);
+      if (!raw) return null;
+
+      const cred = parseStoredOAuthCredential(raw);
+      if (!cred) {
+        const decoded = decodeProviderSecret(raw);
+        return decoded === rejectedAccessToken ? null : decoded;
+      }
+      oauthCredentialCache.set(inflightKey, cred);
+
+      const forceRefresh = cred.access === rejectedAccessToken || cred.accessRejected === true;
+      if (!forceRefresh && !oauthCredentialShouldRefresh(cred, providerId)) {
+        return cred.access;
+      }
+
+      let refreshed;
+      try {
+        refreshed = await refreshStoredOAuthCredential(providerId, cred);
+      } catch (err) {
+        diag?.(err instanceof Error ? err.message : String(err));
+        if (!forceRefresh && cred.access && cred.expires > Date.now()) return cred.access;
+        oauthCredentialCache.delete(inflightKey);
+        throw err;
+      }
+
+      const accessStillRejected = (
+        rejectedAccessToken !== undefined
+        && refreshed.access === rejectedAccessToken
+      ) || (
+        cred.accessRejected === true
+        && refreshed.access === cred.access
+      );
+      const currentRaw = await readStoredCredential(ref, diag);
+      if (currentRaw !== raw) {
+        oauthCredentialCache.delete(inflightKey);
+        continue;
+      }
+
+      const credentialToSave: StoredOAuthCredential = accessStillRejected
+        ? { ...refreshed, accessRejected: true }
+        : refreshed;
+      const json = oauthCredentialToKeychainJson(credentialToSave);
+      const saved = await saveProviderCredential(inflightKey, json, diag);
+      if (!saved) {
+        oauthCredentialCache.delete(inflightKey);
+        throw new Error('Could not persist refreshed OAuth credential');
+      }
+      if (accessStillRejected) {
+        oauthCredentialCache.delete(inflightKey);
+        return null;
+      }
       return refreshed.access;
-    } catch (err) {
-      diag?.(err instanceof Error ? err.message : String(err));
-      if (cred.access && cred.expires > Date.now()) return cred.access;
-      throw err;
     }
+    throw new Error('OAuth credential changed repeatedly while refresh was in progress');
+  }, {
+    waitMs: OAUTH_REFRESH_LOCK_WAIT_MS,
   });
 
-  oauthRefreshInflight.set(authRef, work);
+  oauthRefreshInflight.set(inflightKey, work);
   try {
     return await work;
   } finally {
-    oauthRefreshInflight.delete(authRef);
+    if (oauthRefreshInflight.get(inflightKey) === work) {
+      oauthRefreshInflight.delete(inflightKey);
+    }
   }
 }
 
-async function readProviderSecret(ref: StoredCredentialRef, diag?: (msg: string) => void): Promise<string | null> {
-  const raw = await readStoredCredential(ref, diag);
-  if (!raw) return null;
-
+async function readProviderSecret(
+  ref: StoredCredentialRef,
+  diag?: (msg: string) => void,
+  rejectedAccessToken?: string,
+): Promise<string | null> {
   const oauthProviderId = oauthProviderIdFromAccount(ref.account);
-  if (oauthProviderId && raw.trim().startsWith('{')) {
-    return refreshOAuthStoredCredential(ref, oauthProviderId, diag);
+  if (oauthProviderId) {
+    return readOAuthProviderSecret(ref, oauthProviderId, diag, rejectedAccessToken);
   }
-  return decodeProviderSecret(raw);
+  const raw = await readStoredCredential(ref, diag);
+  const decoded = decodeProviderSecret(raw);
+  return decoded === rejectedAccessToken ? null : decoded;
 }
 
 export async function saveProviderCredential(
@@ -440,10 +563,16 @@ export async function saveProviderCredential(
   const parsed = parseAuthRef(authRef);
   if (!parsed || parsed.kind === 'env' || parsed.kind === 'none') return false;
   return withCredentialMutationLock(authRef, async () => {
+    const cacheKey = storedCredentialAuthRef(parsed);
+    oauthCredentialCache.delete(cacheKey);
     const written = await writeStoredCredential(parsed, key, diag);
     if (!written) return false;
     const readBack = await readStoredCredential(parsed, diag);
-    if (readBack === key) return true;
+    if (readBack === key) {
+      const oauth = parseStoredOAuthCredential(key);
+      if (oauth) oauthCredentialCache.set(cacheKey, oauth);
+      return true;
+    }
     diag?.('credential store read-back verification failed');
     return false;
   });
@@ -488,6 +617,8 @@ export async function deleteProviderCredential(
 ): Promise<boolean> {
   const parsed = parseAuthRef(authRef);
   if (!parsed || parsed.kind === 'env' || parsed.kind === 'none') return false;
-  return withCredentialMutationLock(authRef, () =>
-    deleteStoredCredential(parsed, diag));
+  return withCredentialMutationLock(authRef, () => {
+    oauthCredentialCache.delete(storedCredentialAuthRef(parsed));
+    return deleteStoredCredential(parsed, diag);
+  });
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -155,6 +155,7 @@ const oauthRefreshInflight = new Map<string, Promise<string | null>>();
 const oauthCredentialCache = new Map<string, StoredOAuthCredential>();
 const rejectedEnvCredentialFingerprints = new Map<string, string>();
 const OAUTH_REFRESH_LOCK_WAIT_MS = 150_000;
+const OAUTH_STATE_KEY_SEPARATOR = '\0';
 
 export type ParsedAuthRef =
   | { kind: 'keyring'; account: string }
@@ -377,7 +378,7 @@ export async function resolveProviderCredential(
 
   if (parsed.kind === 'env') {
     return usableEnvCredential(
-      `env:${parsed.varName}`,
+      `provider:${providerId}:env:${parsed.varName}`,
       readEnvCredential(parsed.varName),
       options.rejectedAccessToken,
     );
@@ -417,23 +418,39 @@ export async function resolveProviderOAuthProviderData(
   return parseStoredOAuthCredential(raw)?.providerData;
 }
 
-function decodeProviderSecret(raw: string | null): string | null {
+function decodeProviderSecret(raw: string | null, allowOpaqueJson = false): string | null {
   if (!raw) return null;
   const trimmed = raw.trim();
   if (!trimmed.startsWith('{')) return trimmed;
   const oauth = parseStoredOAuthCredential(trimmed);
   if (oauth) return oauth.access;
   try {
-    const parsed = JSON.parse(trimmed) as { type?: string; token?: string };
+    const parsed = JSON.parse(trimmed) as { type?: string; access?: string; token?: string };
     if (parsed.type === 'wellknown') {
       return typeof parsed.token === 'string' && parsed.token.trim()
         ? parsed.token.trim()
         : null;
     }
+    if (allowOpaqueJson && parsed.type === 'oauth') {
+      return typeof parsed.access === 'string' && parsed.access.trim()
+        ? parsed.access.trim()
+        : null;
+    }
+    return allowOpaqueJson ? raw : null;
   } catch {
     return null;
   }
-  return null;
+}
+
+function oauthCredentialStateKey(providerId: string, authRef: string): string {
+  return `${providerId}${OAUTH_STATE_KEY_SEPARATOR}${authRef}`;
+}
+
+function clearOAuthCredentialCache(authRef: string): void {
+  const suffix = `${OAUTH_STATE_KEY_SEPARATOR}${authRef}`;
+  for (const key of oauthCredentialCache.keys()) {
+    if (key.endsWith(suffix)) oauthCredentialCache.delete(key);
+  }
 }
 
 async function readOAuthProviderSecret(
@@ -442,8 +459,16 @@ async function readOAuthProviderSecret(
   diag?: (msg: string) => void,
   rejectedAccessToken?: string,
 ): Promise<string | null> {
-  const inflightKey = storedCredentialAuthRef(ref);
-  const cached = oauthCredentialCache.get(inflightKey);
+  const authRef = storedCredentialAuthRef(ref);
+  const stateKey = oauthCredentialStateKey(providerId, authRef);
+  const existing = oauthRefreshInflight.get(stateKey);
+  if (existing) {
+    const resolved = await existing;
+    if (resolved !== rejectedAccessToken) return resolved;
+    return readOAuthProviderSecret(ref, providerId, diag, rejectedAccessToken);
+  }
+
+  const cached = oauthCredentialCache.get(stateKey);
   if (
     cached
     && cached.access !== rejectedAccessToken
@@ -452,17 +477,10 @@ async function readOAuthProviderSecret(
   ) {
     return cached.access;
   }
-  if (cached?.access === rejectedAccessToken) oauthCredentialCache.delete(inflightKey);
+  if (cached?.access === rejectedAccessToken) oauthCredentialCache.delete(stateKey);
 
-  const existing = oauthRefreshInflight.get(inflightKey);
-  if (existing) {
-    const resolved = await existing;
-    if (resolved !== rejectedAccessToken) return resolved;
-    return readOAuthProviderSecret(ref, providerId, diag, rejectedAccessToken);
-  }
-
-  const work = withCredentialMutationLock(inflightKey, async (): Promise<string | null> => {
-    const latestCached = oauthCredentialCache.get(inflightKey);
+  const work = withCredentialMutationLock(authRef, async (): Promise<string | null> => {
+    const latestCached = oauthCredentialCache.get(stateKey);
     if (
       latestCached
       && latestCached.access !== rejectedAccessToken
@@ -481,7 +499,7 @@ async function readOAuthProviderSecret(
         const decoded = decodeProviderSecret(raw);
         return decoded === rejectedAccessToken ? null : decoded;
       }
-      oauthCredentialCache.set(inflightKey, cred);
+      oauthCredentialCache.set(stateKey, cred);
 
       const forceRefresh = cred.access === rejectedAccessToken || cred.accessRejected === true;
       if (!forceRefresh && !oauthCredentialShouldRefresh(cred, providerId)) {
@@ -494,7 +512,7 @@ async function readOAuthProviderSecret(
       } catch (err) {
         diag?.(err instanceof Error ? err.message : String(err));
         if (!forceRefresh && cred.access && cred.expires > Date.now()) return cred.access;
-        oauthCredentialCache.delete(inflightKey);
+        oauthCredentialCache.delete(stateKey);
         throw err;
       }
 
@@ -507,7 +525,7 @@ async function readOAuthProviderSecret(
       );
       const currentRaw = await readStoredCredential(ref, diag);
       if (currentRaw !== raw) {
-        oauthCredentialCache.delete(inflightKey);
+        oauthCredentialCache.delete(stateKey);
         continue;
       }
 
@@ -515,13 +533,13 @@ async function readOAuthProviderSecret(
         ? { ...refreshed, accessRejected: true }
         : refreshed;
       const json = oauthCredentialToKeychainJson(credentialToSave);
-      const saved = await saveProviderCredential(inflightKey, json, diag);
+      const saved = await saveProviderCredential(authRef, json, diag);
       if (!saved) {
-        oauthCredentialCache.delete(inflightKey);
+        oauthCredentialCache.delete(stateKey);
         throw new Error('Could not persist refreshed OAuth credential');
       }
       if (accessStillRejected) {
-        oauthCredentialCache.delete(inflightKey);
+        oauthCredentialCache.delete(stateKey);
         return null;
       }
       return refreshed.access;
@@ -531,12 +549,12 @@ async function readOAuthProviderSecret(
     waitMs: OAUTH_REFRESH_LOCK_WAIT_MS,
   });
 
-  oauthRefreshInflight.set(inflightKey, work);
+  oauthRefreshInflight.set(stateKey, work);
   try {
     return await work;
   } finally {
-    if (oauthRefreshInflight.get(inflightKey) === work) {
-      oauthRefreshInflight.delete(inflightKey);
+    if (oauthRefreshInflight.get(stateKey) === work) {
+      oauthRefreshInflight.delete(stateKey);
     }
   }
 }
@@ -551,7 +569,7 @@ async function readProviderSecret(
     return readOAuthProviderSecret(ref, oauthProviderId, diag, rejectedAccessToken);
   }
   const raw = await readStoredCredential(ref, diag);
-  const decoded = decodeProviderSecret(raw);
+  const decoded = decodeProviderSecret(raw, true);
   return decoded === rejectedAccessToken ? null : decoded;
 }
 
@@ -564,13 +582,16 @@ export async function saveProviderCredential(
   if (!parsed || parsed.kind === 'env' || parsed.kind === 'none') return false;
   return withCredentialMutationLock(authRef, async () => {
     const cacheKey = storedCredentialAuthRef(parsed);
-    oauthCredentialCache.delete(cacheKey);
+    clearOAuthCredentialCache(cacheKey);
     const written = await writeStoredCredential(parsed, key, diag);
     if (!written) return false;
     const readBack = await readStoredCredential(parsed, diag);
     if (readBack === key) {
       const oauth = parseStoredOAuthCredential(key);
-      if (oauth) oauthCredentialCache.set(cacheKey, oauth);
+      const oauthProviderId = oauthProviderIdFromAccount(parsed.account);
+      if (oauth && oauthProviderId) {
+        oauthCredentialCache.set(oauthCredentialStateKey(oauthProviderId, cacheKey), oauth);
+      }
       return true;
     }
     diag?.('credential store read-back verification failed');
@@ -618,7 +639,7 @@ export async function deleteProviderCredential(
   const parsed = parseAuthRef(authRef);
   if (!parsed || parsed.kind === 'env' || parsed.kind === 'none') return false;
   return withCredentialMutationLock(authRef, () => {
-    oauthCredentialCache.delete(storedCredentialAuthRef(parsed));
+    clearOAuthCredentialCache(storedCredentialAuthRef(parsed));
     return deleteStoredCredential(parsed, diag);
   });
 }

--- a/src/oauth/refresh-http.ts
+++ b/src/oauth/refresh-http.ts
@@ -28,7 +28,16 @@ export async function postOAuthRefresh(
   });
 
   if (!response.ok) {
-    const detail = options.includeBody ? await response.text().catch(() => '') : '';
+    let detail = '';
+    if (options.includeBody) {
+      detail = await response.text().catch(() => '');
+    } else {
+      try {
+        await response.body?.cancel();
+      } catch {
+        // Preserve the refresh failure when transport cleanup also fails.
+      }
+    }
     const status = options.includeStatus ? ` (${response.status})` : '';
     throw new Error(`${options.errorPrefix}${status}${detail ? `: ${detail}` : ''}`);
   }

--- a/src/oauth/refresh-http.ts
+++ b/src/oauth/refresh-http.ts
@@ -24,9 +24,8 @@ export async function postOAuthRefresh(
     ));
   }, OAUTH_REFRESH_TIMEOUT_MS);
   timeout.unref();
-  let response: Response;
   try {
-    response = await fetch(url, {
+    const response = await fetch(url, {
       method: 'POST',
       signal: abortController.signal,
       headers: {
@@ -36,24 +35,24 @@ export async function postOAuthRefresh(
       },
       body: isJson ? JSON.stringify(body) : (body as URLSearchParams).toString(),
     });
+
+    if (!response.ok) {
+      let detail = '';
+      if (options.includeBody) {
+        detail = await response.text().catch(() => '');
+      } else {
+        try {
+          await response.body?.cancel();
+        } catch {
+          // Preserve the refresh failure when transport cleanup also fails.
+        }
+      }
+      const status = options.includeStatus ? ` (${response.status})` : '';
+      throw new Error(`${options.errorPrefix}${status}${detail ? `: ${detail}` : ''}`);
+    }
+
+    return await response.json() as OAuthTokenResponse;
   } finally {
     clearTimeout(timeout);
   }
-
-  if (!response.ok) {
-    let detail = '';
-    if (options.includeBody) {
-      detail = await response.text().catch(() => '');
-    } else {
-      try {
-        await response.body?.cancel();
-      } catch {
-        // Preserve the refresh failure when transport cleanup also fails.
-      }
-    }
-    const status = options.includeStatus ? ` (${response.status})` : '';
-    throw new Error(`${options.errorPrefix}${status}${detail ? `: ${detail}` : ''}`);
-  }
-
-  return response.json() as Promise<OAuthTokenResponse>;
 }

--- a/src/oauth/refresh-http.ts
+++ b/src/oauth/refresh-http.ts
@@ -1,5 +1,7 @@
 import type { OAuthTokenResponse } from './types.js';
 
+const OAUTH_REFRESH_TIMEOUT_MS = 30_000;
+
 export interface PostOAuthRefreshOptions {
   contentType: 'form' | 'json';
   errorPrefix: string;
@@ -16,6 +18,7 @@ export async function postOAuthRefresh(
   const isJson = options.contentType === 'json';
   const response = await fetch(url, {
     method: 'POST',
+    signal: AbortSignal.timeout(OAUTH_REFRESH_TIMEOUT_MS),
     headers: {
       'Content-Type': isJson ? 'application/json' : 'application/x-www-form-urlencoded',
       Accept: 'application/json',

--- a/src/oauth/refresh-http.ts
+++ b/src/oauth/refresh-http.ts
@@ -16,16 +16,29 @@ export async function postOAuthRefresh(
   options: PostOAuthRefreshOptions,
 ): Promise<OAuthTokenResponse> {
   const isJson = options.contentType === 'json';
-  const response = await fetch(url, {
-    method: 'POST',
-    signal: AbortSignal.timeout(OAUTH_REFRESH_TIMEOUT_MS),
-    headers: {
-      'Content-Type': isJson ? 'application/json' : 'application/x-www-form-urlencoded',
-      Accept: 'application/json',
-      ...options.headers,
-    },
-    body: isJson ? JSON.stringify(body) : (body as URLSearchParams).toString(),
-  });
+  const abortController = new AbortController();
+  const timeout = setTimeout(() => {
+    abortController.abort(new DOMException(
+      'The operation was aborted due to timeout',
+      'TimeoutError',
+    ));
+  }, OAUTH_REFRESH_TIMEOUT_MS);
+  timeout.unref();
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      signal: abortController.signal,
+      headers: {
+        'Content-Type': isJson ? 'application/json' : 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+        ...options.headers,
+      },
+      body: isJson ? JSON.stringify(body) : (body as URLSearchParams).toString(),
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
 
   if (!response.ok) {
     let detail = '';

--- a/src/oauth/refresh.ts
+++ b/src/oauth/refresh.ts
@@ -5,7 +5,7 @@ import type { StoredOAuthCredential } from './types.js';
 import { accessTokenIsExpiring, NATIVE_OAUTH_PROVIDER_IDS, oauthCredentialNeedsRefresh, tokensToStoredCredential } from './types.js';
 
 export function oauthCredentialShouldRefresh(
-  cred: StoredOAuthCredential,
+  cred: Pick<StoredOAuthCredential, 'access' | 'expires'>,
   providerId: string,
 ): boolean {
   if (oauthCredentialNeedsRefresh(cred)) return true;

--- a/src/oauth/types.ts
+++ b/src/oauth/types.ts
@@ -85,7 +85,10 @@ export function parseStoredOAuthCredential(raw: string | null): StoredOAuthCrede
 
 export const OAUTH_REFRESH_SKEW_MS = 120_000;
 
-export function oauthCredentialNeedsRefresh(cred: StoredOAuthCredential, skewMs = OAUTH_REFRESH_SKEW_MS): boolean {
+export function oauthCredentialNeedsRefresh(
+  cred: Pick<StoredOAuthCredential, 'expires'>,
+  skewMs = OAUTH_REFRESH_SKEW_MS,
+): boolean {
   return cred.expires <= Date.now() + Math.max(0, skewMs);
 }
 

--- a/src/oauth/types.ts
+++ b/src/oauth/types.ts
@@ -6,6 +6,7 @@ export interface StoredOAuthCredential {
   refresh: string;
   /** Epoch millis when the access token expires. */
   expires: number;
+  accessRejected?: true;
   accountId?: string;
   providerData?: Record<string, unknown>;
 }
@@ -28,11 +29,36 @@ export function tokensToStoredCredential(
   accountId?: string,
   providerData?: Record<string, unknown>,
 ): StoredOAuthCredential {
+  const access = typeof tokens.access_token === 'string'
+    ? tokens.access_token.trim()
+    : '';
+  if (!access) {
+    throw new Error('OAuth token response is missing a valid access token');
+  }
+
+  if (
+    tokens.expires_in !== undefined
+    && (
+      typeof tokens.expires_in !== 'number'
+      || !Number.isFinite(tokens.expires_in)
+      || tokens.expires_in < 0
+    )
+  ) {
+    throw new Error('OAuth token response has an invalid expiration');
+  }
+
+  const returnedRefresh = typeof tokens.refresh_token === 'string'
+    ? tokens.refresh_token.trim()
+    : '';
+  const expires = Date.now() + (tokens.expires_in ?? 3600) * 1000;
+  if (!Number.isFinite(expires)) {
+    throw new Error('OAuth token response has an invalid expiration');
+  }
   return {
     type: 'oauth',
-    access: tokens.access_token,
-    refresh: tokens.refresh_token ?? existingRefresh ?? '',
-    expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
+    access,
+    refresh: returnedRefresh || existingRefresh || '',
+    expires,
     ...(accountId ? { accountId } : {}),
     ...(providerData ? { providerData } : {}),
   };
@@ -44,8 +70,11 @@ export function parseStoredOAuthCredential(raw: string | null): StoredOAuthCrede
     const parsed = JSON.parse(raw) as StoredOAuthCredential;
     if (parsed.type === 'oauth'
       && typeof parsed.access === 'string'
+      && parsed.access.trim().length > 0
       && typeof parsed.refresh === 'string'
-      && typeof parsed.expires === 'number') {
+      && typeof parsed.expires === 'number'
+      && Number.isFinite(parsed.expires)
+      && (parsed.accessRejected === undefined || parsed.accessRejected === true)) {
       return parsed;
     }
   } catch {

--- a/src/provider-catalog.ts
+++ b/src/provider-catalog.ts
@@ -113,6 +113,7 @@ export function localProvidersToServerModels(localProviders: LocalProvider[]): S
       npm: model.modelFormat === 'openai' ? (model.npm || '@ai-sdk/openai-compatible') : model.npm,
       apiBaseUrl: model.apiBaseUrl,
       apiKey: provider.apiKey,
+      authRef: provider.authRef,
       authType: provider.authType,
       oauthAccountId: provider.oauthAccountId,
       contextWindow: model.contextWindow,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -16,7 +16,11 @@ import {
   writeInferenceResponseErrorLog,
   writeWebSocketDiagnosticLog,
 } from './trace-log.js';
-import { relayAnthropicMessages, UpstreamUnreachableError } from './upstream-forward.js';
+import {
+  relayAnthropicMessages,
+  resolveOAuthRetryReplacement,
+  UpstreamUnreachableError,
+} from './upstream-forward.js';
 import {
   CLAUDE_CODE_CLI_VERSION,
   injectClaudeCodeBillingSystemLine,
@@ -635,21 +639,20 @@ export async function startProxyCatalog(
           const message = formatUpstreamError(err);
           const details = sdkUpstreamErrorDetails(err);
           const upstreamStatus = details?.statusCode ?? upstreamHttpStatus(err, message);
-          if (
-            openAiOAuth &&
-            upstreamStatus === 401 &&
-            sdkAttempt === 0 &&
-            !res.headersSent &&
-            route.refreshToken
-          ) {
-            const replacement = await route.refreshToken(apiKey).catch(() => null);
-            if (replacement && replacement !== apiKey) {
-              apiKey = replacement;
-              route.apiKey = replacement;
-              sdkAttempt += 1;
-              plog(() => 'sdk oauth credential replaced after 401; retrying once');
-              return 'retry';
-            }
+          const replacement = await resolveOAuthRetryReplacement(
+            openAiOAuth,
+            upstreamStatus,
+            sdkAttempt,
+            res.headersSent,
+            apiKey,
+            route.refreshToken,
+          );
+          if (replacement) {
+            apiKey = replacement;
+            route.apiKey = replacement;
+            sdkAttempt += 1;
+            plog(() => 'sdk oauth credential replaced after 401; retrying once');
+            return 'retry';
           }
           translationLifecycle?.fail(
             err instanceof Error ? err.name : 'UpstreamError',

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -16,7 +16,7 @@ import {
   writeInferenceResponseErrorLog,
   writeWebSocketDiagnosticLog,
 } from './trace-log.js';
-import { fetchWithOAuthRetry, relayAnthropicMessages, UpstreamUnreachableError } from './upstream-forward.js';
+import { relayAnthropicMessages, UpstreamUnreachableError } from './upstream-forward.js';
 import {
   CLAUDE_CODE_CLI_VERSION,
   injectClaudeCodeBillingSystemLine,
@@ -222,8 +222,8 @@ export interface ProxyRoute {
   authType?: 'api' | 'oauth' | 'none';
   oauthAccountId?: string;
   providerData?: Record<string, unknown>;
-  /** Called once on upstream HTTP 401 to get a refreshed OAuth token. Retry happens only if token differs from current apiKey. */
-  refreshToken?: () => Promise<string | null>;
+  /** Resolves the current OAuth token before dispatch and once more after an upstream HTTP 401. */
+  refreshToken?: (rejectedAccessToken?: string) => Promise<string | null>;
   supportedParameters?: string[];
   reasoning?: boolean;
   interleavedReasoningField?: string;
@@ -368,7 +368,21 @@ export async function startProxyCatalog(
 
       // Per-request route resolution: look up the alias, fall back to default
       const route = lookupRoute(byAlias, originalModel) ?? defaultRoute;
-      const apiKey = route.apiKey;
+      let apiKey = route.apiKey;
+      if (route.authType === 'oauth' && route.refreshToken) {
+        try {
+          const current = await route.refreshToken();
+          if (!current) throw new Error('credential is missing');
+          apiKey = current;
+          route.apiKey = current;
+        } catch (err) {
+          plog(() =>
+            `oauth credential unavailable: ${err instanceof Error ? err.message : String(err)}`,
+          );
+          anthropicError(res, 401, 'OAuth credential is unavailable');
+          return;
+        }
+      }
       const upstreamUrl = route.upstreamUrl;
       const routeAuthType = route.authType ?? 'api';
 
@@ -486,7 +500,7 @@ export async function startProxyCatalog(
           originalModel,
           route.providerId ?? route.aliasId.split(':')[1] ?? 'unknown',
         );
-        try {
+        const runSdkRequest = async (): Promise<void> => {
           const claudeSessionIdHeader = Array.isArray(req.headers['x-claude-code-session-id'])
             ? req.headers['x-claude-code-session-id'][0]
             : req.headers['x-claude-code-session-id'];
@@ -525,7 +539,6 @@ export async function startProxyCatalog(
               ? event => writeWebSocketDiagnosticLog(webSocketDiagnosticsLogPath, event)
               : undefined,
           });
-          translationLifecycle?.dispatched();
           if (clientWantsStream) {
             // Internal override (primarily a test seam / operational tuning knob).
             const keepAliveMs =
@@ -608,18 +621,39 @@ export async function startProxyCatalog(
             translationLifecycle?.complete();
             sendJson(res, 200, anthropicResponse);
           }
-        } catch (err) {
+        };
+
+        let sdkAttempt = 0;
+        const handleSdkError = async (
+          err: unknown,
+        ): Promise<'retry' | 'cancelled' | 'done'> => {
           if (clientAbort.signal.aborted) {
             translationLifecycle?.cancel();
-            return;
+            return 'cancelled';
+          }
+          const message = formatUpstreamError(err);
+          const details = sdkUpstreamErrorDetails(err);
+          const upstreamStatus = details?.statusCode ?? upstreamHttpStatus(err, message);
+          if (
+            openAiOAuth &&
+            upstreamStatus === 401 &&
+            sdkAttempt === 0 &&
+            !res.headersSent &&
+            route.refreshToken
+          ) {
+            const replacement = await route.refreshToken(apiKey).catch(() => null);
+            if (replacement && replacement !== apiKey) {
+              apiKey = replacement;
+              route.apiKey = replacement;
+              sdkAttempt += 1;
+              plog(() => 'sdk oauth credential replaced after 401; retrying once');
+              return 'retry';
+            }
           }
           translationLifecycle?.fail(
             err instanceof Error ? err.name : 'UpstreamError',
             sdkTranslationErrorSignature(err),
           );
-          const message = formatUpstreamError(err);
-          const details = sdkUpstreamErrorDetails(err);
-          const upstreamStatus = details?.statusCode ?? upstreamHttpStatus(err, message);
           const contextLengthExceeded = upstreamStatus === 400
             && isContextLengthExceededError(err, message);
           const clientMessage = contextLengthExceeded
@@ -656,6 +690,20 @@ export async function startProxyCatalog(
               ...(contextLengthExceeded ? { request_id: relayRequestId ?? randomUUID() } : {}),
             })}\n\n`);
             res.end();
+          }
+          return 'done';
+        };
+
+        translationLifecycle?.dispatched();
+        for (;;) {
+          try {
+            await runSdkRequest();
+            break;
+          } catch (err) {
+            const outcome = await handleSdkError(err);
+            if (outcome === 'retry') continue;
+            if (outcome === 'cancelled') return;
+            break;
           }
         }
         return;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -368,6 +368,14 @@ export async function startProxyCatalog(
 
       // Per-request route resolution: look up the alias, fall back to default
       const route = lookupRoute(byAlias, originalModel) ?? defaultRoute;
+      if (messagesEndpoint === 'count_tokens' && route.modelFormat !== 'anthropic') {
+        const inputTokens = estimateAnthropicInputTokens(anthropicBody);
+        plog(() => `token-count: local estimate model=${originalModel} input_tokens=${inputTokens}`);
+        res.setHeader('x-relay-token-count-source', 'local-estimate');
+        sendJson(res, 200, { input_tokens: inputTokens });
+        return;
+      }
+
       let apiKey = route.apiKey;
       if (route.authType === 'oauth' && route.refreshToken) {
         try {
@@ -393,14 +401,6 @@ export async function startProxyCatalog(
       const usesSdkAdapter = isSdkMigratedNpm(route.npm);
 
       if (messagesEndpoint === 'count_tokens') {
-        if (route.modelFormat !== 'anthropic') {
-          const inputTokens = estimateAnthropicInputTokens(anthropicBody);
-          plog(() => `token-count: local estimate model=${originalModel} input_tokens=${inputTokens}`);
-          res.setHeader('x-relay-token-count-source', 'local-estimate');
-          sendJson(res, 200, { input_tokens: inputTokens });
-          return;
-        }
-
         if (!apiKey && routeAuthType !== 'none') {
           anthropicError(res, 401, 'Missing API key');
           return;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -539,6 +539,7 @@ export async function startProxyCatalog(
               ? event => writeWebSocketDiagnosticLog(webSocketDiagnosticsLogPath, event)
               : undefined,
           });
+          translationLifecycle?.dispatched();
           if (clientWantsStream) {
             // Internal override (primarily a test seam / operational tuning knob).
             const keepAliveMs =
@@ -694,7 +695,6 @@ export async function startProxyCatalog(
           return 'done';
         };
 
-        translationLifecycle?.dispatched();
         for (;;) {
           try {
             await runSdkRequest();

--- a/src/registry/lock.ts
+++ b/src/registry/lock.ts
@@ -421,8 +421,10 @@ export function getCredentialMutationLockPath(authRef: string): string {
 export function withCredentialMutationLock<T>(
   authRef: string,
   operation: () => Promise<T> | T,
+  options: Pick<RegistryLockOptions, 'waitMs' | 'retryMs'> = {},
 ): Promise<T> {
   return withRegistryWriteLock(operation, {
+    ...options,
     lockPath: getCredentialMutationLockPath(authRef),
   });
 }

--- a/src/registry/lock.ts
+++ b/src/registry/lock.ts
@@ -16,6 +16,7 @@ import { dirname } from 'node:path';
 import { getProvidersPath } from '../paths.js';
 
 const DEFAULT_WAIT_MS = 30_000;
+const DEFAULT_CREDENTIAL_MUTATION_WAIT_MS = 150_000;
 const DEFAULT_RETRY_MS = 25;
 
 interface RegistryLockOwner {
@@ -426,5 +427,6 @@ export function withCredentialMutationLock<T>(
   return withRegistryWriteLock(operation, {
     ...options,
     lockPath: getCredentialMutationLockPath(authRef),
+    waitMs: options.waitMs ?? DEFAULT_CREDENTIAL_MUTATION_WAIT_MS,
   });
 }

--- a/src/server/models.ts
+++ b/src/server/models.ts
@@ -34,6 +34,8 @@ export interface ServerModelInfo {
   npm?: string;            // OpenCode api.npm — openai-format models route through the SDK adapter
   apiBaseUrl?: string;     // base URL for openai-compatible / openrouter SDK providers
   apiKey?: string;         // model-specific API key; overrides server-level apiKey if set; never returned in API responses
+  /** Exact registry credential reference used for OAuth retry; never returned in API responses. */
+  authRef?: string;
   authType?: 'api' | 'oauth' | 'none';
   oauthAccountId?: string;
   supportedParameters?: string[];

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -18,7 +18,7 @@ import {
   type OpenAiRequest,
 } from '../openai-adapter.js';
 import { sendJson, readBody } from '../http-utils.js';
-import { relayAnthropicMessages } from '../upstream-forward.js';
+import { relayAnthropicMessages, resolveOAuthRetryReplacement } from '../upstream-forward.js';
 import {
   anthropicPromptTooLongMessage,
   estimateAnthropicInputTokens,
@@ -463,23 +463,19 @@ async function handleAnthropicMessages(
         const message = formatUpstreamError(err);
         const details = sdkUpstreamErrorDetails(err);
         const candidateStatus = details?.statusCode ?? upstreamHttpStatus(err, message);
-        if (
-          openAiOAuth &&
-          candidateStatus === 401 &&
-          sdkAttempt === 0 &&
-          !res.headersSent
-        ) {
-          const replacement = await resolveModelApiKey(
-            model,
-            options.apiKey,
-            apiKey,
-          ).catch(() => null);
-          if (replacement && replacement !== apiKey) {
-            apiKey = replacement;
-            sdkAttempt += 1;
-            plog('sdk oauth credential replaced after 401; retrying once');
-            continue;
-          }
+        const replacement = await resolveOAuthRetryReplacement(
+          openAiOAuth,
+          candidateStatus,
+          sdkAttempt,
+          res.headersSent,
+          apiKey,
+          rejectedAccessToken => resolveModelApiKey(model, options.apiKey, rejectedAccessToken),
+        );
+        if (replacement) {
+          apiKey = replacement;
+          sdkAttempt += 1;
+          plog('sdk oauth credential replaced after 401; retrying once');
+          continue;
         }
         const status = auditSdkError(options, body.model, model, err, message);
         const contextLengthExceeded = status === 400
@@ -657,23 +653,19 @@ async function handleOpenAIChatCompletions(
       const message = formatUpstreamError(err);
       const details = sdkUpstreamErrorDetails(err);
       const candidateStatus = details?.statusCode ?? upstreamHttpStatus(err, message);
-      if (
-        openAiOAuth &&
-        candidateStatus === 401 &&
-        sdkAttempt === 0 &&
-        !res.headersSent
-      ) {
-        const replacement = await resolveModelApiKey(
-          model,
-          options.apiKey,
-          apiKey,
-        ).catch(() => null);
-        if (replacement && replacement !== apiKey) {
-          apiKey = replacement;
-          sdkAttempt += 1;
-          plog('sdk oauth credential replaced after 401; retrying once');
-          continue;
-        }
+      const replacement = await resolveOAuthRetryReplacement(
+        openAiOAuth,
+        candidateStatus,
+        sdkAttempt,
+        res.headersSent,
+        apiKey,
+        rejectedAccessToken => resolveModelApiKey(model, options.apiKey, rejectedAccessToken),
+      );
+      if (replacement) {
+        apiKey = replacement;
+        sdkAttempt += 1;
+        plog('sdk oauth credential replaced after 401; retrying once');
+        continue;
       }
       const status = auditSdkError(options, body.model, model, err, message);
       plog(`sdk error npm=${model.npm} upstream=${upstreamModelId(model)}: ${message}`);

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -24,7 +24,6 @@ import {
   estimateAnthropicInputTokens,
 } from '../anthropic-endpoints.js';
 import { resolveProviderCredential } from '../env.js';
-import { oauthAuthRef } from '../registry/import-build.js';
 import {
   injectClaudeCodeBillingSystemLine,
   injectClaudeIdentity,
@@ -96,6 +95,7 @@ export interface ServerHandle {
 type JsonBody = Record<string, any>;
 
 type PLog = (msg: string | (() => string)) => void;
+type LanguageModelCache = Map<string, { apiKey: string; languageModel: LanguageModel }>;
 
 function makeServerLog(debugLogPath: string | undefined): PLog {
   if (!debugLogPath) return () => {};
@@ -109,6 +109,37 @@ function auditInference(options: ServerOptions, entry: InferenceRequestLogEntry)
 
 function inferenceProvider(model: ServerModelInfo): string {
   return model.providerId ?? String(model.sourceBackend);
+}
+
+async function resolveModelApiKey(
+  model: ServerModelInfo,
+  fallback: string,
+  rejectedAccessToken?: string,
+): Promise<string> {
+  if (model.authType === 'oauth' && model.providerId && model.authRef) {
+    let current: string | null;
+    try {
+      current = rejectedAccessToken === undefined
+        ? await resolveProviderCredential(model.providerId, model.authRef)
+        : await resolveProviderCredential(
+            model.providerId,
+            model.authRef,
+            undefined,
+            { rejectedAccessToken },
+          );
+    } catch (cause) {
+      throw new Error(
+        `OAuth credential is unavailable for ${model.providerId}`,
+        { cause },
+      );
+    }
+    if (!current) {
+      throw new Error(`OAuth credential is unavailable for ${model.providerId}`);
+    }
+    model.apiKey = current;
+    return current;
+  }
+  return model.apiKey ?? fallback;
 }
 
 function auditSdkError(
@@ -147,7 +178,7 @@ function openAiEffort(body: JsonBody): string | undefined {
 
 export async function startServer(options: ServerOptions): Promise<ServerHandle> {
   silenceSdkWarnings();
-  const languageModelCache = new Map<string, LanguageModel>();
+  const languageModelCache: LanguageModelCache = new Map();
   const plog = makeServerLog(options.debugLogPath);
 
   const server = createServer((req, res) => {
@@ -168,7 +199,7 @@ export async function startServer(options: ServerOptions): Promise<ServerHandle>
   };
 }
 
-async function routeRequest(req: IncomingMessage, res: ServerResponse, options: ServerOptions, modelCache: Map<string, LanguageModel>, plog: PLog): Promise<void> {
+async function routeRequest(req: IncomingMessage, res: ServerResponse, options: ServerOptions, modelCache: LanguageModelCache, plog: PLog): Promise<void> {
   try {
     const pathname = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`).pathname;
     plog(`${req.method} ${pathname}`);
@@ -184,7 +215,16 @@ async function routeRequest(req: IncomingMessage, res: ServerResponse, options: 
     }
 
     if (req.method === 'GET' && pathname === '/models') {
-      sendJson(res, 200, { models: options.catalog.list().map(({ apiKey: _apiKey, headers: _headers, ...rest }) => rest) });
+      sendJson(res, 200, {
+        models: options.catalog.list().map(({
+          apiKey: _apiKey,
+          authRef: _authRef,
+          headers: _headers,
+          oauthAccountId: _oauthAccountId,
+          providerData: _providerData,
+          ...rest
+        }) => rest),
+      });
       return;
     }
 
@@ -218,7 +258,7 @@ async function handleAnthropicMessages(
   req: IncomingMessage,
   res: ServerResponse,
   options: ServerOptions,
-  modelCache: Map<string, LanguageModel>,
+  modelCache: LanguageModelCache,
   plog: PLog,
 ): Promise<void> {
   const body = await readJson(req);
@@ -260,7 +300,15 @@ async function handleAnthropicMessages(
       return;
     }
     const messagesUrl = `${model.baseUrl}/v1/messages`;
-    const apiKey = model.apiKey ?? options.apiKey;
+    let apiKey: string;
+    try {
+      apiKey = await resolveModelApiKey(model, options.apiKey);
+    } catch (err) {
+      sendJson(res, 401, {
+        error: { message: err instanceof Error ? err.message : String(err) },
+      });
+      return;
+    }
     const betaHeaderRaw = req.headers['anthropic-beta'];
     const inboundBeta = Array.isArray(betaHeaderRaw) ? betaHeaderRaw.join(',') : betaHeaderRaw;
     const clientWantsStream = Boolean(body.stream);
@@ -288,8 +336,12 @@ async function handleAnthropicMessages(
       effectiveBeta = selectBetaFlags(forwardBody, upstreamModelId(model), inboundBeta);
     }
 
-    const refreshToken = isOAuth && model.providerId
-      ? () => resolveProviderCredential(model.providerId!, oauthAuthRef(model.providerId!))
+    const refreshToken = isOAuth && model.providerId && model.authRef
+      ? (rejectedAccessToken: string) => resolveModelApiKey(
+          model,
+          options.apiKey,
+          rejectedAccessToken,
+        )
       : undefined;
 
     plog(() => `anthropic-passthrough → ${messagesUrl} oauth=${isOAuth} stream=${clientWantsStream}`);
@@ -320,7 +372,15 @@ async function handleAnthropicMessages(
       sendJson(res, 400, { error: { message: `No SDK provider for model: ${model.id}` } });
       return;
     }
-    const apiKey = model.apiKey ?? options.apiKey;
+    let apiKey: string;
+    try {
+      apiKey = await resolveModelApiKey(model, options.apiKey);
+    } catch (err) {
+      sendJson(res, 401, {
+        error: { message: err instanceof Error ? err.message : String(err) },
+      });
+      return;
+    }
     auditInference(options, {
       requestId,
       modelId: body.model,
@@ -330,14 +390,6 @@ async function handleAnthropicMessages(
       route: 'translated',
       requestPreview: getLatestMessagePreview(body.messages, body.system),
     });
-    const languageModel = await getOrInitLanguageModel(
-      modelCache,
-      model,
-      model.npm!,
-      model.apiBaseUrl,
-      apiKey,
-      options.webSocketDiagnosticsLogPath,
-    );
     const npmMaxTools = maxToolsForNpm(model.npm);
     const toolCount = Array.isArray((body as Record<string, unknown>).tools) ? ((body as Record<string, unknown>).tools as unknown[]).length : 0;
     if (npmMaxTools !== undefined && toolCount > npmMaxTools) {
@@ -366,66 +418,99 @@ async function handleAnthropicMessages(
 
     plog(() => `sdk npm=${model.npm} upstream=${upstreamModelId(model)} responseModel=${responseModelId} stream=${clientWantsStream}`);
 
-    try {
-      if (clientWantsStream) {
-        const writeStreamChunk = (chunk: string) => {
-          if (!res.headersSent) {
-            res.writeHead(200, {
-              'Content-Type': 'text/event-stream',
-              'Cache-Control': 'no-cache',
-              'Connection': 'keep-alive',
-            });
-          }
-          res.write(chunk);
-        };
-        await withResponsesWebSocketDiagnosticContext(
-          { requestId, claudeSessionId },
-          () => streamAnthropicResponse(languageModel, params, responseModelId, writeStreamChunk, undefined, {
-            initialInputTokens: estimateAnthropicInputTokens(body),
-          }),
+    let sdkAttempt = 0;
+    for (;;) {
+      try {
+        const languageModel = await getOrInitLanguageModel(
+          modelCache,
+          model,
+          model.npm!,
+          model.apiBaseUrl,
+          apiKey,
+          options.webSocketDiagnosticsLogPath,
         );
-        if (!res.headersSent) writeStreamChunk('');
-        res.end();
-      } else {
-        // ChatGPT/Codex OAuth routes only ever answer as SSE (the WebSocket fetch
-        // returns text/event-stream unconditionally), so stream internally and
-        // collect the result instead of issuing a non-streaming SDK request.
-        const anthropicResponse = await withResponsesWebSocketDiagnosticContext(
-          { requestId, claudeSessionId },
-          () => generateAnthropicResponse(languageModel, params, responseModelId, { forceStream: openAiOAuth }),
-        );
-        sendJson(res, 200, anthropicResponse);
-      }
-    } catch (err) {
-      const message = formatUpstreamError(err);
-      const status = auditSdkError(options, body.model, model, err, message);
-      const contextLengthExceeded = status === 400
-        && isContextLengthExceededError(err, message);
-      const clientMessage = contextLengthExceeded
-        ? anthropicPromptTooLongMessage(
-            body,
-            resolveContextWindow(upstreamModelId(model), model.contextWindow),
-          )
-        : message;
-      plog(`sdk error npm=${model.npm} upstream=${upstreamModelId(model)}: ${message}`);
-      if (!res.headersSent) {
-        if (contextLengthExceeded) {
-          sendJson(res, 400, {
-            type: 'error',
-            error: { type: 'invalid_request_error', message: clientMessage },
-            request_id: requestId,
-          });
+        if (clientWantsStream) {
+          const writeStreamChunk = (chunk: string) => {
+            if (!res.headersSent) {
+              res.writeHead(200, {
+                'Content-Type': 'text/event-stream',
+                'Cache-Control': 'no-cache',
+                'Connection': 'keep-alive',
+              });
+            }
+            res.write(chunk);
+          };
+          await withResponsesWebSocketDiagnosticContext(
+            { requestId, claudeSessionId },
+            () => streamAnthropicResponse(languageModel, params, responseModelId, writeStreamChunk, undefined, {
+              initialInputTokens: estimateAnthropicInputTokens(body),
+            }),
+          );
+          if (!res.headersSent) writeStreamChunk('');
+          res.end();
         } else {
-          sendJson(res, status === 500 ? 502 : status, { error: { message: clientMessage } });
+          // ChatGPT/Codex OAuth routes only ever answer as SSE (the WebSocket fetch
+          // returns text/event-stream unconditionally), so stream internally and
+          // collect the result instead of issuing a non-streaming SDK request.
+          const anthropicResponse = await withResponsesWebSocketDiagnosticContext(
+            { requestId, claudeSessionId },
+            () => generateAnthropicResponse(languageModel, params, responseModelId, { forceStream: openAiOAuth }),
+          );
+          sendJson(res, 200, anthropicResponse);
         }
-      } else {
-        const errorType = anthropicErrorType(status);
-        res.write(`event: error\ndata: ${JSON.stringify({
-          type: 'error',
-          error: { type: errorType, message: clientMessage },
-          ...(contextLengthExceeded ? { request_id: requestId } : {}),
-        })}\n\n`);
-        res.end();
+        break;
+      } catch (err) {
+        const message = formatUpstreamError(err);
+        const details = sdkUpstreamErrorDetails(err);
+        const candidateStatus = details?.statusCode ?? upstreamHttpStatus(err, message);
+        if (
+          openAiOAuth &&
+          candidateStatus === 401 &&
+          sdkAttempt === 0 &&
+          !res.headersSent
+        ) {
+          const replacement = await resolveModelApiKey(
+            model,
+            options.apiKey,
+            apiKey,
+          ).catch(() => null);
+          if (replacement && replacement !== apiKey) {
+            apiKey = replacement;
+            sdkAttempt += 1;
+            plog('sdk oauth credential replaced after 401; retrying once');
+            continue;
+          }
+        }
+        const status = auditSdkError(options, body.model, model, err, message);
+        const contextLengthExceeded = status === 400
+          && isContextLengthExceededError(err, message);
+        const clientMessage = contextLengthExceeded
+          ? anthropicPromptTooLongMessage(
+              body,
+              resolveContextWindow(upstreamModelId(model), model.contextWindow),
+            )
+          : message;
+        plog(`sdk error npm=${model.npm} upstream=${upstreamModelId(model)}: ${message}`);
+        if (!res.headersSent) {
+          if (contextLengthExceeded) {
+            sendJson(res, 400, {
+              type: 'error',
+              error: { type: 'invalid_request_error', message: clientMessage },
+              request_id: requestId,
+            });
+          } else {
+            sendJson(res, status === 500 ? 502 : status, { error: { message: clientMessage } });
+          }
+        } else {
+          const errorType = anthropicErrorType(status);
+          res.write(`event: error\ndata: ${JSON.stringify({
+            type: 'error',
+            error: { type: errorType, message: clientMessage },
+            ...(contextLengthExceeded ? { request_id: requestId } : {}),
+          })}\n\n`);
+          res.end();
+        }
+        break;
       }
     }
     return;
@@ -438,7 +523,7 @@ async function handleOpenAIChatCompletions(
   req: IncomingMessage,
   res: ServerResponse,
   options: ServerOptions,
-  modelCache: Map<string, LanguageModel>,
+  modelCache: LanguageModelCache,
   plog: PLog,
 ): Promise<void> {
   const body = await readJson(req);
@@ -460,7 +545,15 @@ async function handleOpenAIChatCompletions(
       return;
     }
     const completionsUrl = model.completionsUrl;
-    const apiKey = model.apiKey ?? options.apiKey;
+    let apiKey: string;
+    try {
+      apiKey = await resolveModelApiKey(model, options.apiKey);
+    } catch (err) {
+      sendJson(res, 401, {
+        error: { message: err instanceof Error ? err.message : String(err) },
+      });
+      return;
+    }
     // The client may have addressed the model via a gateway alias or saved
     // short alias — the upstream API only knows its own wire id.
     const forwardBody = body.model === upstreamModelId(model) ? body : { ...body, model: upstreamModelId(model) };
@@ -471,9 +564,19 @@ async function handleOpenAIChatCompletions(
       route: 'passthrough',
       requestPreview: getLatestMessagePreview(body.messages, body.system),
     });
+    const isOAuth = model.authType === 'oauth';
+    const refreshToken = isOAuth && model.providerId && model.authRef
+      ? (rejectedAccessToken: string) => resolveModelApiKey(
+          model,
+          options.apiKey,
+          rejectedAccessToken,
+        )
+      : undefined;
     await relayAnthropicMessages(res, completionsUrl, forwardBody, apiKey, Boolean(body.stream), {
       authType: model.authType ?? 'api',
       extraHeaders: model.headers,
+      refreshToken,
+      onTokenRefreshed: refreshed => { model.apiKey = refreshed; },
       onUpstreamError: options.inferenceLogPath
         ? (statusCode, errorContent) => writeInferenceResponseErrorLog(options.inferenceLogPath!, {
             modelId: body.model,
@@ -494,7 +597,15 @@ async function handleOpenAIChatCompletions(
     return;
   }
 
-  const apiKey = model.apiKey ?? options.apiKey;
+  let apiKey: string;
+  try {
+    apiKey = await resolveModelApiKey(model, options.apiKey);
+  } catch (err) {
+    sendJson(res, 401, {
+      error: { message: err instanceof Error ? err.message : String(err) },
+    });
+    return;
+  }
   auditInference(options, {
     modelId: body.model,
     effort: openAiEffort(body),
@@ -503,7 +614,6 @@ async function handleOpenAIChatCompletions(
     requestPreview: getLatestMessagePreview(body.messages, body.system),
   });
   const baseURL = model.modelFormat === 'anthropic' ? model.baseUrl : model.apiBaseUrl;
-  const languageModel = await getOrInitLanguageModel(modelCache, model, npm, baseURL, apiKey);
   const openAiOAuth = npm === '@ai-sdk/openai' && model.authType === 'oauth';
   const params = translateOpenAiRequest(body as unknown as OpenAiRequest, { openAiOAuth });
   const clientWantsStream = Boolean(body.stream);
@@ -511,37 +621,69 @@ async function handleOpenAIChatCompletions(
 
   plog(() => `sdk-openai npm=${npm} upstream=${upstreamModelId(model)} responseModel=${responseModelId} stream=${clientWantsStream}`);
 
-  try {
-    if (clientWantsStream) {
-      const writeStreamChunk = (chunk: string) => {
-        if (!res.headersSent) {
-          res.writeHead(200, {
-            'Content-Type': 'text/event-stream',
-            'Cache-Control': 'no-cache',
-            'Connection': 'keep-alive',
-          });
+  let sdkAttempt = 0;
+  for (;;) {
+    try {
+      const languageModel = await getOrInitLanguageModel(
+        modelCache,
+        model,
+        npm,
+        baseURL,
+        apiKey,
+      );
+      if (clientWantsStream) {
+        const writeStreamChunk = (chunk: string) => {
+          if (!res.headersSent) {
+            res.writeHead(200, {
+              'Content-Type': 'text/event-stream',
+              'Cache-Control': 'no-cache',
+              'Connection': 'keep-alive',
+            });
+          }
+          res.write(chunk);
+        };
+        await streamOpenAiResponse(languageModel, params, responseModelId, writeStreamChunk);
+        if (!res.headersSent) writeStreamChunk('');
+        res.end();
+      } else {
+        // ChatGPT/Codex OAuth routes only ever answer as SSE (the WebSocket fetch
+        // returns text/event-stream unconditionally), so stream internally and
+        // collect the result instead of issuing a non-streaming SDK request.
+        const response = await generateOpenAiResponse(languageModel, params, responseModelId, { forceStream: openAiOAuth });
+        sendJson(res, 200, response);
+      }
+      break;
+    } catch (err) {
+      const message = formatUpstreamError(err);
+      const details = sdkUpstreamErrorDetails(err);
+      const candidateStatus = details?.statusCode ?? upstreamHttpStatus(err, message);
+      if (
+        openAiOAuth &&
+        candidateStatus === 401 &&
+        sdkAttempt === 0 &&
+        !res.headersSent
+      ) {
+        const replacement = await resolveModelApiKey(
+          model,
+          options.apiKey,
+          apiKey,
+        ).catch(() => null);
+        if (replacement && replacement !== apiKey) {
+          apiKey = replacement;
+          sdkAttempt += 1;
+          plog('sdk oauth credential replaced after 401; retrying once');
+          continue;
         }
-        res.write(chunk);
-      };
-      await streamOpenAiResponse(languageModel, params, responseModelId, writeStreamChunk);
-      if (!res.headersSent) writeStreamChunk('');
-      res.end();
-    } else {
-      // ChatGPT/Codex OAuth routes only ever answer as SSE (the WebSocket fetch
-      // returns text/event-stream unconditionally), so stream internally and
-      // collect the result instead of issuing a non-streaming SDK request.
-      const response = await generateOpenAiResponse(languageModel, params, responseModelId, { forceStream: openAiOAuth });
-      sendJson(res, 200, response);
-    }
-  } catch (err) {
-    const message = formatUpstreamError(err);
-    const status = auditSdkError(options, body.model, model, err, message);
-    plog(`sdk error npm=${model.npm} upstream=${upstreamModelId(model)}: ${message}`);
-    if (!res.headersSent) {
-      sendJson(res, status === 500 ? 502 : status, { error: { message } });
-    } else {
-      res.write(`data: ${JSON.stringify({ error: { message, type: 'upstream_error', code: status } })}\n\n`);
-      res.end();
+      }
+      const status = auditSdkError(options, body.model, model, err, message);
+      plog(`sdk error npm=${model.npm} upstream=${upstreamModelId(model)}: ${message}`);
+      if (!res.headersSent) {
+        sendJson(res, status === 500 ? 502 : status, { error: { message } });
+      } else {
+        res.write(`data: ${JSON.stringify({ error: { message, type: 'upstream_error', code: status } })}\n\n`);
+        res.end();
+      }
+      break;
     }
   }
 }
@@ -562,7 +704,7 @@ function lookupModel(res: ServerResponse, catalog: ModelCatalog, modelId: unknow
 }
 
 async function getOrInitLanguageModel(
-  modelCache: Map<string, LanguageModel>,
+  modelCache: LanguageModelCache,
   model: ServerModelInfo,
   npm: string,
   baseURL: string | undefined,
@@ -576,9 +718,9 @@ async function getOrInitLanguageModel(
     npm,
     baseURL ?? '',
   ].join('\x1f');
-  let languageModel = modelCache.get(cacheKey);
-  if (!languageModel) {
-    languageModel = await createLanguageModel({
+  let cached = modelCache.get(cacheKey);
+  if (!cached || cached.apiKey !== apiKey) {
+    const languageModel = await createLanguageModel({
       npm,
       modelId: upstreamModelId(model),
       apiKey,
@@ -593,9 +735,10 @@ async function getOrInitLanguageModel(
         ? event => writeWebSocketDiagnosticLog(webSocketDiagnosticsLogPath, event)
         : undefined,
     });
-    modelCache.set(cacheKey, languageModel);
+    cached = { apiKey, languageModel };
+    modelCache.set(cacheKey, cached);
   }
-  return languageModel;
+  return cached.languageModel;
 }
 
 function getResponseModelId(bodyModel: unknown, model: ServerModelInfo, options: ServerOptions): string {

--- a/src/upstream-forward.ts
+++ b/src/upstream-forward.ts
@@ -49,21 +49,29 @@ export class UpstreamUnreachableError extends Error {
   }
 }
 
-export async function fetchWithOAuthRetry<TResponse extends { status: number }>(
+export async function fetchWithOAuthRetry<TResponse extends {
+  status: number;
+  body?: { cancel?: () => Promise<void> | void } | null;
+}>(
   apiKey: string,
   request: (apiKey: string) => Promise<TResponse>,
-  refreshToken?: () => Promise<string | null>,
+  refreshToken?: (rejectedAccessToken: string) => Promise<string | null>,
 ): Promise<{ response: TResponse; apiKey: string; refreshed: boolean }> {
   let response = await request(apiKey);
   if (response.status !== 401 || !refreshToken) {
     return { response, apiKey, refreshed: false };
   }
 
-  const refreshed = await refreshToken().catch(() => null);
+  const refreshed = await refreshToken(apiKey).catch(() => null);
   if (!refreshed || refreshed === apiKey) {
     return { response, apiKey, refreshed: false };
   }
 
+  try {
+    await response.body?.cancel?.();
+  } catch {
+    // A failed cleanup must not prevent the bounded retry.
+  }
   response = await request(refreshed);
   return { response, apiKey: refreshed, refreshed: true };
 }
@@ -75,7 +83,7 @@ export interface RelayAnthropicOptions {
   log?: (message: string) => void;
   claudeCodeSessionId?: string;
   extraHeaders?: Record<string, string>;
-  refreshToken?: () => Promise<string | null>;
+  refreshToken?: (rejectedAccessToken: string) => Promise<string | null>;
   onTokenRefreshed?: (token: string) => void;
   onUpstreamError?: (statusCode: number, body: string) => void;
   signal?: AbortSignal;

--- a/src/upstream-forward.ts
+++ b/src/upstream-forward.ts
@@ -49,6 +49,21 @@ export class UpstreamUnreachableError extends Error {
   }
 }
 
+export async function resolveOAuthRetryReplacement(
+  enabled: boolean,
+  status: number,
+  attempt: number,
+  headersSent: boolean,
+  apiKey: string,
+  refreshToken?: (rejectedAccessToken: string) => Promise<string | null>,
+): Promise<string | null> {
+  if (!enabled || status !== 401 || attempt !== 0 || headersSent || !refreshToken) {
+    return null;
+  }
+  const replacement = await refreshToken(apiKey).catch(() => null);
+  return replacement && replacement !== apiKey ? replacement : null;
+}
+
 export async function fetchWithOAuthRetry<TResponse extends {
   status: number;
   body?: { cancel?: () => Promise<void> | void } | null;
@@ -58,12 +73,15 @@ export async function fetchWithOAuthRetry<TResponse extends {
   refreshToken?: (rejectedAccessToken: string) => Promise<string | null>,
 ): Promise<{ response: TResponse; apiKey: string; refreshed: boolean }> {
   let response = await request(apiKey);
-  if (response.status !== 401 || !refreshToken) {
-    return { response, apiKey, refreshed: false };
-  }
-
-  const refreshed = await refreshToken(apiKey).catch(() => null);
-  if (!refreshed || refreshed === apiKey) {
+  const refreshed = await resolveOAuthRetryReplacement(
+    true,
+    response.status,
+    0,
+    false,
+    apiKey,
+    refreshToken,
+  );
+  if (!refreshed) {
     return { response, apiKey, refreshed: false };
   }
 

--- a/tests/catalog.test.ts
+++ b/tests/catalog.test.ts
@@ -1,9 +1,12 @@
 // tests/catalog.test.ts
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { MAX_MODEL_CATALOG } from '../src/constants.js';
 import { buildCatalogRoutes, localModelToRoute, makeRouteResolver } from '../src/catalog.js';
+import * as env from '../src/env.js';
 import type { ModelInfo } from '../src/types.js';
 import type { FavoriteModel, LocalProvider } from '../src/types.js';
+
+const TEST_HELPER_REF = `helper:v1:${'a'.repeat(64)}:oauth:provider:openai-oauth`;
 
 describe('buildCatalogRoutes', () => {
   const starting = {
@@ -57,12 +60,14 @@ describe('localModelToRoute', () => {
     });
   });
 
-  it('preserves OAuth provider data for catalog routes', () => {
+  it('preserves OAuth provider data and exact credential references for catalog routes', async () => {
+    const resolveSpy = vi.spyOn(env, 'resolveProviderCredential').mockResolvedValue('refreshed-token');
     const provider: LocalProvider = {
       id: 'openai-oauth',
       name: 'OpenAI OAuth (ChatGPT)',
       apiKey: 'oauth-token',
       authType: 'oauth',
+      authRef: TEST_HELPER_REF,
       providerData: { plan: 'pro' },
       models: [{
         id: 'gpt-5.6-sol',
@@ -80,6 +85,21 @@ describe('localModelToRoute', () => {
       authType: 'oauth',
       providerData: { plan: 'pro' },
     });
+    await expect(route?.refreshToken?.()).resolves.toBe('refreshed-token');
+    expect(resolveSpy).toHaveBeenNthCalledWith(
+      1,
+      'openai-oauth',
+      TEST_HELPER_REF,
+    );
+    await expect(route?.refreshToken?.('rejected-token')).resolves.toBe('refreshed-token');
+    expect(resolveSpy).toHaveBeenNthCalledWith(
+      2,
+      'openai-oauth',
+      TEST_HELPER_REF,
+      undefined,
+      { rejectedAccessToken: 'rejected-token' },
+    );
+    resolveSpy.mockRestore();
   });
 
   it('propagates Responses-Lite / WebSocket capability flags onto the route', () => {

--- a/tests/env-oauth-refresh.test.ts
+++ b/tests/env-oauth-refresh.test.ts
@@ -1,11 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const lockState = vi.hoisted(() => ({ active: false }));
 const mocks = vi.hoisted(() => ({
   readCredential: vi.fn(),
   refreshCredential: vi.fn(),
   writeCredential: vi.fn(),
   withCredentialMutationLock: vi.fn(
-    async (_authRef: string, operation: () => Promise<unknown>) => operation(),
+    async (_authRef: string, operation: () => Promise<unknown>) => {
+      lockState.active = true;
+      try {
+        return await operation();
+      } finally {
+        lockState.active = false;
+      }
+    },
   ),
 }));
 
@@ -29,6 +37,7 @@ import { resolveProviderCredential } from '../src/env.js';
 
 const HELPER_ID = 'a'.repeat(64);
 const AUTH_REF = `helper:v1:${HELPER_ID}:oauth:provider:openai-oauth`;
+const FRESH_AUTH_REF = `helper:v1:${'b'.repeat(64)}:oauth:provider:openai-oauth`;
 
 function oauthCredential(access: string, expires: number): string {
   return JSON.stringify({
@@ -45,26 +54,29 @@ describe('OAuth credential refresh serialization', () => {
     mocks.refreshCredential.mockReset();
     mocks.writeCredential.mockReset();
     mocks.withCredentialMutationLock.mockClear();
+    lockState.active = false;
     delete process.env.CLODEX_KEY_OPENAI_OAUTH;
   });
 
-  it('re-reads the credential after acquiring its mutation lock', async () => {
-    const stale = oauthCredential('stale', 0);
+  it('reads the credential after acquiring its mutation lock', async () => {
     const replacement = oauthCredential('replacement', Date.now() + 3_600_000);
-    mocks.readCredential
-      .mockResolvedValueOnce(stale)
-      .mockResolvedValueOnce(replacement);
+    mocks.readCredential.mockImplementationOnce(async () => {
+      expect(lockState.active).toBe(true);
+      return replacement;
+    });
 
     await expect(
-      resolveProviderCredential('openai-oauth', AUTH_REF),
+      resolveProviderCredential('openai-oauth', FRESH_AUTH_REF),
     ).resolves.toBe('replacement');
 
     expect(mocks.withCredentialMutationLock).toHaveBeenCalledWith(
-      AUTH_REF,
+      FRESH_AUTH_REF,
       expect.any(Function),
+      { waitMs: 150_000 },
     );
     expect(mocks.refreshCredential).not.toHaveBeenCalled();
     expect(mocks.writeCredential).not.toHaveBeenCalled();
+    expect(mocks.readCredential).toHaveBeenCalledOnce();
   });
 
   it('persists a refreshed credential while holding the mutation lock', async () => {

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -125,6 +125,28 @@ describe('provider credentials', () => {
     expect(key).toBe('sk-openai');
     delete process.env['OPENAI_API_KEY'];
   });
+
+  it('scopes rejected shared env credentials to the provider that rejected them', async () => {
+    process.env['CLODEX_TEST_SHARED_KEY'] = 'shared-access';
+    try {
+      await expect(resolveProviderCredential(
+        'first-provider',
+        'env:CLODEX_TEST_SHARED_KEY',
+        undefined,
+        { rejectedAccessToken: 'shared-access' },
+      )).resolves.toBeNull();
+      await expect(resolveProviderCredential(
+        'second-provider',
+        'env:CLODEX_TEST_SHARED_KEY',
+      )).resolves.toBe('shared-access');
+      await expect(resolveProviderCredential(
+        'first-provider',
+        'env:CLODEX_TEST_SHARED_KEY',
+      )).resolves.toBeNull();
+    } finally {
+      delete process.env['CLODEX_TEST_SHARED_KEY'];
+    }
+  });
 });
 
 describe('buildChildEnv', () => {

--- a/tests/fixtures/credential-helper.mjs
+++ b/tests/fixtures/credential-helper.mjs
@@ -55,7 +55,7 @@ if (operation === 'get') {
     } catch {
       firstGet = false;
     }
-    if (firstGet) {
+    if (!firstGet) {
       const deadline = Date.now() + 5_000;
       while (!existsSync(secondSetPath) && Date.now() < deadline) {
         await new Promise(resolve => setTimeout(resolve, 5));

--- a/tests/fixtures/credential-helper.mjs
+++ b/tests/fixtures/credential-helper.mjs
@@ -25,6 +25,45 @@ try {
 const key = `${service}\u0000${account}`;
 
 if (operation === 'get') {
+  if (mode === 'delay-stale-read') {
+    const firstGetPath = `${storePath}.stale-first-get`;
+    let firstGet = false;
+    try {
+      const fd = openSync(firstGetPath, 'wx');
+      closeSync(fd);
+      firstGet = true;
+    } catch {
+      firstGet = false;
+    }
+    if (firstGet) {
+      const releasePath = `${storePath}.release-stale-get`;
+      const deadline = Date.now() + 5_000;
+      while (!existsSync(releasePath) && Date.now() < deadline) {
+        await new Promise(resolve => setTimeout(resolve, 5));
+      }
+      if (!existsSync(releasePath)) process.exit(1);
+    }
+  }
+  if (mode === 'interleave-readback') {
+    const firstGetPath = `${storePath}.first-get`;
+    const secondSetPath = `${storePath}.second-set`;
+    let firstGet = false;
+    try {
+      const fd = openSync(firstGetPath, 'wx');
+      closeSync(fd);
+      firstGet = true;
+    } catch {
+      firstGet = false;
+    }
+    if (firstGet) {
+      const deadline = Date.now() + 5_000;
+      while (!existsSync(secondSetPath) && Date.now() < deadline) {
+        await new Promise(resolve => setTimeout(resolve, 5));
+      }
+      if (!existsSync(secondSetPath)) process.exit(1);
+      store = JSON.parse(readFileSync(storePath, 'utf8'));
+    }
+  }
   if (!(key in store)) process.exit(2);
   process.stdout.write(mode === 'mismatch' ? 'different-value' : store[key]);
   process.exit(0);

--- a/tests/oauth-credential-store.test.ts
+++ b/tests/oauth-credential-store.test.ts
@@ -79,6 +79,7 @@ describe('OAuth credential-store refresh', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     delete process.env[CREDENTIAL_HELPER_ENV];
     delete process.env.CLODEX_TEST_CREDENTIAL_HELPER_STORE;
     delete process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE;
@@ -175,6 +176,26 @@ describe('OAuth credential-store refresh', () => {
     expect(refreshStoredOAuthCredential).toHaveBeenCalledTimes(1);
   });
 
+  it('revalidates a cached access token after the cross-process staleness bound', async () => {
+    let now = Date.now();
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+    await writeCredentialHelperAccount(account, unexpiredCredential('account-a-access'));
+
+    await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBe(
+      'account-a-access',
+    );
+    await writeCredentialHelperAccount(account, unexpiredCredential('account-b-access'));
+    await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBe(
+      'account-a-access',
+    );
+
+    now += 30_000;
+    await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBe(
+      'account-b-access',
+    );
+    expect(refreshStoredOAuthCredential).not.toHaveBeenCalled();
+  });
+
   it('fails when a rotated credential cannot be persisted', async () => {
     process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE = 'fail-set';
     await expect(resolveProviderCredential('openai-oauth', authRef)).rejects.toThrow(
@@ -209,6 +230,60 @@ describe('OAuth credential-store refresh', () => {
     await expect(first).resolves.toBe('new-access');
     await expect(second).resolves.toBe('new-access');
     expect(refreshStoredOAuthCredential).toHaveBeenCalledTimes(1);
+  });
+
+  it('rereads a credential replaced between refresh and compare-and-set readback', async () => {
+    process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE = 'interleave-readback';
+    const storePath = process.env.CLODEX_TEST_CREDENTIAL_HELPER_STORE!;
+    vi.mocked(refreshStoredOAuthCredential).mockImplementationOnce(async () => {
+      await waitForPath(`${storePath}.first-get`);
+      await writeCredentialHelperAccount(account, unexpiredCredential('external-access'));
+      writeFileSync(`${storePath}.second-set`, '', { encoding: 'utf8', mode: 0o600 });
+      return {
+        type: 'oauth',
+        access: 'discarded-refresh-access',
+        refresh: 'discarded-refresh-token',
+        expires: Date.now() + 3_600_000,
+      };
+    });
+
+    await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBe(
+      'external-access',
+    );
+    await expect(readCredentialHelperAccount(account)).resolves.toContain('external-access');
+    await expect(readCredentialHelperAccount(account)).resolves.not.toContain(
+      'discarded-refresh-access',
+    );
+    expect(refreshStoredOAuthCredential).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails after three credentials replace consecutive refresh generations', async () => {
+    process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE = 'interleave-readback';
+    const storePath = process.env.CLODEX_TEST_CREDENTIAL_HELPER_STORE!;
+    let generation = 0;
+    vi.mocked(refreshStoredOAuthCredential).mockImplementation(async () => {
+      generation += 1;
+      await writeCredentialHelperAccount(account, oauthCredentialToKeychainJson({
+        type: 'oauth',
+        access: 'old-access',
+        refresh: `external-refresh-${generation}`,
+        expires: 0,
+        accountId: `generation-${generation}`,
+      }));
+      writeFileSync(`${storePath}.second-set`, '', { encoding: 'utf8', mode: 0o600 });
+      return {
+        type: 'oauth',
+        access: `discarded-access-${generation}`,
+        refresh: `discarded-refresh-${generation}`,
+        expires: Date.now() + 3_600_000,
+      };
+    });
+
+    await expect(resolveProviderCredential('openai-oauth', authRef)).rejects.toThrow(
+      'OAuth credential changed repeatedly while refresh was in progress',
+    );
+    expect(refreshStoredOAuthCredential).toHaveBeenCalledTimes(3);
+    await expect(readCredentialHelperAccount(account)).resolves.toContain('generation-3');
   });
 
   it('updates and clears the in-memory cache with explicit credential writes', async () => {
@@ -406,6 +481,45 @@ describe('OAuth credential-store refresh', () => {
       'new-access',
     ]);
     expect(refreshStoredOAuthCredential).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-resolves after an in-flight refresh returns the caller rejected token', async () => {
+    process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE = 'interleave-readback';
+    const storePath = process.env.CLODEX_TEST_CREDENTIAL_HELPER_STORE!;
+    let releaseRefresh!: () => void;
+    const refreshGate = new Promise<void>(resolve => { releaseRefresh = resolve; });
+    vi.mocked(refreshStoredOAuthCredential)
+      .mockImplementationOnce(async () => {
+        await refreshGate;
+        writeFileSync(`${storePath}.second-set`, '', { encoding: 'utf8', mode: 0o600 });
+        return {
+          type: 'oauth',
+          access: 'joined-rejected-access',
+          refresh: 'joined-refresh',
+          expires: Date.now() + 3_600_000,
+        };
+      })
+      .mockResolvedValueOnce({
+        type: 'oauth',
+        access: 'final-access',
+        refresh: 'final-refresh',
+        expires: Date.now() + 3_600_000,
+      });
+
+    const first = resolveProviderCredential('openai-oauth', authRef);
+    await waitForPath(`${storePath}.first-get`);
+    await vi.waitFor(() => expect(refreshStoredOAuthCredential).toHaveBeenCalledTimes(1));
+    const rejectedCaller = resolveProviderCredential(
+      'openai-oauth',
+      authRef,
+      undefined,
+      { rejectedAccessToken: 'joined-rejected-access' },
+    );
+    releaseRefresh();
+
+    await expect(first).resolves.toBe('joined-rejected-access');
+    await expect(rejectedCaller).resolves.toBe('final-access');
+    expect(refreshStoredOAuthCredential).toHaveBeenCalledTimes(2);
   });
 
   it('does not hold the provider registry lock while OAuth refresh awaits the network', async () => {

--- a/tests/oauth-credential-store.test.ts
+++ b/tests/oauth-credential-store.test.ts
@@ -1,0 +1,416 @@
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/oauth/refresh.js', () => ({
+  oauthCredentialShouldRefresh: vi.fn((credential: { access?: string }) => credential.access === 'old-access'),
+  refreshStoredOAuthCredential: vi.fn(async () => ({
+    type: 'oauth',
+    access: 'new-access',
+    refresh: 'new-refresh',
+    expires: Date.now() + 3_600_000,
+  })),
+}));
+
+import {
+  CREDENTIAL_HELPER_ENV,
+  credentialAuthRef,
+  readCredentialHelperAccount,
+  writeCredentialHelperAccount,
+} from '../src/credential-helper.js';
+import {
+  deleteProviderCredential,
+  resolveProviderCredential,
+  saveProviderCredential,
+} from '../src/env.js';
+import { oauthCredentialToKeychainJson } from '../src/oauth/types.js';
+import { refreshStoredOAuthCredential } from '../src/oauth/refresh.js';
+import { withRegistryWriteLock } from '../src/registry/lock.js';
+
+const helperPath = fileURLToPath(new URL('./fixtures/credential-helper.mjs', import.meta.url));
+let account = '';
+let authRef = '';
+const expiredCredential = oauthCredentialToKeychainJson({
+  type: 'oauth',
+  access: 'old-access',
+  refresh: 'old-refresh',
+  expires: 0,
+});
+
+function unexpiredCredential(access: string): string {
+  return oauthCredentialToKeychainJson({
+    type: 'oauth',
+    access,
+    refresh: `${access}-refresh`,
+    expires: Date.now() + 3_600_000,
+  });
+}
+
+async function waitForPath(path: string): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (!existsSync(path) && Date.now() < deadline) {
+    await new Promise(resolve => setTimeout(resolve, 5));
+  }
+  if (!existsSync(path)) throw new Error(`Timed out waiting for ${path}`);
+}
+
+describe('OAuth credential-store refresh', () => {
+  let tempDir = '';
+  const previousHome = process.env.CLODEX_HOME;
+
+  beforeEach(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'clodex-oauth-store-'));
+    account = `oauth:provider:openai-oauth-${tempDir.split('-').at(-1)}`;
+    process.env[CREDENTIAL_HELPER_ENV] = helperPath;
+    process.env.CLODEX_HOME = tempDir;
+    authRef = credentialAuthRef(account);
+    process.env.CLODEX_TEST_CREDENTIAL_HELPER_STORE = join(tempDir, 'credentials.json');
+    delete process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE;
+    delete process.env.CLODEX_KEY_OPENAI_OAUTH;
+    vi.mocked(refreshStoredOAuthCredential).mockReset().mockResolvedValue({
+      type: 'oauth',
+      access: 'new-access',
+      refresh: 'new-refresh',
+      expires: Date.now() + 3_600_000,
+    });
+    await writeCredentialHelperAccount(account, expiredCredential);
+  });
+
+  afterEach(() => {
+    delete process.env[CREDENTIAL_HELPER_ENV];
+    delete process.env.CLODEX_TEST_CREDENTIAL_HELPER_STORE;
+    delete process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE;
+    delete process.env.CLODEX_TEST_ENV_CREDENTIAL;
+    delete process.env.CLODEX_KEY_OPENAI_OAUTH;
+    if (previousHome === undefined) delete process.env.CLODEX_HOME;
+    else process.env.CLODEX_HOME = previousHome;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('persists and verifies the rotated credential before returning its access token', async () => {
+    await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBe('new-access');
+    const stored = await readCredentialHelperAccount(account);
+    expect(stored).toContain('new-refresh');
+    expect(stored).not.toContain('old-refresh');
+  });
+
+  it('never decodes malformed OAuth JSON as a bearer token', async () => {
+    await writeCredentialHelperAccount(account, JSON.stringify({
+      type: 'oauth',
+      refresh: 'sensitive-refresh-value',
+      expires: Date.now() + 3_600_000,
+    }));
+
+    await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBeNull();
+  });
+
+  it('never sends truncated structured credentials as bearer tokens', async () => {
+    await writeCredentialHelperAccount(
+      account,
+      '{"type":"oauth","access":"partial-access","refresh":"sensitive-refresh-value"',
+    );
+
+    await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBeNull();
+  });
+
+  it.each([
+    {
+      label: 'missing refresh token',
+      credential: {
+        type: 'oauth',
+        access: 'partial-access',
+        expires: Date.now() + 3_600_000,
+      },
+    },
+    {
+      label: 'missing expiration',
+      credential: {
+        type: 'oauth',
+        access: 'partial-access',
+        refresh: 'sensitive-refresh-value',
+      },
+    },
+    {
+      label: 'invalid rejection marker',
+      credential: {
+        type: 'oauth',
+        access: 'partial-access',
+        refresh: 'sensitive-refresh-value',
+        expires: Date.now() + 3_600_000,
+        accessRejected: false,
+      },
+    },
+  ])('rejects an incomplete structured credential with $label', async ({ credential }) => {
+    await writeCredentialHelperAccount(account, JSON.stringify(credential));
+
+    await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBeNull();
+  });
+
+  it('preserves a complete well-known token credential', async () => {
+    await writeCredentialHelperAccount(account, JSON.stringify({
+      type: 'wellknown',
+      token: 'static-access',
+    }));
+
+    await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBe('static-access');
+  });
+
+  it('serves the rotated token from memory without launching the helper again', async () => {
+    await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBe('new-access');
+    process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE = 'fail-get';
+    await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBe('new-access');
+    expect(refreshStoredOAuthCredential).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails when a rotated credential cannot be persisted', async () => {
+    process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE = 'fail-set';
+    await expect(resolveProviderCredential('openai-oauth', authRef)).rejects.toThrow(
+      'Could not persist refreshed OAuth credential',
+    );
+    delete process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE;
+    await expect(readCredentialHelperAccount(account)).resolves.toBe(expiredCredential);
+    await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBe('new-access');
+    expect(refreshStoredOAuthCredential).toHaveBeenCalledTimes(2);
+  });
+
+  it('deduplicates concurrent refreshes per backend and account', async () => {
+    const [first, second] = await Promise.all([
+      resolveProviderCredential('openai-oauth', authRef),
+      resolveProviderCredential('openai-oauth', authRef),
+    ]);
+    expect(first).toBe('new-access');
+    expect(second).toBe('new-access');
+    expect(refreshStoredOAuthCredential).toHaveBeenCalledTimes(1);
+  });
+
+  it('deduplicates before a delayed helper read can return a stale refresh token', async () => {
+    process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE = 'delay-stale-read';
+    const storePath = process.env.CLODEX_TEST_CREDENTIAL_HELPER_STORE!;
+    const first = resolveProviderCredential('openai-oauth', authRef);
+    await waitForPath(`${storePath}.stale-first-get`);
+    const second = resolveProviderCredential('openai-oauth', authRef);
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+    writeFileSync(`${storePath}.release-stale-get`, '', { encoding: 'utf8', mode: 0o600 });
+
+    await expect(first).resolves.toBe('new-access');
+    await expect(second).resolves.toBe('new-access');
+    expect(refreshStoredOAuthCredential).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates and clears the in-memory cache with explicit credential writes', async () => {
+    const replacement = oauthCredentialToKeychainJson({
+      type: 'oauth',
+      access: 'replacement-access',
+      refresh: 'replacement-refresh',
+      expires: Date.now() + 3_600_000,
+    });
+
+    await expect(saveProviderCredential(authRef, replacement)).resolves.toBe(true);
+    process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE = 'fail-get';
+    await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBe('replacement-access');
+
+    delete process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE;
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBeNull();
+  });
+
+  it('rereads an externally replaced credential after a cached token is rejected', async () => {
+    await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBe('new-access');
+    await writeCredentialHelperAccount(account, unexpiredCredential('external-access'));
+
+    await expect(resolveProviderCredential(
+      'openai-oauth',
+      authRef,
+      undefined,
+      { rejectedAccessToken: 'new-access' },
+    )).resolves.toBe('external-access');
+    expect(refreshStoredOAuthCredential).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls through to the stored credential when a rejected namespaced override remains set', async () => {
+    process.env.CLODEX_KEY_OPENAI_OAUTH = 'rejected-env-access';
+    await writeCredentialHelperAccount(account, unexpiredCredential('stored-access'));
+
+    await expect(resolveProviderCredential(
+      'openai-oauth',
+      authRef,
+      undefined,
+      { rejectedAccessToken: 'rejected-env-access' },
+    )).resolves.toBe('stored-access');
+    await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBe('stored-access');
+
+    process.env.CLODEX_KEY_OPENAI_OAUTH = 'changed-env-access';
+    await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBe('changed-env-access');
+  });
+
+  it('remembers a rejected env-backed credential until its value changes', async () => {
+    process.env.CLODEX_TEST_ENV_CREDENTIAL = 'rejected-env-access';
+
+    await expect(resolveProviderCredential(
+      'env-provider',
+      'env:CLODEX_TEST_ENV_CREDENTIAL',
+      undefined,
+      { rejectedAccessToken: 'rejected-env-access' },
+    )).resolves.toBeNull();
+    await expect(resolveProviderCredential(
+      'env-provider',
+      'env:CLODEX_TEST_ENV_CREDENTIAL',
+    )).resolves.toBeNull();
+
+    process.env.CLODEX_TEST_ENV_CREDENTIAL = 'changed-env-access';
+    await expect(resolveProviderCredential(
+      'env-provider',
+      'env:CLODEX_TEST_ENV_CREDENTIAL',
+    )).resolves.toBe('changed-env-access');
+  });
+
+  it('refreshes an unexpired token when the upstream rejects it', async () => {
+    await writeCredentialHelperAccount(account, unexpiredCredential('revoked-access'));
+    await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBe('revoked-access');
+
+    await expect(resolveProviderCredential(
+      'openai-oauth',
+      authRef,
+      undefined,
+      { rejectedAccessToken: 'revoked-access' },
+    )).resolves.toBe('new-access');
+    expect(refreshStoredOAuthCredential).toHaveBeenCalledTimes(1);
+  });
+
+  it('retains a rotated refresh token without reusing a rejected access token', async () => {
+    await writeCredentialHelperAccount(account, unexpiredCredential('revoked-access'));
+    vi.mocked(refreshStoredOAuthCredential).mockResolvedValue({
+      type: 'oauth',
+      access: 'revoked-access',
+      refresh: 'rotated-refresh',
+      expires: Date.now() + 3_600_000,
+    });
+
+    await expect(resolveProviderCredential(
+      'openai-oauth',
+      authRef,
+      undefined,
+      { rejectedAccessToken: 'revoked-access' },
+    )).resolves.toBeNull();
+
+    const stored = await readCredentialHelperAccount(account);
+    expect(stored).toContain('rotated-refresh');
+    expect(stored).toContain('"accessRejected":true');
+    await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBeNull();
+    expect(refreshStoredOAuthCredential).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not replace one rejected access token with another rejected token', async () => {
+    await writeCredentialHelperAccount(account, oauthCredentialToKeychainJson({
+      type: 'oauth',
+      access: 'stored-rejected-access',
+      refresh: 'stored-refresh',
+      expires: Date.now() + 3_600_000,
+      accessRejected: true,
+    }));
+    vi.mocked(refreshStoredOAuthCredential).mockResolvedValue({
+      type: 'oauth',
+      access: 'request-rejected-access',
+      refresh: 'rotated-refresh',
+      expires: Date.now() + 3_600_000,
+    });
+
+    await expect(resolveProviderCredential(
+      'openai-oauth',
+      authRef,
+      undefined,
+      { rejectedAccessToken: 'request-rejected-access' },
+    )).resolves.toBeNull();
+
+    const stored = await readCredentialHelperAccount(account);
+    expect(stored).toContain('request-rejected-access');
+    expect(stored).toContain('"accessRejected":true');
+    await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBeNull();
+  });
+
+  it('deduplicates concurrent rejected-token refreshes', async () => {
+    await writeCredentialHelperAccount(account, unexpiredCredential('revoked-access'));
+    await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBe('revoked-access');
+    let releaseRefresh!: () => void;
+    const refreshGate = new Promise<void>(resolve => { releaseRefresh = resolve; });
+    vi.mocked(refreshStoredOAuthCredential).mockImplementation(async () => {
+      await refreshGate;
+      return {
+        type: 'oauth',
+        access: 'new-access',
+        refresh: 'new-refresh',
+        expires: Date.now() + 3_600_000,
+      };
+    });
+
+    const first = resolveProviderCredential(
+      'openai-oauth',
+      authRef,
+      undefined,
+      { rejectedAccessToken: 'revoked-access' },
+    );
+    const second = resolveProviderCredential(
+      'openai-oauth',
+      authRef,
+      undefined,
+      { rejectedAccessToken: 'revoked-access' },
+    );
+    await vi.waitFor(() => expect(refreshStoredOAuthCredential).toHaveBeenCalledTimes(1));
+    releaseRefresh();
+
+    await expect(Promise.all([first, second])).resolves.toEqual(['new-access', 'new-access']);
+    expect(refreshStoredOAuthCredential).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not hold the provider registry lock while OAuth refresh awaits the network', async () => {
+    let releaseRefresh!: () => void;
+    const refreshGate = new Promise<void>(resolve => { releaseRefresh = resolve; });
+    vi.mocked(refreshStoredOAuthCredential).mockImplementation(async () => {
+      await refreshGate;
+      return {
+        type: 'oauth',
+        access: 'new-access',
+        refresh: 'new-refresh',
+        expires: Date.now() + 3_600_000,
+      };
+    });
+
+    const resolving = resolveProviderCredential('openai-oauth', authRef);
+    await vi.waitFor(() => expect(refreshStoredOAuthCredential).toHaveBeenCalledTimes(1));
+    await expect(withRegistryWriteLock(
+      () => 'registry-write-completed',
+      { waitMs: 100, retryMs: 5 },
+    )).resolves.toBe('registry-write-completed');
+    releaseRefresh();
+    await expect(resolving).resolves.toBe('new-access');
+  });
+
+  it('never falls back to a rejected token after forced refresh failure', async () => {
+    await writeCredentialHelperAccount(account, unexpiredCredential('revoked-access'));
+    await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBe('revoked-access');
+    vi.mocked(refreshStoredOAuthCredential).mockRejectedValueOnce(new Error('refresh rejected'));
+
+    await expect(resolveProviderCredential(
+      'openai-oauth',
+      authRef,
+      undefined,
+      { rejectedAccessToken: 'revoked-access' },
+    )).rejects.toThrow('refresh rejected');
+
+    await writeCredentialHelperAccount(account, unexpiredCredential('external-access'));
+    await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBe('external-access');
+  });
+
+  it('evicts the old cache before an uncertain credential write', async () => {
+    await writeCredentialHelperAccount(account, unexpiredCredential('cached-access'));
+    await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBe('cached-access');
+    process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE = 'fail-set';
+    await expect(saveProviderCredential(authRef, unexpiredCredential('replacement-access'))).resolves.toBe(false);
+    process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE = 'fail-get';
+
+    await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBeNull();
+  });
+});

--- a/tests/oauth-credential-store.test.ts
+++ b/tests/oauth-credential-store.test.ts
@@ -157,6 +157,17 @@ describe('OAuth credential-store refresh', () => {
     await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBe('static-access');
   });
 
+  it('round-trips a valid opaque JSON credential for a non-OAuth provider', async () => {
+    const opaqueAccount = `provider:opaque-${tempDir.split('-').at(-1)}`;
+    const opaqueAuthRef = credentialAuthRef(opaqueAccount);
+    const opaqueCredential = '{"custom":{"credential":"opaque-value"},"version":1}';
+
+    await expect(saveProviderCredential(opaqueAuthRef, opaqueCredential)).resolves.toBe(true);
+    await expect(resolveProviderCredential('opaque-provider', opaqueAuthRef)).resolves.toBe(
+      opaqueCredential,
+    );
+  });
+
   it('serves the rotated token from memory without launching the helper again', async () => {
     await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBe('new-access');
     process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE = 'fail-get';
@@ -362,6 +373,38 @@ describe('OAuth credential-store refresh', () => {
     releaseRefresh();
 
     await expect(Promise.all([first, second])).resolves.toEqual(['new-access', 'new-access']);
+    expect(refreshStoredOAuthCredential).toHaveBeenCalledTimes(1);
+  });
+
+  it('makes fresh callers join an in-flight rejected-token refresh', async () => {
+    await writeCredentialHelperAccount(account, unexpiredCredential('revoked-access'));
+    await expect(resolveProviderCredential('openai-oauth', authRef)).resolves.toBe('revoked-access');
+    let releaseRefresh!: () => void;
+    const refreshGate = new Promise<void>(resolve => { releaseRefresh = resolve; });
+    vi.mocked(refreshStoredOAuthCredential).mockImplementation(async () => {
+      await refreshGate;
+      return {
+        type: 'oauth',
+        access: 'new-access',
+        refresh: 'new-refresh',
+        expires: Date.now() + 3_600_000,
+      };
+    });
+
+    const rejectedCaller = resolveProviderCredential(
+      'openai-oauth',
+      authRef,
+      undefined,
+      { rejectedAccessToken: 'revoked-access' },
+    );
+    await vi.waitFor(() => expect(refreshStoredOAuthCredential).toHaveBeenCalledTimes(1));
+    const freshCaller = resolveProviderCredential('openai-oauth', authRef);
+    releaseRefresh();
+
+    await expect(Promise.all([rejectedCaller, freshCaller])).resolves.toEqual([
+      'new-access',
+      'new-access',
+    ]);
     expect(refreshStoredOAuthCredential).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -175,6 +175,7 @@ describe('openai oauth helpers', () => {
 
 describe('oauth refresh', () => {
   afterEach(() => {
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -47,6 +47,8 @@ describe('oauth types', () => {
 
 describe('oauth refresh http', () => {
   afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
@@ -92,13 +94,22 @@ describe('oauth refresh http', () => {
     expect(text).not.toHaveBeenCalled();
   });
 
-  it('bounds the refresh request with an abort signal', async () => {
-    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
-      access_token: 'new-access',
-    }), { status: 200 }));
+  it('aborts a hung refresh request after 30 seconds', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(
+      async (_url: string | URL | Request, init?: RequestInit): Promise<Response> =>
+        new Promise((_resolve, reject) => {
+          const signal = init?.signal;
+          if (!signal) {
+            reject(new Error('missing abort signal'));
+            return;
+          }
+          signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+        }),
+    );
     vi.stubGlobal('fetch', fetchMock);
 
-    await postOAuthRefresh(
+    const refresh = postOAuthRefresh(
       'https://auth/token',
       new URLSearchParams({ grant_type: 'refresh_token' }),
       {
@@ -106,11 +117,14 @@ describe('oauth refresh http', () => {
         errorPrefix: 'token refresh failed',
       },
     );
+    const signal = fetchMock.mock.calls[0]?.[1]?.signal as AbortSignal;
+    const rejection = refresh.catch((error: unknown) => error);
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      'https://auth/token',
-      expect.objectContaining({ signal: expect.any(AbortSignal) }),
-    );
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(signal.aborted).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(signal.aborted).toBe(true);
+    await expect(rejection).resolves.toMatchObject({ name: 'TimeoutError' });
   });
 });
 

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -22,6 +22,22 @@ describe('oauth types', () => {
     expect(cred.expires).toBeGreaterThan(Date.now());
   });
 
+  it('rejects malformed token responses before they can be stored', () => {
+    expect(() => tokensToStoredCredential(
+      {} as unknown as Parameters<typeof tokensToStoredCredential>[0],
+    )).toThrow(
+      'missing a valid access token',
+    );
+    expect(() => tokensToStoredCredential({
+      access_token: 'access',
+      expires_in: Number.NaN,
+    })).toThrow('invalid expiration');
+    expect(() => tokensToStoredCredential({
+      access_token: 'access',
+      expires_in: 1e308,
+    })).toThrow('invalid expiration');
+  });
+
   it('reads JWT exp for proactive refresh hint', () => {
     const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
     const payload = Buffer.from(JSON.stringify({ exp: Math.floor(Date.now() / 1000) - 10 })).toString('base64url');
@@ -51,6 +67,27 @@ describe('oauth refresh http', () => {
         includeBody: true,
       },
     )).rejects.toThrow('xAI token refresh failed (401): bad refresh');
+  });
+
+  it('bounds the refresh request with an abort signal', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      access_token: 'new-access',
+    }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await postOAuthRefresh(
+      'https://auth/token',
+      new URLSearchParams({ grant_type: 'refresh_token' }),
+      {
+        contentType: 'form',
+        errorPrefix: 'token refresh failed',
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://auth/token',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 });
 
@@ -96,4 +133,3 @@ describe('oauth refresh', () => {
     })).rejects.toThrow('not implemented');
   });
 });
-

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -69,6 +69,29 @@ describe('oauth refresh http', () => {
     )).rejects.toThrow('xAI token refresh failed (401): bad refresh');
   });
 
+  it('cancels an unread failed response body when error details are disabled', async () => {
+    const cancel = vi.fn(async () => {});
+    const text = vi.fn(async () => 'must stay unread');
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      status: 401,
+      body: { cancel },
+      text,
+    })));
+
+    await expect(postOAuthRefresh(
+      'https://auth/token',
+      new URLSearchParams({ grant_type: 'refresh_token' }),
+      {
+        contentType: 'form',
+        errorPrefix: 'token refresh failed',
+        includeStatus: true,
+      },
+    )).rejects.toThrow('token refresh failed (401)');
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(text).not.toHaveBeenCalled();
+  });
+
   it('bounds the refresh request with an abort signal', async () => {
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({
       access_token: 'new-access',

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -126,6 +126,40 @@ describe('oauth refresh http', () => {
     expect(signal.aborted).toBe(true);
     await expect(rejection).resolves.toMatchObject({ name: 'TimeoutError' });
   });
+
+  it('keeps the 30-second timeout active while reading the response body', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(
+      async (_url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+        const signal = init?.signal;
+        if (!signal) throw new Error('missing abort signal');
+        return {
+          ok: true,
+          json: () => new Promise((_resolve, reject) => {
+            signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+          }),
+        } as Response;
+      },
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const refresh = postOAuthRefresh(
+      'https://auth/token',
+      new URLSearchParams({ grant_type: 'refresh_token' }),
+      {
+        contentType: 'form',
+        errorPrefix: 'token refresh failed',
+      },
+    );
+    const signal = fetchMock.mock.calls[0]?.[1]?.signal as AbortSignal;
+    const rejection = refresh.catch((error: unknown) => error);
+
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(signal.aborted).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(signal.aborted).toBe(true);
+    await expect(rejection).resolves.toMatchObject({ name: 'TimeoutError' });
+  });
 });
 
 

--- a/tests/provider-catalog-display.test.ts
+++ b/tests/provider-catalog-display.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import * as env from '../src/env.js';
 import {
   formatRegistryAuthLabel,
+  localProvidersToServerModels,
   providersForPicker,
   resolveLocalProviderApiKey,
   resolveProvidersForDisplay,
@@ -113,6 +114,26 @@ describe('provider-catalog-display', () => {
         'keyring:oauth:provider:openai-oauth',
       );
     });
+  });
+
+  it('propagates exact credential references to server models for OAuth retry', () => {
+    const models = localProvidersToServerModels([{
+      id: 'openai-oauth',
+      name: 'OpenAI (ChatGPT)',
+      apiKey: 'access-token',
+      authRef: TEST_HELPER_REF,
+      authType: 'oauth',
+      models: [{
+        id: 'gpt-oauth-route',
+        name: 'OAuth Route',
+        family: 'gpt',
+        brand: 'GPT',
+        modelFormat: 'openai',
+        upstreamModelId: 'gpt-oauth-route',
+      }],
+    }]);
+
+    expect(models[0]?.authRef).toBe(TEST_HELPER_REF);
   });
 
   describe('formatRegistryAuthLabel', () => {

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -1036,3 +1036,126 @@ describe('anthropic passthrough debug logging', () => {
     expect(body.system?.[1]?.text).toBe('You are helpful.');
   });
 });
+
+describe('OAuth route credential resolution', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('resolves the current token before dispatch and updates the route cache', async () => {
+    const refreshToken = vi.fn(async () => 'fresh-oauth-token');
+    const route: ProxyRoute = {
+      aliasId: 'claude-oauth-route',
+      realModelId: 'claude-oauth-route',
+      displayName: 'OAuth Route',
+      upstreamUrl: 'https://api.example.test',
+      apiKey: 'stale-oauth-token',
+      modelFormat: 'anthropic',
+      providerId: 'oauth-provider',
+      authType: 'oauth',
+      providerData: {},
+      refreshToken,
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ type: 'message', content: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+
+    const handle = await startProxyCatalog([route], route.aliasId, false);
+    try {
+      const response = await postToProxy(handle.port, handle.token, {
+        model: route.aliasId,
+        max_tokens: 100,
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: false,
+      });
+
+      expect(response.status).toBe(200);
+      expect(refreshToken).toHaveBeenCalledTimes(1);
+      expect(route.apiKey).toBe('fresh-oauth-token');
+      const [, init] = vi.mocked(fetch).mock.calls[0]!;
+      expect((init?.headers as Record<string, string>).Authorization).toBe(
+        'Bearer fresh-oauth-token',
+      );
+    } finally {
+      handle.close();
+    }
+  });
+
+  it('rebuilds the translated SDK route and retries once after an OAuth 401', async () => {
+    const refreshToken = vi.fn(async (rejectedAccessToken?: string) =>
+      rejectedAccessToken === undefined
+        ? 'rejected-oauth-token'
+        : 'fresh-oauth-token',
+    );
+    const route: ProxyRoute = {
+      aliasId: 'anthropic-oauth-provider__chat-route',
+      realModelId: 'chat-route',
+      displayName: 'OAuth Retry Route',
+      upstreamUrl: '',
+      apiKey: 'launch-token',
+      modelFormat: 'openai',
+      npm: '@ai-sdk/openai',
+      providerId: 'oauth-provider',
+      authType: 'oauth',
+      refreshToken,
+    };
+    const fetchMock = vi.fn(
+      async (_input: string | URL | Request, init?: RequestInit) => {
+        const authorization = new Headers(init?.headers).get('authorization');
+        if (authorization === 'Bearer rejected-oauth-token') {
+          return new Response(
+            JSON.stringify({ error: { message: 'expired token' } }),
+            {
+              status: 401,
+              headers: { 'Content-Type': 'application/json' },
+            },
+          );
+        }
+        return new Response(
+          [
+            'data: {"id":"chatcmpl-retry","object":"chat.completion.chunk","created":1,"model":"chat-route","choices":[{"index":0,"delta":{"role":"assistant","content":"recovered"},"finish_reason":null}]}',
+            'data: {"id":"chatcmpl-retry","object":"chat.completion.chunk","created":1,"model":"chat-route","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+            'data: [DONE]',
+            '',
+          ].join('\n\n'),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'text/event-stream' },
+          },
+        );
+      },
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const handle = await startProxyCatalog([route], route.aliasId, false);
+    try {
+      const response = await postToProxy(handle.port, handle.token, {
+        model: route.aliasId,
+        max_tokens: 100,
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: false,
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toContain('recovered');
+      expect(refreshToken).toHaveBeenNthCalledWith(1);
+      expect(refreshToken).toHaveBeenNthCalledWith(2, 'rejected-oauth-token');
+      expect(route.apiKey).toBe('fresh-oauth-token');
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(
+        fetchMock.mock.calls.map(([, init]) =>
+          new Headers(init?.headers).get('authorization'),
+        ),
+      ).toEqual(['Bearer rejected-oauth-token', 'Bearer fresh-oauth-token']);
+    } finally {
+      handle.close();
+    }
+  });
+});

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -1164,4 +1164,92 @@ describe('OAuth route credential resolution', () => {
       handle.close();
     }
   });
+
+  it('surfaces a second translated OAuth 401 without another retry', async () => {
+    const refreshToken = vi.fn(async (rejectedAccessToken?: string) =>
+      rejectedAccessToken === undefined
+        ? 'rejected-oauth-token'
+        : 'fresh-oauth-token',
+    );
+    const route: ProxyRoute = {
+      aliasId: 'anthropic-oauth-provider__gpt-3-5-turbo-second-401',
+      realModelId: 'gpt-3.5-turbo-instruct',
+      displayName: 'OAuth Second 401 Route',
+      upstreamUrl: '',
+      apiKey: 'launch-token',
+      modelFormat: 'openai',
+      npm: '@ai-sdk/openai',
+      providerId: 'oauth-provider',
+      authType: 'oauth',
+      refreshToken,
+    };
+    const fetchMock = vi.fn(async () => new Response(
+      JSON.stringify({ error: { message: 'expired token' } }),
+      {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    ));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const handle = await startProxyCatalog([route], route.aliasId, false);
+    try {
+      const response = await postToProxy(handle.port, handle.token, {
+        model: route.aliasId,
+        max_tokens: 100,
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: false,
+      });
+
+      expect(response.status).toBe(401);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(refreshToken).toHaveBeenCalledTimes(2);
+      expect(route.apiKey).toBe('fresh-oauth-token');
+    } finally {
+      handle.close();
+    }
+  });
+
+  it('refuses to retry a translated OAuth 401 with an unchanged token', async () => {
+    const refreshToken = vi.fn(async (rejectedAccessToken?: string) =>
+      rejectedAccessToken ?? 'rejected-oauth-token',
+    );
+    const route: ProxyRoute = {
+      aliasId: 'anthropic-oauth-provider__gpt-3-5-turbo-unchanged',
+      realModelId: 'gpt-3.5-turbo-instruct',
+      displayName: 'OAuth Unchanged Token Route',
+      upstreamUrl: '',
+      apiKey: 'launch-token',
+      modelFormat: 'openai',
+      npm: '@ai-sdk/openai',
+      providerId: 'oauth-provider',
+      authType: 'oauth',
+      refreshToken,
+    };
+    const fetchMock = vi.fn(async () => new Response(
+      JSON.stringify({ error: { message: 'expired token' } }),
+      {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    ));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const handle = await startProxyCatalog([route], route.aliasId, false);
+    try {
+      const response = await postToProxy(handle.port, handle.token, {
+        model: route.aliasId,
+        max_tokens: 100,
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: false,
+      });
+
+      expect(response.status).toBe(401);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(refreshToken).toHaveBeenCalledTimes(2);
+      expect(route.apiKey).toBe('rejected-oauth-token');
+    } finally {
+      handle.close();
+    }
+  });
 });

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -1101,8 +1101,8 @@ describe('OAuth route credential resolution', () => {
         : 'fresh-oauth-token',
     );
     const route: ProxyRoute = {
-      aliasId: 'anthropic-oauth-provider__chat-route',
-      realModelId: 'chat-route',
+      aliasId: 'anthropic-oauth-provider__gpt-3-5-turbo-instruct',
+      realModelId: 'gpt-3.5-turbo-instruct',
       displayName: 'OAuth Retry Route',
       upstreamUrl: '',
       apiKey: 'launch-token',
@@ -1116,7 +1116,7 @@ describe('OAuth route credential resolution', () => {
       async (_input: string | URL | Request, init?: RequestInit) => {
         const authorization = new Headers(init?.headers).get('authorization');
         if (authorization === 'Bearer rejected-oauth-token') {
-          return new Response(
+        return new Response(
             JSON.stringify({ error: { message: 'expired token' } }),
             {
               status: 401,
@@ -1124,10 +1124,10 @@ describe('OAuth route credential resolution', () => {
             },
           );
         }
-        return new Response(
+          return new Response(
           [
-            'data: {"id":"chatcmpl-retry","object":"chat.completion.chunk","created":1,"model":"chat-route","choices":[{"index":0,"delta":{"role":"assistant","content":"recovered"},"finish_reason":null}]}',
-            'data: {"id":"chatcmpl-retry","object":"chat.completion.chunk","created":1,"model":"chat-route","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+            'data: {"id":"chatcmpl-retry","object":"chat.completion.chunk","created":1,"model":"gpt-3.5-turbo-instruct","choices":[{"index":0,"delta":{"role":"assistant","content":"recovered"},"finish_reason":null}]}',
+            'data: {"id":"chatcmpl-retry","object":"chat.completion.chunk","created":1,"model":"gpt-3.5-turbo-instruct","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
             'data: [DONE]',
             '',
           ].join('\n\n'),

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -350,7 +350,10 @@ describe('catalog model aliases', () => {
 });
 
 describe('token counting', () => {
-  it('returns a local estimate for translated routes without loading or invoking the provider', async () => {
+  it('returns a local estimate for translated OAuth routes before resolving credentials', async () => {
+    const refreshToken = vi.fn(async () => {
+      throw new Error('credential resolution must not run for local token counts');
+    });
     const route: ProxyRoute = {
       aliasId: 'clodex:test:translated-model',
       realModelId: 'translated-model',
@@ -360,6 +363,8 @@ describe('token counting', () => {
       modelFormat: 'openai',
       npm: 'missing-sdk-provider-that-must-not-load',
       providerId: 'test-provider',
+      authType: 'oauth',
+      refreshToken,
     };
     const handle = await startProxyCatalog([route], route.aliasId, false);
 
@@ -372,6 +377,7 @@ describe('token counting', () => {
       expect(res.status).toBe(200);
       expect(JSON.parse(res.body)).toEqual({ input_tokens: expect.any(Number) });
       expect(JSON.parse(res.body).input_tokens).toBeGreaterThan(0);
+      expect(refreshToken).not.toHaveBeenCalled();
     } finally {
       handle.close();
     }

--- a/tests/registry-lock.test.ts
+++ b/tests/registry-lock.test.ts
@@ -12,7 +12,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { build } from 'tsup';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   RegistryLockLostError,
   getCredentialMutationLockPath,
@@ -396,6 +396,53 @@ describe('provider registry lock', () => {
       await Promise.all([first, second]);
       expect(events).toEqual(['first-enter', 'first-exit', 'second-enter']);
     } finally {
+      if (previousHome === undefined) delete process.env.CLODEX_HOME;
+      else process.env.CLODEX_HOME = previousHome;
+    }
+  });
+
+  it('waits for a credential mutation holder through the refresh budget', async () => {
+    vi.useFakeTimers();
+    const home = dirname(temporaryLockPath());
+    const previousHome = process.env.CLODEX_HOME;
+    process.env.CLODEX_HOME = home;
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let first: Promise<void> | undefined;
+    let second: Promise<void> | undefined;
+
+    try {
+      first = withCredentialMutationLock(
+        'keyring:oauth:provider:openai-oauth',
+        () => firstGate,
+      );
+      let outcome: 'pending' | 'acquired' | 'rejected' = 'pending';
+      second = withCredentialMutationLock(
+        'keyring:oauth:provider:openai-oauth',
+        () => {
+          outcome = 'acquired';
+        },
+        { retryMs: 30_000 },
+      ).catch(() => {
+        outcome = 'rejected';
+      });
+
+      await vi.advanceTimersByTimeAsync(149_999);
+      expect(outcome).toBe('pending');
+      releaseFirst();
+      await first;
+      await vi.advanceTimersByTimeAsync(1);
+      await second;
+      expect(outcome).toBe('acquired');
+    } finally {
+      releaseFirst();
+      await vi.runOnlyPendingTimersAsync();
+      await Promise.allSettled([first, second].filter(
+        (operation): operation is Promise<void> => operation !== undefined,
+      ));
+      vi.useRealTimers();
       if (previousHome === undefined) delete process.env.CLODEX_HOME;
       else process.env.CLODEX_HOME = previousHome;
     }

--- a/tests/server-router.test.ts
+++ b/tests/server-router.test.ts
@@ -6,8 +6,8 @@ import { join } from 'node:path';
 import { createGatewayModelCatalog, type ServerModelInfo } from '../src/server/models.js';
 import { startServer, type ServerHandle } from '../src/server/router.js';
 import { createLanguageModel } from '../src/provider-factory.js';
-import { generateAnthropicResponse } from '../src/sdk-adapter.js';
-import { generateOpenAiResponse } from '../src/openai-adapter.js';
+import { generateAnthropicResponse, streamAnthropicResponse } from '../src/sdk-adapter.js';
+import { generateOpenAiResponse, streamOpenAiResponse } from '../src/openai-adapter.js';
 import { resolveProviderCredential } from '../src/env.js';
 
 const TEST_HELPER_REF = `helper:v1:${'a'.repeat(64)}:oauth:provider:oauth-provider`;
@@ -32,6 +32,7 @@ vi.mock('../src/sdk-adapter.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../src/sdk-adapter.js')>();
   return {
     ...actual,
+    streamAnthropicResponse: vi.fn(async () => {}),
     generateAnthropicResponse: vi.fn(async (_model: unknown, _params: unknown, modelId: string) => ({
       id: 'msg-test',
       type: 'message',
@@ -48,6 +49,7 @@ vi.mock('../src/openai-adapter.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../src/openai-adapter.js')>();
   return {
     ...actual,
+    streamOpenAiResponse: vi.fn(async () => {}),
     generateOpenAiResponse: vi.fn(async (_model: unknown, _params: unknown, modelId: string) => ({
       id: 'chatcmpl-test',
       object: 'chat.completion',
@@ -107,6 +109,35 @@ async function startUpstream(responseBody: any): Promise<{ baseUrl: string; requ
   };
 }
 
+async function startSequencedUpstream(
+  responses: Array<{ status: number; body: unknown }>,
+): Promise<{ baseUrl: string; requests: UpstreamRequest[]; close: () => Promise<void> }> {
+  const requests: UpstreamRequest[] = [];
+  const server = createServer(async (req, res) => {
+    requests.push({
+      method: req.method ?? '',
+      url: req.url ?? '',
+      authorization: Array.isArray(req.headers.authorization)
+        ? req.headers.authorization[0]
+        : req.headers.authorization,
+      body: await readRequestBody(req),
+    });
+    const response = responses[Math.min(requests.length - 1, responses.length - 1)]!;
+    res.writeHead(response.status, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(response.body));
+  });
+
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('missing upstream address');
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    requests,
+    close: () => new Promise<void>((resolve, reject) =>
+      server.close(err => (err ? reject(err) : resolve()))),
+  };
+}
+
 const handles: Array<ServerHandle | { close: () => Promise<void> }> = [];
 
 function model(
@@ -161,6 +192,8 @@ async function closeHandle(handle: ServerHandle | { close: () => Promise<void> }
 afterEach(async () => {
   vi.mocked(createLanguageModel).mockClear();
   vi.mocked(resolveProviderCredential).mockReset();
+  vi.mocked(streamAnthropicResponse).mockClear();
+  vi.mocked(streamOpenAiResponse).mockClear();
   while (handles.length > 0) {
     const handle = handles.pop();
     if (handle) await closeHandle(handle);
@@ -444,6 +477,59 @@ describe('server router', () => {
     expect(upstream.requests[0]?.authorization).toBe('Bearer current-oauth-token');
   });
 
+  it('retries native Anthropic passthrough once with the replacement credential', async () => {
+    const upstream = await startSequencedUpstream([
+      { status: 401, body: { error: { message: 'rejected token' } } },
+      {
+        status: 200,
+        body: {
+          id: 'msg-oauth-retry',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'native oauth recovered' }],
+        },
+      },
+    ]);
+    handles.push(upstream);
+    vi.mocked(resolveProviderCredential)
+      .mockResolvedValueOnce('rejected-token')
+      .mockResolvedValueOnce('replacement-token');
+    const server = await startTestServer({
+      catalog: createGatewayModelCatalog([{
+        ...model('claude-oauth-retry', 'anthropic', 'oauth-provider', {
+          baseUrl: upstream.baseUrl,
+        }),
+        providerId: 'oauth-provider',
+        authType: 'oauth',
+        authRef: TEST_HELPER_REF,
+        apiKey: 'launch-token',
+      }]),
+    });
+
+    const response = await fetch(`${server.url}/anthropic/v1/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'claude-oauth-retry',
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ id: 'msg-oauth-retry' });
+    expect(upstream.requests.map(request => request.authorization)).toEqual([
+      'Bearer rejected-token',
+      'Bearer replacement-token',
+    ]);
+    expect(resolveProviderCredential).toHaveBeenNthCalledWith(
+      2,
+      'oauth-provider',
+      TEST_HELPER_REF,
+      undefined,
+      { rejectedAccessToken: 'rejected-token' },
+    );
+  });
+
   // OpenAI-format Anthropic translation now routes through the Vercel AI SDK adapter
   // (createLanguageModel + streamAnthropicResponse/generateAnthropicResponse), which
   // requires an SDK `npm` on the model. Translation correctness is covered by
@@ -704,6 +790,84 @@ describe('server router', () => {
     ).toEqual(['rejected-token', 'refreshed-token']);
   });
 
+  it('surfaces a second translated Anthropic-facing OAuth 401 without another retry', async () => {
+    vi.mocked(generateAnthropicResponse).mockClear();
+    vi.mocked(generateAnthropicResponse)
+      .mockRejectedValueOnce(Object.assign(new Error('rejected token'), { statusCode: 401 }))
+      .mockRejectedValueOnce(Object.assign(new Error('rejected token'), { statusCode: 401 }));
+    vi.mocked(resolveProviderCredential)
+      .mockResolvedValueOnce('rejected-token')
+      .mockResolvedValueOnce('refreshed-token');
+    const oauthCatalog = createGatewayModelCatalog([{
+      id: 'oauth-second-401-anthropic',
+      name: 'OAuth Second 401 Anthropic',
+      isFree: false,
+      brand: 'Other',
+      providerId: 'oauth-provider',
+      sourceBackend: 'oauth-provider',
+      modelFormat: 'openai',
+      npm: '@ai-sdk/openai',
+      authType: 'oauth',
+      authRef: TEST_HELPER_REF,
+      apiKey: 'launch-token',
+    }]);
+    const server = await startTestServer({ catalog: oauthCatalog });
+
+    const response = await fetch(`${server.url}/anthropic/v1/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'anthropic-oauth-provider__oauth-second-401-anthropic',
+        messages: [{ role: 'user', content: 'ping' }],
+      }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(generateAnthropicResponse).toHaveBeenCalledTimes(2);
+    expect(resolveProviderCredential).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry a translated OAuth stream after output has started', async () => {
+    vi.mocked(streamAnthropicResponse).mockImplementationOnce(
+      async (_model, _params, _modelId, write) => {
+        write('event: message_start\ndata: {"type":"message_start"}\n\n');
+        throw Object.assign(new Error('rejected token'), { statusCode: 401 });
+      },
+    );
+    vi.mocked(resolveProviderCredential).mockResolvedValue('rejected-token');
+    const oauthCatalog = createGatewayModelCatalog([{
+      id: 'oauth-stream-rejected',
+      name: 'OAuth Stream Rejected',
+      isFree: false,
+      brand: 'Other',
+      providerId: 'oauth-provider',
+      sourceBackend: 'oauth-provider',
+      modelFormat: 'openai',
+      npm: '@ai-sdk/openai',
+      authType: 'oauth',
+      authRef: TEST_HELPER_REF,
+      apiKey: 'launch-token',
+    }]);
+    const server = await startTestServer({ catalog: oauthCatalog });
+
+    const response = await fetch(`${server.url}/anthropic/v1/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'anthropic-oauth-provider__oauth-stream-rejected',
+        messages: [{ role: 'user', content: 'ping' }],
+        stream: true,
+      }),
+    });
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(body).toContain('message_start');
+    expect(body).toContain('event: error');
+    expect(streamAnthropicResponse).toHaveBeenCalledTimes(1);
+    expect(resolveProviderCredential).toHaveBeenCalledTimes(1);
+  });
+
   it('refreshes once after a translated OpenAI-facing OAuth 401', async () => {
     vi.mocked(generateOpenAiResponse).mockClear();
     vi.mocked(generateOpenAiResponse).mockRejectedValueOnce(
@@ -755,6 +919,43 @@ describe('server router', () => {
     expect(
       vi.mocked(createLanguageModel).mock.calls.map(call => (call[0] as any).apiKey),
     ).toEqual(['rejected-token', 'refreshed-token']);
+  });
+
+  it('surfaces a second translated OpenAI-facing OAuth 401 without another retry', async () => {
+    vi.mocked(generateOpenAiResponse).mockClear();
+    vi.mocked(generateOpenAiResponse)
+      .mockRejectedValueOnce(Object.assign(new Error('rejected token'), { statusCode: 401 }))
+      .mockRejectedValueOnce(Object.assign(new Error('rejected token'), { statusCode: 401 }));
+    vi.mocked(resolveProviderCredential)
+      .mockResolvedValueOnce('rejected-token')
+      .mockResolvedValueOnce('refreshed-token');
+    const oauthCatalog = createGatewayModelCatalog([{
+      id: 'oauth-second-401-openai',
+      name: 'OAuth Second 401 OpenAI',
+      isFree: false,
+      brand: 'Other',
+      providerId: 'oauth-provider',
+      sourceBackend: 'oauth-provider',
+      modelFormat: 'openai',
+      npm: '@ai-sdk/openai',
+      authType: 'oauth',
+      authRef: TEST_HELPER_REF,
+      apiKey: 'launch-token',
+    }]);
+    const server = await startTestServer({ catalog: oauthCatalog });
+
+    const response = await fetch(`${server.url}/openai/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'oauth-second-401-openai',
+        messages: [{ role: 'user', content: 'ping' }],
+      }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(generateOpenAiResponse).toHaveBeenCalledTimes(2);
+    expect(resolveProviderCredential).toHaveBeenCalledTimes(2);
   });
 
   it('does not force streaming for non-streaming requests on API-key routes', async () => {

--- a/tests/server-router.test.ts
+++ b/tests/server-router.test.ts
@@ -8,6 +8,17 @@ import { startServer, type ServerHandle } from '../src/server/router.js';
 import { createLanguageModel } from '../src/provider-factory.js';
 import { generateAnthropicResponse } from '../src/sdk-adapter.js';
 import { generateOpenAiResponse } from '../src/openai-adapter.js';
+import { resolveProviderCredential } from '../src/env.js';
+
+const TEST_HELPER_REF = `helper:v1:${'a'.repeat(64)}:oauth:provider:oauth-provider`;
+
+vi.mock('../src/env.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/env.js')>();
+  return {
+    ...actual,
+    resolveProviderCredential: vi.fn(),
+  };
+});
 
 vi.mock('../src/provider-factory.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../src/provider-factory.js')>();
@@ -149,6 +160,7 @@ async function closeHandle(handle: ServerHandle | { close: () => Promise<void> }
 
 afterEach(async () => {
   vi.mocked(createLanguageModel).mockClear();
+  vi.mocked(resolveProviderCredential).mockReset();
   while (handles.length > 0) {
     const handle = handles.pop();
     if (handle) await closeHandle(handle);
@@ -207,7 +219,16 @@ describe('server router', () => {
   });
 
   it('serves health and model list endpoints', async () => {
-    const server = await startTestServer();
+    const catalog = defaultCatalog('https://upstream.example.test');
+    const internalModel = catalog.get('claude-native');
+    if (!internalModel) throw new Error('missing test model');
+    internalModel.authRef = TEST_HELPER_REF;
+    internalModel.oauthAccountId = 'private-account-id';
+    internalModel.providerData = {
+      accountUUID: 'private-account-uuid',
+      cliUserID: 'private-user-id',
+    };
+    const server = await startTestServer({ catalog });
 
     const health = await fetch(`${server.url}/health`);
     expect(health.status).toBe(200);
@@ -215,12 +236,23 @@ describe('server router', () => {
 
     const models = await fetch(`${server.url}/models`);
     expect(models.status).toBe(200);
-    expect(await models.json()).toEqual({
+    const modelList = await models.json();
+    expect(modelList).toEqual({
       models: expect.arrayContaining([
         expect.objectContaining({ id: 'claude-native' }),
         expect.objectContaining({ id: 'openai-format' }),
       ]),
     });
+    expect(JSON.stringify(modelList)).not.toContain(TEST_HELPER_REF);
+    expect(JSON.stringify(modelList)).not.toContain('private-account');
+    expect(JSON.stringify(modelList)).not.toContain('private-user');
+    expect(modelList.models).toEqual(
+      expect.not.arrayContaining([
+        expect.objectContaining({ authRef: expect.anything() }),
+        expect.objectContaining({ oauthAccountId: expect.anything() }),
+        expect.objectContaining({ providerData: expect.anything() }),
+      ]),
+    );
 
     const anthropic = await fetch(`${server.url}/anthropic/v1/models`);
     expect(anthropic.status).toBe(200);
@@ -374,6 +406,44 @@ describe('server router', () => {
     });
   });
 
+  it('resolves the current stored token before Anthropic passthrough dispatch', async () => {
+    const upstream = await startUpstream({
+      id: 'msg-oauth',
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'text', text: 'native oauth ok' }],
+    });
+    handles.push(upstream);
+    vi.mocked(resolveProviderCredential).mockResolvedValue('current-oauth-token');
+    const server = await startTestServer({
+      catalog: createGatewayModelCatalog([{
+        ...model('claude-oauth', 'anthropic', 'oauth-provider', {
+          baseUrl: upstream.baseUrl,
+        }),
+        providerId: 'oauth-provider',
+        authType: 'oauth',
+        authRef: TEST_HELPER_REF,
+        apiKey: 'launch-token',
+      }]),
+    });
+
+    const response = await fetch(`${server.url}/anthropic/v1/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'claude-oauth',
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(resolveProviderCredential).toHaveBeenCalledWith(
+      'oauth-provider',
+      TEST_HELPER_REF,
+    );
+    expect(upstream.requests[0]?.authorization).toBe('Bearer current-oauth-token');
+  });
+
   // OpenAI-format Anthropic translation now routes through the Vercel AI SDK adapter
   // (createLanguageModel + streamAnthropicResponse/generateAnthropicResponse), which
   // requires an SDK `npm` on the model. Translation correctness is covered by
@@ -488,6 +558,203 @@ describe('server router', () => {
       expect.any(String),
       expect.objectContaining({ forceStream: true }),
     );
+  });
+
+  it('uses the exact OAuth reference and rebuilds the cached model when the token changes', async () => {
+    vi.mocked(resolveProviderCredential)
+      .mockResolvedValueOnce('oauth-token-a')
+      .mockResolvedValueOnce('oauth-token-b');
+    const oauthCatalog = createGatewayModelCatalog([
+      {
+        id: 'oauth-refresh-route',
+        name: 'OAuth Refresh Route',
+        isFree: false,
+        brand: 'Other',
+        providerId: 'oauth-provider',
+        sourceBackend: 'oauth-provider',
+        modelFormat: 'openai',
+        npm: '@ai-sdk/openai',
+        authType: 'oauth',
+        authRef: TEST_HELPER_REF,
+        apiKey: 'launch-token',
+      },
+    ]);
+    const server = await startTestServer({ catalog: oauthCatalog });
+
+    const messagesResponse = await fetch(`${server.url}/anthropic/v1/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'anthropic-oauth-provider__oauth-refresh-route',
+        messages: [{ role: 'user', content: 'first' }],
+      }),
+    });
+    expect(messagesResponse.status).toBe(200);
+
+    const chatResponse = await fetch(`${server.url}/openai/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'oauth-refresh-route',
+        messages: [{ role: 'user', content: 'second' }],
+      }),
+    });
+    expect(chatResponse.status).toBe(200);
+
+    expect(resolveProviderCredential).toHaveBeenNthCalledWith(
+      1,
+      'oauth-provider',
+      TEST_HELPER_REF,
+    );
+    expect(resolveProviderCredential).toHaveBeenNthCalledWith(
+      2,
+      'oauth-provider',
+      TEST_HELPER_REF,
+    );
+    expect(createLanguageModel).toHaveBeenCalledTimes(2);
+    expect(
+      vi.mocked(createLanguageModel).mock.calls.map(call => (call[0] as any).apiKey),
+    ).toEqual(['oauth-token-a', 'oauth-token-b']);
+  });
+
+  it('does not expose credential-state paths when token resolution fails', async () => {
+    vi.mocked(resolveProviderCredential).mockRejectedValue(
+      new Error('Timed out waiting for provider registry lock: /private/state/providers.json.lock'),
+    );
+    const oauthCatalog = createGatewayModelCatalog([{
+      id: 'oauth-resolution-failure',
+      name: 'OAuth Resolution Failure',
+      isFree: false,
+      brand: 'Other',
+      providerId: 'oauth-provider',
+      sourceBackend: 'oauth-provider',
+      modelFormat: 'openai',
+      npm: '@ai-sdk/openai',
+      authType: 'oauth',
+      authRef: TEST_HELPER_REF,
+      apiKey: 'launch-token',
+    }]);
+    const server = await startTestServer({ catalog: oauthCatalog });
+
+    const response = await fetch(`${server.url}/anthropic/v1/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'anthropic-oauth-provider__oauth-resolution-failure',
+        messages: [{ role: 'user', content: 'ping' }],
+      }),
+    });
+
+    expect(response.status).toBe(401);
+    const responseBody = JSON.stringify(await response.json());
+    expect(responseBody).toContain('OAuth credential is unavailable for oauth-provider');
+    expect(responseBody).not.toContain('/private/state');
+  });
+
+  it('refreshes once after a translated Anthropic-facing OAuth 401', async () => {
+    vi.mocked(generateAnthropicResponse).mockClear();
+    vi.mocked(generateAnthropicResponse).mockRejectedValueOnce(
+      Object.assign(new Error('rejected token'), { statusCode: 401 }),
+    );
+    vi.mocked(resolveProviderCredential)
+      .mockResolvedValueOnce('rejected-token')
+      .mockResolvedValueOnce('refreshed-token');
+    const oauthCatalog = createGatewayModelCatalog([
+      {
+        id: 'oauth-retry-anthropic',
+        name: 'OAuth Retry Anthropic',
+        isFree: false,
+        brand: 'Other',
+        providerId: 'oauth-provider',
+        sourceBackend: 'oauth-provider',
+        modelFormat: 'openai',
+        npm: '@ai-sdk/openai',
+        authType: 'oauth',
+        authRef: TEST_HELPER_REF,
+        apiKey: 'launch-token',
+      },
+    ]);
+    const server = await startTestServer({ catalog: oauthCatalog });
+
+    const response = await fetch(`${server.url}/anthropic/v1/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'anthropic-oauth-provider__oauth-retry-anthropic',
+        messages: [{ role: 'user', content: 'ping' }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(generateAnthropicResponse).toHaveBeenCalledTimes(2);
+    expect(resolveProviderCredential).toHaveBeenNthCalledWith(
+      1,
+      'oauth-provider',
+      TEST_HELPER_REF,
+    );
+    expect(resolveProviderCredential).toHaveBeenNthCalledWith(
+      2,
+      'oauth-provider',
+      TEST_HELPER_REF,
+      undefined,
+      { rejectedAccessToken: 'rejected-token' },
+    );
+    expect(
+      vi.mocked(createLanguageModel).mock.calls.map(call => (call[0] as any).apiKey),
+    ).toEqual(['rejected-token', 'refreshed-token']);
+  });
+
+  it('refreshes once after a translated OpenAI-facing OAuth 401', async () => {
+    vi.mocked(generateOpenAiResponse).mockClear();
+    vi.mocked(generateOpenAiResponse).mockRejectedValueOnce(
+      Object.assign(new Error('rejected token'), { statusCode: 401 }),
+    );
+    vi.mocked(resolveProviderCredential)
+      .mockResolvedValueOnce('rejected-token')
+      .mockResolvedValueOnce('refreshed-token');
+    const oauthCatalog = createGatewayModelCatalog([
+      {
+        id: 'oauth-retry-openai',
+        name: 'OAuth Retry OpenAI',
+        isFree: false,
+        brand: 'Other',
+        providerId: 'oauth-provider',
+        sourceBackend: 'oauth-provider',
+        modelFormat: 'openai',
+        npm: '@ai-sdk/openai',
+        authType: 'oauth',
+        authRef: TEST_HELPER_REF,
+        apiKey: 'launch-token',
+      },
+    ]);
+    const server = await startTestServer({ catalog: oauthCatalog });
+
+    const response = await fetch(`${server.url}/openai/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'oauth-retry-openai',
+        messages: [{ role: 'user', content: 'ping' }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(generateOpenAiResponse).toHaveBeenCalledTimes(2);
+    expect(resolveProviderCredential).toHaveBeenNthCalledWith(
+      1,
+      'oauth-provider',
+      TEST_HELPER_REF,
+    );
+    expect(resolveProviderCredential).toHaveBeenNthCalledWith(
+      2,
+      'oauth-provider',
+      TEST_HELPER_REF,
+      undefined,
+      { rejectedAccessToken: 'rejected-token' },
+    );
+    expect(
+      vi.mocked(createLanguageModel).mock.calls.map(call => (call[0] as any).apiKey),
+    ).toEqual(['rejected-token', 'refreshed-token']);
   });
 
   it('does not force streaming for non-streaming requests on API-key routes', async () => {

--- a/tests/upstream-forward.test.ts
+++ b/tests/upstream-forward.test.ts
@@ -80,8 +80,9 @@ describe('anthropicUpstreamHeaders', () => {
 describe('fetchWithOAuthRetry', () => {
   it('refreshes once on 401 and retries with the refreshed token', async () => {
     const refreshToken = vi.fn(async () => 'new-token');
+    const cancel = vi.fn(async () => {});
     const request = vi.fn()
-      .mockResolvedValueOnce({ status: 401 })
+      .mockResolvedValueOnce({ status: 401, body: { cancel } })
       .mockResolvedValueOnce({ status: 200 });
 
     const result = await fetchWithOAuthRetry('old-token', request, refreshToken);
@@ -89,7 +90,38 @@ describe('fetchWithOAuthRetry', () => {
     expect(result.response.status).toBe(200);
     expect(result.apiKey).toBe('new-token');
     expect(result.refreshed).toBe(true);
+    expect(refreshToken).toHaveBeenCalledWith('old-token');
     expect(request).toHaveBeenNthCalledWith(1, 'old-token');
     expect(request).toHaveBeenNthCalledWith(2, 'new-token');
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ['the rejected token', 'old-token'],
+    ['no token', null],
+  ])('does not retry when resolution returns %s', async (_label, resolved) => {
+    const refreshToken = vi.fn(async () => resolved);
+    const cancel = vi.fn(async () => {});
+    const request = vi.fn().mockResolvedValue({ status: 401, body: { cancel } });
+
+    const result = await fetchWithOAuthRetry('old-token', request, refreshToken);
+
+    expect(result.response.status).toBe(401);
+    expect(result.refreshed).toBe(false);
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(cancel).not.toHaveBeenCalled();
+  });
+
+  it('returns a second 401 without entering another refresh loop', async () => {
+    const refreshToken = vi.fn(async () => 'new-token');
+    const request = vi.fn().mockResolvedValue({ status: 401 });
+
+    const result = await fetchWithOAuthRetry('old-token', request, refreshToken);
+
+    expect(result.response.status).toBe(401);
+    expect(result.apiKey).toBe('new-token');
+    expect(result.refreshed).toBe(true);
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(refreshToken).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

- cache only access-token metadata and revalidate the shared store within 30 seconds
- resolve a replacement after an upstream authentication rejection and retry at most once before output starts
- share the replacement decision across native and translated dispatch without restructuring route-specific error handling
- preserve valid opaque JSON for non-refresh references while rejecting unknown JSON on refresh references
- strip credential references, account identifiers, and provider data from public model listings
- enforce the 30-second refresh-request timeout
- let serialized credential mutations wait through the 150-second refresh-holder budget

## Recovery guarantees

- an unchanged replacement token is never retried
- a second rejection surfaces without another refresh attempt
- a response that has started is never replayed
- concurrent refresh callers join in-flight work but re-resolve if the joined token is the caller's rejected token
- repeated compare-and-set generation changes stop at the bounded exhaustion error
- a valid refresh holder cannot make a waiting persistence operation time out at 30 seconds

## Test plan

- [x] focused authentication, route, lock, and transport regressions
- [x] complete suite: 71 files and 776 tests
- [x] type checking
- [x] production build
- [x] diff hygiene
- [x] secret and personal-identifier scans
