### PR TITLE
fix(auth): make chunked credentials crash-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,17 +214,33 @@ clodex --version    # version
 ## Configuration
 
 - Config home: `~/.clodex` (override with `CLODEX_HOME`). On first run, config is migrated automatically from a legacy `~/.relay-ai` directory if present; the legacy directory is never modified.
-- The config-home filesystem must support hard links because registry locks are
-  published atomically. Keep `CLODEX_HOME` on a local filesystem rather than
-  FAT, exFAT, or a network mount that rejects hard links. An abrupt process kill
-  during lock publication can leave a `*.lock.*.tmp` file; it does
-  not block later lock acquisition and can be removed when no Clodex process is
+- The config-home filesystem and the native account home must support hard
+  links because registry and credential locks are published atomically. Keep
+  `CLODEX_HOME` and `~/.clodex/credential-locks` on local filesystems rather
+  than FAT, exFAT, or a network mount that rejects hard links. An abrupt process
+  kill during lock publication can leave a `*.lock.*.tmp` file; it does not
+  block later lock acquisition and can be removed when no Clodex process is
   running. A canonical `providers.json.lock` whose recorded PID is no longer
-  running is reclaimed automatically on the next lock acquisition. If it remains
-  while that PID is active, stop every Clodex process and verify the recorded PID
-  before removing the lock manually. Never remove the canonical lock while a
-  Clodex process is active.
-- Credentials live in the OS credential store (Keychain / Windows Credential Manager / Secret Service) under the `clodex` service. Set `CLODEX_CREDENTIAL_HELPER` to an absolute executable path to use an external secure store instead; see [credential helpers](docs/credential-helpers.md).
+  running is reclaimed automatically on the next lock acquisition. If it
+  remains while that PID is active, stop every Clodex process and verify the
+  recorded PID before removing the lock manually. Never remove the canonical
+  lock while a Clodex process is active.
+- Credentials live in the OS credential store (Keychain / Windows Credential
+  Manager / Secret Service). The `clodex` service holds the main value or
+  published marker; `clodex-chunks` holds current long-credential chunks;
+  `clodex-journal` holds crash-recovery metadata and a deletion marker; and
+  `clodex-deleted` holds a redundant non-secret deletion guard. Use Clodex
+  provider removal instead of deleting these entries individually. Non-secret
+  per-account managed-state markers live under the native OS account home at
+  `~/.clodex/keyring-state`; before each journal write they record the exact
+  non-secret intent so a retry can replay and verify it. They also prevent a
+  temporarily unavailable keyring journal from being mistaken for an absent
+  one. Credential mutation locks live beside that state at
+  `~/.clodex/credential-locks`. Both paths are independent of `CLODEX_HOME` and
+  runtime or temporary-directory environment overrides. This keeps concurrent
+  processes serialized when they use different config homes. Set
+  `CLODEX_CREDENTIAL_HELPER` to an absolute executable path to use an external
+  secure store instead; see [credential helpers](docs/credential-helpers.md).
 - Proxied routes forward configured provider headers for API-key and OAuth authentication. Anonymous routes preserve non-credential headers while removing authorization, API-key, cookie, token, secret, and credential-bearing header names before dispatch.
 - `CLODEX_CLAUDE_PATH` overrides Claude Code binary discovery.
 - **Outbound proxy:** when `HTTP_PROXY`/`HTTPS_PROXY` (and optionally `NO_PROXY`) are set in clodex's environment, all clodex-originated network calls honor them — OAuth sign-in and token refresh, model-list and models.dev refreshes, upstream OpenAI API calls, and the ChatGPT/Codex OAuth WebSocket transport (tunneled via HTTP CONNECT).

--- a/README.md
+++ b/README.md
@@ -229,13 +229,19 @@ clodex --version    # version
   Manager / Secret Service). The `clodex` service holds the main value or
   published marker; `clodex-chunks` holds current long-credential chunks;
   `clodex-journal` holds crash-recovery metadata and a deletion marker; and
-  `clodex-deleted` holds a redundant non-secret deletion guard. Use Clodex
-  provider removal instead of deleting these entries individually. Non-secret
-  per-account managed-state markers live under the native OS account home at
-  `~/.clodex/keyring-state`; before each journal write they record the exact
-  non-secret intent so a retry can replay and verify it. They also prevent a
-  temporarily unavailable keyring journal from being mistaken for an absent
-  one. Credential mutation locks live beside that state at
+  `clodex-deleted` holds a redundant non-secret deletion guard. A
+  `clodex-state-key` entry protects each account's recovery metadata. Use
+  Clodex provider removal instead of deleting these entries individually.
+  Authenticated encrypted per-account managed-state markers live under the
+  native OS account home at `~/.clodex/keyring-state`; before each journal
+  write they record the exact recovery intent so a retry can replay and verify
+  it. The encryption key remains in the OS credential store, so the filesystem
+  marker alone cannot be used to test credential guesses. The marker also
+  prevents a temporarily unavailable keyring journal from being mistaken for
+  an absent one. If the OS credential store was completely reset, Clodex
+  permits direct reauthorization only after sentinel checks prove the main and
+  chunk namespaces are empty. Hidden, locked, or partially restored state
+  remains fail-closed. Credential mutation locks live beside that state at
   `~/.clodex/credential-locks`. Both paths are independent of `CLODEX_HOME` and
   runtime or temporary-directory environment overrides. This keeps concurrent
   processes serialized when they use different config homes. Set

--- a/docs/credential-helpers.md
+++ b/docs/credential-helpers.md
@@ -59,6 +59,68 @@ credential instances. It rejects symbolic links, foreign ownership, broad
 permissions on POSIX, files over 1 MiB, and more than 1,024 queued entries
 before attempting any credential-store deletion.
 
+## OS keyring layout and compatibility
+
+The default OS credential-store backend uses four service namespaces:
+
+- `clodex` stores a short credential directly or publishes the marker for a
+  long credential;
+- `clodex-chunks` stores the chunks for current long credentials;
+- `clodex-journal` records crash recovery, the active chunk generation, and a
+  deletion marker;
+- `clodex-deleted` stores a redundant non-secret deletion guard.
+
+Clodex also keeps a non-secret per-account managed-state marker under the
+native OS account home at `~/.clodex/keyring-state`. Before each
+cleanup-journal write, the marker records the exact non-secret journal intent.
+A retry republishes and verifies that intent before continuing, then marks it
+managed. If the OS keyring temporarily reports a managed journal as absent,
+the marker makes reads, writes, and deletes fail closed instead of replacing
+unknown chunk inventory. Malformed local intent also remains fail-closed.
+Credential mutation locks live beside that state under
+`~/.clodex/credential-locks`. Neither path depends on `CLODEX_HOME`,
+`XDG_RUNTIME_DIR`, or temporary-directory environment variables because the OS
+keyring service and account namespaces are shared across those process-local
+settings. The native account-home filesystem must support hard links so lock
+publication remains atomic.
+
+New provider credentials use a stable, versioned account instance owned by the
+provider slot and selected credential backend. A retry derives the same
+candidate, so an ambiguous result cannot make its reference unreachable.
+Provisioning resumes well-formed candidate state, while unavailable or
+malformed recovery metadata remains fail-closed. Refresh paths replace the
+registry's current account only when its prior keyring state can be confirmed.
+Reauthorization provisions the selected backend first, then updates the
+registry after read-back verification. If the keyring hides both the main value
+and its metadata, replacement and deletion stop without publishing new state
+or reporting success.
+
+The active-generation journal is live metadata, not stale debris. Clodex keeps
+one generation after a successful long-credential write so a later release can
+retire the chunks through a current provider-removal operation if an older
+release removes or replaces only the main marker. Use the Clodex
+provider-removal path instead of deleting one of these entries manually.
+
+Long chunked credentials are not readable by older releases that do not
+understand their marker format. If a downgrade removes the main marker while
+leaving chunks behind, passive resolution preserves the recorded inventory
+because a missing keyring value cannot be distinguished from a collapsed read
+error on every platform. Remove the provider with a current Clodex release
+before reauthorizing to retire the orphaned generation. A published marker that
+does not match its recovery journal fails closed and leaves every recorded
+generation intact.
+
+Clodex does not implicitly import credentials from the legacy `relay-ai`
+service. Existing legacy entries remain untouched. Reauthorize or explicitly
+save the provider credential to publish it under the `clodex` service, verify
+the new credential, and remove the old entry separately if it is no longer
+needed. Provider removal deletes only the Clodex credential. Redundant
+non-secret deletion guards keep ambiguous deleted state from becoming readable;
+an explicit later credential save clears those guards. Unknown JSON-shaped
+values in non-OAuth keyring and helper accounts remain opaque. Historical
+`wellknown` token and OAuth access envelopes retain their existing decoding
+behavior, while structured OAuth validation applies only to OAuth accounts.
+
 ## Protocol
 
 The helper receives one of these invocations:

--- a/docs/credential-helpers.md
+++ b/docs/credential-helpers.md
@@ -61,22 +61,36 @@ before attempting any credential-store deletion.
 
 ## OS keyring layout and compatibility
 
-The default OS credential-store backend uses four service namespaces:
+The default OS credential-store backend uses five service namespaces:
 
 - `clodex` stores a short credential directly or publishes the marker for a
   long credential;
 - `clodex-chunks` stores the chunks for current long credentials;
 - `clodex-journal` records crash recovery, the active chunk generation, and a
   deletion marker;
-- `clodex-deleted` stores a redundant non-secret deletion guard.
+- `clodex-deleted` stores a redundant non-secret deletion guard;
+- `clodex-state-key` stores a random per-account key that protects the
+  filesystem recovery marker.
 
-Clodex also keeps a non-secret per-account managed-state marker under the
-native OS account home at `~/.clodex/keyring-state`. Before each
-cleanup-journal write, the marker records the exact non-secret journal intent.
-A retry republishes and verifies that intent before continuing, then marks it
-managed. If the OS keyring temporarily reports a managed journal as absent,
-the marker makes reads, writes, and deletes fail closed instead of replacing
-unknown chunk inventory. Malformed local intent also remains fail-closed.
+Clodex also keeps an authenticated encrypted per-account managed-state marker
+under the native OS account home at `~/.clodex/keyring-state`. Before each
+cleanup-journal write, the marker records the exact journal intent. A retry
+decrypts, republishes, and verifies that intent before continuing, then marks
+it managed. The encryption key remains only in the OS credential store, so a
+copied filesystem marker does not expose credentials or an offline credential
+confirmation value. If the OS keyring temporarily reports a managed journal as
+absent, the marker makes reads, writes, and deletes fail closed instead of
+replacing unknown chunk inventory. Malformed or unauthenticated local intent
+also remains fail-closed.
+
+If the filesystem marker outlives a complete OS credential-store reset,
+Clodex allows direct reauthorization only after sentinel-backed service
+enumeration proves that the main credential and chunk namespaces are empty.
+The recovery first records durable deleted state, then follows the normal
+journal-before-publication path for the replacement. A hidden, locked,
+incomplete, or partially restored namespace cannot take this path and remains
+fail-closed.
+
 Credential mutation locks live beside that state under
 `~/.clodex/credential-locks`. Neither path depends on `CLODEX_HOME`,
 `XDG_RUNTIME_DIR`, or temporary-directory environment variables because the OS

--- a/src/credential-helper.ts
+++ b/src/credential-helper.ts
@@ -1,10 +1,14 @@
 import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { accessSync, constants, statSync } from 'node:fs';
-import { isAbsolute, normalize } from 'node:path';
+import { isAbsolute, normalize, resolve } from 'node:path';
+import { getAppHome } from './paths.js';
 
 export const CREDENTIAL_HELPER_ENV = 'CLODEX_CREDENTIAL_HELPER';
 export const CREDENTIAL_HELPER_SERVICE = 'clodex';
+
+const CREDENTIAL_ACCOUNT_INSTANCE_SEPARATOR = '::credential::';
+const CREDENTIAL_ACCOUNT_INSTANCE_PATTERN = /^v1:[0-9a-f]{32}$/;
 
 const HELPER_TIMEOUT_MS = 10_000;
 const HELPER_MAX_OUTPUT_BYTES = 1024 * 1024;
@@ -57,6 +61,30 @@ export function credentialAuthRef(account: string): string {
   return helper
     ? `helper:v1:${helper.id}:${account}`
     : `keyring:${account}`;
+}
+
+export function credentialInstanceAuthRef(account: string): string {
+  const configScope = createHash('sha256')
+    .update('clodex-credential-account\0')
+    .update(normalize(resolve(getAppHome())))
+    .digest('hex')
+    .slice(0, 32);
+  return credentialAuthRef(
+    `${account}${CREDENTIAL_ACCOUNT_INSTANCE_SEPARATOR}v1:${configScope}`,
+  );
+}
+
+export function isCredentialAccountInstance(account: string): boolean {
+  const separatorIndex = account.lastIndexOf(CREDENTIAL_ACCOUNT_INSTANCE_SEPARATOR);
+  if (separatorIndex <= 0) return false;
+  return CREDENTIAL_ACCOUNT_INSTANCE_PATTERN.test(
+    account.slice(separatorIndex + CREDENTIAL_ACCOUNT_INSTANCE_SEPARATOR.length),
+  );
+}
+
+export function credentialAccountBase(account: string): string {
+  if (!isCredentialAccountInstance(account)) return account;
+  return account.slice(0, account.lastIndexOf(CREDENTIAL_ACCOUNT_INSTANCE_SEPARATOR));
 }
 
 async function runCredentialHelper(

--- a/src/env.ts
+++ b/src/env.ts
@@ -1736,6 +1736,30 @@ function recoverEmptyOpaqueManagedKeyringState(
   return true;
 }
 
+function retireUnreadableManagedStateForDeletion(
+  keyring: KeyringApi,
+  account: string,
+  diag?: (msg: string) => void,
+): boolean {
+  try {
+    readKeyringManagedState(keyring, account);
+    return true;
+  } catch (err) {
+    diag?.(classifyKeyringError(err));
+    if (!(err instanceof KeyringManagedStateKeyUnavailableError)) {
+      return false;
+    }
+  }
+  try {
+    removeKeyringManagedState(account);
+    diag?.('retired unreadable managed credential metadata for explicit deletion');
+    return true;
+  } catch (err) {
+    diag?.(classifyKeyringError(err));
+    return false;
+  }
+}
+
 function writeKeyringAccountLocked(
   keyring: KeyringApi,
   account: string,
@@ -1969,6 +1993,7 @@ function deleteJournalLessManagedKeyringAccount(
   keyring: KeyringApi,
   account: string,
   diag?: (msg: string) => void,
+  retireUnreadableManagedState = false,
 ): boolean {
   const sentinels: KeyringEnumerationSentinel[] = [];
   let sentinelsRemoved = false;
@@ -2028,6 +2053,10 @@ function deleteJournalLessManagedKeyringAccount(
       }
     }
     sentinelsRemoved = true;
+    if (retireUnreadableManagedState) {
+      removeKeyringManagedState(account);
+      diag?.('retired unreadable managed credential metadata for explicit deletion');
+    }
     writeKeyringJournal(keyring, account, {
       mode: 'deleted',
       generations: [],
@@ -2066,11 +2095,11 @@ async function deleteKeyringAccount(
           managedState = readKeyringManagedState(keyring, account);
         } catch (err) {
           diag?.(classifyKeyringError(err));
-          if (
-            err instanceof KeyringManagedStateKeyUnavailableError &&
-            recoverEmptyOpaqueManagedKeyringState(keyring, account, diag)
-          ) {
-            return true;
+          if (err instanceof KeyringManagedStateKeyUnavailableError) {
+            if (recoverEmptyOpaqueManagedKeyringState(keyring, account, diag)) {
+              return true;
+            }
+            return deleteJournalLessManagedKeyringAccount(keyring, account, diag, true);
           }
           return false;
         }
@@ -2082,12 +2111,17 @@ async function deleteKeyringAccount(
             pendingJournalRaw = encodeKeyringJournal(managedState.journal);
             diag?.('restored keyring cleanup journal from managed state');
           }
+        } else if (readKeyringDeletionGuard(keyring, account) !== null) {
+          return reconcileKeyringJournal(keyring, account, diag);
         }
       }
       let pendingJournal: KeyringChunkJournal | null = null;
       try {
         if (pendingJournalRaw !== null) {
           pendingJournal = parseKeyringChunkJournal(pendingJournalRaw);
+          if (!retireUnreadableManagedStateForDeletion(keyring, account, diag)) {
+            return false;
+          }
           if (pendingJournal.mode === 'deleted') {
             return reconcileKeyringJournal(keyring, account, diag);
           }

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,6 +1,8 @@
 // src/env.ts
 import { CONFLICTING_ENV_VARS } from './constants.js';
 import { createHash, randomUUID } from 'node:crypto';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import {
   deleteCredentialHelperAccount,
   readCredentialHelperAccount,
@@ -14,7 +16,10 @@ import {
   type StoredOAuthCredential,
 } from './oauth/types.js';
 import { refreshStoredOAuthCredential, oauthCredentialShouldRefresh } from './oauth/refresh.js';
-import { withCredentialMutationLock } from './registry/lock.js';
+import {
+  withCredentialMutationLock,
+  withRegistryWriteLock,
+} from './registry/lock.js';
 import type { ConflictInfo } from './types.js';
 import { removeAnthropicProxyBypass } from './wrapper-env.js';
 
@@ -105,13 +110,37 @@ export function classifyKeyringError(err: unknown): string {
 }
 
 const KEYRING_SERVICE = 'clodex';
+const KEYRING_CHUNK_SERVICE = 'clodex-chunks';
+const KEYRING_JOURNAL_SERVICE = 'clodex-journal';
+/** One-time silent migration source: credentials stored by relay-ai. */
+const LEGACY_KEYRING_SERVICE = 'relay-ai';
 // Windows Credential Manager caps a single credential blob at 2560 bytes (CredWriteW).
 // keyring-rs encodes the password as UTF-16 (2 bytes/char) before that check, so the
 // usable limit is 2560 / 2 = 1280 chars — long OAuth tokens (e.g. OpenAI's JWTs) exceed
 // this, so secrets above the threshold are split across multiple keyring entries.
 // Harmless on macOS/Linux, which have no such limit.
 const KEYRING_CHUNK_PREFIX = '__relay_chunked__:';
-const KEYRING_CHUNK_SIZE = 1200;
+const KEYRING_JOURNAL_PREFIX = '__relay_chunk_journal__:v1:';
+const KEYRING_MAX_ENTRY_CHARS = 1200;
+const KEYRING_CHUNK_SIZE = KEYRING_MAX_ENTRY_CHARS;
+const KEYRING_MAX_CHUNKS = 128;
+const KEYRING_MAX_WRITE_GENERATIONS = 2;
+const KEYRING_MAX_DELETE_GENERATIONS = 6;
+const KEYRING_MAX_LEGACY_GENERATIONS = 4;
+const KEYRING_GENERATION_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+interface KeyringChunkMarker {
+  count: number;
+  generation?: string;
+  digest?: string;
+}
+
+interface KeyringChunkJournal {
+  mode: 'write' | 'delete';
+  generations: KeyringChunkMarker[];
+  legacyGenerations?: KeyringChunkMarker[];
+  unverifiable?: true;
+}
 
 export function providerKeyringAccount(providerId: string): string {
   return `provider:${providerId}`;
@@ -149,6 +178,25 @@ export type ParsedAuthRef =
   | { kind: 'env'; varName: string }
   | { kind: 'none' };
 
+function isReservedKeyringAccount(account: string): boolean {
+  const separator = '::chunk::';
+  const separatorIndex = account.lastIndexOf(separator);
+  if (separatorIndex <= 0) return false;
+  const suffix = account.slice(separatorIndex + separator.length);
+  const parts = suffix.split('::');
+  if (parts.length === 2 && !KEYRING_GENERATION_PATTERN.test(parts[0]!)) {
+    return false;
+  }
+  if (parts.length !== 1 && parts.length !== 2) return false;
+  const indexText = parts.at(-1)!;
+  if (!/^\d+$/.test(indexText)) return false;
+  const index = Number(indexText);
+  return Number.isSafeInteger(index)
+    && indexText === String(index)
+    && index >= 0
+    && index < KEYRING_MAX_CHUNKS;
+}
+
 export interface ResolveCredentialOptions {
   rejectedAccessToken?: string;
 }
@@ -158,7 +206,9 @@ export function parseAuthRef(authRef: string): ParsedAuthRef | null {
   if (authRef === 'none:anonymous') return { kind: 'none' };
   if (authRef.startsWith('keyring:')) {
     const account = authRef.slice('keyring:'.length);
-    return account ? { kind: 'keyring', account } : null;
+    return account && !isReservedKeyringAccount(account)
+      ? { kind: 'keyring', account }
+      : null;
   }
   if (authRef.startsWith('env:')) {
     const varName = authRef.slice('env:'.length);
@@ -215,24 +265,634 @@ function readKeyringAccountFromService(
   Entry: typeof import('@napi-rs/keyring').Entry,
   service: string,
   account: string,
+  retries = 2,
 ): string | null {
-  const value = new Entry(service, account).getPassword() ?? null;
-  if (!value?.startsWith(KEYRING_CHUNK_PREFIX)) return value;
-  const chunkCount = Number(value.slice(KEYRING_CHUNK_PREFIX.length));
-  let combined = '';
-  for (let i = 0; i < chunkCount; i++) {
-    combined += new Entry(service, `${account}::chunk::${i}`).getPassword() ?? '';
+  const accountEntry = new Entry(service, account);
+  const value = accountEntry.getPassword() ?? null;
+  const marker = parseKeyringChunkMarker(value);
+  if (!marker) return value;
+  let combined: string;
+  try {
+    combined = readKeyringMarkerChunks(Entry, service, account, marker);
+  } catch (err) {
+    if (retries > 0 && accountEntry.getPassword() !== value) {
+      return readKeyringAccountFromService(Entry, service, account, retries - 1);
+    }
+    throw err;
+  }
+  if (accountEntry.getPassword() !== value) {
+    if (retries > 0) {
+      return readKeyringAccountFromService(Entry, service, account, retries - 1);
+    }
+    throw new Error('keyring credential changed repeatedly while it was being read');
   }
   return combined;
 }
 
-async function readKeyringAccount(account: string, diag?: (msg: string) => void): Promise<string | null> {
+function readKeyringMarkerChunks(
+  Entry: typeof import('@napi-rs/keyring').Entry,
+  service: string,
+  account: string,
+  marker: KeyringChunkMarker,
+): string {
+  let combined = '';
+  const chunkService = keyringChunkService(service, marker);
+  for (let i = 0; i < marker.count; i++) {
+    const chunk = new Entry(chunkService, keyringChunkAccount(account, marker, i)).getPassword();
+    if (chunk === null) {
+      throw new Error(`keyring credential chunk ${i + 1} of ${marker.count} is missing`);
+    }
+    combined += chunk;
+  }
+  if (
+    marker.digest
+    && createHash('sha256').update(combined).digest('hex') !== marker.digest
+  ) {
+    throw new Error('keyring credential chunk digest does not match');
+  }
+  return combined;
+}
+
+function parseKeyringChunkMarker(value: string | null): KeyringChunkMarker | null {
+  if (!value?.startsWith(KEYRING_CHUNK_PREFIX)) return null;
+  const encoded = value.slice(KEYRING_CHUNK_PREFIX.length);
+  const current = /^v3:([^:]+):(\d+):([0-9a-f]{64})$/.exec(encoded);
+  const versioned = /^v2:([^:]+):(\d+)$/.exec(encoded);
+  const legacy = /^(\d+)$/.exec(encoded);
+  const countText = current?.[2] ?? versioned?.[2] ?? legacy?.[1];
+  const count = countText === undefined ? Number.NaN : Number(countText);
+  const generation = current?.[1] ?? versioned?.[1];
+  const digest = current?.[3];
+  if (
+    !Number.isSafeInteger(count)
+    || count < 1
+    || count > KEYRING_MAX_CHUNKS
+    || (generation !== undefined && !KEYRING_GENERATION_PATTERN.test(generation))
+  ) {
+    throw new Error('keyring credential has an invalid chunk marker');
+  }
+  return {
+    count,
+    ...(generation ? { generation } : {}),
+    ...(digest ? { digest } : {}),
+  };
+}
+
+function encodeKeyringChunkMarker(marker: KeyringChunkMarker): string {
+  if (!marker.generation) return `${KEYRING_CHUNK_PREFIX}${marker.count}`;
+  if (marker.digest) {
+    return `${KEYRING_CHUNK_PREFIX}v3:${marker.generation}:${marker.count}:${marker.digest}`;
+  }
+  return `${KEYRING_CHUNK_PREFIX}v2:${marker.generation}:${marker.count}`;
+}
+
+function parseJournalMarker(value: unknown): KeyringChunkMarker {
+  if (!value || typeof value !== 'object') {
+    throw new Error('keyring credential has an invalid cleanup journal');
+  }
+  const candidate = value as Partial<KeyringChunkMarker>;
+  if (
+    !Number.isSafeInteger(candidate.count)
+    || (candidate.count ?? 0) < 1
+    || (candidate.count ?? 0) > KEYRING_MAX_CHUNKS
+    || (
+      candidate.generation !== undefined
+      && (
+        typeof candidate.generation !== 'string'
+        || !KEYRING_GENERATION_PATTERN.test(candidate.generation)
+      )
+    )
+    || (
+      candidate.digest !== undefined
+      && (
+        typeof candidate.digest !== 'string'
+        || !/^[0-9a-f]{64}$/.test(candidate.digest)
+        || candidate.generation === undefined
+      )
+    )
+  ) {
+    throw new Error('keyring credential has an invalid cleanup journal');
+  }
+  return {
+    count: candidate.count!,
+    ...(candidate.generation ? { generation: candidate.generation } : {}),
+    ...(candidate.digest ? { digest: candidate.digest } : {}),
+  };
+}
+
+class InvalidKeyringJournalError extends Error {
+  constructor() {
+    super('keyring credential has an invalid cleanup journal');
+    this.name = 'InvalidKeyringJournalError';
+  }
+}
+
+function parseKeyringChunkJournal(value: string): KeyringChunkJournal {
+  if (!value.startsWith(KEYRING_JOURNAL_PREFIX)) {
+    throw new InvalidKeyringJournalError();
+  }
   try {
-    const { Entry } = await import('@napi-rs/keyring');
-    return readKeyringAccountFromService(Entry, KEYRING_SERVICE, account);
+    const parsed = JSON.parse(value.slice(KEYRING_JOURNAL_PREFIX.length)) as Partial<KeyringChunkJournal>;
+    if (
+      (parsed.mode !== 'write' && parsed.mode !== 'delete')
+      || !Array.isArray(parsed.generations)
+      || parsed.generations.length > (
+        parsed.mode === 'write'
+          ? KEYRING_MAX_WRITE_GENERATIONS
+          : KEYRING_MAX_DELETE_GENERATIONS
+      )
+      || (
+        parsed.legacyGenerations !== undefined
+        && (
+          !Array.isArray(parsed.legacyGenerations)
+          || parsed.legacyGenerations.length > KEYRING_MAX_LEGACY_GENERATIONS
+        )
+      )
+      || (parsed.mode === 'write' && parsed.generations.length < 1)
+      || (
+        parsed.mode === 'write'
+        && ((parsed.legacyGenerations?.length ?? 0) > 0 || parsed.unverifiable !== undefined)
+      )
+      || (parsed.unverifiable !== undefined && parsed.unverifiable !== true)
+    ) {
+      throw new Error('invalid');
+    }
+    const generations = parsed.generations.map(parseJournalMarker);
+    const legacyGenerations = parsed.legacyGenerations?.map(parseJournalMarker);
+    if (
+      parsed.mode === 'write'
+      && generations.some((marker, index) =>
+        generations.slice(index + 1).some(candidate =>
+          sameKeyringGeneration(marker, candidate),
+        ),
+      )
+    ) {
+      throw new Error('invalid');
+    }
+    return {
+      mode: parsed.mode,
+      generations,
+      ...(legacyGenerations
+        ? { legacyGenerations }
+        : {}),
+      ...(parsed.unverifiable ? { unverifiable: true } : {}),
+    };
+  } catch {
+    throw new InvalidKeyringJournalError();
+  }
+}
+
+function sameKeyringGeneration(
+  left: KeyringChunkMarker | null,
+  right: KeyringChunkMarker,
+): boolean {
+  return left !== null
+    && left.generation === right.generation
+    && Boolean(left.digest) === Boolean(right.digest);
+}
+
+function sameKeyringMarker(
+  left: KeyringChunkMarker,
+  right: KeyringChunkMarker,
+): boolean {
+  return sameKeyringGeneration(left, right)
+    && left.count === right.count
+    && left.digest === right.digest;
+}
+
+function appendUniqueKeyringMarker(
+  target: KeyringChunkMarker[],
+  marker: KeyringChunkMarker,
+): void {
+  const existing = target.find(candidate => sameKeyringGeneration(candidate, marker));
+  if (!existing) {
+    target.push(marker);
+    return;
+  }
+  existing.count = Math.max(existing.count, marker.count);
+  if (!existing.digest && marker.digest) existing.digest = marker.digest;
+}
+
+function encodeKeyringJournal(journal: KeyringChunkJournal): string {
+  return `${KEYRING_JOURNAL_PREFIX}${JSON.stringify(journal)}`;
+}
+
+function keyringDeleteJournalFits(
+  generations: KeyringChunkMarker[],
+  legacyGenerations: KeyringChunkMarker[],
+  unverifiable = false,
+): boolean {
+  if (
+    generations.length > KEYRING_MAX_DELETE_GENERATIONS
+    || legacyGenerations.length > KEYRING_MAX_LEGACY_GENERATIONS
+  ) {
+    return false;
+  }
+  return encodeKeyringJournal({
+    mode: 'delete',
+    generations,
+    ...(legacyGenerations.length > 0 ? { legacyGenerations } : {}),
+    ...(unverifiable ? { unverifiable: true } : {}),
+  }).length <= KEYRING_MAX_ENTRY_CHARS;
+}
+
+function keyringChunkAccount(
+  account: string,
+  marker: KeyringChunkMarker,
+  index: number,
+): string {
+  return marker.generation
+    ? `${account}::chunk::${marker.generation}::${index}`
+    : `${account}::chunk::${index}`;
+}
+
+function keyringChunkService(
+  mainService: string,
+  marker: KeyringChunkMarker,
+): string {
+  return marker.digest ? KEYRING_CHUNK_SERVICE : mainService;
+}
+
+function removeKeyringChunkRange(
+  Entry: typeof import('@napi-rs/keyring').Entry,
+  service: string,
+  account: string,
+  marker: KeyringChunkMarker,
+  firstIndex: number,
+  diag?: (msg: string) => void,
+): boolean {
+  let removed = true;
+  const chunkService = keyringChunkService(service, marker);
+  for (let i = firstIndex; i < marker.count; i++) {
+    try {
+      const entry = new Entry(chunkService, keyringChunkAccount(account, marker, i));
+      if (entry.getPassword() !== null) entry.deletePassword();
+    } catch (err) {
+      removed = false;
+      diag?.(classifyKeyringError(err));
+    }
+  }
+  return removed;
+}
+
+function removeKeyringChunks(
+  Entry: typeof import('@napi-rs/keyring').Entry,
+  service: string,
+  account: string,
+  marker: KeyringChunkMarker | null,
+  diag?: (msg: string) => void,
+): boolean {
+  if (!marker) return true;
+  return removeKeyringChunkRange(Entry, service, account, marker, 0, diag);
+}
+
+function writeKeyringJournal(
+  Entry: typeof import('@napi-rs/keyring').Entry,
+  account: string,
+  journal: KeyringChunkJournal,
+): void {
+  const entry = new Entry(KEYRING_JOURNAL_SERVICE, account);
+  const encoded = encodeKeyringJournal(journal);
+  if (encoded.length > KEYRING_MAX_ENTRY_CHARS) {
+    throw new Error('keyring cleanup journal exceeds the credential entry limit');
+  }
+  entry.setPassword(encoded);
+  if (entry.getPassword() !== encoded) {
+    throw new Error('keyring cleanup journal verification failed');
+  }
+}
+
+function reconcileKeyringJournal(
+  Entry: typeof import('@napi-rs/keyring').Entry,
+  account: string,
+  diag?: (msg: string) => void,
+): boolean {
+  const journalEntry = new Entry(KEYRING_JOURNAL_SERVICE, account);
+  const rawJournal = journalEntry.getPassword();
+  if (rawJournal === null) return true;
+  let journal = parseKeyringChunkJournal(rawJournal);
+  const accountEntry = new Entry(KEYRING_SERVICE, account);
+  const legacyAccountEntry = new Entry(LEGACY_KEYRING_SERVICE, account);
+
+  let activeMarker: KeyringChunkMarker | null = null;
+  if (journal.mode === 'delete') {
+    let currentMarker: KeyringChunkMarker | null = null;
+    let currentLegacyMarker: KeyringChunkMarker | null = null;
+    let unverifiable = journal.unverifiable === true;
+    let currentValue: string | null;
+    let currentLegacyValue: string | null;
+    try {
+      currentValue = accountEntry.getPassword();
+      currentLegacyValue = legacyAccountEntry.getPassword();
+    } catch (err) {
+      diag?.(classifyKeyringError(err));
+      return false;
+    }
+    for (const [storedValue, assign] of [
+      [currentValue, (marker: KeyringChunkMarker | null) => {
+        currentMarker = marker;
+      }],
+      [currentLegacyValue, (marker: KeyringChunkMarker | null) => {
+        currentLegacyMarker = marker;
+      }],
+    ] as const) {
+      try {
+        assign(parseKeyringChunkMarker(storedValue));
+      } catch (err) {
+        unverifiable = true;
+        diag?.(classifyKeyringError(err));
+      }
+    }
+
+    let preparedGenerations = journal.generations.map(marker => ({ ...marker }));
+    let preparedLegacyGenerations = (journal.legacyGenerations ?? []).map(marker => ({
+      ...marker,
+    }));
+    if (currentMarker) appendUniqueKeyringMarker(preparedGenerations, currentMarker);
+    if (currentLegacyMarker) {
+      appendUniqueKeyringMarker(preparedLegacyGenerations, currentLegacyMarker);
+    }
+    if (!keyringDeleteJournalFits(
+      preparedGenerations,
+      preparedLegacyGenerations,
+      unverifiable,
+    )) {
+      let compacted = true;
+      for (const marker of journal.generations) {
+        if (!removeKeyringChunks(Entry, KEYRING_SERVICE, account, marker, diag)) {
+          compacted = false;
+        }
+      }
+      for (const marker of journal.legacyGenerations ?? []) {
+        if (!removeKeyringChunks(Entry, LEGACY_KEYRING_SERVICE, account, marker, diag)) {
+          compacted = false;
+        }
+      }
+      if (!compacted) return false;
+      preparedGenerations = currentMarker ? [currentMarker] : [];
+      preparedLegacyGenerations = currentLegacyMarker ? [currentLegacyMarker] : [];
+    }
+    if (!keyringDeleteJournalFits(
+      preparedGenerations,
+      preparedLegacyGenerations,
+      unverifiable,
+    )) {
+      diag?.('keyring cleanup journal cannot represent the pending generations');
+      return false;
+    }
+    const preparedJournal: KeyringChunkJournal = {
+      mode: 'delete',
+      generations: preparedGenerations,
+      ...(preparedLegacyGenerations.length > 0
+        ? { legacyGenerations: preparedLegacyGenerations }
+        : {}),
+      ...(unverifiable ? { unverifiable: true } : {}),
+    };
+    if (encodeKeyringJournal(preparedJournal) !== rawJournal) {
+      try {
+        writeKeyringJournal(Entry, account, preparedJournal);
+      } catch (err) {
+        diag?.(classifyKeyringError(err));
+        return false;
+      }
+    }
+    journal = preparedJournal;
+    try {
+      if (accountEntry.getPassword() !== null) accountEntry.deletePassword();
+      if (legacyAccountEntry.getPassword() !== null) legacyAccountEntry.deletePassword();
+    } catch (err) {
+      diag?.(classifyKeyringError(err));
+      return false;
+    }
+  } else {
+    try {
+      activeMarker = parseKeyringChunkMarker(accountEntry.getPassword());
+    } catch (err) {
+      diag?.(classifyKeyringError(err));
+      return false;
+    }
+
+    const activeJournalMarker = activeMarker
+      ? journal.generations.find(marker => sameKeyringGeneration(activeMarker, marker))
+      : undefined;
+    if (activeMarker && activeJournalMarker) {
+      try {
+        readKeyringMarkerChunks(Entry, KEYRING_SERVICE, account, activeMarker);
+        if (
+          activeJournalMarker.count > activeMarker.count
+          && !removeKeyringChunkRange(
+            Entry,
+            KEYRING_SERVICE,
+            account,
+            activeJournalMarker,
+            activeMarker.count,
+            diag,
+          )
+        ) {
+          return false;
+        }
+      } catch (err) {
+        diag?.(classifyKeyringError(err));
+        const recoveryCandidates = [
+          ...(!sameKeyringMarker(activeMarker, activeJournalMarker)
+            ? [activeJournalMarker]
+            : []),
+          ...journal.generations.filter(marker =>
+            !sameKeyringGeneration(activeMarker, marker),
+          ),
+        ];
+        let recovered = false;
+        for (const candidate of recoveryCandidates) {
+          try {
+            readKeyringMarkerChunks(Entry, KEYRING_SERVICE, account, candidate);
+            if (
+              activeMarker.count > activeJournalMarker.count
+              && !removeKeyringChunkRange(
+                Entry,
+                KEYRING_SERVICE,
+                account,
+                activeMarker,
+                activeJournalMarker.count,
+                diag,
+              )
+            ) {
+              return false;
+            }
+            accountEntry.setPassword(encodeKeyringChunkMarker(candidate));
+            activeMarker = candidate;
+            recovered = true;
+            break;
+          } catch (candidateErr) {
+            diag?.(classifyKeyringError(candidateErr));
+          }
+        }
+        if (!recovered) return false;
+      }
+    }
+  }
+
+  let cleaned = true;
+  for (const marker of journal.generations) {
+    if (journal.mode === 'write' && sameKeyringGeneration(activeMarker, marker)) continue;
+    if (!removeKeyringChunks(Entry, KEYRING_SERVICE, account, marker, diag)) {
+      cleaned = false;
+    }
+  }
+  for (const marker of journal.legacyGenerations ?? []) {
+    if (!removeKeyringChunks(Entry, LEGACY_KEYRING_SERVICE, account, marker, diag)) {
+      cleaned = false;
+    }
+  }
+  if (!cleaned) return false;
+  if (journal.unverifiable === true) return false;
+
+  try {
+    journalEntry.deletePassword();
+    return true;
   } catch (err) {
     diag?.(classifyKeyringError(err));
-    return null;
+    return false;
+  }
+}
+
+function keyringAccountLockPath(account: string): string {
+  const identity = createHash('sha256').update(account).digest('hex');
+  return join(homedir(), '.clodex', 'keyring-locks', `${identity}.lock`);
+}
+
+async function withKeyringAccountLock<T>(
+  account: string,
+  fallback: T,
+  diag: ((msg: string) => void) | undefined,
+  operation: () => Promise<T> | T,
+): Promise<T> {
+  try {
+    return await withRegistryWriteLock(operation, {
+      lockPath: keyringAccountLockPath(account),
+    });
+  } catch {
+    diag?.('keyring credential store is busy or unavailable');
+    return fallback;
+  }
+}
+
+async function readKeyringAccount(account: string, diag?: (msg: string) => void): Promise<string | null> {
+  return withKeyringAccountLock(account, null, diag, async () => {
+    try {
+      const { Entry } = await import('@napi-rs/keyring');
+      const rawJournal = new Entry(KEYRING_JOURNAL_SERVICE, account).getPassword();
+      const pendingMode = rawJournal === null
+        ? null
+        : parseKeyringChunkJournal(rawJournal).mode;
+      const cleanupComplete = reconcileKeyringJournal(Entry, account, diag);
+      if (pendingMode === 'delete') return null;
+      const value = readKeyringAccountFromService(Entry, KEYRING_SERVICE, account);
+      if (value !== null || !cleanupComplete) return value;
+      // One-time silent migration: fall back to the relay-ai keychain service and
+      // copy the credential into the clodex service on first read.
+      let legacy: string | null = null;
+      try {
+        legacy = readKeyringAccountFromService(Entry, LEGACY_KEYRING_SERVICE, account);
+      } catch {
+        legacy = null;
+      }
+      if (legacy !== null) {
+        writeKeyringAccountLocked(Entry, account, legacy, diag);
+      }
+      return legacy;
+    } catch (err) {
+      diag?.(classifyKeyringError(err));
+      return null;
+    }
+  });
+}
+
+function replaceMalformedKeyringJournalWithTombstone(
+  Entry: typeof import('@napi-rs/keyring').Entry,
+  account: string,
+  diag?: (msg: string) => void,
+): boolean {
+  try {
+    writeKeyringJournal(Entry, account, {
+      mode: 'delete',
+      generations: [],
+      unverifiable: true,
+    });
+    diag?.('invalid keyring cleanup journal was replaced with a deletion tombstone');
+    return true;
+  } catch {
+    diag?.('invalid keyring cleanup journal could not be replaced');
+    return false;
+  }
+}
+
+function writeKeyringAccountLocked(
+  Entry: typeof import('@napi-rs/keyring').Entry,
+  account: string,
+  key: string,
+  diag?: (msg: string) => void,
+): boolean {
+  try {
+    let reconciled: boolean;
+    try {
+      reconciled = reconcileKeyringJournal(Entry, account, diag);
+    } catch (err) {
+      diag?.(classifyKeyringError(err));
+      if (err instanceof InvalidKeyringJournalError) {
+        replaceMalformedKeyringJournalWithTombstone(Entry, account, diag);
+      }
+      return false;
+    }
+    if (!reconciled) return false;
+
+    const accountEntry = new Entry(KEYRING_SERVICE, account);
+    const previousValue = accountEntry.getPassword() ?? null;
+    let previousMarker: KeyringChunkMarker | null = null;
+    try {
+      previousMarker = parseKeyringChunkMarker(previousValue);
+    } catch (err) {
+      diag?.(classifyKeyringError(err));
+      replaceMalformedKeyringJournalWithTombstone(Entry, account, diag);
+      return false;
+    }
+    if (key.length <= KEYRING_CHUNK_SIZE) {
+      if (previousMarker) {
+        writeKeyringJournal(Entry, account, {
+          mode: 'write',
+          generations: [previousMarker],
+        });
+      }
+      accountEntry.setPassword(key);
+      if (previousMarker && !reconcileKeyringJournal(Entry, account, diag)) {
+        diag?.('keyring cleanup is pending and will be retried');
+      }
+      return true;
+    }
+    const chunkCount = Math.ceil(key.length / KEYRING_CHUNK_SIZE);
+    if (chunkCount > KEYRING_MAX_CHUNKS) {
+      throw new Error('keyring credential exceeds the supported chunk count');
+    }
+    const marker: KeyringChunkMarker = {
+      count: chunkCount,
+      generation: randomUUID(),
+      digest: createHash('sha256').update(key).digest('hex'),
+    };
+    writeKeyringJournal(Entry, account, {
+      mode: 'write',
+      generations: [marker, ...(previousMarker ? [previousMarker] : [])],
+    });
+    for (let i = 0; i < chunkCount; i++) {
+      const chunk = key.slice(i * KEYRING_CHUNK_SIZE, (i + 1) * KEYRING_CHUNK_SIZE);
+      new Entry(KEYRING_CHUNK_SERVICE, keyringChunkAccount(account, marker, i)).setPassword(chunk);
+    }
+    accountEntry.setPassword(encodeKeyringChunkMarker(marker));
+    if (!reconcileKeyringJournal(Entry, account, diag)) {
+      diag?.('keyring cleanup is pending and will be retried');
+    }
+    return true;
+  } catch (err) {
+    diag?.(classifyKeyringError(err));
+    return false;
   }
 }
 
@@ -241,42 +901,98 @@ async function writeKeyringAccount(
   key: string,
   diag?: (msg: string) => void,
 ): Promise<boolean> {
-  try {
-    const { Entry } = await import('@napi-rs/keyring');
-    if (key.length <= KEYRING_CHUNK_SIZE) {
-      new Entry(KEYRING_SERVICE, account).setPassword(key);
-      return true;
+  return withKeyringAccountLock(account, false, diag, async () => {
+    try {
+      const { Entry } = await import('@napi-rs/keyring');
+      return writeKeyringAccountLocked(Entry, account, key, diag);
+    } catch (err) {
+      diag?.(classifyKeyringError(err));
+      return false;
     }
-    const chunkCount = Math.ceil(key.length / KEYRING_CHUNK_SIZE);
-    for (let i = 0; i < chunkCount; i++) {
-      const chunk = key.slice(i * KEYRING_CHUNK_SIZE, (i + 1) * KEYRING_CHUNK_SIZE);
-      new Entry(KEYRING_SERVICE, `${account}::chunk::${i}`).setPassword(chunk);
-    }
-    new Entry(KEYRING_SERVICE, account).setPassword(`${KEYRING_CHUNK_PREFIX}${chunkCount}`);
-    return true;
-  } catch (err) {
-    diag?.(classifyKeyringError(err));
-    return false;
-  }
+  });
 }
 
 async function deleteKeyringAccount(account: string, diag?: (msg: string) => void): Promise<boolean> {
-  try {
-    const { Entry } = await import('@napi-rs/keyring');
-    const value = new Entry(KEYRING_SERVICE, account).getPassword();
-    if (value === null) return true;
-    if (value?.startsWith(KEYRING_CHUNK_PREFIX)) {
-      const chunkCount = Number(value.slice(KEYRING_CHUNK_PREFIX.length));
-      for (let i = 0; i < chunkCount; i++) {
-        new Entry(KEYRING_SERVICE, `${account}::chunk::${i}`).deletePassword();
+  return withKeyringAccountLock(account, false, diag, async () => {
+    try {
+      const { Entry } = await import('@napi-rs/keyring');
+      const journalEntry = new Entry(KEYRING_JOURNAL_SERVICE, account);
+      const accountEntry = new Entry(KEYRING_SERVICE, account);
+      const legacyAccountEntry = new Entry(LEGACY_KEYRING_SERVICE, account);
+      const pendingJournalRaw = journalEntry.getPassword();
+      const initialValue = accountEntry.getPassword();
+      const initialLegacyValue = legacyAccountEntry.getPassword();
+      let pendingJournal: KeyringChunkJournal | null = null;
+      let pendingMode: KeyringChunkJournal['mode'] | null = null;
+      try {
+        if (pendingJournalRaw !== null) {
+          pendingJournal = parseKeyringChunkJournal(pendingJournalRaw);
+          pendingMode = pendingJournal.mode;
+        }
+        const cleanupComplete = reconcileKeyringJournal(Entry, account, diag);
+        if (pendingMode === 'delete' && !cleanupComplete) return false;
+        if (cleanupComplete) pendingJournal = null;
+      } catch (err) {
+        diag?.(classifyKeyringError(err));
+        if (err instanceof InvalidKeyringJournalError) {
+          replaceMalformedKeyringJournalWithTombstone(Entry, account, diag);
+        }
+        return false;
       }
+      const value = accountEntry.getPassword();
+      const legacyValue = legacyAccountEntry.getPassword();
+      const generations: KeyringChunkMarker[] = [];
+      const legacyGenerations: KeyringChunkMarker[] = [];
+      for (const marker of pendingJournal?.generations ?? []) {
+        appendUniqueKeyringMarker(generations, marker);
+      }
+      for (const marker of pendingJournal?.legacyGenerations ?? []) {
+        appendUniqueKeyringMarker(legacyGenerations, marker);
+      }
+      let unverifiable = pendingJournal?.unverifiable === true;
+      for (const [storedValue, target] of [
+        ...(pendingMode === 'delete'
+          ? []
+          : [
+            [initialValue, generations],
+            [initialLegacyValue, legacyGenerations],
+          ] as const),
+        [value, generations],
+        [legacyValue, legacyGenerations],
+      ] as const) {
+        try {
+          const marker = parseKeyringChunkMarker(storedValue);
+          if (marker) appendUniqueKeyringMarker(target, marker);
+        } catch (err) {
+          unverifiable = true;
+          diag?.(classifyKeyringError(err));
+        }
+      }
+      if (
+        value === null
+        && legacyValue === null
+        && generations.length === 0
+        && legacyGenerations.length === 0
+        && !unverifiable
+      ) {
+        return true;
+      }
+      if (!keyringDeleteJournalFits(generations, legacyGenerations, unverifiable)) {
+        diag?.('keyring cleanup has too many pending generations');
+        return false;
+      }
+      writeKeyringJournal(Entry, account, {
+        mode: 'delete',
+        generations,
+        ...(legacyGenerations.length > 0 ? { legacyGenerations } : {}),
+        ...(unverifiable ? { unverifiable: true } : {}),
+      });
+      return reconcileKeyringJournal(Entry, account, diag);
+    } catch (err) {
+      diag?.(classifyKeyringError(err));
+      return false;
     }
-    new Entry(KEYRING_SERVICE, account).deletePassword();
-    return true;
-  } catch (err) {
-    diag?.(classifyKeyringError(err));
-    return false;
-  }
+  });
 }
 
 type StoredCredentialRef = Extract<ParsedAuthRef, { kind: 'keyring' | 'helper' }>;

--- a/src/env.ts
+++ b/src/env.ts
@@ -670,6 +670,19 @@ function writeKeyringJournal(
   persistKeyringManagedState(account, { mode: 'managed' });
 }
 
+function adoptKeyringJournal(
+  keyring: KeyringApi,
+  account: string,
+  journal: KeyringChunkJournal,
+  diag?: (msg: string) => void,
+): void {
+  try {
+    writeKeyringJournal(keyring, account, journal);
+  } catch (err) {
+    diag?.(classifyKeyringError(err));
+  }
+}
+
 function readKeyringDeletionGuard(
   keyring: KeyringApi,
   account: string,
@@ -714,12 +727,23 @@ function reconcileKeyringJournal(
     }
   }
   const deletionGuard = readKeyringDeletionGuard(keyring, account);
+  if (rawJournal === null && deletionGuard === null && managedState !== null) {
+    const confirmedJournal = readKeyringEntry(keyring, KEYRING_JOURNAL_SERVICE, account);
+    if (confirmedJournal !== null) {
+      diag?.('managed keyring cleanup metadata was temporarily unavailable');
+      return false;
+    }
+    try {
+      removeKeyringManagedState(account);
+      diag?.('removed stale keyring managed-state marker');
+    } catch (err) {
+      diag?.(classifyKeyringError(err));
+      return false;
+    }
+    return true;
+  }
   if (rawJournal === null) {
     if (deletionGuard === null) {
-      if (managedState !== null) {
-        diag?.('managed keyring cleanup metadata is temporarily unavailable');
-        return false;
-      }
       return true;
     }
     const restoredJournal: KeyringChunkJournal =
@@ -1286,17 +1310,27 @@ async function readKeyringAccount(
       const marker = parseKeyringChunkMarker(rawValue);
       if (marker) {
         const value = readKeyringAccountFromService(keyring, KEYRING_SERVICE, account);
-        writeKeyringJournal(keyring, account, {
-          mode: 'write',
-          generations: [marker],
-        });
+        adoptKeyringJournal(
+          keyring,
+          account,
+          {
+            mode: 'write',
+            generations: [marker],
+          },
+          diag,
+        );
         return value;
       }
-      writeKeyringJournal(keyring, account, {
-        mode: 'short',
-        generations: [],
-        shortDigest: createHash('sha256').update(rawValue).digest('hex'),
-      });
+      adoptKeyringJournal(
+        keyring,
+        account,
+        {
+          mode: 'short',
+          generations: [],
+          shortDigest: createHash('sha256').update(rawValue).digest('hex'),
+        },
+        diag,
+      );
       return rawValue;
     } catch (err) {
       diag?.(classifyKeyringError(err));
@@ -1555,7 +1589,9 @@ async function deleteKeyringAccount(
       if (pendingJournalRaw === null && readKeyringManagedState(account) !== null) {
         if (!reconcileKeyringJournal(keyring, account, diag)) return false;
         pendingJournalRaw = readKeyringEntry(keyring, KEYRING_JOURNAL_SERVICE, account);
-        if (pendingJournalRaw === null) return false;
+        if (pendingJournalRaw === null) {
+          return readKeyringManagedState(account) === null;
+        }
       }
       let pendingJournal: KeyringChunkJournal | null = null;
       try {

--- a/src/env.ts
+++ b/src/env.ts
@@ -137,6 +137,7 @@ const KEYRING_PENDING_DELETE_VALUE = 'v1:pending';
 const KEYRING_CHUNK_PREFIX = '__relay_chunked__:';
 const KEYRING_JOURNAL_PREFIX = '__relay_chunk_journal__:v1:';
 const KEYRING_DELETE_TOMBSTONE_PREFIX = '__clodex_delete__:';
+const KEYRING_ENUMERATION_SENTINEL_PREFIX = '__clodex_inventory__:';
 const KEYRING_MAX_ENTRY_CHARS = 1200;
 const KEYRING_CHUNK_SIZE = KEYRING_MAX_ENTRY_CHARS;
 const KEYRING_MAX_CHUNKS = 128;
@@ -315,6 +316,63 @@ function hasUnjournaledKeyringChunks(keyring: KeyringApi, account: string): bool
           credential.account.startsWith(prefix) && isReservedKeyringAccount(credential.account),
       ),
   );
+}
+
+function listUnjournaledKeyringChunks(
+  keyring: KeyringApi,
+  account: string,
+): Array<{ service: string; account: string }> {
+  const prefix = `${account}::chunk::`;
+  return [KEYRING_SERVICE, KEYRING_CHUNK_SERVICE].flatMap(service =>
+    keyring
+      .findCredentials(service)
+      .filter(
+        credential =>
+          credential.account.startsWith(prefix) && isReservedKeyringAccount(credential.account),
+      )
+      .map(credential => ({ service, account: credential.account })),
+  );
+}
+
+interface KeyringEnumerationSentinel {
+  service: string;
+  account: string;
+  value: string;
+}
+
+function createKeyringEnumerationSentinel(
+  service: string,
+  account: string,
+): KeyringEnumerationSentinel {
+  return {
+    service,
+    account: `${account}::chunk::${randomUUID()}::0`,
+    value: `${KEYRING_ENUMERATION_SENTINEL_PREFIX}${randomUUID()}`,
+  };
+}
+
+function writeKeyringEnumerationSentinel(
+  keyring: KeyringApi,
+  sentinel: KeyringEnumerationSentinel,
+): void {
+  new keyring.Entry(sentinel.service, sentinel.account).setPassword(sentinel.value);
+  if (readKeyringEntry(keyring, sentinel.service, sentinel.account) !== sentinel.value) {
+    throw new Error('keyring credential inventory sentinel could not be verified');
+  }
+}
+
+function sameKeyringEnumerationEntry(
+  entry: { service: string; account: string },
+  sentinel: KeyringEnumerationSentinel,
+): boolean {
+  return entry.service === sentinel.service && entry.account === sentinel.account;
+}
+
+function removeKeyringEnumerationSentinel(
+  keyring: KeyringApi,
+  sentinel: KeyringEnumerationSentinel,
+): boolean {
+  return deleteKeyringEntry(keyring, sentinel.service, sentinel.account);
 }
 
 function isDisposableCredentialProbeAccount(account: string): boolean {
@@ -667,7 +725,7 @@ function writeKeyringJournal(
   if (readKeyringEntry(keyring, KEYRING_JOURNAL_SERVICE, account) !== encoded) {
     throw new Error('keyring cleanup journal verification failed');
   }
-  persistKeyringManagedState(account, { mode: 'managed' });
+  persistKeyringManagedState(account, { mode: 'managed', journal });
 }
 
 function adoptKeyringJournal(
@@ -720,28 +778,26 @@ function reconcileKeyringJournal(
     try {
       writeKeyringJournal(keyring, account, managedState.journal);
       rawJournal = encodeKeyringJournal(managedState.journal);
-      managedState = { mode: 'managed' };
+      managedState = { mode: 'managed', journal: managedState.journal };
+    } catch (err) {
+      diag?.(classifyKeyringError(err));
+      return false;
+    }
+  } else if (rawJournal === null && managedState?.mode === 'managed') {
+    if (managedState.journal === null) {
+      diag?.('managed keyring state has no recoverable cleanup journal');
+      return false;
+    }
+    try {
+      writeKeyringJournal(keyring, account, managedState.journal);
+      rawJournal = encodeKeyringJournal(managedState.journal);
+      diag?.('restored keyring cleanup journal from managed state');
     } catch (err) {
       diag?.(classifyKeyringError(err));
       return false;
     }
   }
   const deletionGuard = readKeyringDeletionGuard(keyring, account);
-  if (rawJournal === null && deletionGuard === null && managedState !== null) {
-    const confirmedJournal = readKeyringEntry(keyring, KEYRING_JOURNAL_SERVICE, account);
-    if (confirmedJournal !== null) {
-      diag?.('managed keyring cleanup metadata was temporarily unavailable');
-      return false;
-    }
-    try {
-      removeKeyringManagedState(account);
-      diag?.('removed stale keyring managed-state marker');
-    } catch (err) {
-      diag?.(classifyKeyringError(err));
-      return false;
-    }
-    return true;
-  }
   if (rawJournal === null) {
     if (deletionGuard === null) {
       return true;
@@ -758,15 +814,20 @@ function reconcileKeyringJournal(
           };
     writeKeyringJournal(keyring, account, restoredJournal);
     rawJournal = encodeKeyringJournal(restoredJournal);
-  } else if (managedState?.mode !== 'managed') {
+  }
+  let journal = parseKeyringChunkJournal(rawJournal);
+  if (
+    managedState?.mode !== 'managed' ||
+    managedState.journal === null ||
+    encodeKeyringJournal(managedState.journal) !== rawJournal
+  ) {
     try {
-      persistKeyringManagedState(account, { mode: 'managed' });
+      persistKeyringManagedState(account, { mode: 'managed', journal });
     } catch (err) {
       diag?.(classifyKeyringError(err));
       return false;
     }
   }
-  let journal = parseKeyringChunkJournal(rawJournal);
   const accountEntry = new keyring.Entry(KEYRING_SERVICE, account);
 
   if (journal.mode === 'deleted') {
@@ -1147,10 +1208,11 @@ function reconcileKeyringJournal(
 }
 
 const KEYRING_PREPARING_STATE_PREFIX = 'v1:preparing:';
-const KEYRING_MANAGED_STATE_VALUE = 'v1:managed\n';
+const KEYRING_MANAGED_STATE_PREFIX = 'v1:managed:';
+const KEYRING_EMPTY_MANAGED_STATE_VALUE = 'v1:managed\n';
 type KeyringManagedState =
   | { mode: 'preparing'; journal: KeyringChunkJournal }
-  | { mode: 'managed' };
+  | { mode: 'managed'; journal: KeyringChunkJournal | null };
 
 function keyringAccountIdentity(account: string): string {
   return createHash('sha256').update(account).digest('hex');
@@ -1163,18 +1225,25 @@ function keyringManagedStatePath(account: string): string {
 function readKeyringManagedState(account: string): KeyringManagedState | null {
   try {
     const value = readFileSync(keyringManagedStatePath(account), 'utf8');
-    if (value === KEYRING_MANAGED_STATE_VALUE) return { mode: 'managed' };
-    if (value.startsWith(KEYRING_PREPARING_STATE_PREFIX) && value.endsWith('\n')) {
-      const encodedJournal = value.slice(KEYRING_PREPARING_STATE_PREFIX.length, -1);
+    if (value === KEYRING_EMPTY_MANAGED_STATE_VALUE) {
+      return { mode: 'managed', journal: null };
+    }
+    const statePrefix = value.startsWith(KEYRING_PREPARING_STATE_PREFIX)
+      ? KEYRING_PREPARING_STATE_PREFIX
+      : value.startsWith(KEYRING_MANAGED_STATE_PREFIX)
+        ? KEYRING_MANAGED_STATE_PREFIX
+        : null;
+    if (statePrefix && value.endsWith('\n')) {
+      const encodedJournal = value.slice(statePrefix.length, -1);
       try {
         const rawJournal = Buffer.from(encodedJournal, 'base64url').toString('utf8');
         if (Buffer.from(rawJournal, 'utf8').toString('base64url') !== encodedJournal) {
           throw new Error('non-canonical encoding');
         }
-        return {
-          mode: 'preparing',
-          journal: parseKeyringChunkJournal(rawJournal),
-        };
+        const journal = parseKeyringChunkJournal(rawJournal);
+        return statePrefix === KEYRING_PREPARING_STATE_PREFIX
+          ? { mode: 'preparing', journal }
+          : { mode: 'managed', journal };
       } catch {
         throw new Error('keyring managed-state marker is invalid');
       }
@@ -1187,11 +1256,15 @@ function readKeyringManagedState(account: string): KeyringManagedState | null {
 }
 
 function encodeKeyringManagedState(state: KeyringManagedState): string {
-  if (state.mode === 'managed') return KEYRING_MANAGED_STATE_VALUE;
-  const encodedJournal = Buffer.from(encodeKeyringJournal(state.journal), 'utf8').toString(
-    'base64url',
-  );
-  return `${KEYRING_PREPARING_STATE_PREFIX}${encodedJournal}\n`;
+  if (state.mode === 'managed' && state.journal === null) {
+    return KEYRING_EMPTY_MANAGED_STATE_VALUE;
+  }
+  const journal = state.journal;
+  if (journal === null) return KEYRING_EMPTY_MANAGED_STATE_VALUE;
+  const encodedJournal = Buffer.from(encodeKeyringJournal(journal), 'utf8').toString('base64url');
+  const prefix =
+    state.mode === 'preparing' ? KEYRING_PREPARING_STATE_PREFIX : KEYRING_MANAGED_STATE_PREFIX;
+  return `${prefix}${encodedJournal}\n`;
 }
 
 function syncDirectory(path: string): void {
@@ -1577,6 +1650,102 @@ async function writeKeyringAccount(
   });
 }
 
+function deleteJournalLessManagedKeyringAccount(
+  keyring: KeyringApi,
+  account: string,
+  diag?: (msg: string) => void,
+): boolean {
+  const sentinels: KeyringEnumerationSentinel[] = [];
+  let sentinelsRemoved = false;
+  try {
+    for (const service of [KEYRING_SERVICE, KEYRING_CHUNK_SERVICE]) {
+      const sentinel = createKeyringEnumerationSentinel(service, account);
+      sentinels.push(sentinel);
+      writeKeyringEnumerationSentinel(keyring, sentinel);
+    }
+    const currentValue = readKeyringEntry(keyring, KEYRING_SERVICE, account);
+    const currentMarker = parseKeyringChunkMarker(currentValue);
+    // The keyring binding returns a complete service snapshot or an error. Sentinels detect
+    // backends that make this account namespace temporarily invisible without throwing.
+    const inventory = listUnjournaledKeyringChunks(keyring, account);
+    if (
+      sentinels.some(
+        sentinel => !inventory.some(entry => sameKeyringEnumerationEntry(entry, sentinel)),
+      )
+    ) {
+      diag?.('keyring credential chunk inventory could not be verified');
+      return false;
+    }
+    const chunks = inventory.filter(
+      entry => !sentinels.some(sentinel => sameKeyringEnumerationEntry(entry, sentinel)),
+    );
+    if (currentMarker) {
+      const chunkService = keyringChunkService(KEYRING_SERVICE, currentMarker);
+      for (let index = 0; index < currentMarker.count; index++) {
+        const chunkAccount = keyringChunkAccount(account, currentMarker, index);
+        if (
+          !chunks.some(chunk => chunk.service === chunkService && chunk.account === chunkAccount)
+        ) {
+          diag?.('keyring credential chunk inventory could not be verified');
+          return false;
+        }
+      }
+    }
+    if (!writeKeyringDeletionGuard(keyring, account, 'deleted')) {
+      diag?.('keyring deletion guard could not be verified');
+      return false;
+    }
+    if (!deleteKeyringEntry(keyring, KEYRING_SERVICE, account)) {
+      diag?.('keyring credential deletion could not be verified');
+      return false;
+    }
+    for (const chunk of chunks) {
+      if (!deleteKeyringEntry(keyring, chunk.service, chunk.account)) {
+        diag?.('keyring credential chunk deletion could not be verified');
+        return false;
+      }
+    }
+    const remainingInventory = listUnjournaledKeyringChunks(keyring, account);
+    if (
+      sentinels.some(
+        sentinel =>
+          !remainingInventory.some(entry => sameKeyringEnumerationEntry(entry, sentinel)),
+      ) ||
+      remainingInventory.some(
+        entry => !sentinels.some(sentinel => sameKeyringEnumerationEntry(entry, sentinel)),
+      )
+    ) {
+      diag?.('keyring credential chunk deletion could not be verified');
+      return false;
+    }
+    for (const sentinel of sentinels) {
+      if (!removeKeyringEnumerationSentinel(keyring, sentinel)) {
+        diag?.('keyring credential inventory sentinel could not be removed');
+        return false;
+      }
+    }
+    sentinelsRemoved = true;
+    writeKeyringJournal(keyring, account, {
+      mode: 'deleted',
+      generations: [],
+    });
+    return true;
+  } catch (err) {
+    diag?.(classifyKeyringError(err));
+    return false;
+  } finally {
+    if (!sentinelsRemoved) {
+      for (const sentinel of sentinels) {
+        try {
+          new keyring.Entry(sentinel.service, sentinel.account).deletePassword();
+        } catch (err) {
+          diag?.(classifyKeyringError(err));
+        }
+      }
+    }
+  }
+}
+
 async function deleteKeyringAccount(
   account: string,
   diag?: (msg: string) => void,
@@ -1586,11 +1755,16 @@ async function deleteKeyringAccount(
     try {
       const keyring = await import('@napi-rs/keyring');
       let pendingJournalRaw = readKeyringEntry(keyring, KEYRING_JOURNAL_SERVICE, account);
-      if (pendingJournalRaw === null && readKeyringManagedState(account) !== null) {
-        if (!reconcileKeyringJournal(keyring, account, diag)) return false;
-        pendingJournalRaw = readKeyringEntry(keyring, KEYRING_JOURNAL_SERVICE, account);
-        if (pendingJournalRaw === null) {
-          return readKeyringManagedState(account) === null;
+      if (pendingJournalRaw === null) {
+        const managedState = readKeyringManagedState(account);
+        if (managedState !== null) {
+          if (managedState.journal === null) {
+            return deleteJournalLessManagedKeyringAccount(keyring, account, diag);
+          } else {
+            writeKeyringJournal(keyring, account, managedState.journal);
+            pendingJournalRaw = encodeKeyringJournal(managedState.journal);
+            diag?.('restored keyring cleanup journal from managed state');
+          }
         }
       }
       let pendingJournal: KeyringChunkJournal | null = null;

--- a/src/env.ts
+++ b/src/env.ts
@@ -310,8 +310,14 @@ function readKeyringEntry(keyring: KeyringApi, service: string, account: string)
 
 function deleteKeyringEntry(keyring: KeyringApi, service: string, account: string): boolean {
   const entry = new keyring.Entry(service, account);
-  if (!persistKeyringDeletionTombstone(keyring, service, account)) return false;
-  return entry.deletePassword();
+  const existing = readKeyringEntry(keyring, service, account);
+  if (existing === null) {
+    entry.deletePassword();
+    return readKeyringEntry(keyring, service, account) === null;
+  }
+  if (!persistKeyringDeletionTombstone(keyring, service, account, existing)) return false;
+  if (!entry.deletePassword()) return false;
+  return readKeyringEntry(keyring, service, account) === null;
 }
 
 function hasUnjournaledKeyringChunks(keyring: KeyringApi, account: string): boolean {
@@ -329,7 +335,7 @@ function hasUnjournaledKeyringChunks(keyring: KeyringApi, account: string): bool
 function listUnjournaledKeyringChunks(
   keyring: KeyringApi,
   account: string,
-): Array<{ service: string; account: string }> {
+): Array<{ service: string; account: string; value: string }> {
   const prefix = `${account}::chunk::`;
   return [KEYRING_SERVICE, KEYRING_CHUNK_SERVICE].flatMap(service =>
     keyring
@@ -338,7 +344,11 @@ function listUnjournaledKeyringChunks(
         credential =>
           credential.account.startsWith(prefix) && isReservedKeyringAccount(credential.account),
       )
-      .map(credential => ({ service, account: credential.account })),
+      .map(credential => ({
+        service,
+        account: credential.account,
+        value: credential.password,
+      })),
   );
 }
 
@@ -352,10 +362,11 @@ function createKeyringEnumerationSentinel(
   service: string,
   account: string,
 ): KeyringEnumerationSentinel {
+  const generation = randomUUID();
   return {
     service,
-    account: `${account}::chunk::${randomUUID()}::0`,
-    value: `${KEYRING_ENUMERATION_SENTINEL_PREFIX}${randomUUID()}`,
+    account: `${account}::chunk::${generation}::0`,
+    value: `${KEYRING_ENUMERATION_SENTINEL_PREFIX}${generation}`,
   };
 }
 
@@ -380,7 +391,42 @@ function removeKeyringEnumerationSentinel(
   keyring: KeyringApi,
   sentinel: KeyringEnumerationSentinel,
 ): boolean {
-  return deleteKeyringEntry(keyring, sentinel.service, sentinel.account);
+  const current = readKeyringEntry(keyring, sentinel.service, sentinel.account);
+  if (current === null) return true;
+  if (current !== sentinel.value) return false;
+  if (!new keyring.Entry(sentinel.service, sentinel.account).deletePassword()) {
+    return false;
+  }
+  return readKeyringEntry(keyring, sentinel.service, sentinel.account) === null;
+}
+
+function isKeyringInventoryBookkeepingEntry(
+  entry: { account: string; value: string },
+  ownerAccount: string,
+): boolean {
+  const accountPrefix = `${ownerAccount}::chunk::`;
+  const accountSuffix = '::0';
+  if (!entry.account.startsWith(accountPrefix) || !entry.account.endsWith(accountSuffix)) {
+    return false;
+  }
+  const generation = entry.account.slice(accountPrefix.length, -accountSuffix.length);
+  return (
+    KEYRING_GENERATION_PATTERN.test(generation) &&
+    entry.value === `${KEYRING_ENUMERATION_SENTINEL_PREFIX}${generation}`
+  );
+}
+
+function removeKeyringBookkeepingEntry(
+  keyring: KeyringApi,
+  ownerAccount: string,
+  entry: { service: string; account: string; value: string },
+): boolean {
+  if (!isKeyringInventoryBookkeepingEntry(entry, ownerAccount)) return false;
+  if (readKeyringEntry(keyring, entry.service, entry.account) !== entry.value) return false;
+  if (!new keyring.Entry(entry.service, entry.account).deletePassword()) {
+    return false;
+  }
+  return readKeyringEntry(keyring, entry.service, entry.account) === null;
 }
 
 function verifyEmptyKeyringCredentialInventory(
@@ -403,11 +449,26 @@ function verifyEmptyKeyringCredentialInventory(
       inventory.some(entry => sameKeyringEnumerationEntry(entry, sentinel)),
     );
     const credentialEntries = inventory.filter(
-      entry => !sentinels.some(sentinel => sameKeyringEnumerationEntry(entry, sentinel)),
+      entry =>
+        !sentinels.some(sentinel => sameKeyringEnumerationEntry(entry, sentinel)) &&
+        !isKeyringInventoryBookkeepingEntry(entry, account),
     );
+    const bookkeepingEntries = inventory.filter(
+      entry =>
+        !sentinels.some(sentinel => sameKeyringEnumerationEntry(entry, sentinel)) &&
+        isKeyringInventoryBookkeepingEntry(entry, account),
+    );
+    for (const entry of bookkeepingEntries) {
+      if (!removeKeyringBookkeepingEntry(keyring, account, entry)) {
+        cleanupComplete = false;
+        diag?.('keyring credential inventory bookkeeping could not be removed');
+      }
+    }
     empty = complete && currentValue === null && credentialEntries.length === 0;
     if (!complete) {
       diag?.('keyring credential inventory could not be verified');
+    } else if (!empty) {
+      diag?.('keyring credential inventory is not empty');
     }
   } catch (err) {
     diag?.(classifyKeyringError(err));
@@ -440,9 +501,9 @@ function persistKeyringDeletionTombstone(
   keyring: KeyringApi,
   service: string,
   account: string,
+  existing: string,
 ): boolean {
-  const existing = readKeyringEntry(keyring, service, account);
-  if (existing?.startsWith(KEYRING_DELETE_TOMBSTONE_PREFIX)) return true;
+  if (existing.startsWith(KEYRING_DELETE_TOMBSTONE_PREFIX)) return true;
   const tombstone = `${KEYRING_DELETE_TOMBSTONE_PREFIX}${randomUUID()}`;
   new keyring.Entry(service, account).setPassword(tombstone);
   return readKeyringEntry(keyring, service, account) === tombstone;
@@ -1186,7 +1247,24 @@ function reconcileKeyringJournal(
     }
   }
   if (!cleaned) return false;
-  if (journal.unverifiable === true) return false;
+  if (journal.unverifiable === true) {
+    if (!verifyEmptyKeyringCredentialInventory(keyring, account, diag)) {
+      return false;
+    }
+    const verifiedDelete: KeyringChunkJournal = {
+      mode: 'delete',
+      generations: [],
+      ...(journal.blockLegacy ? { blockLegacy: true } : {}),
+    };
+    try {
+      writeKeyringJournal(keyring, account, verifiedDelete);
+      journal = verifiedDelete;
+      diag?.('retired unverifiable credential metadata after verifying an empty keyring');
+    } catch (err) {
+      diag?.(classifyKeyringError(err));
+      return false;
+    }
+  }
 
   if (journal.mode === 'delete' && journal.blockLegacy === true) {
     try {
@@ -1296,12 +1374,12 @@ function keyringManagedStatePath(account: string): string {
 
 function parseKeyringManagedStateKey(value: string): Buffer {
   if (!value.startsWith(KEYRING_MANAGED_STATE_KEY_PREFIX)) {
-    throw new Error('keyring managed-state encryption key is invalid');
+    throw new KeyringManagedStateKeyUnavailableError();
   }
   const encoded = value.slice(KEYRING_MANAGED_STATE_KEY_PREFIX.length);
   const key = Buffer.from(encoded, 'base64url');
   if (key.length !== 32 || key.toString('base64url') !== encoded) {
-    throw new Error('keyring managed-state encryption key is invalid');
+    throw new KeyringManagedStateKeyUnavailableError();
   }
   return key;
 }
@@ -1312,7 +1390,13 @@ function readKeyringManagedStateKey(keyring: KeyringApi, account: string): Buffe
 }
 
 function ensureKeyringManagedStateKey(keyring: KeyringApi, account: string): Buffer {
-  const current = readKeyringManagedStateKey(keyring, account);
+  let current: Buffer | null;
+  try {
+    current = readKeyringManagedStateKey(keyring, account);
+  } catch (err) {
+    if (!(err instanceof KeyringManagedStateKeyUnavailableError)) throw err;
+    current = null;
+  }
   if (current !== null) return current;
   const key = randomBytes(32);
   const encoded = `${KEYRING_MANAGED_STATE_KEY_PREFIX}${key.toString('base64url')}`;
@@ -1577,7 +1661,7 @@ async function readKeyringAccount(
   });
 }
 
-function replaceMalformedKeyringJournalWithTombstone(
+function persistUnverifiableKeyringDeletion(
   keyring: KeyringApi,
   account: string,
   diag?: (msg: string) => void,
@@ -1590,10 +1674,10 @@ function replaceMalformedKeyringJournalWithTombstone(
       ...(blockLegacy ? { blockLegacy: true } : {}),
       unverifiable: true,
     });
-    diag?.('invalid keyring cleanup journal was replaced with a deletion tombstone');
+    diag?.('unverifiable credential state was marked for verified deletion');
     return true;
   } catch {
-    diag?.('invalid keyring cleanup journal could not be replaced');
+    diag?.('unverifiable credential state could not be marked for deletion');
     return false;
   }
 }
@@ -1709,9 +1793,6 @@ function writeKeyringAccountLocked(
         recoverEmptyOpaqueManagedKeyringState(keyring, account, diag)
       ) {
         reconciled = reconcileKeyringJournal(keyring, account, diag);
-      } else if (err instanceof InvalidKeyringJournalError) {
-        replaceMalformedKeyringJournalWithTombstone(keyring, account, diag);
-        return false;
       } else {
         return false;
       }
@@ -1794,7 +1875,7 @@ function writeKeyringAccountLocked(
       }
     } catch (err) {
       diag?.(classifyKeyringError(err));
-      replaceMalformedKeyringJournalWithTombstone(keyring, account, diag);
+      persistUnverifiableKeyringDeletion(keyring, account, diag);
       return false;
     }
     const unpublished =
@@ -1980,7 +2061,19 @@ async function deleteKeyringAccount(
       const keyring = await import('@napi-rs/keyring');
       let pendingJournalRaw = readKeyringEntry(keyring, KEYRING_JOURNAL_SERVICE, account);
       if (pendingJournalRaw === null) {
-        const managedState = readKeyringManagedState(keyring, account);
+        let managedState: KeyringManagedState | null;
+        try {
+          managedState = readKeyringManagedState(keyring, account);
+        } catch (err) {
+          diag?.(classifyKeyringError(err));
+          if (
+            err instanceof KeyringManagedStateKeyUnavailableError &&
+            recoverEmptyOpaqueManagedKeyringState(keyring, account, diag)
+          ) {
+            return true;
+          }
+          return false;
+        }
         if (managedState !== null) {
           if (managedState.journal === null) {
             return deleteJournalLessManagedKeyringAccount(keyring, account, diag);
@@ -2011,9 +2104,6 @@ async function deleteKeyringAccount(
         }
       } catch (err) {
         diag?.(classifyKeyringError(err));
-        if (err instanceof InvalidKeyringJournalError) {
-          replaceMalformedKeyringJournalWithTombstone(keyring, account, diag, blockLegacy);
-        }
         return false;
       }
       const value = readKeyringEntry(keyring, KEYRING_SERVICE, account);

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,10 +1,21 @@
 // src/env.ts
 import { CONFLICTING_ENV_VARS } from './constants.js';
 import { createHash, randomUUID } from 'node:crypto';
-import { homedir } from 'node:os';
+import {
+  closeSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import {
+  credentialAccountBase,
   deleteCredentialHelperAccount,
+  isCredentialAccountInstance,
   readCredentialHelperAccount,
   writeCredentialHelperAccount,
 } from './credential-helper.js';
@@ -17,6 +28,8 @@ import {
 } from './oauth/types.js';
 import { refreshStoredOAuthCredential, oauthCredentialShouldRefresh } from './oauth/refresh.js';
 import {
+  getCredentialMutationLockPath,
+  getCredentialStateRoot,
   withCredentialMutationLock,
   withRegistryWriteLock,
 } from './registry/lock.js';
@@ -24,9 +37,10 @@ import type { ConflictInfo } from './types.js';
 import { removeAnthropicProxyBypass } from './wrapper-env.js';
 
 export function detectConflicts(): ConflictInfo[] {
-  return CONFLICTING_ENV_VARS
-    .filter(name => process.env[name] !== undefined)
-    .map(name => ({ name, value: process.env[name]! }));
+  return CONFLICTING_ENV_VARS.filter(name => process.env[name] !== undefined).map(name => ({
+    name,
+    value: process.env[name]!,
+  }));
 }
 
 /** Restore first-party-like Claude Code behavior when routing through a proxy or gateway. */
@@ -112,8 +126,9 @@ export function classifyKeyringError(err: unknown): string {
 const KEYRING_SERVICE = 'clodex';
 const KEYRING_CHUNK_SERVICE = 'clodex-chunks';
 const KEYRING_JOURNAL_SERVICE = 'clodex-journal';
-/** One-time silent migration source: credentials stored by relay-ai. */
-const LEGACY_KEYRING_SERVICE = 'relay-ai';
+const KEYRING_DELETED_SERVICE = 'clodex-deleted';
+const KEYRING_DELETED_VALUE = 'v1:deleted';
+const KEYRING_PENDING_DELETE_VALUE = 'v1:pending';
 // Windows Credential Manager caps a single credential blob at 2560 bytes (CredWriteW).
 // keyring-rs encodes the password as UTF-16 (2 bytes/char) before that check, so the
 // usable limit is 2560 / 2 = 1280 chars — long OAuth tokens (e.g. OpenAI's JWTs) exceed
@@ -121,13 +136,14 @@ const LEGACY_KEYRING_SERVICE = 'relay-ai';
 // Harmless on macOS/Linux, which have no such limit.
 const KEYRING_CHUNK_PREFIX = '__relay_chunked__:';
 const KEYRING_JOURNAL_PREFIX = '__relay_chunk_journal__:v1:';
+const KEYRING_DELETE_TOMBSTONE_PREFIX = '__clodex_delete__:';
 const KEYRING_MAX_ENTRY_CHARS = 1200;
 const KEYRING_CHUNK_SIZE = KEYRING_MAX_ENTRY_CHARS;
 const KEYRING_MAX_CHUNKS = 128;
 const KEYRING_MAX_WRITE_GENERATIONS = 2;
 const KEYRING_MAX_DELETE_GENERATIONS = 6;
-const KEYRING_MAX_LEGACY_GENERATIONS = 4;
-const KEYRING_GENERATION_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const KEYRING_GENERATION_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
 interface KeyringChunkMarker {
   count: number;
@@ -136,11 +152,17 @@ interface KeyringChunkMarker {
 }
 
 interface KeyringChunkJournal {
-  mode: 'write' | 'delete';
+  mode: 'write' | 'short' | 'delete' | 'deleted';
   generations: KeyringChunkMarker[];
-  legacyGenerations?: KeyringChunkMarker[];
+  shortDigest?: string;
+  fallbackShortDigest?: string;
+  unpublished?: true;
+  publicationAttempted?: true;
+  blockLegacy?: true;
   unverifiable?: true;
 }
+
+type KeyringApi = Pick<typeof import('@napi-rs/keyring'), 'Entry' | 'findCredentials'>;
 
 export function providerKeyringAccount(providerId: string): string {
   return `provider:${providerId}`;
@@ -152,7 +174,8 @@ export function oauthProviderKeyringAccount(providerId: string): string {
 
 function oauthProviderIdFromAccount(account: string): string | null {
   const prefix = 'oauth:provider:';
-  return account.startsWith(prefix) ? account.slice(prefix.length) : null;
+  const baseAccount = credentialAccountBase(account);
+  return baseAccount.startsWith(prefix) ? baseAccount.slice(prefix.length) : null;
 }
 
 const oauthRefreshInflight = new Map<string, Promise<string | null>>();
@@ -191,10 +214,12 @@ function isReservedKeyringAccount(account: string): boolean {
   const indexText = parts.at(-1)!;
   if (!/^\d+$/.test(indexText)) return false;
   const index = Number(indexText);
-  return Number.isSafeInteger(index)
-    && indexText === String(index)
-    && index >= 0
-    && index < KEYRING_MAX_CHUNKS;
+  return (
+    Number.isSafeInteger(index) &&
+    indexText === String(index) &&
+    index >= 0 &&
+    index < KEYRING_MAX_CHUNKS
+  );
 }
 
 export interface ResolveCredentialOptions {
@@ -261,28 +286,79 @@ function usableEnvCredential(
   return value;
 }
 
+function readKeyringEntry(keyring: KeyringApi, service: string, account: string): string | null {
+  const value = new keyring.Entry(service, account).getPassword();
+  if (value !== null) return value;
+
+  const matches = keyring
+    .findCredentials(service)
+    .filter(credential => credential.account === account);
+  if (matches.length > 1) {
+    throw new Error(`keyring credential account is ambiguous: ${account}`);
+  }
+  return matches[0]?.password ?? null;
+}
+
+function deleteKeyringEntry(keyring: KeyringApi, service: string, account: string): boolean {
+  const entry = new keyring.Entry(service, account);
+  if (!persistKeyringDeletionTombstone(keyring, service, account)) return false;
+  return entry.deletePassword();
+}
+
+function hasUnjournaledKeyringChunks(keyring: KeyringApi, account: string): boolean {
+  const prefix = `${account}::chunk::`;
+  return [KEYRING_SERVICE, KEYRING_CHUNK_SERVICE].some(service =>
+    keyring
+      .findCredentials(service)
+      .some(
+        credential =>
+          credential.account.startsWith(prefix) && isReservedKeyringAccount(credential.account),
+      ),
+  );
+}
+
+function isDisposableCredentialProbeAccount(account: string): boolean {
+  const separator = '::probe::';
+  const separatorIndex = account.lastIndexOf(separator);
+  return (
+    separatorIndex > 0 &&
+    KEYRING_GENERATION_PATTERN.test(account.slice(separatorIndex + separator.length))
+  );
+}
+
+function persistKeyringDeletionTombstone(
+  keyring: KeyringApi,
+  service: string,
+  account: string,
+): boolean {
+  const existing = readKeyringEntry(keyring, service, account);
+  if (existing?.startsWith(KEYRING_DELETE_TOMBSTONE_PREFIX)) return true;
+  const tombstone = `${KEYRING_DELETE_TOMBSTONE_PREFIX}${randomUUID()}`;
+  new keyring.Entry(service, account).setPassword(tombstone);
+  return readKeyringEntry(keyring, service, account) === tombstone;
+}
+
 function readKeyringAccountFromService(
-  Entry: typeof import('@napi-rs/keyring').Entry,
+  keyring: KeyringApi,
   service: string,
   account: string,
   retries = 2,
 ): string | null {
-  const accountEntry = new Entry(service, account);
-  const value = accountEntry.getPassword() ?? null;
+  const value = readKeyringEntry(keyring, service, account);
   const marker = parseKeyringChunkMarker(value);
   if (!marker) return value;
   let combined: string;
   try {
-    combined = readKeyringMarkerChunks(Entry, service, account, marker);
+    combined = readKeyringMarkerChunks(keyring, service, account, marker);
   } catch (err) {
-    if (retries > 0 && accountEntry.getPassword() !== value) {
-      return readKeyringAccountFromService(Entry, service, account, retries - 1);
+    if (retries > 0 && readKeyringEntry(keyring, service, account) !== value) {
+      return readKeyringAccountFromService(keyring, service, account, retries - 1);
     }
     throw err;
   }
-  if (accountEntry.getPassword() !== value) {
+  if (readKeyringEntry(keyring, service, account) !== value) {
     if (retries > 0) {
-      return readKeyringAccountFromService(Entry, service, account, retries - 1);
+      return readKeyringAccountFromService(keyring, service, account, retries - 1);
     }
     throw new Error('keyring credential changed repeatedly while it was being read');
   }
@@ -290,7 +366,7 @@ function readKeyringAccountFromService(
 }
 
 function readKeyringMarkerChunks(
-  Entry: typeof import('@napi-rs/keyring').Entry,
+  keyring: KeyringApi,
   service: string,
   account: string,
   marker: KeyringChunkMarker,
@@ -298,7 +374,7 @@ function readKeyringMarkerChunks(
   let combined = '';
   const chunkService = keyringChunkService(service, marker);
   for (let i = 0; i < marker.count; i++) {
-    const chunk = new Entry(chunkService, keyringChunkAccount(account, marker, i)).getPassword();
+    const chunk = readKeyringEntry(keyring, chunkService, keyringChunkAccount(account, marker, i));
     if (chunk === null) {
       throw new Error(`keyring credential chunk ${i + 1} of ${marker.count} is missing`);
     }
@@ -392,39 +468,57 @@ function parseKeyringChunkJournal(value: string): KeyringChunkJournal {
     throw new InvalidKeyringJournalError();
   }
   try {
-    const parsed = JSON.parse(value.slice(KEYRING_JOURNAL_PREFIX.length)) as Partial<KeyringChunkJournal>;
+    const parsed = JSON.parse(
+      value.slice(KEYRING_JOURNAL_PREFIX.length),
+    ) as Partial<KeyringChunkJournal>;
     if (
-      (parsed.mode !== 'write' && parsed.mode !== 'delete')
-      || !Array.isArray(parsed.generations)
-      || parsed.generations.length > (
-        parsed.mode === 'write'
+      (parsed.mode !== 'write' &&
+        parsed.mode !== 'short' &&
+        parsed.mode !== 'delete' &&
+        parsed.mode !== 'deleted') ||
+      !Array.isArray(parsed.generations) ||
+      parsed.generations.length >
+        (parsed.mode === 'write' || parsed.mode === 'short'
           ? KEYRING_MAX_WRITE_GENERATIONS
-          : KEYRING_MAX_DELETE_GENERATIONS
-      )
-      || (
-        parsed.legacyGenerations !== undefined
-        && (
-          !Array.isArray(parsed.legacyGenerations)
-          || parsed.legacyGenerations.length > KEYRING_MAX_LEGACY_GENERATIONS
-        )
-      )
-      || (parsed.mode === 'write' && parsed.generations.length < 1)
-      || (
-        parsed.mode === 'write'
-        && ((parsed.legacyGenerations?.length ?? 0) > 0 || parsed.unverifiable !== undefined)
-      )
-      || (parsed.unverifiable !== undefined && parsed.unverifiable !== true)
+          : KEYRING_MAX_DELETE_GENERATIONS) ||
+      (parsed.mode === 'write' && parsed.generations.length < 1) ||
+      (parsed.mode === 'short' &&
+        (typeof parsed.shortDigest !== 'string' || !/^[0-9a-f]{64}$/.test(parsed.shortDigest))) ||
+      (parsed.mode !== 'short' && parsed.mode !== 'delete' && parsed.shortDigest !== undefined) ||
+      (parsed.mode === 'delete' &&
+        parsed.shortDigest !== undefined &&
+        (typeof parsed.shortDigest !== 'string' || !/^[0-9a-f]{64}$/.test(parsed.shortDigest))) ||
+      (parsed.fallbackShortDigest !== undefined &&
+        ((parsed.mode !== 'write' && parsed.mode !== 'short') ||
+          typeof parsed.fallbackShortDigest !== 'string' ||
+          !/^[0-9a-f]{64}$/.test(parsed.fallbackShortDigest))) ||
+      (parsed.unpublished !== undefined &&
+        ((parsed.mode !== 'write' && parsed.mode !== 'short') || parsed.unpublished !== true)) ||
+      (parsed.publicationAttempted !== undefined &&
+        ((parsed.mode !== 'write' && parsed.mode !== 'short') ||
+          parsed.publicationAttempted !== true ||
+          parsed.unpublished !== true)) ||
+      (parsed.unpublished === true && parsed.fallbackShortDigest !== undefined) ||
+      (parsed.mode === 'deleted' &&
+        (parsed.generations.length > 0 ||
+          parsed.shortDigest !== undefined ||
+          parsed.fallbackShortDigest !== undefined ||
+          parsed.unpublished !== undefined ||
+          parsed.publicationAttempted !== undefined ||
+          parsed.blockLegacy !== undefined ||
+          parsed.unverifiable !== undefined)) ||
+      (parsed.mode !== 'delete' &&
+        (parsed.blockLegacy !== undefined || parsed.unverifiable !== undefined)) ||
+      (parsed.blockLegacy !== undefined && parsed.blockLegacy !== true) ||
+      (parsed.unverifiable !== undefined && parsed.unverifiable !== true)
     ) {
       throw new Error('invalid');
     }
     const generations = parsed.generations.map(parseJournalMarker);
-    const legacyGenerations = parsed.legacyGenerations?.map(parseJournalMarker);
     if (
-      parsed.mode === 'write'
-      && generations.some((marker, index) =>
-        generations.slice(index + 1).some(candidate =>
-          sameKeyringGeneration(marker, candidate),
-        ),
+      (parsed.mode === 'write' || parsed.mode === 'short') &&
+      generations.some((marker, index) =>
+        generations.slice(index + 1).some(candidate => sameKeyringGeneration(marker, candidate)),
       )
     ) {
       throw new Error('invalid');
@@ -432,9 +526,11 @@ function parseKeyringChunkJournal(value: string): KeyringChunkJournal {
     return {
       mode: parsed.mode,
       generations,
-      ...(legacyGenerations
-        ? { legacyGenerations }
-        : {}),
+      ...(parsed.shortDigest ? { shortDigest: parsed.shortDigest } : {}),
+      ...(parsed.fallbackShortDigest ? { fallbackShortDigest: parsed.fallbackShortDigest } : {}),
+      ...(parsed.unpublished ? { unpublished: true } : {}),
+      ...(parsed.publicationAttempted ? { publicationAttempted: true } : {}),
+      ...(parsed.blockLegacy ? { blockLegacy: true } : {}),
       ...(parsed.unverifiable ? { unverifiable: true } : {}),
     };
   } catch {
@@ -446,24 +542,20 @@ function sameKeyringGeneration(
   left: KeyringChunkMarker | null,
   right: KeyringChunkMarker,
 ): boolean {
-  return left !== null
-    && left.generation === right.generation
-    && Boolean(left.digest) === Boolean(right.digest);
+  return (
+    left !== null &&
+    left.generation === right.generation &&
+    Boolean(left.digest) === Boolean(right.digest)
+  );
 }
 
-function sameKeyringMarker(
-  left: KeyringChunkMarker,
-  right: KeyringChunkMarker,
-): boolean {
-  return sameKeyringGeneration(left, right)
-    && left.count === right.count
-    && left.digest === right.digest;
+function sameKeyringMarker(left: KeyringChunkMarker, right: KeyringChunkMarker): boolean {
+  return (
+    sameKeyringGeneration(left, right) && left.count === right.count && left.digest === right.digest
+  );
 }
 
-function appendUniqueKeyringMarker(
-  target: KeyringChunkMarker[],
-  marker: KeyringChunkMarker,
-): void {
+function appendUniqueKeyringMarker(target: KeyringChunkMarker[], marker: KeyringChunkMarker): void {
   const existing = target.find(candidate => sameKeyringGeneration(candidate, marker));
   if (!existing) {
     target.push(marker);
@@ -479,42 +571,55 @@ function encodeKeyringJournal(journal: KeyringChunkJournal): string {
 
 function keyringDeleteJournalFits(
   generations: KeyringChunkMarker[],
-  legacyGenerations: KeyringChunkMarker[],
   unverifiable = false,
+  blockLegacy = false,
+  shortDigest?: string,
 ): boolean {
-  if (
-    generations.length > KEYRING_MAX_DELETE_GENERATIONS
-    || legacyGenerations.length > KEYRING_MAX_LEGACY_GENERATIONS
-  ) {
+  if (generations.length > KEYRING_MAX_DELETE_GENERATIONS) {
     return false;
   }
-  return encodeKeyringJournal({
-    mode: 'delete',
-    generations,
-    ...(legacyGenerations.length > 0 ? { legacyGenerations } : {}),
-    ...(unverifiable ? { unverifiable: true } : {}),
-  }).length <= KEYRING_MAX_ENTRY_CHARS;
+  return (
+    encodeKeyringJournal({
+      mode: 'delete',
+      generations,
+      ...(shortDigest ? { shortDigest } : {}),
+      ...(blockLegacy ? { blockLegacy: true } : {}),
+      ...(unverifiable ? { unverifiable: true } : {}),
+    }).length <= KEYRING_MAX_ENTRY_CHARS
+  );
 }
 
-function keyringChunkAccount(
-  account: string,
-  marker: KeyringChunkMarker,
-  index: number,
-): string {
+function keyringChunkAccount(account: string, marker: KeyringChunkMarker, index: number): string {
   return marker.generation
     ? `${account}::chunk::${marker.generation}::${index}`
     : `${account}::chunk::${index}`;
 }
 
-function keyringChunkService(
-  mainService: string,
-  marker: KeyringChunkMarker,
-): string {
+function keyringChunkService(mainService: string, marker: KeyringChunkMarker): string {
   return marker.digest ? KEYRING_CHUNK_SERVICE : mainService;
 }
 
+function splitKeyringCredential(value: string): string[] {
+  const chunks: string[] = [];
+  for (let start = 0; start < value.length; ) {
+    let end = Math.min(start + KEYRING_CHUNK_SIZE, value.length);
+    if (
+      end < value.length &&
+      value.charCodeAt(end - 1) >= 0xd800 &&
+      value.charCodeAt(end - 1) <= 0xdbff &&
+      value.charCodeAt(end) >= 0xdc00 &&
+      value.charCodeAt(end) <= 0xdfff
+    ) {
+      end -= 1;
+    }
+    chunks.push(value.slice(start, end));
+    start = end;
+  }
+  return chunks;
+}
+
 function removeKeyringChunkRange(
-  Entry: typeof import('@napi-rs/keyring').Entry,
+  keyring: KeyringApi,
   service: string,
   account: string,
   marker: KeyringChunkMarker,
@@ -525,8 +630,9 @@ function removeKeyringChunkRange(
   const chunkService = keyringChunkService(service, marker);
   for (let i = firstIndex; i < marker.count; i++) {
     try {
-      const entry = new Entry(chunkService, keyringChunkAccount(account, marker, i));
-      if (entry.getPassword() !== null) entry.deletePassword();
+      if (!deleteKeyringEntry(keyring, chunkService, keyringChunkAccount(account, marker, i))) {
+        removed = false;
+      }
     } catch (err) {
       removed = false;
       diag?.(classifyKeyringError(err));
@@ -536,121 +642,211 @@ function removeKeyringChunkRange(
 }
 
 function removeKeyringChunks(
-  Entry: typeof import('@napi-rs/keyring').Entry,
+  keyring: KeyringApi,
   service: string,
   account: string,
   marker: KeyringChunkMarker | null,
   diag?: (msg: string) => void,
 ): boolean {
   if (!marker) return true;
-  return removeKeyringChunkRange(Entry, service, account, marker, 0, diag);
+  return removeKeyringChunkRange(keyring, service, account, marker, 0, diag);
 }
 
 function writeKeyringJournal(
-  Entry: typeof import('@napi-rs/keyring').Entry,
+  keyring: KeyringApi,
   account: string,
   journal: KeyringChunkJournal,
 ): void {
-  const entry = new Entry(KEYRING_JOURNAL_SERVICE, account);
+  const entry = new keyring.Entry(KEYRING_JOURNAL_SERVICE, account);
   const encoded = encodeKeyringJournal(journal);
   if (encoded.length > KEYRING_MAX_ENTRY_CHARS) {
     throw new Error('keyring cleanup journal exceeds the credential entry limit');
   }
+  persistKeyringManagedState(account, { mode: 'preparing', journal });
   entry.setPassword(encoded);
-  if (entry.getPassword() !== encoded) {
+  if (readKeyringEntry(keyring, KEYRING_JOURNAL_SERVICE, account) !== encoded) {
     throw new Error('keyring cleanup journal verification failed');
   }
+  persistKeyringManagedState(account, { mode: 'managed' });
+}
+
+function readKeyringDeletionGuard(
+  keyring: KeyringApi,
+  account: string,
+): 'deleted' | 'pending' | null {
+  const value = readKeyringEntry(keyring, KEYRING_DELETED_SERVICE, account);
+  if (value === null) return null;
+  if (value === KEYRING_DELETED_VALUE) return 'deleted';
+  if (value === KEYRING_PENDING_DELETE_VALUE) return 'pending';
+  throw new Error('keyring credential has an invalid deletion guard');
+}
+
+function writeKeyringDeletionGuard(
+  keyring: KeyringApi,
+  account: string,
+  mode: 'deleted' | 'pending',
+): boolean {
+  const entry = new keyring.Entry(KEYRING_DELETED_SERVICE, account);
+  const value = mode === 'deleted' ? KEYRING_DELETED_VALUE : KEYRING_PENDING_DELETE_VALUE;
+  entry.setPassword(value);
+  return readKeyringEntry(keyring, KEYRING_DELETED_SERVICE, account) === value;
+}
+
+function clearKeyringDeletionGuard(keyring: KeyringApi, account: string): boolean {
+  return new keyring.Entry(KEYRING_DELETED_SERVICE, account).deletePassword();
 }
 
 function reconcileKeyringJournal(
-  Entry: typeof import('@napi-rs/keyring').Entry,
+  keyring: KeyringApi,
   account: string,
   diag?: (msg: string) => void,
 ): boolean {
-  const journalEntry = new Entry(KEYRING_JOURNAL_SERVICE, account);
-  const rawJournal = journalEntry.getPassword();
-  if (rawJournal === null) return true;
-  let journal = parseKeyringChunkJournal(rawJournal);
-  const accountEntry = new Entry(KEYRING_SERVICE, account);
-  const legacyAccountEntry = new Entry(LEGACY_KEYRING_SERVICE, account);
-
-  let activeMarker: KeyringChunkMarker | null = null;
-  if (journal.mode === 'delete') {
-    let currentMarker: KeyringChunkMarker | null = null;
-    let currentLegacyMarker: KeyringChunkMarker | null = null;
-    let unverifiable = journal.unverifiable === true;
-    let currentValue: string | null;
-    let currentLegacyValue: string | null;
+  let rawJournal = readKeyringEntry(keyring, KEYRING_JOURNAL_SERVICE, account);
+  let managedState = readKeyringManagedState(account);
+  if (managedState?.mode === 'preparing') {
     try {
-      currentValue = accountEntry.getPassword();
-      currentLegacyValue = legacyAccountEntry.getPassword();
+      writeKeyringJournal(keyring, account, managedState.journal);
+      rawJournal = encodeKeyringJournal(managedState.journal);
+      managedState = { mode: 'managed' };
     } catch (err) {
       diag?.(classifyKeyringError(err));
       return false;
     }
-    for (const [storedValue, assign] of [
-      [currentValue, (marker: KeyringChunkMarker | null) => {
-        currentMarker = marker;
-      }],
-      [currentLegacyValue, (marker: KeyringChunkMarker | null) => {
-        currentLegacyMarker = marker;
-      }],
-    ] as const) {
+  }
+  const deletionGuard = readKeyringDeletionGuard(keyring, account);
+  if (rawJournal === null) {
+    if (deletionGuard === null) {
+      if (managedState !== null) {
+        diag?.('managed keyring cleanup metadata is temporarily unavailable');
+        return false;
+      }
+      return true;
+    }
+    const restoredJournal: KeyringChunkJournal =
+      deletionGuard === 'deleted'
+        ? {
+            mode: 'deleted',
+            generations: [],
+          }
+        : {
+            mode: 'delete',
+            generations: [],
+          };
+    writeKeyringJournal(keyring, account, restoredJournal);
+    rawJournal = encodeKeyringJournal(restoredJournal);
+  } else if (managedState?.mode !== 'managed') {
+    try {
+      persistKeyringManagedState(account, { mode: 'managed' });
+    } catch (err) {
+      diag?.(classifyKeyringError(err));
+      return false;
+    }
+  }
+  let journal = parseKeyringChunkJournal(rawJournal);
+  const accountEntry = new keyring.Entry(KEYRING_SERVICE, account);
+
+  if (journal.mode === 'deleted') {
+    let currentValue: string | null;
+    let currentMarker: KeyringChunkMarker | null = null;
+    let unverifiable = false;
+    try {
+      currentValue = readKeyringEntry(keyring, KEYRING_SERVICE, account);
+      currentMarker = parseKeyringChunkMarker(currentValue);
+    } catch (err) {
+      unverifiable = true;
+      diag?.(classifyKeyringError(err));
+    }
+    const resumedJournal: KeyringChunkJournal = {
+      mode: 'delete',
+      generations: currentMarker ? [currentMarker] : [],
+      blockLegacy: true,
+      ...(unverifiable ? { unverifiable: true } : {}),
+    };
+    try {
+      writeKeyringJournal(keyring, account, resumedJournal);
+    } catch (err) {
+      diag?.(classifyKeyringError(err));
+      return false;
+    }
+    journal = resumedJournal;
+  }
+
+  let activeMarker: KeyringChunkMarker | null = null;
+  let activeShortDigest: string | null = null;
+  if (journal.mode === 'delete') {
+    let currentMarker: KeyringChunkMarker | null = null;
+    let activeShortDigest = journal.shortDigest;
+    let unverifiable = journal.unverifiable === true;
+    let currentValue: string | null;
+    try {
+      currentValue = readKeyringEntry(keyring, KEYRING_SERVICE, account);
+    } catch (err) {
+      diag?.(classifyKeyringError(err));
+      return false;
+    }
+    if (
+      currentValue === null ||
+      !activeShortDigest ||
+      createHash('sha256').update(currentValue).digest('hex') !== activeShortDigest
+    ) {
+      activeShortDigest = undefined;
       try {
-        assign(parseKeyringChunkMarker(storedValue));
+        currentMarker = parseKeyringChunkMarker(currentValue);
       } catch (err) {
         unverifiable = true;
         diag?.(classifyKeyringError(err));
       }
     }
 
-    let preparedGenerations = journal.generations.map(marker => ({ ...marker }));
-    let preparedLegacyGenerations = (journal.legacyGenerations ?? []).map(marker => ({
+    let preparedGenerations = journal.generations.map(marker => ({
       ...marker,
     }));
     if (currentMarker) appendUniqueKeyringMarker(preparedGenerations, currentMarker);
-    if (currentLegacyMarker) {
-      appendUniqueKeyringMarker(preparedLegacyGenerations, currentLegacyMarker);
-    }
-    if (!keyringDeleteJournalFits(
-      preparedGenerations,
-      preparedLegacyGenerations,
-      unverifiable,
-    )) {
+    if (
+      !keyringDeleteJournalFits(
+        preparedGenerations,
+        unverifiable,
+        journal.blockLegacy === true,
+        activeShortDigest,
+      )
+    ) {
+      const protectedMarker = currentMarker
+        ? (preparedGenerations.find(marker => sameKeyringGeneration(currentMarker, marker)) ??
+          currentMarker)
+        : null;
       let compacted = true;
       for (const marker of journal.generations) {
-        if (!removeKeyringChunks(Entry, KEYRING_SERVICE, account, marker, diag)) {
-          compacted = false;
+        if (protectedMarker && sameKeyringGeneration(protectedMarker, marker)) {
+          continue;
         }
-      }
-      for (const marker of journal.legacyGenerations ?? []) {
-        if (!removeKeyringChunks(Entry, LEGACY_KEYRING_SERVICE, account, marker, diag)) {
+        if (!removeKeyringChunks(keyring, KEYRING_SERVICE, account, marker, diag)) {
           compacted = false;
         }
       }
       if (!compacted) return false;
-      preparedGenerations = currentMarker ? [currentMarker] : [];
-      preparedLegacyGenerations = currentLegacyMarker ? [currentLegacyMarker] : [];
+      preparedGenerations = protectedMarker ? [protectedMarker] : [];
     }
-    if (!keyringDeleteJournalFits(
-      preparedGenerations,
-      preparedLegacyGenerations,
-      unverifiable,
-    )) {
+    if (
+      !keyringDeleteJournalFits(
+        preparedGenerations,
+        unverifiable,
+        journal.blockLegacy === true,
+        activeShortDigest,
+      )
+    ) {
       diag?.('keyring cleanup journal cannot represent the pending generations');
       return false;
     }
     const preparedJournal: KeyringChunkJournal = {
       mode: 'delete',
       generations: preparedGenerations,
-      ...(preparedLegacyGenerations.length > 0
-        ? { legacyGenerations: preparedLegacyGenerations }
-        : {}),
+      ...(activeShortDigest ? { shortDigest: activeShortDigest } : {}),
+      ...(journal.blockLegacy ? { blockLegacy: true } : {}),
       ...(unverifiable ? { unverifiable: true } : {}),
     };
     if (encodeKeyringJournal(preparedJournal) !== rawJournal) {
       try {
-        writeKeyringJournal(Entry, account, preparedJournal);
+        writeKeyringJournal(keyring, account, preparedJournal);
       } catch (err) {
         diag?.(classifyKeyringError(err));
         return false;
@@ -658,30 +854,89 @@ function reconcileKeyringJournal(
     }
     journal = preparedJournal;
     try {
-      if (accountEntry.getPassword() !== null) accountEntry.deletePassword();
-      if (legacyAccountEntry.getPassword() !== null) legacyAccountEntry.deletePassword();
+      if (
+        !writeKeyringDeletionGuard(
+          keyring,
+          account,
+          journal.blockLegacy === true ? 'deleted' : 'pending',
+        )
+      ) {
+        diag?.('keyring deletion guard could not be verified');
+        return false;
+      }
     } catch (err) {
       diag?.(classifyKeyringError(err));
       return false;
     }
-  } else {
     try {
-      activeMarker = parseKeyringChunkMarker(accountEntry.getPassword());
+      if (!deleteKeyringEntry(keyring, KEYRING_SERVICE, account)) {
+        diag?.('keyring credential deletion could not be verified');
+        return false;
+      }
     } catch (err) {
       diag?.(classifyKeyringError(err));
       return false;
+    }
+  } else if (journal.mode === 'write') {
+    let activeValue: string | null;
+    try {
+      activeValue = readKeyringEntry(keyring, KEYRING_SERVICE, account);
+    } catch (err) {
+      diag?.(classifyKeyringError(err));
+      return false;
+    }
+    if (activeValue === null) {
+      if (journal.unpublished !== true) {
+        diag?.('published credential state cannot be confirmed while cleanup metadata is active');
+        return false;
+      }
+      if (journal.publicationAttempted === true) {
+        const candidate = journal.generations[0];
+        if (!candidate) return false;
+        try {
+          readKeyringMarkerChunks(keyring, KEYRING_SERVICE, account, candidate);
+          const encodedCandidate = encodeKeyringChunkMarker(candidate);
+          accountEntry.setPassword(encodedCandidate);
+          if (readKeyringEntry(keyring, KEYRING_SERVICE, account) !== encodedCandidate) {
+            throw new Error('keyring credential recovery verification failed');
+          }
+          activeMarker = candidate;
+        } catch (err) {
+          diag?.(classifyKeyringError(err));
+          return false;
+        }
+      }
+    } else if (
+      journal.fallbackShortDigest &&
+      createHash('sha256').update(activeValue).digest('hex') === journal.fallbackShortDigest
+    ) {
+      activeShortDigest = journal.fallbackShortDigest;
+    } else {
+      try {
+        activeMarker = parseKeyringChunkMarker(activeValue);
+      } catch (err) {
+        diag?.(classifyKeyringError(err));
+        return false;
+      }
+      if (!activeMarker) {
+        diag?.('published credential kind is not represented by cleanup journal');
+        return false;
+      }
     }
 
     const activeJournalMarker = activeMarker
       ? journal.generations.find(marker => sameKeyringGeneration(activeMarker, marker))
       : undefined;
+    if (activeMarker && !activeJournalMarker) {
+      throw new Error('published credential generation is not represented by cleanup journal');
+    }
     if (activeMarker && activeJournalMarker) {
       try {
-        readKeyringMarkerChunks(Entry, KEYRING_SERVICE, account, activeMarker);
+        readKeyringMarkerChunks(keyring, KEYRING_SERVICE, account, activeMarker);
         if (
-          activeJournalMarker.count > activeMarker.count
-          && !removeKeyringChunkRange(
-            Entry,
+          activeJournalMarker.count > activeMarker.count &&
+          !removeKeyringChunkRange(
+            keyring,
             KEYRING_SERVICE,
             account,
             activeJournalMarker,
@@ -694,21 +949,17 @@ function reconcileKeyringJournal(
       } catch (err) {
         diag?.(classifyKeyringError(err));
         const recoveryCandidates = [
-          ...(!sameKeyringMarker(activeMarker, activeJournalMarker)
-            ? [activeJournalMarker]
-            : []),
-          ...journal.generations.filter(marker =>
-            !sameKeyringGeneration(activeMarker, marker),
-          ),
+          ...(!sameKeyringMarker(activeMarker, activeJournalMarker) ? [activeJournalMarker] : []),
+          ...journal.generations.filter(marker => !sameKeyringGeneration(activeMarker, marker)),
         ];
         let recovered = false;
         for (const candidate of recoveryCandidates) {
           try {
-            readKeyringMarkerChunks(Entry, KEYRING_SERVICE, account, candidate);
+            readKeyringMarkerChunks(keyring, KEYRING_SERVICE, account, candidate);
             if (
-              activeMarker.count > activeJournalMarker.count
-              && !removeKeyringChunkRange(
-                Entry,
+              activeMarker.count > activeJournalMarker.count &&
+              !removeKeyringChunkRange(
+                keyring,
                 KEYRING_SERVICE,
                 account,
                 activeMarker,
@@ -718,7 +969,11 @@ function reconcileKeyringJournal(
             ) {
               return false;
             }
-            accountEntry.setPassword(encodeKeyringChunkMarker(candidate));
+            const encodedCandidate = encodeKeyringChunkMarker(candidate);
+            accountEntry.setPassword(encodedCandidate);
+            if (readKeyringEntry(keyring, KEYRING_SERVICE, account) !== encodedCandidate) {
+              throw new Error('keyring credential recovery verification failed');
+            }
             activeMarker = candidate;
             recovered = true;
             break;
@@ -729,25 +984,137 @@ function reconcileKeyringJournal(
         if (!recovered) return false;
       }
     }
+  } else {
+    let activeValue: string | null;
+    try {
+      activeValue = readKeyringEntry(keyring, KEYRING_SERVICE, account);
+    } catch (err) {
+      diag?.(classifyKeyringError(err));
+      return false;
+    }
+    if (activeValue === null) {
+      if (journal.unpublished !== true) {
+        diag?.('published credential state cannot be confirmed while cleanup metadata is active');
+        return false;
+      }
+      if (journal.publicationAttempted === true) return false;
+    } else {
+      const observedDigest = createHash('sha256').update(activeValue).digest('hex');
+      if (observedDigest === journal.shortDigest) {
+        activeShortDigest = observedDigest;
+      } else if (observedDigest === journal.fallbackShortDigest) {
+        activeShortDigest = observedDigest;
+      } else {
+        try {
+          activeMarker = parseKeyringChunkMarker(activeValue);
+        } catch (err) {
+          diag?.(classifyKeyringError(err));
+          return false;
+        }
+        if (
+          !activeMarker ||
+          !journal.generations.some(marker => sameKeyringGeneration(activeMarker, marker))
+        ) {
+          diag?.('published credential kind is not represented by cleanup journal');
+          return false;
+        }
+        try {
+          readKeyringMarkerChunks(keyring, KEYRING_SERVICE, account, activeMarker);
+        } catch (err) {
+          diag?.(classifyKeyringError(err));
+          return false;
+        }
+      }
+    }
   }
 
   let cleaned = true;
   for (const marker of journal.generations) {
-    if (journal.mode === 'write' && sameKeyringGeneration(activeMarker, marker)) continue;
-    if (!removeKeyringChunks(Entry, KEYRING_SERVICE, account, marker, diag)) {
-      cleaned = false;
-    }
-  }
-  for (const marker of journal.legacyGenerations ?? []) {
-    if (!removeKeyringChunks(Entry, LEGACY_KEYRING_SERVICE, account, marker, diag)) {
+    if (
+      (journal.mode === 'write' || journal.mode === 'short') &&
+      sameKeyringGeneration(activeMarker, marker)
+    )
+      continue;
+    if (!removeKeyringChunks(keyring, KEYRING_SERVICE, account, marker, diag)) {
       cleaned = false;
     }
   }
   if (!cleaned) return false;
   if (journal.unverifiable === true) return false;
 
+  if (journal.mode === 'delete' && journal.blockLegacy === true) {
+    try {
+      writeKeyringJournal(keyring, account, {
+        mode: 'deleted',
+        generations: [],
+      });
+      return true;
+    } catch (err) {
+      diag?.(classifyKeyringError(err));
+      return false;
+    }
+  }
+
+  if (journal.mode === 'delete') {
+    try {
+      if (!deleteKeyringEntry(keyring, KEYRING_JOURNAL_SERVICE, account)) {
+        diag?.('keyring cleanup journal could not be removed');
+        return false;
+      }
+      if (!clearKeyringDeletionGuard(keyring, account)) {
+        diag?.('keyring deletion guard could not be removed');
+        return false;
+      }
+      removeKeyringManagedState(account);
+      return true;
+    } catch (err) {
+      diag?.(classifyKeyringError(err));
+      return false;
+    }
+  }
+
+  if (activeShortDigest) {
+    const activeInventory: KeyringChunkJournal = {
+      mode: 'short',
+      generations: [],
+      shortDigest: activeShortDigest,
+    };
+    if (encodeKeyringJournal(activeInventory) !== rawJournal) {
+      try {
+        writeKeyringJournal(keyring, account, activeInventory);
+      } catch (err) {
+        diag?.(classifyKeyringError(err));
+        return false;
+      }
+    }
+    return true;
+  }
+
+  if (activeMarker) {
+    const activeInventory: KeyringChunkJournal = {
+      mode: 'write',
+      generations: [{ ...activeMarker }],
+    };
+    if (encodeKeyringJournal(activeInventory) !== rawJournal) {
+      try {
+        writeKeyringJournal(keyring, account, activeInventory);
+      } catch (err) {
+        diag?.(classifyKeyringError(err));
+        return false;
+      }
+    }
+    return true;
+  }
+
   try {
-    journalEntry.deletePassword();
+    if (!writeKeyringDeletionGuard(keyring, account, 'deleted')) {
+      diag?.('keyring deletion guard could not be verified');
+      return false;
+    }
+    writeKeyringJournal(keyring, account, {
+      mode: 'deleted',
+      generations: [],
+    });
     return true;
   } catch (err) {
     diag?.(classifyKeyringError(err));
@@ -755,9 +1122,118 @@ function reconcileKeyringJournal(
   }
 }
 
+const KEYRING_PREPARING_STATE_PREFIX = 'v1:preparing:';
+const KEYRING_MANAGED_STATE_VALUE = 'v1:managed\n';
+type KeyringManagedState =
+  | { mode: 'preparing'; journal: KeyringChunkJournal }
+  | { mode: 'managed' };
+
+function keyringAccountIdentity(account: string): string {
+  return createHash('sha256').update(account).digest('hex');
+}
+
+function keyringManagedStatePath(account: string): string {
+  return join(getCredentialStateRoot(), `${keyringAccountIdentity(account)}.managed`);
+}
+
+function readKeyringManagedState(account: string): KeyringManagedState | null {
+  try {
+    const value = readFileSync(keyringManagedStatePath(account), 'utf8');
+    if (value === KEYRING_MANAGED_STATE_VALUE) return { mode: 'managed' };
+    if (value.startsWith(KEYRING_PREPARING_STATE_PREFIX) && value.endsWith('\n')) {
+      const encodedJournal = value.slice(KEYRING_PREPARING_STATE_PREFIX.length, -1);
+      try {
+        const rawJournal = Buffer.from(encodedJournal, 'base64url').toString('utf8');
+        if (Buffer.from(rawJournal, 'utf8').toString('base64url') !== encodedJournal) {
+          throw new Error('non-canonical encoding');
+        }
+        return {
+          mode: 'preparing',
+          journal: parseKeyringChunkJournal(rawJournal),
+        };
+      } catch {
+        throw new Error('keyring managed-state marker is invalid');
+      }
+    }
+    throw new Error('keyring managed-state marker is invalid');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+function encodeKeyringManagedState(state: KeyringManagedState): string {
+  if (state.mode === 'managed') return KEYRING_MANAGED_STATE_VALUE;
+  const encodedJournal = Buffer.from(encodeKeyringJournal(state.journal), 'utf8').toString(
+    'base64url',
+  );
+  return `${KEYRING_PREPARING_STATE_PREFIX}${encodedJournal}\n`;
+}
+
+function syncDirectory(path: string): void {
+  let fd: number | undefined;
+  try {
+    fd = openSync(path, 'r');
+    fsyncSync(fd);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'EINVAL' && code !== 'ENOTSUP' && code !== 'EISDIR' && code !== 'EPERM') {
+      throw err;
+    }
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+}
+
+function persistKeyringManagedState(account: string, state: KeyringManagedState): void {
+  const currentState = readKeyringManagedState(account);
+  const encodedState = encodeKeyringManagedState(state);
+  if (currentState !== null && encodeKeyringManagedState(currentState) === encodedState) return;
+  const path = keyringManagedStatePath(account);
+  const directory = getCredentialStateRoot();
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const tempPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  let fd: number | undefined;
+  try {
+    fd = openSync(tempPath, 'wx', 0o600);
+    writeFileSync(fd, encodedState, 'utf8');
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = undefined;
+    try {
+      renameSync(tempPath, path);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'EEXIST' && code !== 'EPERM') {
+        throw err;
+      }
+      unlinkSync(path);
+      renameSync(tempPath, path);
+    }
+    syncDirectory(directory);
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+    try {
+      unlinkSync(tempPath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    }
+  }
+}
+
+function removeKeyringManagedState(account: string): void {
+  const path = keyringManagedStatePath(account);
+  try {
+    unlinkSync(path);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw err;
+  }
+  syncDirectory(getCredentialStateRoot());
+}
+
 function keyringAccountLockPath(account: string): string {
-  const identity = createHash('sha256').update(account).digest('hex');
-  return join(homedir(), '.clodex', 'keyring-locks', `${identity}.lock`);
+  return getCredentialMutationLockPath(`keyring:${account}`);
 }
 
 async function withKeyringAccountLock<T>(
@@ -776,30 +1252,52 @@ async function withKeyringAccountLock<T>(
   }
 }
 
-async function readKeyringAccount(account: string, diag?: (msg: string) => void): Promise<string | null> {
+async function readKeyringAccount(
+  account: string,
+  diag?: (msg: string) => void,
+): Promise<string | null> {
   return withKeyringAccountLock(account, null, diag, async () => {
     try {
-      const { Entry } = await import('@napi-rs/keyring');
-      const rawJournal = new Entry(KEYRING_JOURNAL_SERVICE, account).getPassword();
-      const pendingMode = rawJournal === null
-        ? null
-        : parseKeyringChunkJournal(rawJournal).mode;
-      const cleanupComplete = reconcileKeyringJournal(Entry, account, diag);
-      if (pendingMode === 'delete') return null;
-      const value = readKeyringAccountFromService(Entry, KEYRING_SERVICE, account);
-      if (value !== null || !cleanupComplete) return value;
-      // One-time silent migration: fall back to the relay-ai keychain service and
-      // copy the credential into the clodex service on first read.
-      let legacy: string | null = null;
-      try {
-        legacy = readKeyringAccountFromService(Entry, LEGACY_KEYRING_SERVICE, account);
-      } catch {
-        legacy = null;
+      const keyring = await import('@napi-rs/keyring');
+      const cleanupComplete = reconcileKeyringJournal(keyring, account, diag);
+      const finalJournalRaw = readKeyringEntry(keyring, KEYRING_JOURNAL_SERVICE, account);
+      const finalJournal =
+        finalJournalRaw === null ? null : parseKeyringChunkJournal(finalJournalRaw);
+      if (finalJournal?.mode === 'delete' || finalJournal?.mode === 'deleted') return null;
+      if (finalJournalRaw === null && readKeyringManagedState(account)?.mode === 'managed') {
+        return null;
       }
-      if (legacy !== null) {
-        writeKeyringAccountLocked(Entry, account, legacy, diag);
+      if (finalJournal?.mode === 'short') {
+        const value = readKeyringEntry(keyring, KEYRING_SERVICE, account);
+        if (
+          value === null ||
+          createHash('sha256').update(value).digest('hex') !== finalJournal.shortDigest
+        )
+          return null;
+        return value;
       }
-      return legacy;
+      if (finalJournal?.mode === 'write') {
+        return readKeyringAccountFromService(keyring, KEYRING_SERVICE, account);
+      }
+      if (!cleanupComplete) return null;
+
+      const rawValue = readKeyringEntry(keyring, KEYRING_SERVICE, account);
+      if (rawValue === null) return null;
+      const marker = parseKeyringChunkMarker(rawValue);
+      if (marker) {
+        const value = readKeyringAccountFromService(keyring, KEYRING_SERVICE, account);
+        writeKeyringJournal(keyring, account, {
+          mode: 'write',
+          generations: [marker],
+        });
+        return value;
+      }
+      writeKeyringJournal(keyring, account, {
+        mode: 'short',
+        generations: [],
+        shortDigest: createHash('sha256').update(rawValue).digest('hex'),
+      });
+      return rawValue;
     } catch (err) {
       diag?.(classifyKeyringError(err));
       return null;
@@ -808,14 +1306,16 @@ async function readKeyringAccount(account: string, diag?: (msg: string) => void)
 }
 
 function replaceMalformedKeyringJournalWithTombstone(
-  Entry: typeof import('@napi-rs/keyring').Entry,
+  keyring: KeyringApi,
   account: string,
   diag?: (msg: string) => void,
+  blockLegacy = false,
 ): boolean {
   try {
-    writeKeyringJournal(Entry, account, {
+    writeKeyringJournal(keyring, account, {
       mode: 'delete',
       generations: [],
+      ...(blockLegacy ? { blockLegacy: true } : {}),
       unverifiable: true,
     });
     diag?.('invalid keyring cleanup journal was replaced with a deletion tombstone');
@@ -827,48 +1327,164 @@ function replaceMalformedKeyringJournalWithTombstone(
 }
 
 function writeKeyringAccountLocked(
-  Entry: typeof import('@napi-rs/keyring').Entry,
+  keyring: KeyringApi,
   account: string,
   key: string,
+  intent: 'probe' | 'provision' | 'replace',
   diag?: (msg: string) => void,
 ): boolean {
   try {
     let reconciled: boolean;
+    let deletedMarkerActive = false;
     try {
-      reconciled = reconcileKeyringJournal(Entry, account, diag);
+      const deletionGuard = readKeyringDeletionGuard(keyring, account);
+      const rawJournal = readKeyringEntry(keyring, KEYRING_JOURNAL_SERVICE, account);
+      const initialJournal = rawJournal === null ? null : parseKeyringChunkJournal(rawJournal);
+      deletedMarkerActive = deletionGuard !== null || initialJournal?.mode === 'deleted';
+      if (
+        initialJournal?.mode === 'short' &&
+        initialJournal.unpublished === true &&
+        initialJournal.publicationAttempted === true
+      ) {
+        if (deletedMarkerActive) {
+          if (!clearKeyringDeletionGuard(keyring, account)) {
+            throw new Error('keyring deletion guard could not be cleared');
+          }
+          deletedMarkerActive = false;
+        }
+        const shortDigest = createHash('sha256').update(key).digest('hex');
+        if (shortDigest !== initialJournal.shortDigest) {
+          writeKeyringJournal(keyring, account, {
+            ...initialJournal,
+            shortDigest,
+          });
+        }
+        const accountEntry = new keyring.Entry(KEYRING_SERVICE, account);
+        accountEntry.setPassword(key);
+        if (readKeyringEntry(keyring, KEYRING_SERVICE, account) !== key) {
+          throw new Error('keyring credential write verification failed');
+        }
+        if (!reconcileKeyringJournal(keyring, account, diag)) return false;
+        return true;
+      }
+      reconciled = reconcileKeyringJournal(keyring, account, diag);
     } catch (err) {
       diag?.(classifyKeyringError(err));
       if (err instanceof InvalidKeyringJournalError) {
-        replaceMalformedKeyringJournalWithTombstone(Entry, account, diag);
+        replaceMalformedKeyringJournalWithTombstone(keyring, account, diag);
       }
       return false;
     }
     if (!reconciled) return false;
 
-    const accountEntry = new Entry(KEYRING_SERVICE, account);
-    const previousValue = accountEntry.getPassword() ?? null;
-    let previousMarker: KeyringChunkMarker | null = null;
-    try {
-      previousMarker = parseKeyringChunkMarker(previousValue);
-    } catch (err) {
-      diag?.(classifyKeyringError(err));
-      replaceMalformedKeyringJournalWithTombstone(Entry, account, diag);
+    const activeJournalRaw = readKeyringEntry(keyring, KEYRING_JOURNAL_SERVICE, account);
+    const activeJournal =
+      activeJournalRaw === null ? null : parseKeyringChunkJournal(activeJournalRaw);
+    const managedState = readKeyringManagedState(account);
+    deletedMarkerActive =
+      deletedMarkerActive ||
+      activeJournal?.mode === 'deleted' ||
+      readKeyringDeletionGuard(keyring, account) !== null;
+
+    const accountEntry = new keyring.Entry(KEYRING_SERVICE, account);
+    const previousValue = readKeyringEntry(keyring, KEYRING_SERVICE, account);
+    if (intent === 'probe') {
+      if (
+        !isDisposableCredentialProbeAccount(account) ||
+        activeJournal !== null ||
+        managedState !== null ||
+        deletedMarkerActive ||
+        previousValue !== null ||
+        hasUnjournaledKeyringChunks(keyring, account)
+      ) {
+        diag?.('credential account is not available for a new credential');
+        return false;
+      }
+    } else if (intent === 'provision') {
+      if (!isCredentialAccountInstance(account)) {
+        diag?.('provisioned credentials require a versioned account instance');
+        return false;
+      }
+    } else if (activeJournal === null && managedState === null && previousValue === null) {
+      diag?.('existing credential state could not be confirmed');
       return false;
     }
+    if (deletedMarkerActive) {
+      if (!clearKeyringDeletionGuard(keyring, account)) {
+        throw new Error('keyring deletion guard could not be cleared');
+      }
+      deletedMarkerActive = false;
+    }
+    let previousMarker =
+      activeJournal?.mode === 'write' ? (activeJournal.generations[0] ?? null) : null;
+    let previousShortDigest =
+      activeJournal?.mode === 'short' ? activeJournal.shortDigest : undefined;
+    try {
+      if (activeJournal?.mode === 'short') {
+        if (
+          previousValue !== null &&
+          createHash('sha256').update(previousValue).digest('hex') !== previousShortDigest
+        ) {
+          throw new Error('published short credential changed after reconciliation');
+        }
+      } else if (activeJournal?.mode === 'write') {
+        if (previousValue !== null) {
+          const observedMarker = parseKeyringChunkMarker(previousValue);
+          if (
+            !observedMarker ||
+            !previousMarker ||
+            !sameKeyringMarker(observedMarker, previousMarker)
+          ) {
+            throw new Error('published chunk credential changed after reconciliation');
+          }
+        }
+      } else if (activeJournal === null) {
+        previousMarker = parseKeyringChunkMarker(previousValue);
+        if (previousMarker) {
+          try {
+            readKeyringMarkerChunks(keyring, KEYRING_SERVICE, account, previousMarker);
+          } catch {
+            previousMarker = null;
+          }
+        }
+        if (previousValue !== null && !previousMarker) {
+          previousShortDigest = createHash('sha256').update(previousValue).digest('hex');
+        }
+      }
+    } catch (err) {
+      diag?.(classifyKeyringError(err));
+      replaceMalformedKeyringJournalWithTombstone(keyring, account, diag);
+      return false;
+    }
+    const unpublished =
+      activeJournal?.mode !== 'write' && activeJournal?.mode !== 'short' && previousValue === null;
     if (key.length <= KEYRING_CHUNK_SIZE) {
-      if (previousMarker) {
-        writeKeyringJournal(Entry, account, {
-          mode: 'write',
-          generations: [previousMarker],
+      const shortDigest = createHash('sha256').update(key).digest('hex');
+      const transitionJournal: KeyringChunkJournal = {
+        mode: 'short',
+        generations: previousMarker ? [previousMarker] : [],
+        shortDigest,
+        ...(previousShortDigest ? { fallbackShortDigest: previousShortDigest } : {}),
+        ...(unpublished ? { unpublished: true } : {}),
+      };
+      writeKeyringJournal(keyring, account, transitionJournal);
+      accountEntry.setPassword(key);
+      if (unpublished) {
+        writeKeyringJournal(keyring, account, {
+          ...transitionJournal,
+          publicationAttempted: true,
         });
       }
-      accountEntry.setPassword(key);
-      if (previousMarker && !reconcileKeyringJournal(Entry, account, diag)) {
+      if (readKeyringEntry(keyring, KEYRING_SERVICE, account) !== key) {
+        throw new Error('keyring credential write verification failed');
+      }
+      if (!reconcileKeyringJournal(keyring, account, diag)) {
         diag?.('keyring cleanup is pending and will be retried');
       }
       return true;
     }
-    const chunkCount = Math.ceil(key.length / KEYRING_CHUNK_SIZE);
+    const chunks = splitKeyringCredential(key);
+    const chunkCount = chunks.length;
     if (chunkCount > KEYRING_MAX_CHUNKS) {
       throw new Error('keyring credential exceeds the supported chunk count');
     }
@@ -877,16 +1493,30 @@ function writeKeyringAccountLocked(
       generation: randomUUID(),
       digest: createHash('sha256').update(key).digest('hex'),
     };
-    writeKeyringJournal(Entry, account, {
+    const transitionJournal: KeyringChunkJournal = {
       mode: 'write',
       generations: [marker, ...(previousMarker ? [previousMarker] : [])],
-    });
-    for (let i = 0; i < chunkCount; i++) {
-      const chunk = key.slice(i * KEYRING_CHUNK_SIZE, (i + 1) * KEYRING_CHUNK_SIZE);
-      new Entry(KEYRING_CHUNK_SERVICE, keyringChunkAccount(account, marker, i)).setPassword(chunk);
+      ...(previousShortDigest ? { fallbackShortDigest: previousShortDigest } : {}),
+      ...(unpublished ? { unpublished: true } : {}),
+    };
+    writeKeyringJournal(keyring, account, transitionJournal);
+    for (const [i, chunk] of chunks.entries()) {
+      new keyring.Entry(KEYRING_CHUNK_SERVICE, keyringChunkAccount(account, marker, i)).setPassword(
+        chunk,
+      );
     }
-    accountEntry.setPassword(encodeKeyringChunkMarker(marker));
-    if (!reconcileKeyringJournal(Entry, account, diag)) {
+    const encodedMarker = encodeKeyringChunkMarker(marker);
+    accountEntry.setPassword(encodedMarker);
+    if (unpublished) {
+      writeKeyringJournal(keyring, account, {
+        ...transitionJournal,
+        publicationAttempted: true,
+      });
+    }
+    if (readKeyringEntry(keyring, KEYRING_SERVICE, account) !== encodedMarker) {
+      throw new Error('keyring credential write verification failed');
+    }
+    if (!reconcileKeyringJournal(keyring, account, diag)) {
       diag?.('keyring cleanup is pending and will be retried');
     }
     return true;
@@ -899,12 +1529,13 @@ function writeKeyringAccountLocked(
 async function writeKeyringAccount(
   account: string,
   key: string,
+  intent: 'probe' | 'provision' | 'replace',
   diag?: (msg: string) => void,
 ): Promise<boolean> {
   return withKeyringAccountLock(account, false, diag, async () => {
     try {
-      const { Entry } = await import('@napi-rs/keyring');
-      return writeKeyringAccountLocked(Entry, account, key, diag);
+      const keyring = await import('@napi-rs/keyring');
+      return writeKeyringAccountLocked(keyring, account, key, intent, diag);
     } catch (err) {
       diag?.(classifyKeyringError(err));
       return false;
@@ -912,82 +1543,76 @@ async function writeKeyringAccount(
   });
 }
 
-async function deleteKeyringAccount(account: string, diag?: (msg: string) => void): Promise<boolean> {
+async function deleteKeyringAccount(
+  account: string,
+  diag?: (msg: string) => void,
+  blockLegacy = true,
+): Promise<boolean> {
   return withKeyringAccountLock(account, false, diag, async () => {
     try {
-      const { Entry } = await import('@napi-rs/keyring');
-      const journalEntry = new Entry(KEYRING_JOURNAL_SERVICE, account);
-      const accountEntry = new Entry(KEYRING_SERVICE, account);
-      const legacyAccountEntry = new Entry(LEGACY_KEYRING_SERVICE, account);
-      const pendingJournalRaw = journalEntry.getPassword();
-      const initialValue = accountEntry.getPassword();
-      const initialLegacyValue = legacyAccountEntry.getPassword();
+      const keyring = await import('@napi-rs/keyring');
+      let pendingJournalRaw = readKeyringEntry(keyring, KEYRING_JOURNAL_SERVICE, account);
+      if (pendingJournalRaw === null && readKeyringManagedState(account) !== null) {
+        if (!reconcileKeyringJournal(keyring, account, diag)) return false;
+        pendingJournalRaw = readKeyringEntry(keyring, KEYRING_JOURNAL_SERVICE, account);
+        if (pendingJournalRaw === null) return false;
+      }
       let pendingJournal: KeyringChunkJournal | null = null;
-      let pendingMode: KeyringChunkJournal['mode'] | null = null;
       try {
         if (pendingJournalRaw !== null) {
           pendingJournal = parseKeyringChunkJournal(pendingJournalRaw);
-          pendingMode = pendingJournal.mode;
+          if (pendingJournal.mode === 'deleted') {
+            return reconcileKeyringJournal(keyring, account, diag);
+          }
+          if (pendingJournal.mode === 'delete') {
+            if (blockLegacy && pendingJournal.blockLegacy !== true) {
+              pendingJournal = {
+                ...pendingJournal,
+                blockLegacy: true,
+              };
+              writeKeyringJournal(keyring, account, pendingJournal);
+            }
+            return reconcileKeyringJournal(keyring, account, diag);
+          }
         }
-        const cleanupComplete = reconcileKeyringJournal(Entry, account, diag);
-        if (pendingMode === 'delete' && !cleanupComplete) return false;
-        if (cleanupComplete) pendingJournal = null;
       } catch (err) {
         diag?.(classifyKeyringError(err));
         if (err instanceof InvalidKeyringJournalError) {
-          replaceMalformedKeyringJournalWithTombstone(Entry, account, diag);
+          replaceMalformedKeyringJournalWithTombstone(keyring, account, diag, blockLegacy);
         }
         return false;
       }
-      const value = accountEntry.getPassword();
-      const legacyValue = legacyAccountEntry.getPassword();
+      const value = readKeyringEntry(keyring, KEYRING_SERVICE, account);
+      if (pendingJournal === null && value === null) {
+        throw new Error('existing credential state could not be confirmed');
+      }
       const generations: KeyringChunkMarker[] = [];
-      const legacyGenerations: KeyringChunkMarker[] = [];
       for (const marker of pendingJournal?.generations ?? []) {
         appendUniqueKeyringMarker(generations, marker);
       }
-      for (const marker of pendingJournal?.legacyGenerations ?? []) {
-        appendUniqueKeyringMarker(legacyGenerations, marker);
-      }
-      let unverifiable = pendingJournal?.unverifiable === true;
-      for (const [storedValue, target] of [
-        ...(pendingMode === 'delete'
-          ? []
-          : [
-            [initialValue, generations],
-            [initialLegacyValue, legacyGenerations],
-          ] as const),
-        [value, generations],
-        [legacyValue, legacyGenerations],
-      ] as const) {
+      let unverifiable = false;
+      const shortDigest = pendingJournal?.mode === 'short' ? pendingJournal.shortDigest : undefined;
+      if (pendingJournal?.mode !== 'short') {
         try {
-          const marker = parseKeyringChunkMarker(storedValue);
-          if (marker) appendUniqueKeyringMarker(target, marker);
+          const marker = parseKeyringChunkMarker(value);
+          if (marker) appendUniqueKeyringMarker(generations, marker);
         } catch (err) {
           unverifiable = true;
           diag?.(classifyKeyringError(err));
         }
       }
-      if (
-        value === null
-        && legacyValue === null
-        && generations.length === 0
-        && legacyGenerations.length === 0
-        && !unverifiable
-      ) {
-        return true;
-      }
-      if (!keyringDeleteJournalFits(generations, legacyGenerations, unverifiable)) {
+      if (!keyringDeleteJournalFits(generations, unverifiable, blockLegacy, shortDigest)) {
         diag?.('keyring cleanup has too many pending generations');
         return false;
       }
-      writeKeyringJournal(Entry, account, {
+      writeKeyringJournal(keyring, account, {
         mode: 'delete',
         generations,
-        ...(legacyGenerations.length > 0 ? { legacyGenerations } : {}),
+        ...(shortDigest ? { shortDigest } : {}),
+        ...(blockLegacy ? { blockLegacy: true } : {}),
         ...(unverifiable ? { unverifiable: true } : {}),
       });
-      return reconcileKeyringJournal(Entry, account, diag);
+      return reconcileKeyringJournal(keyring, account, diag);
     } catch (err) {
       diag?.(classifyKeyringError(err));
       return false;
@@ -1019,9 +1644,12 @@ async function readStoredCredential(
 async function writeStoredCredential(
   ref: StoredCredentialRef,
   value: string,
+  intent: 'probe' | 'provision' | 'replace',
   diag?: (msg: string) => void,
 ): Promise<boolean> {
-  if (ref.kind === 'keyring') return writeKeyringAccount(ref.account, value, diag);
+  if (ref.kind === 'keyring') {
+    return writeKeyringAccount(ref.account, value, intent, diag);
+  }
   try {
     await writeCredentialHelperAccount(ref.account, value, ref.helperId);
     return true;
@@ -1034,8 +1662,11 @@ async function writeStoredCredential(
 async function deleteStoredCredential(
   ref: StoredCredentialRef,
   diag?: (msg: string) => void,
+  blockLegacy = true,
 ): Promise<boolean> {
-  if (ref.kind === 'keyring') return deleteKeyringAccount(ref.account, diag);
+  if (ref.kind === 'keyring') {
+    return deleteKeyringAccount(ref.account, diag, blockLegacy);
+  }
   try {
     await deleteCredentialHelperAccount(ref.account, ref.helperId);
     return true;
@@ -1281,17 +1912,22 @@ async function readProviderSecret(
   return decoded === rejectedAccessToken ? null : decoded;
 }
 
-export async function saveProviderCredential(
+async function persistProviderCredential(
   authRef: string,
   key: string,
+  intent: 'provision' | 'replace',
   diag?: (msg: string) => void,
 ): Promise<boolean> {
   const parsed = parseAuthRef(authRef);
   if (!parsed || parsed.kind === 'env' || parsed.kind === 'none') return false;
+  if (intent === 'provision' && !isCredentialAccountInstance(parsed.account)) {
+    diag?.('provisioned credentials require a versioned account instance');
+    return false;
+  }
   return withCredentialMutationLock(authRef, async () => {
     const cacheKey = storedCredentialAuthRef(parsed);
     clearOAuthCredentialCache(cacheKey);
-    const written = await writeStoredCredential(parsed, key, diag);
+    const written = await writeStoredCredential(parsed, key, intent, diag);
     if (!written) return false;
     const readBack = await readStoredCredential(parsed, diag);
     if (readBack === key) {
@@ -1305,6 +1941,24 @@ export async function saveProviderCredential(
     diag?.('credential store read-back verification failed');
     return false;
   });
+}
+
+/** Create or resume a credential at its provider-owned account reference. */
+export async function provisionProviderCredential(
+  authRef: string,
+  key: string,
+  diag?: (msg: string) => void,
+): Promise<boolean> {
+  return persistProviderCredential(authRef, key, 'provision', diag);
+}
+
+/** Replace a credential whose prior state can be confirmed. */
+export async function saveProviderCredential(
+  authRef: string,
+  key: string,
+  diag?: (msg: string) => void,
+): Promise<boolean> {
+  return persistProviderCredential(authRef, key, 'replace', diag);
 }
 
 /** Verify that a credential backend can durably round-trip a disposable secret. */
@@ -1321,7 +1975,7 @@ export async function probeProviderCredentialStore(
   const value = randomUUID();
   let verified = false;
   try {
-    const written = await writeStoredCredential(probeRef, value, diag);
+    const written = await writeStoredCredential(probeRef, value, 'probe', diag);
     if (!written) return false;
     const readBack = await readStoredCredential(probeRef, diag);
     if (readBack !== value) {
@@ -1330,7 +1984,7 @@ export async function probeProviderCredentialStore(
     }
     verified = true;
   } finally {
-    const deleted = await deleteStoredCredential(probeRef, diag);
+    const deleted = await deleteStoredCredential(probeRef, diag, false);
     if (!deleted) {
       diag?.('credential store probe cleanup failed');
       verified = false;

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,6 +1,12 @@
 // src/env.ts
 import { CONFLICTING_ENV_VARS } from './constants.js';
-import { createHash, randomUUID } from 'node:crypto';
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  randomBytes,
+  randomUUID,
+} from 'node:crypto';
 import {
   closeSync,
   fsyncSync,
@@ -127,15 +133,17 @@ const KEYRING_SERVICE = 'clodex';
 const KEYRING_CHUNK_SERVICE = 'clodex-chunks';
 const KEYRING_JOURNAL_SERVICE = 'clodex-journal';
 const KEYRING_DELETED_SERVICE = 'clodex-deleted';
+const KEYRING_MANAGED_STATE_KEY_SERVICE = 'clodex-state-key';
 const KEYRING_DELETED_VALUE = 'v1:deleted';
 const KEYRING_PENDING_DELETE_VALUE = 'v1:pending';
+const KEYRING_MANAGED_STATE_KEY_PREFIX = 'v1:';
 // Windows Credential Manager caps a single credential blob at 2560 bytes (CredWriteW).
 // keyring-rs encodes the password as UTF-16 (2 bytes/char) before that check, so the
 // usable limit is 2560 / 2 = 1280 chars — long OAuth tokens (e.g. OpenAI's JWTs) exceed
 // this, so secrets above the threshold are split across multiple keyring entries.
 // Harmless on macOS/Linux, which have no such limit.
 const KEYRING_CHUNK_PREFIX = '__relay_chunked__:';
-const KEYRING_JOURNAL_PREFIX = '__relay_chunk_journal__:v1:';
+const KEYRING_JOURNAL_PREFIX = '__clodex_chunk_journal__:v1:';
 const KEYRING_DELETE_TOMBSTONE_PREFIX = '__clodex_delete__:';
 const KEYRING_ENUMERATION_SENTINEL_PREFIX = '__clodex_inventory__:';
 const KEYRING_MAX_ENTRY_CHARS = 1200;
@@ -373,6 +381,50 @@ function removeKeyringEnumerationSentinel(
   sentinel: KeyringEnumerationSentinel,
 ): boolean {
   return deleteKeyringEntry(keyring, sentinel.service, sentinel.account);
+}
+
+function verifyEmptyKeyringCredentialInventory(
+  keyring: KeyringApi,
+  account: string,
+  diag?: (msg: string) => void,
+): boolean {
+  const sentinels: KeyringEnumerationSentinel[] = [];
+  let empty = false;
+  let cleanupComplete = true;
+  try {
+    for (const service of [KEYRING_SERVICE, KEYRING_CHUNK_SERVICE]) {
+      const sentinel = createKeyringEnumerationSentinel(service, account);
+      sentinels.push(sentinel);
+      writeKeyringEnumerationSentinel(keyring, sentinel);
+    }
+    const currentValue = readKeyringEntry(keyring, KEYRING_SERVICE, account);
+    const inventory = listUnjournaledKeyringChunks(keyring, account);
+    const complete = sentinels.every(sentinel =>
+      inventory.some(entry => sameKeyringEnumerationEntry(entry, sentinel)),
+    );
+    const credentialEntries = inventory.filter(
+      entry => !sentinels.some(sentinel => sameKeyringEnumerationEntry(entry, sentinel)),
+    );
+    empty = complete && currentValue === null && credentialEntries.length === 0;
+    if (!complete) {
+      diag?.('keyring credential inventory could not be verified');
+    }
+  } catch (err) {
+    diag?.(classifyKeyringError(err));
+  } finally {
+    for (const sentinel of sentinels) {
+      try {
+        if (!removeKeyringEnumerationSentinel(keyring, sentinel)) {
+          cleanupComplete = false;
+          diag?.('keyring credential inventory sentinel could not be removed');
+        }
+      } catch (err) {
+        cleanupComplete = false;
+        diag?.(classifyKeyringError(err));
+      }
+    }
+  }
+  return empty && cleanupComplete;
 }
 
 function isDisposableCredentialProbeAccount(account: string): boolean {
@@ -720,12 +772,12 @@ function writeKeyringJournal(
   if (encoded.length > KEYRING_MAX_ENTRY_CHARS) {
     throw new Error('keyring cleanup journal exceeds the credential entry limit');
   }
-  persistKeyringManagedState(account, { mode: 'preparing', journal });
+  persistKeyringManagedState(keyring, account, { mode: 'preparing', journal });
   entry.setPassword(encoded);
   if (readKeyringEntry(keyring, KEYRING_JOURNAL_SERVICE, account) !== encoded) {
     throw new Error('keyring cleanup journal verification failed');
   }
-  persistKeyringManagedState(account, { mode: 'managed', journal });
+  persistKeyringManagedState(keyring, account, { mode: 'managed', journal });
 }
 
 function adoptKeyringJournal(
@@ -735,7 +787,16 @@ function adoptKeyringJournal(
   diag?: (msg: string) => void,
 ): void {
   try {
-    writeKeyringJournal(keyring, account, journal);
+    const encoded = encodeKeyringJournal(journal);
+    if (encoded.length > KEYRING_MAX_ENTRY_CHARS) {
+      throw new Error('keyring cleanup journal exceeds the credential entry limit');
+    }
+    const entry = new keyring.Entry(KEYRING_JOURNAL_SERVICE, account);
+    entry.setPassword(encoded);
+    if (readKeyringEntry(keyring, KEYRING_JOURNAL_SERVICE, account) !== encoded) {
+      throw new Error('keyring cleanup journal verification failed');
+    }
+    persistKeyringManagedState(keyring, account, { mode: 'managed', journal });
   } catch (err) {
     diag?.(classifyKeyringError(err));
   }
@@ -773,7 +834,7 @@ function reconcileKeyringJournal(
   diag?: (msg: string) => void,
 ): boolean {
   let rawJournal = readKeyringEntry(keyring, KEYRING_JOURNAL_SERVICE, account);
-  let managedState = readKeyringManagedState(account);
+  let managedState = readKeyringManagedState(keyring, account);
   if (managedState?.mode === 'preparing') {
     try {
       writeKeyringJournal(keyring, account, managedState.journal);
@@ -822,7 +883,7 @@ function reconcileKeyringJournal(
     encodeKeyringJournal(managedState.journal) !== rawJournal
   ) {
     try {
-      persistKeyringManagedState(account, { mode: 'managed', journal });
+      persistKeyringManagedState(keyring, account, { mode: 'managed', journal });
     } catch (err) {
       diag?.(classifyKeyringError(err));
       return false;
@@ -1151,6 +1212,10 @@ function reconcileKeyringJournal(
         return false;
       }
       removeKeyringManagedState(account);
+      if (!deleteKeyringEntry(keyring, KEYRING_MANAGED_STATE_KEY_SERVICE, account)) {
+        diag?.('keyring managed-state encryption key could not be removed');
+        return false;
+      }
       return true;
     } catch (err) {
       diag?.(classifyKeyringError(err));
@@ -1207,12 +1272,19 @@ function reconcileKeyringJournal(
   }
 }
 
-const KEYRING_PREPARING_STATE_PREFIX = 'v1:preparing:';
-const KEYRING_MANAGED_STATE_PREFIX = 'v1:managed:';
+const KEYRING_PREPARING_STATE_PREFIX = 'v2:preparing:';
+const KEYRING_MANAGED_STATE_PREFIX = 'v2:managed:';
 const KEYRING_EMPTY_MANAGED_STATE_VALUE = 'v1:managed\n';
 type KeyringManagedState =
   | { mode: 'preparing'; journal: KeyringChunkJournal }
   | { mode: 'managed'; journal: KeyringChunkJournal | null };
+
+class KeyringManagedStateKeyUnavailableError extends Error {
+  constructor() {
+    super('keyring managed-state encryption key is unavailable');
+    this.name = 'KeyringManagedStateKeyUnavailableError';
+  }
+}
 
 function keyringAccountIdentity(account: string): string {
   return createHash('sha256').update(account).digest('hex');
@@ -1222,7 +1294,64 @@ function keyringManagedStatePath(account: string): string {
   return join(getCredentialStateRoot(), `${keyringAccountIdentity(account)}.managed`);
 }
 
-function readKeyringManagedState(account: string): KeyringManagedState | null {
+function parseKeyringManagedStateKey(value: string): Buffer {
+  if (!value.startsWith(KEYRING_MANAGED_STATE_KEY_PREFIX)) {
+    throw new Error('keyring managed-state encryption key is invalid');
+  }
+  const encoded = value.slice(KEYRING_MANAGED_STATE_KEY_PREFIX.length);
+  const key = Buffer.from(encoded, 'base64url');
+  if (key.length !== 32 || key.toString('base64url') !== encoded) {
+    throw new Error('keyring managed-state encryption key is invalid');
+  }
+  return key;
+}
+
+function readKeyringManagedStateKey(keyring: KeyringApi, account: string): Buffer | null {
+  const value = readKeyringEntry(keyring, KEYRING_MANAGED_STATE_KEY_SERVICE, account);
+  return value === null ? null : parseKeyringManagedStateKey(value);
+}
+
+function ensureKeyringManagedStateKey(keyring: KeyringApi, account: string): Buffer {
+  const current = readKeyringManagedStateKey(keyring, account);
+  if (current !== null) return current;
+  const key = randomBytes(32);
+  const encoded = `${KEYRING_MANAGED_STATE_KEY_PREFIX}${key.toString('base64url')}`;
+  const entry = new keyring.Entry(KEYRING_MANAGED_STATE_KEY_SERVICE, account);
+  entry.setPassword(encoded);
+  if (readKeyringEntry(keyring, KEYRING_MANAGED_STATE_KEY_SERVICE, account) !== encoded) {
+    throw new Error('keyring managed-state encryption key verification failed');
+  }
+  return key;
+}
+
+function keyringManagedStateAad(account: string, mode: KeyringManagedState['mode']): Buffer {
+  return Buffer.from(`clodex-managed-state:v2:${mode}:${account}`, 'utf8');
+}
+
+function decryptKeyringManagedState(
+  key: Buffer,
+  account: string,
+  mode: KeyringManagedState['mode'],
+  encoded: string,
+): KeyringChunkJournal {
+  const payload = Buffer.from(encoded, 'base64url');
+  if (payload.toString('base64url') !== encoded || payload.length <= 28) {
+    throw new Error('keyring managed-state marker is invalid');
+  }
+  const nonce = payload.subarray(0, 12);
+  const tag = payload.subarray(12, 28);
+  const ciphertext = payload.subarray(28);
+  const decipher = createDecipheriv('aes-256-gcm', key, nonce);
+  decipher.setAAD(keyringManagedStateAad(account, mode));
+  decipher.setAuthTag(tag);
+  const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+  return parseKeyringChunkJournal(plaintext);
+}
+
+function readKeyringManagedState(
+  keyring: KeyringApi,
+  account: string,
+): KeyringManagedState | null {
   try {
     const value = readFileSync(keyringManagedStatePath(account), 'utf8');
     if (value === KEYRING_EMPTY_MANAGED_STATE_VALUE) {
@@ -1234,17 +1363,23 @@ function readKeyringManagedState(account: string): KeyringManagedState | null {
         ? KEYRING_MANAGED_STATE_PREFIX
         : null;
     if (statePrefix && value.endsWith('\n')) {
-      const encodedJournal = value.slice(statePrefix.length, -1);
       try {
-        const rawJournal = Buffer.from(encodedJournal, 'base64url').toString('utf8');
-        if (Buffer.from(rawJournal, 'utf8').toString('base64url') !== encodedJournal) {
-          throw new Error('non-canonical encoding');
+        const mode = statePrefix === KEYRING_PREPARING_STATE_PREFIX ? 'preparing' : 'managed';
+        const key = readKeyringManagedStateKey(keyring, account);
+        if (key === null) {
+          throw new KeyringManagedStateKeyUnavailableError();
         }
-        const journal = parseKeyringChunkJournal(rawJournal);
-        return statePrefix === KEYRING_PREPARING_STATE_PREFIX
+        const journal = decryptKeyringManagedState(
+          key,
+          account,
+          mode,
+          value.slice(statePrefix.length, -1),
+        );
+        return mode === 'preparing'
           ? { mode: 'preparing', journal }
           : { mode: 'managed', journal };
-      } catch {
+      } catch (err) {
+        if (err instanceof KeyringManagedStateKeyUnavailableError) throw err;
         throw new Error('keyring managed-state marker is invalid');
       }
     }
@@ -1255,16 +1390,39 @@ function readKeyringManagedState(account: string): KeyringManagedState | null {
   }
 }
 
-function encodeKeyringManagedState(state: KeyringManagedState): string {
+function sameKeyringManagedState(
+  left: KeyringManagedState,
+  right: KeyringManagedState,
+): boolean {
+  if (left.mode !== right.mode) return false;
+  if (left.journal === null || right.journal === null) {
+    return left.journal === right.journal;
+  }
+  return encodeKeyringJournal(left.journal) === encodeKeyringJournal(right.journal);
+}
+
+function encodeKeyringManagedState(
+  keyring: KeyringApi,
+  account: string,
+  state: KeyringManagedState,
+): string {
   if (state.mode === 'managed' && state.journal === null) {
     return KEYRING_EMPTY_MANAGED_STATE_VALUE;
   }
   const journal = state.journal;
   if (journal === null) return KEYRING_EMPTY_MANAGED_STATE_VALUE;
-  const encodedJournal = Buffer.from(encodeKeyringJournal(journal), 'utf8').toString('base64url');
+  const key = ensureKeyringManagedStateKey(keyring, account);
+  const nonce = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', key, nonce);
+  cipher.setAAD(keyringManagedStateAad(account, state.mode));
+  const ciphertext = Buffer.concat([
+    cipher.update(encodeKeyringJournal(journal), 'utf8'),
+    cipher.final(),
+  ]);
+  const payload = Buffer.concat([nonce, cipher.getAuthTag(), ciphertext]).toString('base64url');
   const prefix =
     state.mode === 'preparing' ? KEYRING_PREPARING_STATE_PREFIX : KEYRING_MANAGED_STATE_PREFIX;
-  return `${prefix}${encodedJournal}\n`;
+  return `${prefix}${payload}\n`;
 }
 
 function syncDirectory(path: string): void {
@@ -1282,10 +1440,14 @@ function syncDirectory(path: string): void {
   }
 }
 
-function persistKeyringManagedState(account: string, state: KeyringManagedState): void {
-  const currentState = readKeyringManagedState(account);
-  const encodedState = encodeKeyringManagedState(state);
-  if (currentState !== null && encodeKeyringManagedState(currentState) === encodedState) return;
+function persistKeyringManagedState(
+  keyring: KeyringApi,
+  account: string,
+  state: KeyringManagedState,
+): void {
+  const currentState = readKeyringManagedState(keyring, account);
+  if (currentState !== null && sameKeyringManagedState(currentState, state)) return;
+  const encodedState = encodeKeyringManagedState(keyring, account, state);
   const path = keyringManagedStatePath(account);
   const directory = getCredentialStateRoot();
   mkdirSync(directory, { recursive: true, mode: 0o700 });
@@ -1361,7 +1523,10 @@ async function readKeyringAccount(
       const finalJournal =
         finalJournalRaw === null ? null : parseKeyringChunkJournal(finalJournalRaw);
       if (finalJournal?.mode === 'delete' || finalJournal?.mode === 'deleted') return null;
-      if (finalJournalRaw === null && readKeyringManagedState(account)?.mode === 'managed') {
+      if (
+        finalJournalRaw === null &&
+        readKeyringManagedState(keyring, account)?.mode === 'managed'
+      ) {
         return null;
       }
       if (finalJournal?.mode === 'short') {
@@ -1433,6 +1598,60 @@ function replaceMalformedKeyringJournalWithTombstone(
   }
 }
 
+function recoverEmptyPublishedKeyringState(
+  keyring: KeyringApi,
+  account: string,
+  diag?: (msg: string) => void,
+): boolean {
+  const rawJournal = readKeyringEntry(keyring, KEYRING_JOURNAL_SERVICE, account);
+  if (rawJournal === null) return false;
+  const journal = parseKeyringChunkJournal(rawJournal);
+  if (
+    (journal.mode !== 'write' && journal.mode !== 'short') ||
+    journal.unpublished === true ||
+    readKeyringEntry(keyring, KEYRING_SERVICE, account) !== null
+  ) {
+    return false;
+  }
+  if (!verifyEmptyKeyringCredentialInventory(keyring, account, diag)) {
+    return false;
+  }
+  if (!writeKeyringDeletionGuard(keyring, account, 'deleted')) {
+    diag?.('keyring deletion guard could not be verified');
+    return false;
+  }
+  writeKeyringJournal(keyring, account, {
+    mode: 'deleted',
+    generations: [],
+  });
+  diag?.('discarded missing published credential metadata after verifying an empty keyring');
+  return true;
+}
+
+function recoverEmptyOpaqueManagedKeyringState(
+  keyring: KeyringApi,
+  account: string,
+  diag?: (msg: string) => void,
+): boolean {
+  if (readKeyringEntry(keyring, KEYRING_SERVICE, account) !== null) {
+    return false;
+  }
+  if (!verifyEmptyKeyringCredentialInventory(keyring, account, diag)) {
+    return false;
+  }
+  if (!writeKeyringDeletionGuard(keyring, account, 'deleted')) {
+    diag?.('keyring deletion guard could not be verified');
+    return false;
+  }
+  removeKeyringManagedState(account);
+  writeKeyringJournal(keyring, account, {
+    mode: 'deleted',
+    generations: [],
+  });
+  diag?.('recovered managed credential metadata after verifying an empty keyring');
+  return true;
+}
+
 function writeKeyringAccountLocked(
   keyring: KeyringApi,
   account: string,
@@ -1475,19 +1694,34 @@ function writeKeyringAccountLocked(
         return true;
       }
       reconciled = reconcileKeyringJournal(keyring, account, diag);
+      if (
+        !reconciled &&
+        intent !== 'probe' &&
+        recoverEmptyPublishedKeyringState(keyring, account, diag)
+      ) {
+        reconciled = reconcileKeyringJournal(keyring, account, diag);
+      }
     } catch (err) {
       diag?.(classifyKeyringError(err));
-      if (err instanceof InvalidKeyringJournalError) {
+      if (
+        err instanceof KeyringManagedStateKeyUnavailableError &&
+        intent !== 'probe' &&
+        recoverEmptyOpaqueManagedKeyringState(keyring, account, diag)
+      ) {
+        reconciled = reconcileKeyringJournal(keyring, account, diag);
+      } else if (err instanceof InvalidKeyringJournalError) {
         replaceMalformedKeyringJournalWithTombstone(keyring, account, diag);
+        return false;
+      } else {
+        return false;
       }
-      return false;
     }
     if (!reconciled) return false;
 
     const activeJournalRaw = readKeyringEntry(keyring, KEYRING_JOURNAL_SERVICE, account);
     const activeJournal =
       activeJournalRaw === null ? null : parseKeyringChunkJournal(activeJournalRaw);
-    const managedState = readKeyringManagedState(account);
+    const managedState = readKeyringManagedState(keyring, account);
     deletedMarkerActive =
       deletedMarkerActive ||
       activeJournal?.mode === 'deleted' ||
@@ -1664,7 +1898,7 @@ function deleteJournalLessManagedKeyringAccount(
       writeKeyringEnumerationSentinel(keyring, sentinel);
     }
     const currentValue = readKeyringEntry(keyring, KEYRING_SERVICE, account);
-    const currentMarker = parseKeyringChunkMarker(currentValue);
+    parseKeyringChunkMarker(currentValue);
     // The keyring binding returns a complete service snapshot or an error. Sentinels detect
     // backends that make this account namespace temporarily invisible without throwing.
     const inventory = listUnjournaledKeyringChunks(keyring, account);
@@ -1679,18 +1913,6 @@ function deleteJournalLessManagedKeyringAccount(
     const chunks = inventory.filter(
       entry => !sentinels.some(sentinel => sameKeyringEnumerationEntry(entry, sentinel)),
     );
-    if (currentMarker) {
-      const chunkService = keyringChunkService(KEYRING_SERVICE, currentMarker);
-      for (let index = 0; index < currentMarker.count; index++) {
-        const chunkAccount = keyringChunkAccount(account, currentMarker, index);
-        if (
-          !chunks.some(chunk => chunk.service === chunkService && chunk.account === chunkAccount)
-        ) {
-          diag?.('keyring credential chunk inventory could not be verified');
-          return false;
-        }
-      }
-    }
     if (!writeKeyringDeletionGuard(keyring, account, 'deleted')) {
       diag?.('keyring deletion guard could not be verified');
       return false;
@@ -1737,7 +1959,9 @@ function deleteJournalLessManagedKeyringAccount(
     if (!sentinelsRemoved) {
       for (const sentinel of sentinels) {
         try {
-          new keyring.Entry(sentinel.service, sentinel.account).deletePassword();
+          if (!removeKeyringEnumerationSentinel(keyring, sentinel)) {
+            diag?.('keyring credential inventory sentinel could not be removed');
+          }
         } catch (err) {
           diag?.(classifyKeyringError(err));
         }
@@ -1756,7 +1980,7 @@ async function deleteKeyringAccount(
       const keyring = await import('@napi-rs/keyring');
       let pendingJournalRaw = readKeyringEntry(keyring, KEYRING_JOURNAL_SERVICE, account);
       if (pendingJournalRaw === null) {
-        const managedState = readKeyringManagedState(account);
+        const managedState = readKeyringManagedState(keyring, account);
         if (managedState !== null) {
           if (managedState.journal === null) {
             return deleteJournalLessManagedKeyringAccount(keyring, account, diag);

--- a/src/registry/add-template.ts
+++ b/src/registry/add-template.ts
@@ -1,8 +1,7 @@
 // src/registry/add-template.ts — add a provider from a builtin template
 
-import { randomUUID } from 'node:crypto';
-import { saveProviderCredential } from '../env.js';
-import { credentialAuthRef } from '../credential-helper.js';
+import { provisionProviderCredential, saveProviderCredential } from '../env.js';
+import { credentialInstanceAuthRef } from '../credential-helper.js';
 import { isSdkMigratedNpm } from '../provider-factory.js';
 import type { ProviderTemplate } from '../provider-templates.js';
 import { classifyFreeStatus, isFreeStatus } from '../free-models.js';
@@ -16,6 +15,7 @@ import { fetchTemplateModels } from './fetch-template-models.js';
 import { loadRegistryStrict, saveRegistry } from './io.js';
 import {
   withCredentialMutationLock,
+  withProviderMutationLock,
   withRegistryWriteLock,
 } from './lock.js';
 import {
@@ -84,7 +84,6 @@ export async function addProviderFromTemplate(
     const existing = registry.providers.find(p => p.id === template.id);
     if (existing && !opts?.replaceExisting) {
       return {
-        existing: false,
         error: {
           added: false as const,
           error: `${template.name} is already configured.`,
@@ -92,7 +91,7 @@ export async function addProviderFromTemplate(
         },
       };
     }
-    return { existing: existing !== undefined, error: null };
+    return { authRef: existing?.authRef ?? null, error: null };
   });
   if (existingState.error) return existingState.error;
 
@@ -122,76 +121,43 @@ export async function addProviderFromTemplate(
     buildPricingIndex(pricingCache),
     platform,
   );
-  const authRef = trimmedKey
-    ? credentialAuthRef(
-      existingState.existing
-        ? `provider:${template.id}:replacement:${randomUUID()}`
-        : `provider:${template.id}`,
-    )
-    : 'none:anonymous';
-  const commitProvider = () => withRegistryWriteLock(async () => {
-    const registry = loadRegistryStrict();
-    const existing = registry.providers.find(p => p.id === template.id);
-    if (existing && !opts?.replaceExisting) {
-      return {
-        added: false,
-        error: `${template.name} is already configured.`,
-        hint: `Remove it first with: clodex providers remove ${template.id}`,
-      };
-    }
-
-    const now = new Date().toISOString();
-    const entry: RegistryProvider = {
-      id: template.id,
-      templateId: template.id,
-      name: template.name,
-      enabled: true,
-      authRef,
-      authType: trimmedKey ? template.authType : 'none',
-      ...(!trimmedKey && template.anonymousFreeModels
-        ? { subscriptionFilter: 'free' as const }
-        : {}),
-      api: {
-        npm: template.npm,
-        url: fetched.baseUrl,
-      },
-      addedAt: existing?.addedAt ?? now,
-      refreshedAt: now,
-      modelsCache: {
-        fetchedAt: now,
-        models: pricedModels,
-      },
-    };
-
-    if (existing) {
-      const idx = registry.providers.findIndex(p => p.id === template.id);
-      registry.providers[idx] = entry;
-    } else {
-      registry.providers.push(entry);
-    }
-    if (existing?.authRef && existing.authRef !== authRef) {
-      await queueCredentialDelete(existing.authRef);
-    }
-    saveRegistry(registry);
-    let credentialCleanupPending = false;
-    if (trimmedKey) {
-      try {
-        await cancelCredentialDelete(authRef);
-      } catch {
-        credentialCleanupPending = true;
+  const account = `provider:${template.id}`;
+  const result: AddTemplateResult = await withProviderMutationLock(template.id, async () => {
+    const currentState = await withRegistryWriteLock(() => {
+      const registry = loadRegistryStrict();
+      const existing = registry.providers.find(p => p.id === template.id);
+      if (existing && !opts?.replaceExisting) {
+        return {
+          existingAuthRef: null,
+          error: {
+            added: false as const,
+            error: `${template.name} is already configured.`,
+            hint: `Remove it first with: clodex providers remove ${template.id}`,
+          },
+        };
       }
-    }
-    return {
-      added: true,
-      provider: entry,
-      modelCount: pricedModels.length,
-      ...(credentialCleanupPending ? { credentialCleanupPending: true } : {}),
-    };
-  });
+      return { existingAuthRef: existing?.authRef ?? null, error: null };
+    });
+    if (currentState.error) return currentState.error;
 
-  const result: AddTemplateResult = trimmedKey
-    ? await withCredentialMutationLock(authRef, async () => {
-      const prepareError = await withRegistryWriteLock(() => {
+    const authRef = trimmedKey ? credentialInstanceAuthRef(account) : 'none:anonymous';
+    const persistAndCommit = async (): Promise<AddTemplateResult> => {
+      if (trimmedKey) {
+        await journalCredentialWrite(authRef);
+        const saved =
+          currentState.existingAuthRef === authRef
+            ? await saveProviderCredential(authRef, trimmedKey)
+            : await provisionProviderCredential(authRef, trimmedKey);
+        if (!saved) {
+          return {
+            added: false,
+            error: 'Could not save API key to the credential store.',
+            hint: 'Check credential-store access and try again.',
+          };
+        }
+      }
+
+      return withRegistryWriteLock(async () => {
         const registry = loadRegistryStrict();
         const existing = registry.providers.find(p => p.id === template.id);
         if (existing && !opts?.replaceExisting) {
@@ -201,23 +167,67 @@ export async function addProviderFromTemplate(
             hint: `Remove it first with: clodex providers remove ${template.id}`,
           };
         }
-        return null;
-      });
-      if (prepareError) return prepareError;
+        if ((existing?.authRef ?? null) !== currentState.existingAuthRef) {
+          return {
+            added: false,
+            error: `${template.name} changed while its credential was being saved.`,
+            hint: 'Retry the provider update.',
+          };
+        }
 
-      await journalCredentialWrite(authRef);
-
-      const saved = await saveProviderCredential(authRef, trimmedKey);
-      if (!saved) {
-        return {
-          added: false,
-          error: 'Could not save API key to the credential store.',
-          hint: 'Check credential-store access and try again.',
+        const now = new Date().toISOString();
+        const entry: RegistryProvider = {
+          id: template.id,
+          templateId: template.id,
+          name: template.name,
+          enabled: true,
+          authRef,
+          authType: trimmedKey ? template.authType : 'none',
+          ...(!trimmedKey && template.anonymousFreeModels
+            ? { subscriptionFilter: 'free' as const }
+            : {}),
+          api: {
+            npm: template.npm,
+            url: fetched.baseUrl,
+          },
+          addedAt: existing?.addedAt ?? now,
+          refreshedAt: now,
+          modelsCache: {
+            fetchedAt: now,
+            models: pricedModels,
+          },
         };
-      }
-      return commitProvider();
-    })
-    : await commitProvider();
+
+        if (existing) {
+          const idx = registry.providers.findIndex(p => p.id === template.id);
+          registry.providers[idx] = entry;
+        } else {
+          registry.providers.push(entry);
+        }
+        if (existing?.authRef && existing.authRef !== authRef) {
+          await queueCredentialDelete(existing.authRef);
+        }
+        saveRegistry(registry);
+        let credentialCleanupPending = false;
+        if (trimmedKey) {
+          try {
+            await cancelCredentialDelete(authRef);
+          } catch {
+            credentialCleanupPending = true;
+          }
+        }
+        return {
+          added: true,
+          provider: entry,
+          modelCount: pricedModels.length,
+          ...(credentialCleanupPending ? { credentialCleanupPending: true } : {}),
+        };
+      });
+    };
+
+    if (!trimmedKey) return persistAndCommit();
+    return withCredentialMutationLock(authRef, persistAndCommit);
+  });
 
   if (result.added) {
     try {

--- a/src/registry/crud.ts
+++ b/src/registry/crud.ts
@@ -6,6 +6,7 @@ import {
 } from './credential-lifecycle.js';
 import { loadRegistryStrict, saveRegistry } from './io.js';
 import {
+  withProviderMutationLock,
   withRegistryWriteLock,
   withRegistryWriteLockSync,
 } from './lock.js';
@@ -26,7 +27,7 @@ interface PendingProviderRemoval {
 }
 
 /** Remove a provider from the registry; delete its stored credential when safe. */
-export async function removeProviderFromRegistry(
+async function removeProviderWithinLifecycle(
   id: string,
   opts?: { deleteCredential?: boolean },
 ): Promise<RemoveProviderResult> {
@@ -74,6 +75,13 @@ export async function removeProviderFromRegistry(
     removal.result.credentialCleanupReconciled = true;
   }
   return removal.result;
+}
+
+export async function removeProviderFromRegistry(
+  id: string,
+  opts?: { deleteCredential?: boolean },
+): Promise<RemoveProviderResult> {
+  return withProviderMutationLock(id, () => removeProviderWithinLifecycle(id, opts));
 }
 
 export function toggleProviderEnabled(id: string): { toggled: boolean; enabled?: boolean; error?: string } {

--- a/src/registry/custom-endpoint.ts
+++ b/src/registry/custom-endpoint.ts
@@ -1,8 +1,7 @@
 // src/registry/custom-endpoint.ts — add custom OpenAI/Anthropic-compatible providers
 
-import { randomUUID } from 'node:crypto';
-import { saveProviderCredential } from '../env.js';
-import { credentialAuthRef } from '../credential-helper.js';
+import { provisionProviderCredential } from '../env.js';
+import { credentialInstanceAuthRef } from '../credential-helper.js';
 import { deriveBrand } from '../models.js';
 import { resolveContextWindow } from '../context-window.js';
 import {
@@ -14,6 +13,7 @@ import { fetchTemplateModels } from './fetch-template-models.js';
 import { loadRegistryStrict, saveRegistry } from './io.js';
 import {
   withCredentialMutationLock,
+  withProviderMutationLock,
   withRegistryWriteLock,
 } from './lock.js';
 import type { CachedModel, RegistryProvider } from './types.js';
@@ -26,6 +26,8 @@ import {
 } from '../trace-log.js';
 
 export type CustomEndpointKind = 'openai' | 'anthropic';
+
+const CUSTOM_PROVIDER_ALLOCATION_SLOT = 'custom-provider-allocation';
 
 export interface AddCustomEndpointInput {
   displayName: string;
@@ -146,13 +148,12 @@ function uniqueProviderId(displayName: string, registry: { providers: RegistryPr
   if (!isValidProviderId(base)) base = 'custom-provider';
 
   if (!registry.providers.some(p => p.id === base)) return base;
-  for (let i = 2; i < 100; i++) {
+  for (let i = 2; ; i++) {
     const candidate = `${base}-${i}`;
     if (isValidProviderId(candidate) && !registry.providers.some(p => p.id === candidate)) {
       return candidate;
     }
   }
-  return `${base}-${Date.now()}`;
 }
 
 export async function addCustomEndpointProvider(input: AddCustomEndpointInput): Promise<AddCustomEndpointResult> {
@@ -196,68 +197,78 @@ export async function addCustomEndpointProvider(input: AddCustomEndpointInput): 
     return { added: false, error: fetched.error ?? 'No models returned.', hint: fetched.hint };
   }
 
-  const authRef = anonymous
-    ? 'none:anonymous'
-    : credentialAuthRef(`provider:${probeProviderId}:${randomUUID()}`);
-  const commitProvider = () => withRegistryWriteLock(async () => {
-    const registry = loadRegistryStrict();
-    const providerId = uniqueProviderId(displayName, registry);
-
-    const now = new Date().toISOString();
-    const entry: RegistryProvider = {
-      id: providerId,
-      templateId: input.kind === 'anthropic' ? 'custom-anthropic' : 'custom-openai',
-      name: displayName,
-      enabled: true,
-      authRef,
-      authType: anonymous ? 'none' : 'api',
-      api: { npm, url: fetched.baseUrl, ...(headers ? { headers } : {}) },
-      addedAt: now,
-      refreshedAt: now,
-      modelsCache: {
-        fetchedAt: now,
-        models: fetched.models.map(m => ({
-          ...m,
-          modelFormat: modelFormatForKind(input.kind),
-          npm,
-          apiUrl: fetched.baseUrl,
-        })),
-      },
-    };
-
-    registry.providers.push(entry);
-    saveRegistry(registry);
-    let credentialCleanupPending = false;
-    if (!anonymous) {
-      try {
-        await cancelCredentialDelete(authRef);
-      } catch {
-        credentialCleanupPending = true;
+  const result = await withProviderMutationLock(CUSTOM_PROVIDER_ALLOCATION_SLOT, async () => {
+    const providerId = await withRegistryWriteLock(() =>
+      uniqueProviderId(displayName, loadRegistryStrict()),
+    );
+    const account = `provider:${providerId}`;
+    const authRef = anonymous ? 'none:anonymous' : credentialInstanceAuthRef(account);
+    const persistAndCommit = async (): Promise<AddCustomEndpointResult> => {
+      if (!anonymous) {
+        await journalCredentialWrite(authRef);
+        const saved = await provisionProviderCredential(authRef, apiKey);
+        if (!saved) {
+          return {
+            added: false,
+            error: 'Could not save API key to the credential store.',
+            hint: 'Check credential-store access and try again.',
+          };
+        }
       }
-    }
 
-    return {
-      added: true,
-      provider: entry,
-      modelCount: fetched.models.length,
-      ...(credentialCleanupPending ? { credentialCleanupPending: true } : {}),
-    };
-  });
-
-  const result: AddCustomEndpointResult = anonymous
-    ? await commitProvider()
-    : await withCredentialMutationLock(authRef, async () => {
-      await journalCredentialWrite(authRef);
-      const saved = await saveProviderCredential(authRef, apiKey);
-      if (!saved) {
-        return {
-          added: false,
-          error: 'Could not save API key to the credential store.',
-          hint: 'Check credential-store access and try again.',
+      return withRegistryWriteLock(async () => {
+        const registry = loadRegistryStrict();
+        if (registry.providers.some(provider => provider.id === providerId)) {
+          return {
+            added: false,
+            error: `Provider ID ${providerId} changed while its credential was being saved.`,
+            hint: 'Retry adding the custom provider.',
+          };
+        }
+        const now = new Date().toISOString();
+        const entry: RegistryProvider = {
+          id: providerId,
+          templateId: input.kind === 'anthropic' ? 'custom-anthropic' : 'custom-openai',
+          name: displayName,
+          enabled: true,
+          authRef,
+          authType: anonymous ? 'none' : 'api',
+          api: { npm, url: fetched.baseUrl, ...(headers ? { headers } : {}) },
+          addedAt: now,
+          refreshedAt: now,
+          modelsCache: {
+            fetchedAt: now,
+            models: fetched.models.map(m => ({
+              ...m,
+              modelFormat: modelFormatForKind(input.kind),
+              npm,
+              apiUrl: fetched.baseUrl,
+            })),
+          },
         };
-      }
-      return commitProvider();
-    });
+
+        registry.providers.push(entry);
+        saveRegistry(registry);
+        let credentialCleanupPending = false;
+        if (!anonymous) {
+          try {
+            await cancelCredentialDelete(authRef);
+          } catch {
+            credentialCleanupPending = true;
+          }
+        }
+        return {
+          added: true,
+          provider: entry,
+          modelCount: fetched.models.length,
+          ...(credentialCleanupPending ? { credentialCleanupPending: true } : {}),
+        };
+      });
+    };
+
+    if (anonymous) return persistAndCommit();
+    return withCredentialMutationLock(authRef, persistAndCommit);
+  });
 
   if (result.added) {
     try {
@@ -269,9 +280,11 @@ export async function addCustomEndpointProvider(input: AddCustomEndpointInput): 
     }
   } else {
     try {
-      await reconcilePendingCredentialDeletes();
+      const cleanup = await reconcilePendingCredentialDeletes();
+      result.credentialCleanupPending =
+        cleanup.pending.length > 0 || cleanup.persistenceError !== undefined;
     } catch {
-      // The failed credential remains journaled for a later retry.
+      result.credentialCleanupPending = true;
     }
   }
   return result;

--- a/src/registry/lock.ts
+++ b/src/registry/lock.ts
@@ -12,7 +12,8 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { dirname } from 'node:path';
+import { userInfo } from 'node:os';
+import { dirname, isAbsolute, join } from 'node:path';
 import { getProvidersPath } from '../paths.js';
 
 const DEFAULT_WAIT_MS = 30_000;
@@ -416,7 +417,23 @@ export function getCredentialMutationLockPath(authRef: string): string {
     .update('clodex-credential-mutation\0')
     .update(authRef)
     .digest('hex');
-  return `${getProvidersPath()}.credential-${digest}.lock`;
+  return join(getCredentialLockRoot(), `${digest}.lock`);
+}
+
+function getNativeCredentialRoot(): string {
+  const nativeHome = userInfo().homedir;
+  if (!nativeHome || !isAbsolute(nativeHome)) {
+    throw new Error('Could not determine the native user home for credential coordination');
+  }
+  return join(nativeHome, '.clodex');
+}
+
+export function getCredentialLockRoot(): string {
+  return join(getNativeCredentialRoot(), 'credential-locks');
+}
+
+export function getCredentialStateRoot(): string {
+  return join(getNativeCredentialRoot(), 'keyring-state');
 }
 
 export function withCredentialMutationLock<T>(
@@ -428,5 +445,22 @@ export function withCredentialMutationLock<T>(
     ...options,
     lockPath: getCredentialMutationLockPath(authRef),
     waitMs: options.waitMs ?? DEFAULT_CREDENTIAL_MUTATION_WAIT_MS,
+  });
+}
+
+export function getProviderMutationLockPath(providerSlot: string): string {
+  const digest = createHash('sha256')
+    .update('clodex-provider-mutation\0')
+    .update(providerSlot)
+    .digest('hex');
+  return `${getProvidersPath()}.provider-${digest}.lock`;
+}
+
+export function withProviderMutationLock<T>(
+  providerSlot: string,
+  operation: () => Promise<T> | T,
+): Promise<T> {
+  return withRegistryWriteLock(operation, {
+    lockPath: getProviderMutationLockPath(providerSlot),
   });
 }

--- a/src/registry/provider-auth.ts
+++ b/src/registry/provider-auth.ts
@@ -6,8 +6,10 @@ import * as p from '@clack/prompts';
 import open from 'open';
 import {
   probeProviderCredentialStore,
+  provisionProviderCredential,
   saveProviderCredential,
 } from '../env.js';
+import { credentialInstanceAuthRef } from '../credential-helper.js';
 import { runOpenAiDeviceCodeFlow } from '../oauth/openai.js';
 import {
   supportsNativeOAuth,
@@ -27,6 +29,7 @@ import {
 import { loadRegistryStrict, saveRegistry } from './io.js';
 import {
   withCredentialMutationLock,
+  withProviderMutationLock,
   withRegistryWriteLock,
 } from './lock.js';
 import { refreshProviderModels } from './refresh-models.js';
@@ -87,9 +90,7 @@ export async function saveNativeOAuthCredential(
   providerData?: Record<string, unknown>,
 ): Promise<void> {
   const cred = tokensToStoredCredential(tokens, undefined, accountId, providerData);
-  const registryId = toOAuthRegistryId(providerId);
-  const authRef = oauthAuthRef(registryId);
-  await persistOAuthProvider(providerId, cred, authRef);
+  await persistNativeOAuthCredential(providerId, cred);
 }
 
 /**
@@ -101,78 +102,104 @@ function oauthDisplayName(registryId: string, fallbackName: string): string {
   return fallbackName;
 }
 
-async function persistOAuthProvider(
+async function upsertOAuthProvider(
   providerId: string,
-  cred: StoredOAuthCredential,
   authRef: string,
-): Promise<{ registryProvider: RegistryProvider; credentialCleanupPending: boolean }> {
-  const registryProvider = await withCredentialMutationLock(authRef, async () => {
+  expectedAuthRef: string | undefined,
+): Promise<RegistryProvider> {
+  return withRegistryWriteLock(async () => {
     const registryId = toOAuthRegistryId(providerId);
     const templateId = providerId.replace(/-oauth$/, '') || providerId;
-    await withRegistryWriteLock(() => {
-      const registry = loadRegistryStrict();
-      const previousEntry = registry.providers.find(provider => provider.id === registryId);
-      if (!previousEntry && !getTemplateById(templateId)) {
-        throw new Error(`Provider "${providerId}" is not in your registry and has no template`);
-      }
-    });
-    await journalCredentialWrite(authRef);
-
-    let diagMsg = '';
-    const saved = await saveProviderCredential(
-      authRef,
-      oauthCredentialToKeychainJson(cred),
-      (msg) => { diagMsg = msg; },
-    );
-    if (!saved) {
-      throw new Error(`Could not save OAuth tokens to the credential store${diagMsg ? ` — ${diagMsg}` : ' — check access and try again'}`);
+    const registry = loadRegistryStrict();
+    const template = getTemplateById(templateId);
+    let entry: RegistryProvider | undefined = registry.providers.find(pr => pr.id === registryId);
+    if (entry?.authRef !== expectedAuthRef) {
+      throw new Error(`Provider "${registryId}" changed while its credential was being saved`);
     }
 
-    const committed = await withRegistryWriteLock(async () => {
-      const registry = loadRegistryStrict();
-      const template = getTemplateById(templateId);
-      const previousEntry = registry.providers.find(provider => provider.id === registryId);
-      if (!previousEntry && !template) {
+    if (!entry) {
+      if (!template) {
         throw new Error(`Provider "${providerId}" is not in your registry and has no template`);
       }
+    }
 
-      let entry: RegistryProvider;
-      if (!previousEntry) {
-        if (!template) throw new Error(`Provider "${providerId}" has no template`);
-        const displayName = oauthDisplayName(registryId, template.name);
-        entry = {
-          id: registryId,
-          templateId,
-          name: displayName,
-          enabled: true,
-          authRef,
-          authType: 'oauth',
-          api: {
-            npm: template.npm,
-            url: template.defaultBaseUrl ?? '',
-            ...(template.headers ? { headers: template.headers } : {}),
-          },
-          addedAt: new Date().toISOString(),
-        };
-      } else {
-        entry = { ...previousEntry, authType: 'oauth', authRef, templateId };
-      }
+    const previousAuthRef = entry?.authRef;
+    if (!entry) {
+      if (!template) throw new Error(`Provider "${providerId}" has no template`);
+      const displayName = oauthDisplayName(registryId, template.name);
+      entry = {
+        id: registryId,
+        templateId,
+        name: displayName,
+        enabled: true,
+        authRef,
+        authType: 'oauth',
+        api: {
+          npm: template.npm,
+          url: template.defaultBaseUrl ?? '',
+          ...(template.headers ? { headers: template.headers } : {}),
+        },
+        addedAt: new Date().toISOString(),
+      };
+    } else {
+      entry = { ...entry, authType: 'oauth', authRef, templateId };
+    }
 
-      const idx = registry.providers.findIndex(provider => provider.id === registryId);
-      if (idx >= 0) registry.providers[idx] = entry;
-      else registry.providers.push(entry);
-      if (previousEntry?.authRef && previousEntry.authRef !== authRef) {
-        await queueCredentialDelete(previousEntry.authRef);
+    const idx = registry.providers.findIndex(provider => provider.id === registryId);
+    if (idx >= 0) registry.providers[idx] = entry;
+    else registry.providers.push(entry);
+    if (previousAuthRef && previousAuthRef !== authRef) {
+      await queueCredentialDelete(previousAuthRef);
+    }
+    saveRegistry(registry);
+    try {
+      await cancelCredentialDelete(authRef);
+    } catch {
+      // Reconciliation below reports and retries the committed marker.
+    }
+    return entry;
+  });
+}
+
+async function persistNativeOAuthCredential(
+  providerId: string,
+  cred: StoredOAuthCredential,
+): Promise<{ registryProvider: RegistryProvider; credentialCleanupPending: boolean }> {
+  const registryId = toOAuthRegistryId(providerId);
+  const account = `oauth:provider:${registryId}`;
+  const registryProvider = await withProviderMutationLock(registryId, async () => {
+    const existingAuthRef = await withRegistryWriteLock(
+      () => {
+        const registry = loadRegistryStrict();
+        const templateId = providerId.replace(/-oauth$/, '') || providerId;
+        const existing = registry.providers.find(provider => provider.id === registryId);
+        if (!existing && !getTemplateById(templateId)) {
+          throw new Error(`Provider "${providerId}" is not in your registry and has no template`);
+        }
+        return existing?.authRef;
+      },
+    );
+    const authRef = credentialInstanceAuthRef(account);
+    return withCredentialMutationLock(authRef, async () => {
+      await journalCredentialWrite(authRef);
+      let diagMsg = '';
+      const saved =
+        existingAuthRef === authRef
+          ? await saveProviderCredential(authRef, oauthCredentialToKeychainJson(cred), msg => {
+              diagMsg = msg;
+            })
+          : await provisionProviderCredential(authRef, oauthCredentialToKeychainJson(cred), msg => {
+              diagMsg = msg;
+            });
+      if (!saved) {
+        throw new Error(
+          `Could not save OAuth tokens to the credential store${
+            diagMsg ? ` — ${diagMsg}` : ' — check access and try again'
+          }`,
+        );
       }
-      saveRegistry(registry);
-      try {
-        await cancelCredentialDelete(authRef);
-      } catch {
-        // Reconciliation below reports and retries the committed marker.
-      }
-      return entry;
+      return upsertOAuthProvider(providerId, authRef, existingAuthRef);
     });
-    return committed;
   });
 
   let credentialCleanupPending = true;
@@ -199,9 +226,10 @@ export async function authenticateProvider(
     throw new Error('OAuth sign-in is only available for openai (ChatGPT Plus/Pro).');
   }
 
-  const authRef = oauthAuthRef(registryId);
   let storeDiagMsg = '';
-  const storeReady = await probeProviderCredentialStore(authRef, (msg) => { storeDiagMsg = msg; });
+  const storeReady = await probeProviderCredentialStore(oauthAuthRef(registryId), msg => {
+    storeDiagMsg = msg;
+  });
   if (!storeReady) {
     throw new Error(
       `Credential store is unavailable${storeDiagMsg ? `: ${storeDiagMsg}` : ''}. `
@@ -210,7 +238,7 @@ export async function authenticateProvider(
   }
 
   const cred = await runNativeDeviceCode(providerId);
-  const persisted = await persistOAuthProvider(providerId, cred, authRef);
+  const persisted = await persistNativeOAuthCredential(providerId, cred);
 
   const refreshSpinner = p.spinner();
   refreshSpinner.start('Refreshing model list...');

--- a/tests/credential-helper.test.ts
+++ b/tests/credential-helper.test.ts
@@ -1,4 +1,12 @@
-import { chmodSync, copyFileSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -7,14 +15,18 @@ import {
   CREDENTIAL_HELPER_ENV,
   configuredCredentialHelper,
   configuredCredentialHelperPath,
+  credentialAccountBase,
   credentialAuthRef,
+  credentialInstanceAuthRef,
   deleteCredentialHelperAccount,
+  isCredentialAccountInstance,
   readCredentialHelperAccount,
   writeCredentialHelperAccount,
 } from '../src/credential-helper.js';
 import {
   deleteProviderCredential,
   probeProviderCredentialStore,
+  provisionProviderCredential,
   resolveProviderCredential,
   saveProviderCredential,
 } from '../src/env.js';
@@ -60,8 +72,30 @@ describe('external credential helper', () => {
     const authRef = credentialAuthRef('provider:openai');
     expect(authRef).toBe(`helper:v1:${helper!.id}:provider:openai`);
     expect(authRef).not.toContain(helperPath);
+    const newAuthRef = credentialInstanceAuthRef('provider:openai');
+    expect(newAuthRef).toMatch(
+      new RegExp(`^helper:v1:${helper!.id}:provider:openai::credential::v1:[0-9a-f]{32}$`),
+    );
+    const newAccount = newAuthRef.slice(`helper:v1:${helper!.id}:`.length);
+    expect(isCredentialAccountInstance(newAccount)).toBe(true);
+    expect(credentialAccountBase(newAccount)).toBe('provider:openai');
     delete process.env[CREDENTIAL_HELPER_ENV];
     expect(credentialAuthRef('provider:openai')).toBe('keyring:provider:openai');
+  });
+
+  it('scopes provider-owned accounts to the config home without exposing its path', () => {
+    const firstHome = join(tempDir, 'first-config');
+    const secondHome = join(tempDir, 'second-config');
+    process.env.CLODEX_HOME = firstHome;
+    const first = credentialInstanceAuthRef('provider:openai');
+    process.env.CLODEX_HOME = secondHome;
+    const second = credentialInstanceAuthRef('provider:openai');
+
+    expect(second).not.toBe(first);
+    expect(first).not.toContain(firstHome);
+    expect(second).not.toContain(secondHome);
+    expect(first).toMatch(/::credential::v1:[0-9a-f]{32}$/);
+    expect(second).toMatch(/::credential::v1:[0-9a-f]{32}$/);
   });
 
   it('rejects relative helper paths', () => {
@@ -77,7 +111,10 @@ describe('external credential helper', () => {
     expect(() => configuredCredentialHelperPath()).toThrow('must point to a file');
 
     const nonExecutable = join(tempDir, 'non-executable-helper');
-    writeFileSync(nonExecutable, '#!/bin/sh\n', { encoding: 'utf8', mode: 0o600 });
+    writeFileSync(nonExecutable, '#!/bin/sh\n', {
+      encoding: 'utf8',
+      mode: 0o600,
+    });
     process.env[CREDENTIAL_HELPER_ENV] = nonExecutable;
     expect(() => configuredCredentialHelperPath()).toThrow('not an executable file');
   });
@@ -91,16 +128,16 @@ describe('external credential helper', () => {
   });
 
   it('writes and verifies helper-backed provider credentials', async () => {
-    const authRef = credentialAuthRef('provider:test');
-    await expect(saveProviderCredential(authRef, 'secret-value')).resolves.toBe(true);
+    const authRef = credentialInstanceAuthRef('provider:test');
+    await expect(provisionProviderCredential(authRef, 'secret-value')).resolves.toBe(true);
     await expect(resolveProviderCredential('test', authRef)).resolves.toBe('secret-value');
     await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
     await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
   });
 
   it('removes a helper-backed credential with its provider', async () => {
-    const authRef = credentialAuthRef('provider:openai');
-    await expect(saveProviderCredential(authRef, 'secret-value')).resolves.toBe(true);
+    const authRef = credentialInstanceAuthRef('provider:openai');
+    await expect(provisionProviderCredential(authRef, 'secret-value')).resolves.toBe(true);
     const registry = emptyRegistry();
     registry.providers.push({
       id: 'openai',
@@ -121,11 +158,14 @@ describe('external credential helper', () => {
       credentialDeleted: true,
     });
     expect(loadRegistry().providers).toHaveLength(0);
-    await expect(readCredentialHelperAccount('provider:openai')).resolves.toBeNull();
+    const account = authRef.slice(authRef.lastIndexOf(':provider:') + 1);
+    await expect(readCredentialHelperAccount(account)).resolves.toBeNull();
   });
 
   it('probes the helper with a disposable round trip', async () => {
-    await expect(probeProviderCredentialStore(credentialAuthRef('oauth:provider:test'))).resolves.toBe(true);
+    await expect(
+      probeProviderCredentialStore(credentialAuthRef('oauth:provider:test')),
+    ).resolves.toBe(true);
   });
 
   it('fails the probe when its disposable credential cannot be removed', async () => {
@@ -133,48 +173,70 @@ describe('external credential helper', () => {
     const diagnostics: string[] = [];
     await expect(probeProviderCredentialStore(credentialAuthRef('oauth:provider:test'), message => {
       diagnostics.push(message);
-    })).resolves.toBe(false);
+      }),
+    ).resolves.toBe(false);
     expect(diagnostics).toContain('credential store probe cleanup failed');
   });
 
   it('rejects a helper write whose read-back does not match', async () => {
     process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE = 'mismatch';
     const diagnostics: string[] = [];
-    await expect(saveProviderCredential(credentialAuthRef('provider:test'), 'secret-value', message => {
+    await expect(
+      provisionProviderCredential(
+        credentialInstanceAuthRef('provider:test'),
+        'secret-value',
+        message => {
       diagnostics.push(message);
-    })).resolves.toBe(false);
+        },
+      ),
+    ).resolves.toBe(false);
     expect(diagnostics).toContain('credential store read-back verification failed');
+
+    delete process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE;
+    await expect(
+      provisionProviderCredential(credentialInstanceAuthRef('provider:test'), 'secret-value'),
+    ).resolves.toBe(true);
   });
 
   it('serializes concurrent writes to the same helper credential', async () => {
     process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE = 'detect-overlap';
-    const authRef = credentialAuthRef('provider:test');
+    const authRef = credentialInstanceAuthRef('provider:test');
     const storePath = process.env.CLODEX_TEST_CREDENTIAL_HELPER_STORE!;
 
-    const firstWrite = saveProviderCredential(authRef, 'first-value');
+    const firstWrite = provisionProviderCredential(authRef, 'first-value');
     await waitForPath(`${storePath}.set-started`);
     const secondWrite = saveProviderCredential(authRef, 'second-value');
     await new Promise(resolve => setTimeout(resolve, 50));
 
     expect(existsSync(`${storePath}.overlapping-set`)).toBe(false);
-    writeFileSync(`${storePath}.release-set`, '', { encoding: 'utf8', mode: 0o600 });
+    writeFileSync(`${storePath}.release-set`, '', {
+      encoding: 'utf8',
+      mode: 0o600,
+    });
     await expect(firstWrite).resolves.toBe(true);
     await expect(secondWrite).resolves.toBe(true);
-    await expect(readCredentialHelperAccount('provider:test')).resolves.toBe('second-value');
+    const account = authRef.slice(authRef.lastIndexOf(':provider:') + 1);
+    await expect(readCredentialHelperAccount(account)).resolves.toBe('second-value');
   });
 
   it('does not silently fall back when the configured helper fails', async () => {
     process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE = 'fail';
     const diagnostics: string[] = [];
-    await expect(saveProviderCredential(credentialAuthRef('provider:test'), 'secret-value', message => {
+    await expect(
+      provisionProviderCredential(
+        credentialInstanceAuthRef('provider:test'),
+        'secret-value',
+        message => {
       diagnostics.push(message);
-    })).resolves.toBe(false);
+        },
+      ),
+    ).resolves.toBe(false);
     expect(diagnostics.join('\n')).toContain('credential helper set failed');
   });
 
   it('refuses to redirect a credential reference to a different helper path', async () => {
-    const authRef = credentialAuthRef('provider:test');
-    await expect(saveProviderCredential(authRef, 'secret-value')).resolves.toBe(true);
+    const authRef = credentialInstanceAuthRef('provider:test');
+    await expect(provisionProviderCredential(authRef, 'secret-value')).resolves.toBe(true);
 
     const replacementHelper = join(tempDir, 'replacement-helper.mjs');
     copyFileSync(helperPath, replacementHelper);
@@ -182,8 +244,12 @@ describe('external credential helper', () => {
     process.env[CREDENTIAL_HELPER_ENV] = replacementHelper;
     const diagnostics: string[] = [];
 
-    await expect(resolveProviderCredential('test', authRef, message => diagnostics.push(message))).resolves.toBeNull();
-    await expect(deleteProviderCredential(authRef, message => diagnostics.push(message))).resolves.toBe(false);
+    await expect(
+      resolveProviderCredential('test', authRef, message => diagnostics.push(message)),
+    ).resolves.toBeNull();
+    await expect(
+      deleteProviderCredential(authRef, message => diagnostics.push(message)),
+    ).resolves.toBe(false);
     expect(diagnostics.join('\n')).toContain('does not match the helper that owns this credential');
   });
 
@@ -198,7 +264,9 @@ describe('external credential helper', () => {
       const pid = Number.parseInt(readFileSync(`${storePath}.helper-pid`, 'utf8'), 10);
 
       await vi.advanceTimersByTimeAsync(10_001);
-      await expect(outcome).resolves.toMatchObject({ message: 'credential helper get timed out' });
+      await expect(outcome).resolves.toMatchObject({
+        message: 'credential helper get timed out',
+      });
 
       vi.useRealTimers();
       let running = true;

--- a/tests/credential-helper.test.ts
+++ b/tests/credential-helper.test.ts
@@ -219,6 +219,26 @@ describe('external credential helper', () => {
     await expect(readCredentialHelperAccount(account)).resolves.toBe('second-value');
   });
 
+  it('serializes a delete behind an active helper credential write', async () => {
+    process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE = 'detect-overlap';
+    const authRef = credentialInstanceAuthRef('provider:test');
+    const storePath = process.env.CLODEX_TEST_CREDENTIAL_HELPER_STORE!;
+
+    const write = provisionProviderCredential(authRef, 'secret-value');
+    await waitForPath(`${storePath}.set-started`);
+    const deletion = deleteProviderCredential(authRef);
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(existsSync(`${storePath}.overlapping-delete`)).toBe(false);
+    writeFileSync(`${storePath}.release-set`, '', {
+      encoding: 'utf8',
+      mode: 0o600,
+    });
+    await expect(write).resolves.toBe(true);
+    await expect(deletion).resolves.toBe(true);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+  });
+
   it('does not silently fall back when the configured helper fails', async () => {
     process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE = 'fail';
     const diagnostics: string[] = [];

--- a/tests/custom-endpoint.test.ts
+++ b/tests/custom-endpoint.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ProviderRegistry } from '../src/registry/types.js';
+import { credentialInstanceAuthRef } from '../src/credential-helper.js';
 
 const registryState = vi.hoisted(() => ({
   current: { schemaVersion: 1, providers: [] } as ProviderRegistry,
@@ -8,6 +9,8 @@ const registryState = vi.hoisted(() => ({
 const lockState = vi.hoisted(() => ({
   active: false,
   credentialActive: false,
+  providerActive: false,
+  providerTails: new Map<string, Promise<void>>(),
   entries: 0,
   afterRegistryUnlock: null as null | (() => void),
 }));
@@ -16,8 +19,9 @@ const journalState = vi.hoisted(() => ({
 }));
 
 vi.mock('../src/env.js', async importOriginal => ({
-  ...await importOriginal<typeof import('../src/env.js')>(),
+  ...(await importOriginal<typeof import('../src/env.js')>()),
   deleteProviderCredential: vi.fn(),
+  provisionProviderCredential: vi.fn(),
   saveProviderCredential: vi.fn(),
 }));
 vi.mock('../src/registry/fetch-template-models.js', () => ({
@@ -58,10 +62,8 @@ vi.mock('../src/registry/lock.js', () => ({
       afterUnlock?.();
     }
   }),
-  withCredentialMutationLock: vi.fn(async <T>(
-    _authRef: string,
-    operation: () => Promise<T> | T,
-  ): Promise<T> => {
+  withCredentialMutationLock: vi.fn(
+    async <T>(_authRef: string, operation: () => Promise<T> | T): Promise<T> => {
     if (lockState.credentialActive) {
       throw new Error('credential lock re-entered');
     }
@@ -71,7 +73,30 @@ vi.mock('../src/registry/lock.js', () => ({
     } finally {
       lockState.credentialActive = false;
     }
-  }),
+    },
+  ),
+  withProviderMutationLock: vi.fn(
+    async <T>(providerSlot: string, operation: () => Promise<T> | T): Promise<T> => {
+      const previous = lockState.providerTails.get(providerSlot) ?? Promise.resolve();
+      let release!: () => void;
+      const gate = new Promise<void>(resolve => {
+        release = resolve;
+      });
+      const tail = previous.then(() => gate);
+      lockState.providerTails.set(providerSlot, tail);
+      await previous;
+      lockState.providerActive = true;
+      try {
+        return await operation();
+      } finally {
+        lockState.providerActive = false;
+        release();
+        if (lockState.providerTails.get(providerSlot) === tail) {
+          lockState.providerTails.delete(providerSlot);
+        }
+      }
+    },
+  ),
 }));
 vi.mock('../src/registry/url-security.js', () => ({
   validateCustomEndpointUrl: vi.fn(),
@@ -80,6 +105,7 @@ vi.mock('../src/registry/url-security.js', () => ({
 import {
   clodexKeyEnvVar,
   deleteProviderCredential,
+  provisionProviderCredential,
   resolveProviderCredential,
   saveProviderCredential,
 } from '../src/env.js';
@@ -117,18 +143,22 @@ function successfulDiscovery() {
 
 describe('custom endpoint credential lifecycle', () => {
   const previousHelper = process.env.CLODEX_CREDENTIAL_HELPER;
-
+  const firstCredentialRef = credentialInstanceAuthRef('provider:custom-test-endpoint');
+  const secondCredentialRef = credentialInstanceAuthRef('provider:custom-test-endpoint-2');
   beforeEach(() => {
     delete process.env.CLODEX_CREDENTIAL_HELPER;
     registryState.current = { schemaVersion: 1, providers: [] };
     registryState.persisted = [];
     lockState.active = false;
     lockState.credentialActive = false;
+    lockState.providerActive = false;
+    lockState.providerTails.clear();
     lockState.entries = 0;
     lockState.afterRegistryUnlock = null;
     journalState.pending.clear();
 
     vi.mocked(deleteProviderCredential).mockReset().mockResolvedValue(true);
+    vi.mocked(provisionProviderCredential).mockReset().mockResolvedValue(true);
     vi.mocked(saveProviderCredential).mockReset().mockResolvedValue(true);
     vi.mocked(cleanupJournal.loadPendingCredentialDeletes).mockReset()
       .mockImplementation(async () => [...journalState.pending]);
@@ -161,9 +191,10 @@ describe('custom endpoint credential lifecycle', () => {
       observedLockStates.push(lockState.active);
       return successfulDiscovery();
     });
-    vi.mocked(saveProviderCredential).mockImplementation(async () => {
+    vi.mocked(provisionProviderCredential).mockImplementation(async () => {
       observedLockStates.push(lockState.active);
       expect(lockState.credentialActive).toBe(true);
+      expect(lockState.providerActive).toBe(true);
       return true;
     });
 
@@ -171,7 +202,7 @@ describe('custom endpoint credential lifecycle', () => {
 
     expect(result.added).toBe(true);
     expect(observedLockStates).toEqual([false, false]);
-    expect(lockState.entries).toBeGreaterThanOrEqual(1);
+    expect(lockState.entries).toBe(2);
     expect(lockState.active).toBe(false);
   });
 
@@ -195,21 +226,24 @@ describe('custom endpoint credential lifecycle', () => {
       endpointInput.baseUrl,
       undefined,
     );
+    expect(provisionProviderCredential).not.toHaveBeenCalled();
     expect(saveProviderCredential).not.toHaveBeenCalled();
     expect(registryState.current.providers[0]).toMatchObject({
       authRef: 'none:anonymous',
       authType: 'none',
     });
-    await expect(resolveProviderCredential(
-      result.provider!.id,
-      result.provider!.authRef,
-    )).resolves.toBeNull();
+    await expect(
+      resolveProviderCredential(result.provider!.id, result.provider!.authRef),
+    ).resolves.toBeNull();
   });
 
   it('omits the Anthropic API key header for anonymous discovery', async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
       data: [{ id: 'local-model', name: 'Local Model' }],
-    }), { status: 200 }));
+        }),
+        { status: 200 },
+      ),
+    );
     vi.stubGlobal('fetch', fetchMock);
 
     const result = await fetchAnthropicModels('https://local.example/v1', '');
@@ -239,14 +273,12 @@ describe('custom endpoint credential lifecycle', () => {
       added: true,
       provider: { id: 'custom-test-endpoint-2' },
     });
-    expect(result.provider?.authRef).toMatch(
-      /^keyring:provider:custom-test-endpoint:[0-9a-f-]{36}$/,
-    );
-    expect(saveProviderCredential).toHaveBeenCalledWith(
+    expect(result.provider?.authRef).toBe(secondCredentialRef);
+    expect(provisionProviderCredential).toHaveBeenCalledWith(
       result.provider?.authRef,
       endpointInput.apiKey,
     );
-    expect(registryState.current.providers.map((provider) => provider.id)).toEqual([
+    expect(registryState.current.providers.map(provider => provider.id)).toEqual([
       'custom-test-endpoint',
       'custom-test-endpoint-2',
     ]);
@@ -267,6 +299,7 @@ describe('custom endpoint credential lifecycle', () => {
       error: 'Network discovery failed.',
       hint: 'Check the endpoint.',
     });
+    expect(provisionProviderCredential).not.toHaveBeenCalled();
     expect(saveProviderCredential).not.toHaveBeenCalled();
     expect(deleteProviderCredential).not.toHaveBeenCalled();
     expect(saveRegistry).not.toHaveBeenCalled();
@@ -275,20 +308,18 @@ describe('custom endpoint credential lifecycle', () => {
   });
 
   it('cleans the journal without activating a provider when credential writing fails', async () => {
-    vi.mocked(saveProviderCredential).mockResolvedValue(false);
+    vi.mocked(provisionProviderCredential).mockResolvedValue(false);
 
     const result = await addCustomEndpointProvider(endpointInput);
 
-    const authRef = vi.mocked(saveProviderCredential).mock.calls[0]?.[0];
-    expect(authRef).toMatch(
-      /^keyring:provider:custom-test-endpoint:[0-9a-f-]{36}$/,
-    );
+    const authRef = vi.mocked(provisionProviderCredential).mock.calls[0]?.[0];
+    expect(authRef).toBe(firstCredentialRef);
     expect(result).toMatchObject({
       added: false,
       error: 'Could not save API key to the credential store.',
     });
     expect(cleanupJournal.queueCredentialDelete).toHaveBeenCalledWith(authRef);
-    expect(saveProviderCredential).toHaveBeenCalledWith(authRef!, endpointInput.apiKey);
+    expect(provisionProviderCredential).toHaveBeenCalledWith(authRef!, endpointInput.apiKey);
     expect(deleteProviderCredential).toHaveBeenCalledWith(authRef!);
     expect(registryState.current.providers).toEqual([]);
     expect(journalState.pending.size).toBe(0);
@@ -301,11 +332,9 @@ describe('custom endpoint credential lifecycle', () => {
 
     await expect(addCustomEndpointProvider(endpointInput)).rejects.toThrow('activation failed');
 
-    const authRef = vi.mocked(saveProviderCredential).mock.calls[0]?.[0];
-    expect(authRef).toMatch(
-      /^keyring:provider:custom-test-endpoint:[0-9a-f-]{36}$/,
-    );
-    expect(saveProviderCredential).toHaveBeenCalledWith(authRef!, endpointInput.apiKey);
+    const authRef = vi.mocked(provisionProviderCredential).mock.calls[0]?.[0];
+    expect(authRef).toBe(firstCredentialRef);
+    expect(provisionProviderCredential).toHaveBeenCalledWith(authRef!, endpointInput.apiKey);
     expect(registryState.current.providers).toEqual([]);
     expect(journalState.pending).toEqual(new Set([authRef]));
     expect(deleteProviderCredential).not.toHaveBeenCalled();
@@ -359,9 +388,7 @@ describe('custom endpoint credential lifecycle', () => {
     const authRef = result.provider?.authRef;
 
     expect(cancellationLockStates).toEqual([true]);
-    expect(authRef).toMatch(
-      /^keyring:provider:custom-test-endpoint:[0-9a-f-]{36}$/,
-    );
+    expect(authRef).toBe(firstCredentialRef);
     expect(journalState.pending).toContain(authRef);
     expect(result.credentialCleanupPending).toBe(true);
   });
@@ -376,5 +403,67 @@ describe('custom endpoint credential lifecycle', () => {
     expect(result.added).toBe(true);
     expect(result.credentialCleanupPending).toBe(true);
     expect(registryState.current.providers).toHaveLength(1);
+  });
+
+  it('reuses the same provider slot after a failed credential verification', async () => {
+    vi.mocked(provisionProviderCredential).mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    const first = await addCustomEndpointProvider(endpointInput);
+    const second = await addCustomEndpointProvider(endpointInput);
+
+    expect(first.added).toBe(false);
+    expect(second.added).toBe(true);
+    expect(vi.mocked(provisionProviderCredential).mock.calls.map(call => call[0])).toEqual([
+      firstCredentialRef,
+      firstCredentialRef,
+    ]);
+    expect(registryState.current.providers).toHaveLength(1);
+  });
+
+  it('serializes concurrent allocation for colliding custom provider names', async () => {
+    const results = await Promise.all([
+      addCustomEndpointProvider(endpointInput),
+      addCustomEndpointProvider({
+        ...endpointInput,
+        displayName: 'Test--Endpoint',
+      }),
+    ]);
+
+    expect(results.every(result => result.added)).toBe(true);
+    expect(registryState.current.providers.map(provider => provider.id)).toEqual([
+      'custom-test-endpoint',
+      'custom-test-endpoint-2',
+    ]);
+    expect(registryState.current.providers.map(provider => provider.authRef)).toEqual([
+      firstCredentialRef,
+      secondCredentialRef,
+    ]);
+  });
+
+  it('serializes base and suffix collisions in one allocation domain', async () => {
+    registryState.current.providers.push({
+      id: 'custom-foo',
+      templateId: 'custom-openai',
+      name: 'Existing Foo',
+      enabled: true,
+      authRef: 'none:anonymous',
+      authType: 'none',
+      api: { npm: '@ai-sdk/openai-compatible', url: endpointInput.baseUrl },
+      addedAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    const results = await Promise.all([
+      addCustomEndpointProvider({ ...endpointInput, displayName: 'Foo' }),
+      addCustomEndpointProvider({ ...endpointInput, displayName: 'Foo 2' }),
+    ]);
+
+    expect(results.every(result => result.added)).toBe(true);
+    const addedProviders = results.map(result => result.provider!);
+    expect(new Set(addedProviders.map(provider => provider.id)).size).toBe(2);
+    for (const provider of addedProviders) {
+      expect(provider.authRef).toBe(
+        credentialInstanceAuthRef(`provider:${provider.id}`),
+      );
+    }
   });
 });

--- a/tests/env-oauth-refresh.test.ts
+++ b/tests/env-oauth-refresh.test.ts
@@ -18,7 +18,9 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../src/credential-helper.js', () => ({
+  credentialAccountBase: (account: string) => account,
   deleteCredentialHelperAccount: vi.fn(),
+  isCredentialAccountInstance: vi.fn(() => false),
   readCredentialHelperAccount: mocks.readCredential,
   writeCredentialHelperAccount: mocks.writeCredential,
 }));

--- a/tests/fixtures/credential-helper.mjs
+++ b/tests/fixtures/credential-helper.mjs
@@ -98,6 +98,9 @@ if (operation === 'set') {
 }
 
 if (operation === 'delete') {
+  if (mode === 'detect-overlap' && existsSync(`${storePath}.active-set`)) {
+    writeFileSync(`${storePath}.overlapping-delete`, '', { encoding: 'utf8', mode: 0o600 });
+  }
   if (!(key in store)) process.exit(2);
   delete store[key];
   writeFileSync(storePath, JSON.stringify(store), { encoding: 'utf8', mode: 0o600 });

--- a/tests/fixtures/registry-lock-worker.ts
+++ b/tests/fixtures/registry-lock-worker.ts
@@ -22,7 +22,7 @@ async function waitForFile(path: string, timeoutMs: number): Promise<void> {
     if (Date.now() >= deadline) {
       throw new Error(`Timed out waiting for signal: ${path}`);
     }
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await new Promise(resolve => setTimeout(resolve, 10));
   }
 }
 
@@ -38,8 +38,8 @@ function waitForFileSync(path: string, timeoutMs: number): void {
 }
 
 const role = requiredEnv('REGISTRY_LOCK_WORKER_ROLE');
-const root = requiredEnv('CLODEX_HOME');
-const registryPath = join(root, 'providers.json');
+const root = process.env.REGISTRY_LOCK_WORKER_ROOT ?? requiredEnv('CLODEX_HOME');
+const registryPath = join(requiredEnv('CLODEX_HOME'), 'providers.json');
 const lockPath = `${registryPath}.lock`;
 
 async function runHolder(): Promise<void> {
@@ -53,20 +53,14 @@ async function runHolder(): Promise<void> {
   try {
     await withRegistryWriteLock(
       async () => {
-        saveRegistry(
-          { ...emptyRegistry(), importedAt: 'holder-initial' },
-          registryPath,
-        );
+        saveRegistry({ ...emptyRegistry(), importedAt: 'holder-initial' }, registryPath);
         const owner = JSON.parse(fs.readFileSync(lockPath, 'utf8')) as {
           pid: number;
           token: string;
         };
         writeJson(readyPath, { pid: owner.pid, token: owner.token });
         await waitForFile(releasePath, 10_000);
-        saveRegistry(
-          { ...emptyRegistry(), importedAt: 'holder-final' },
-          registryPath,
-        );
+        saveRegistry({ ...emptyRegistry(), importedAt: 'holder-final' }, registryPath);
       },
       { lockPath, waitMs: 2_000, retryMs: 10 },
     );
@@ -86,10 +80,7 @@ async function runContender(): Promise<void> {
   try {
     await withRegistryWriteLock(
       () => {
-        saveRegistry(
-          { ...emptyRegistry(), importedAt: 'contender' },
-          registryPath,
-        );
+        saveRegistry({ ...emptyRegistry(), importedAt: 'contender' }, registryPath);
       },
       { lockPath, waitMs: 250, retryMs: 10 },
     );
@@ -147,17 +138,16 @@ async function runLeaseLoss(): Promise<void> {
   fs.writeFileSync(
     registryPath,
     `${JSON.stringify({ ...emptyRegistry(), importedAt: 'sentinel' })}\n`,
-    { mode: 0o600 },
+    {
+      mode: 0o600,
+    },
   );
 
   let error: unknown;
   try {
     withRegistryWriteLockSync(
       () => {
-        saveRegistry(
-          { ...emptyRegistry(), importedAt: 'unwanted' },
-          registryPath,
-        );
+        saveRegistry({ ...emptyRegistry(), importedAt: 'unwanted' }, registryPath);
       },
       { lockPath },
     );
@@ -171,9 +161,7 @@ async function runLeaseLoss(): Promise<void> {
   const replacement = JSON.parse(fs.readFileSync(lockPath, 'utf8')) as {
     token?: string;
   };
-  const temporaryArtifacts = fs
-    .readdirSync(root)
-    .filter((name) => name.endsWith('.tmp'));
+  const temporaryArtifacts = fs.readdirSync(root).filter(name => name.endsWith('.tmp'));
   writeJson(resultPath, {
     errorName: error instanceof Error ? error.name : null,
     error: errorMessage(error),
@@ -234,19 +222,26 @@ async function runAtomicAcquire(): Promise<void> {
   });
 }
 
-const credentialAuthRef = 'keyring:provider:openai';
+function credentialAuthRef(): string {
+  return requiredEnv('REGISTRY_LOCK_CREDENTIAL_REF');
+}
 
 async function runCredentialHolder(): Promise<void> {
-  const { getCredentialMutationLockPath, withCredentialMutationLock } =
-    await import('../../src/registry/lock.js');
+  const {
+    getCredentialMutationLockPath,
+    getCredentialStateRoot,
+    withCredentialMutationLock,
+  } = await import('../../src/registry/lock.js');
+  const authRef = credentialAuthRef();
   const readyPath = join(root, 'credential-holder-ready.json');
   const releasePath = join(root, 'release-credential-holder');
   const resultPath = join(root, 'credential-holder-result.json');
 
-  await withCredentialMutationLock(credentialAuthRef, async () => {
+  await withCredentialMutationLock(authRef, async () => {
     writeJson(readyPath, {
       pid: process.pid,
-      lockPath: getCredentialMutationLockPath(credentialAuthRef),
+      lockPath: getCredentialMutationLockPath(authRef),
+      stateRoot: getCredentialStateRoot(),
     });
     await waitForFile(releasePath, 5_000);
   });
@@ -254,14 +249,22 @@ async function runCredentialHolder(): Promise<void> {
 }
 
 async function runCredentialContender(): Promise<void> {
-  const { withCredentialMutationLock } =
-    await import('../../src/registry/lock.js');
+  const {
+    getCredentialMutationLockPath,
+    getCredentialStateRoot,
+    withCredentialMutationLock,
+  } = await import('../../src/registry/lock.js');
+  const authRef = credentialAuthRef();
   const readyPath = join(root, 'credential-contender-ready.json');
   const enteredPath = join(root, 'credential-contender-entered.json');
   const resultPath = join(root, 'credential-contender-result.json');
 
-  writeJson(readyPath, { pid: process.pid });
-  await withCredentialMutationLock(credentialAuthRef, () => {
+  writeJson(readyPath, {
+    pid: process.pid,
+    lockPath: getCredentialMutationLockPath(authRef),
+    stateRoot: getCredentialStateRoot(),
+  });
+  await withCredentialMutationLock(authRef, () => {
     writeJson(enteredPath, { pid: process.pid });
   });
   writeJson(resultPath, { ok: true });

--- a/tests/fixtures/registry-lock-worker.ts
+++ b/tests/fixtures/registry-lock-worker.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import { syncBuiltinESMExports } from 'node:module';
+import os from 'node:os';
 import { join } from 'node:path';
 
 function requiredEnv(name: string): string {
@@ -15,6 +16,16 @@ function errorMessage(error: unknown): string {
 function writeJson(path: string, value: unknown): void {
   fs.writeFileSync(path, `${JSON.stringify(value)}\n`, { mode: 0o600 });
 }
+
+const nativeHome = requiredEnv('REGISTRY_LOCK_WORKER_NATIVE_HOME');
+os.userInfo = (() => ({
+  username: 'clodex-test',
+  uid: process.getuid?.() ?? -1,
+  gid: process.getgid?.() ?? -1,
+  shell: null,
+  homedir: nativeHome,
+})) as typeof os.userInfo;
+syncBuiltinESMExports();
 
 async function waitForFile(path: string, timeoutMs: number): Promise<void> {
   const deadline = Date.now() + timeoutMs;

--- a/tests/keyring-credentials.test.ts
+++ b/tests/keyring-credentials.test.ts
@@ -1,0 +1,985 @@
+import { createHash } from 'node:crypto';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const keyring = vi.hoisted(() => ({
+  values: new Map<string, string>(),
+  failSetSuffix: '' as string,
+  failSetKey: '' as string,
+  failDeleteSuffix: '' as string,
+  failDeleteKey: '' as string,
+  onGet: null as ((key: string) => void) | null,
+  operations: [] as Array<{ type: 'set' | 'delete'; key: string; value?: string }>,
+  lockHome: '' as string,
+}));
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return {
+    ...actual,
+    homedir: () => keyring.lockHome || actual.homedir(),
+  };
+});
+
+vi.mock('@napi-rs/keyring', () => ({
+  Entry: class {
+    private readonly key: string;
+
+    constructor(service: string, account: string) {
+      this.key = `${service}:${account}`;
+    }
+
+    getPassword(): string | null {
+      keyring.onGet?.(this.key);
+      return keyring.values.get(this.key) ?? null;
+    }
+
+    setPassword(value: string): void {
+      if (
+        (keyring.failSetSuffix && this.key.endsWith(keyring.failSetSuffix))
+        || (keyring.failSetKey && this.key === keyring.failSetKey)
+      ) {
+        throw new Error('injected keyring write failure');
+      }
+      keyring.operations.push({ type: 'set', key: this.key, value });
+      keyring.values.set(this.key, value);
+    }
+
+    deletePassword(): void {
+      if (
+        (keyring.failDeleteSuffix && this.key.endsWith(keyring.failDeleteSuffix))
+        || (keyring.failDeleteKey && this.key === keyring.failDeleteKey)
+      ) {
+        throw new Error('injected keyring delete failure');
+      }
+      keyring.operations.push({ type: 'delete', key: this.key });
+      keyring.values.delete(this.key);
+    }
+  },
+}));
+
+import {
+  deleteProviderCredential,
+  resolveProviderCredential,
+  saveProviderCredential,
+} from '../src/env.js';
+
+const account = 'oauth:provider:test';
+const authRef = `keyring:${account}`;
+const mainKey = `clodex:${account}`;
+const journalKey = `clodex-journal:${account}`;
+const journalPrefix = '__relay_chunk_journal__:v1:';
+const previousHome = process.env.CLODEX_HOME;
+let tempDir = '';
+
+function currentChunkKeys(): string[] {
+  return [...keyring.values.keys()].filter(key => key.includes(`${account}::chunk::`));
+}
+
+function expectUnverifiableTombstone(): string {
+  const raw = keyring.values.get(journalKey);
+  expect(raw?.startsWith(journalPrefix)).toBe(true);
+  expect(JSON.parse(raw!.slice(journalPrefix.length))).toEqual({
+    mode: 'delete',
+    generations: [],
+    unverifiable: true,
+  });
+  return raw!;
+}
+
+describe('keyring credential chunks', () => {
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'clodex-keyring-'));
+    process.env.CLODEX_HOME = tempDir;
+    keyring.lockHome = tempDir;
+    keyring.values.clear();
+    keyring.failSetSuffix = '';
+    keyring.failSetKey = '';
+    keyring.failDeleteSuffix = '';
+    keyring.failDeleteKey = '';
+    keyring.onGet = null;
+    keyring.operations = [];
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) delete process.env.CLODEX_HOME;
+    else process.env.CLODEX_HOME = previousHome;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('publishes a new chunk generation before removing the previous one', async () => {
+    const first = 'a'.repeat(2_500);
+    const second = 'b'.repeat(1_500);
+
+    await expect(saveProviderCredential(authRef, first)).resolves.toBe(true);
+    const firstMarker = keyring.values.get(mainKey)!;
+    const firstChunks = currentChunkKeys();
+    keyring.operations = [];
+
+    await expect(saveProviderCredential(authRef, second)).resolves.toBe(true);
+
+    const secondMarker = keyring.values.get(mainKey)!;
+    expect(secondMarker).toMatch(/^__relay_chunked__:v3:[0-9a-f-]{36}:2:[0-9a-f]{64}$/);
+    expect(secondMarker).not.toBe(firstMarker);
+    expect(firstChunks.every(key => !keyring.values.has(key))).toBe(true);
+    const markerSetIndex = keyring.operations.findIndex(operation =>
+      operation.type === 'set'
+      && operation.key === mainKey
+      && operation.value === secondMarker,
+    );
+    const newChunkSetIndices = keyring.operations
+      .map((operation, index) => ({ operation, index }))
+      .filter(({ operation }) =>
+        operation.type === 'set'
+        && operation.key.includes(`${account}::chunk::`)
+        && !firstChunks.includes(operation.key),
+      )
+      .map(({ index }) => index);
+    const oldChunkDeleteIndices = keyring.operations
+      .map((operation, index) => ({ operation, index }))
+      .filter(({ operation }) => operation.type === 'delete' && firstChunks.includes(operation.key))
+      .map(({ index }) => index);
+    const journalSetIndex = keyring.operations.findIndex(operation =>
+      operation.type === 'set' && operation.key === journalKey,
+    );
+    const journalDeleteIndex = keyring.operations.findIndex(operation =>
+      operation.type === 'delete' && operation.key === journalKey,
+    );
+    expect(markerSetIndex).toBeGreaterThanOrEqual(0);
+    expect(journalSetIndex).toBeGreaterThanOrEqual(0);
+    expect(journalDeleteIndex).toBeGreaterThanOrEqual(0);
+    expect(newChunkSetIndices).toHaveLength(2);
+    expect(oldChunkDeleteIndices).toHaveLength(3);
+    expect(newChunkSetIndices.every(index => journalSetIndex < index)).toBe(true);
+    expect(newChunkSetIndices.every(index => index < markerSetIndex)).toBe(true);
+    expect(oldChunkDeleteIndices.every(index => index > markerSetIndex)).toBe(true);
+    expect(oldChunkDeleteIndices.every(index => index < journalDeleteIndex)).toBe(true);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe(second);
+  });
+
+  it('keeps the published credential readable when a new generation fails', async () => {
+    const first = 'a'.repeat(2_500);
+    await expect(saveProviderCredential(authRef, first)).resolves.toBe(true);
+    const firstMarker = keyring.values.get(mainKey);
+    const firstChunks = currentChunkKeys();
+
+    keyring.failSetSuffix = '::1';
+    await expect(saveProviderCredential(authRef, 'b'.repeat(2_500))).resolves.toBe(false);
+
+    expect(keyring.values.get(mainKey)).toBe(firstMarker);
+    expect(keyring.values.has(journalKey)).toBe(true);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe(first);
+    expect(currentChunkKeys().sort()).toEqual(firstChunks.sort());
+    expect(keyring.values.has(journalKey)).toBe(false);
+  });
+
+  it('recovers journaled chunks when publishing the new marker fails', async () => {
+    const first = 'a'.repeat(2_500);
+    await expect(saveProviderCredential(authRef, first)).resolves.toBe(true);
+    const firstMarker = keyring.values.get(mainKey);
+    const firstChunks = currentChunkKeys();
+
+    keyring.failSetKey = mainKey;
+    await expect(saveProviderCredential(authRef, 'b'.repeat(2_500))).resolves.toBe(false);
+
+    expect(keyring.values.get(mainKey)).toBe(firstMarker);
+    expect(keyring.values.has(journalKey)).toBe(true);
+    keyring.failSetKey = '';
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe(first);
+    expect(currentChunkKeys().sort()).toEqual(firstChunks.sort());
+    expect(keyring.values.has(journalKey)).toBe(false);
+  });
+
+  it('removes old chunks after replacing a long credential with a short one', async () => {
+    await expect(saveProviderCredential(authRef, 'a'.repeat(2_500))).resolves.toBe(true);
+    expect(currentChunkKeys()).toHaveLength(3);
+
+    await expect(saveProviderCredential(authRef, 'short-secret')).resolves.toBe(true);
+
+    expect(keyring.values.get(mainKey)).toBe('short-secret');
+    expect(currentChunkKeys()).toEqual([]);
+  });
+
+  it('reads and deletes valid legacy chunks', async () => {
+    keyring.values.set(mainKey, '__relay_chunked__:2');
+    keyring.values.set(`clodex:${account}::chunk::0`, 'legacy-');
+    keyring.values.set(`clodex:${account}::chunk::1`, 'secret');
+
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe('legacy-secret');
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    expect(keyring.values.size).toBe(0);
+  });
+
+  it('does not report deletion success while credential chunks remain', async () => {
+    await expect(saveProviderCredential(authRef, 'a'.repeat(2_500))).resolves.toBe(true);
+    keyring.failDeleteSuffix = '::1';
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
+
+    expect(keyring.values.has(mainKey)).toBe(false);
+    expect(keyring.values.has(journalKey)).toBe(true);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+    keyring.failDeleteSuffix = '';
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    expect(currentChunkKeys()).toEqual([]);
+    expect(keyring.values.has(journalKey)).toBe(false);
+  });
+
+  it('persists an expanded same-generation count before unpublishing', async () => {
+    const generation = '11111111-1111-4111-8111-111111111111';
+    const firstChunk = `clodex:${account}::chunk::${generation}::0`;
+    const secondChunk = `clodex:${account}::chunk::${generation}::1`;
+    keyring.values.set(mainKey, `__relay_chunked__:v2:${generation}:2`);
+    keyring.values.set(firstChunk, 'first-');
+    keyring.values.set(secondChunk, 'second');
+    keyring.values.set(
+      journalKey,
+      `${journalPrefix}${JSON.stringify({
+        mode: 'delete',
+        generations: [{ count: 1, generation }],
+      })}`,
+    );
+    keyring.failDeleteSuffix = '::1';
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
+
+    const pending = JSON.parse(keyring.values.get(journalKey)!.slice(journalPrefix.length)) as {
+      generations: Array<{ count: number }>;
+    };
+    expect(pending.generations).toEqual([{ count: 2, generation }]);
+    expect(keyring.values.has(mainKey)).toBe(false);
+    expect(keyring.values.has(secondChunk)).toBe(true);
+    keyring.failDeleteSuffix = '';
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    expect(keyring.values.has(firstChunk)).toBe(false);
+    expect(keyring.values.has(secondChunk)).toBe(false);
+    expect(keyring.values.has(journalKey)).toBe(false);
+  });
+
+  it('keeps a credential inaccessible while a deletion journal cannot unpublish it', async () => {
+    const journal = `${journalPrefix}${JSON.stringify({
+      mode: 'delete',
+      generations: [],
+    })}`;
+    keyring.values.set(mainKey, 'pending-delete-secret');
+    keyring.values.set(journalKey, journal);
+    keyring.failDeleteKey = mainKey;
+
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+
+    expect(keyring.values.get(mainKey)).toBe('pending-delete-secret');
+    expect(keyring.values.get(journalKey)).toBe(journal);
+    keyring.failDeleteKey = '';
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+    expect(keyring.values.has(mainKey)).toBe(false);
+    expect(keyring.values.has(journalKey)).toBe(false);
+  });
+
+  it('retries from the published marker when rotation removes chunks mid-read', async () => {
+    await expect(saveProviderCredential(authRef, 'a'.repeat(2_500))).resolves.toBe(true);
+    const oldChunks = currentChunkKeys();
+    const generation = '11111111-1111-4111-8111-111111111111';
+    keyring.onGet = (key) => {
+      if (key !== oldChunks[0]) return;
+      keyring.onGet = null;
+      keyring.values.set(mainKey, `__relay_chunked__:v2:${generation}:2`);
+      for (const oldChunk of oldChunks) keyring.values.delete(oldChunk);
+      keyring.values.set(`clodex:${account}::chunk::${generation}::0`, 'replace');
+      keyring.values.set(`clodex:${account}::chunk::${generation}::1`, 'ment');
+    };
+
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe('replacement');
+  });
+
+  it('fails closed for invalid markers and missing chunks', async () => {
+    const diagnostics: string[] = [];
+    keyring.values.set(mainKey, '__relay_chunked__:Infinity');
+    await expect(resolveProviderCredential('test', authRef, message => {
+      diagnostics.push(message);
+    })).resolves.toBeNull();
+    expect(diagnostics.join('\n')).toContain('invalid chunk marker');
+    await expect(deleteProviderCredential(authRef, message => {
+      diagnostics.push(message);
+    })).resolves.toBe(false);
+    expect(keyring.values.has(mainKey)).toBe(false);
+    expect(keyring.values.has(journalKey)).toBe(true);
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
+    expect(keyring.values.has(journalKey)).toBe(true);
+
+    keyring.values.clear();
+    diagnostics.length = 0;
+    keyring.values.set(mainKey, '__relay_chunked__:2');
+    keyring.values.set(`clodex:${account}::chunk::0`, 'partial');
+    await expect(resolveProviderCredential('test', authRef, message => {
+      diagnostics.push(message);
+    })).resolves.toBeNull();
+    expect(diagnostics.join('\n')).toContain('chunk 2 of 2 is missing');
+
+    diagnostics.length = 0;
+    keyring.values.set(
+      mainKey,
+      `__relay_chunked__:v2:${'-'.repeat(36)}:2`,
+    );
+    await expect(resolveProviderCredential('test', authRef, message => {
+      diagnostics.push(message);
+    })).resolves.toBeNull();
+    expect(diagnostics.join('\n')).toContain('invalid chunk marker');
+  });
+
+  it('tombstones invalid chunk state before rejecting a replacement', async () => {
+    keyring.values.set(mainKey, '__relay_chunked__:Infinity');
+    keyring.values.set(`clodex:${account}::chunk::0`, 'untracked-secret');
+
+    await expect(saveProviderCredential(authRef, 'replacement-secret')).resolves.toBe(false);
+
+    expect(keyring.values.get(mainKey)).toBe('__relay_chunked__:Infinity');
+    const tombstone = expectUnverifiableTombstone();
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+    expect(keyring.values.has(mainKey)).toBe(false);
+    expect(keyring.values.get(journalKey)).toBe(tombstone);
+    await expect(saveProviderCredential(authRef, 'replacement-secret')).resolves.toBe(false);
+    expect(keyring.values.get(journalKey)).toBe(tombstone);
+  });
+
+  it('reconciles journaled generations on either side of marker publication', async () => {
+    const oldGeneration = '11111111-1111-4111-8111-111111111111';
+    const newGeneration = '22222222-2222-4222-8222-222222222222';
+    const oldMarker = `__relay_chunked__:v2:${oldGeneration}:2`;
+    const newMarker = `__relay_chunked__:v2:${newGeneration}:2`;
+    const journal = `__relay_chunk_journal__:v1:${JSON.stringify({
+      mode: 'write',
+      generations: [
+        { count: 2, generation: newGeneration },
+        { count: 2, generation: oldGeneration },
+      ],
+    })}`;
+    const oldChunkKeys = [0, 1].map(index =>
+      `clodex:${account}::chunk::${oldGeneration}::${index}`,
+    );
+    const newChunkKeys = [0, 1].map(index =>
+      `clodex:${account}::chunk::${newGeneration}::${index}`,
+    );
+
+    keyring.values.set(mainKey, oldMarker);
+    keyring.values.set(oldChunkKeys[0]!, 'old-');
+    keyring.values.set(oldChunkKeys[1]!, 'secret');
+    keyring.values.set(newChunkKeys[0]!, 'new-');
+    keyring.values.set(newChunkKeys[1]!, 'secret');
+    keyring.values.set(journalKey, journal);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe('old-secret');
+    expect(newChunkKeys.every(key => !keyring.values.has(key))).toBe(true);
+    expect(oldChunkKeys.every(key => keyring.values.has(key))).toBe(true);
+    expect(keyring.values.has(journalKey)).toBe(false);
+
+    keyring.values.set(mainKey, newMarker);
+    keyring.values.set(newChunkKeys[0]!, 'new-');
+    keyring.values.set(newChunkKeys[1]!, 'secret');
+    keyring.values.set(journalKey, journal);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe('new-secret');
+    expect(oldChunkKeys.every(key => !keyring.values.has(key))).toBe(true);
+    expect(newChunkKeys.every(key => keyring.values.has(key))).toBe(true);
+    expect(keyring.values.has(journalKey)).toBe(false);
+  });
+
+  it('rolls back before retiring the last complete generation', async () => {
+    const oldGeneration = '11111111-1111-4111-8111-111111111111';
+    const newGeneration = '22222222-2222-4222-8222-222222222222';
+    const oldMarker = {
+      count: 2,
+      generation: oldGeneration,
+    };
+    const newValue = 'new-secret';
+    const newMarker = {
+      count: 2,
+      generation: newGeneration,
+      digest: createHash('sha256').update(newValue).digest('hex'),
+    };
+    keyring.values.set(
+      mainKey,
+      `__relay_chunked__:v3:${newGeneration}:2:${newMarker.digest}`,
+    );
+    keyring.values.set(`clodex:${account}::chunk::${oldGeneration}::0`, 'old-');
+    keyring.values.set(`clodex:${account}::chunk::${oldGeneration}::1`, 'secret');
+    keyring.values.set(`clodex-chunks:${account}::chunk::${newGeneration}::0`, 'new-');
+    keyring.values.set(
+      journalKey,
+      `__relay_chunk_journal__:v1:${JSON.stringify({
+        mode: 'write',
+        generations: [newMarker, oldMarker],
+      })}`,
+    );
+
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe('old-secret');
+
+    expect(keyring.values.get(mainKey)).toBe(
+      `__relay_chunked__:v2:${oldGeneration}:2`,
+    );
+    expect(keyring.values.has(`clodex:${account}::chunk::${oldGeneration}::0`)).toBe(true);
+    expect(keyring.values.has(`clodex-chunks:${account}::chunk::${newGeneration}::0`)).toBe(false);
+    expect(keyring.values.has(journalKey)).toBe(false);
+  });
+
+  it('trusts the published digest over a stale journal digest', async () => {
+    const oldGeneration = '11111111-1111-4111-8111-111111111111';
+    const newGeneration = '22222222-2222-4222-8222-222222222222';
+    const oldMarker = {
+      count: 2,
+      generation: oldGeneration,
+    };
+    const newValue = 'new-secret';
+    const publishedDigest = createHash('sha256').update(newValue).digest('hex');
+    const staleDigest = createHash('sha256').update('stale-secret').digest('hex');
+    const journalMarker = {
+      count: 2,
+      generation: newGeneration,
+      digest: staleDigest,
+    };
+    keyring.values.set(
+      mainKey,
+      `__relay_chunked__:v3:${newGeneration}:2:${publishedDigest}`,
+    );
+    keyring.values.set(`clodex-chunks:${account}::chunk::${newGeneration}::0`, 'new-');
+    keyring.values.set(`clodex-chunks:${account}::chunk::${newGeneration}::1`, 'secret');
+    keyring.values.set(`clodex:${account}::chunk::${oldGeneration}::0`, 'old-');
+    keyring.values.set(`clodex:${account}::chunk::${oldGeneration}::1`, 'secret');
+    keyring.values.set(
+      journalKey,
+      `__relay_chunk_journal__:v1:${JSON.stringify({
+        mode: 'write',
+        generations: [journalMarker, oldMarker],
+      })}`,
+    );
+
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe(newValue);
+
+    expect(keyring.values.get(mainKey)).toBe(
+      `__relay_chunked__:v3:${newGeneration}:2:${publishedDigest}`,
+    );
+    expect(keyring.values.has(`clodex-chunks:${account}::chunk::${newGeneration}::0`)).toBe(true);
+    expect(keyring.values.has(`clodex:${account}::chunk::${oldGeneration}::0`)).toBe(false);
+    expect(keyring.values.has(journalKey)).toBe(false);
+  });
+
+  it('removes journal-only tail chunks from the published generation', async () => {
+    const generation = '22222222-2222-4222-8222-222222222222';
+    const publishedValue = 'a';
+    const journalValue = 'ab';
+    const publishedDigest = createHash('sha256').update(publishedValue).digest('hex');
+    const journalDigest = createHash('sha256').update(journalValue).digest('hex');
+    const firstChunk = `clodex-chunks:${account}::chunk::${generation}::0`;
+    const secondChunk = `clodex-chunks:${account}::chunk::${generation}::1`;
+    keyring.values.set(
+      mainKey,
+      `__relay_chunked__:v3:${generation}:1:${publishedDigest}`,
+    );
+    keyring.values.set(firstChunk, 'a');
+    keyring.values.set(secondChunk, 'b');
+    keyring.values.set(
+      journalKey,
+      `${journalPrefix}${JSON.stringify({
+        mode: 'write',
+        generations: [{ count: 2, digest: journalDigest, generation }],
+      })}`,
+    );
+
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe(publishedValue);
+
+    expect(keyring.values.get(mainKey)).toBe(
+      `__relay_chunked__:v3:${generation}:1:${publishedDigest}`,
+    );
+    expect(keyring.values.has(firstChunk)).toBe(true);
+    expect(keyring.values.has(secondChunk)).toBe(false);
+    expect(keyring.values.has(journalKey)).toBe(false);
+  });
+
+  it('repairs a stale published digest from a valid journal copy', async () => {
+    const oldGeneration = '11111111-1111-4111-8111-111111111111';
+    const newGeneration = '22222222-2222-4222-8222-222222222222';
+    const newValue = 'new-secret';
+    const currentDigest = createHash('sha256').update(newValue).digest('hex');
+    const staleDigest = createHash('sha256').update('stale-secret').digest('hex');
+    const currentMarker = {
+      count: 2,
+      generation: newGeneration,
+      digest: currentDigest,
+    };
+    keyring.values.set(
+      mainKey,
+      `__relay_chunked__:v3:${newGeneration}:2:${staleDigest}`,
+    );
+    keyring.values.set(`clodex-chunks:${account}::chunk::${newGeneration}::0`, 'new-');
+    keyring.values.set(`clodex-chunks:${account}::chunk::${newGeneration}::1`, 'secret');
+    keyring.values.set(`clodex:${account}::chunk::${oldGeneration}::0`, 'old-');
+    keyring.values.set(`clodex:${account}::chunk::${oldGeneration}::1`, 'secret');
+    keyring.values.set(
+      journalKey,
+      `__relay_chunk_journal__:v1:${JSON.stringify({
+        mode: 'write',
+        generations: [
+          currentMarker,
+          { count: 2, generation: oldGeneration },
+        ],
+      })}`,
+    );
+
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe(newValue);
+
+    expect(keyring.values.get(mainKey)).toBe(
+      `__relay_chunked__:v3:${newGeneration}:2:${currentDigest}`,
+    );
+    expect(keyring.values.has(`clodex-chunks:${account}::chunk::${newGeneration}::0`)).toBe(true);
+    expect(keyring.values.has(`clodex:${account}::chunk::${oldGeneration}::0`)).toBe(false);
+    expect(keyring.values.has(journalKey)).toBe(false);
+  });
+
+  it('removes published tail chunks before restoring a shorter journal marker', async () => {
+    const generation = '22222222-2222-4222-8222-222222222222';
+    const recoveredValue = 'a';
+    const recoveredDigest = createHash('sha256').update(recoveredValue).digest('hex');
+    const staleDigest = createHash('sha256').update('stale-value').digest('hex');
+    const firstChunk = `clodex-chunks:${account}::chunk::${generation}::0`;
+    const secondChunk = `clodex-chunks:${account}::chunk::${generation}::1`;
+    keyring.values.set(
+      mainKey,
+      `__relay_chunked__:v3:${generation}:2:${staleDigest}`,
+    );
+    keyring.values.set(firstChunk, 'a');
+    keyring.values.set(secondChunk, 'b');
+    keyring.values.set(
+      journalKey,
+      `${journalPrefix}${JSON.stringify({
+        mode: 'write',
+        generations: [{ count: 1, digest: recoveredDigest, generation }],
+      })}`,
+    );
+
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe(recoveredValue);
+
+    expect(keyring.values.get(mainKey)).toBe(
+      `__relay_chunked__:v3:${generation}:1:${recoveredDigest}`,
+    );
+    expect(keyring.values.has(firstChunk)).toBe(true);
+    expect(keyring.values.has(secondChunk)).toBe(false);
+    expect(keyring.values.has(journalKey)).toBe(false);
+  });
+
+  it('migrates under one account lock and deletes both keyring services', async () => {
+    const legacyMainKey = `relay-ai:${account}`;
+    keyring.values.set(legacyMainKey, 'legacy-secret');
+
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe('legacy-secret');
+    expect(keyring.values.get(mainKey)).toBe('legacy-secret');
+    expect(keyring.values.get(legacyMainKey)).toBe('legacy-secret');
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    expect(keyring.values.has(mainKey)).toBe(false);
+    expect(keyring.values.has(legacyMainKey)).toBe(false);
+  });
+
+  it('keeps deletion journaled until current and legacy chunks are gone', async () => {
+    const currentGeneration = '11111111-1111-4111-8111-111111111111';
+    const legacyGeneration = '22222222-2222-4222-8222-222222222222';
+    const currentChunk = `clodex:${account}::chunk::${currentGeneration}::0`;
+    const legacyChunk = `relay-ai:${account}::chunk::${legacyGeneration}::0`;
+    keyring.values.set(mainKey, `__relay_chunked__:v2:${currentGeneration}:1`);
+    keyring.values.set(`relay-ai:${account}`, `__relay_chunked__:v2:${legacyGeneration}:1`);
+    keyring.values.set(currentChunk, 'current-secret');
+    keyring.values.set(legacyChunk, 'legacy-secret');
+    keyring.failDeleteSuffix = '::0';
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
+    expect(keyring.values.has(journalKey)).toBe(true);
+    expect(keyring.values.has(mainKey)).toBe(false);
+    expect(keyring.values.has(`relay-ai:${account}`)).toBe(false);
+
+    keyring.failDeleteSuffix = '';
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    expect(keyring.values.has(currentChunk)).toBe(false);
+    expect(keyring.values.has(legacyChunk)).toBe(false);
+    expect(keyring.values.has(journalKey)).toBe(false);
+  });
+
+  it('captures a published generation missing from an existing deletion journal', async () => {
+    const generation = '11111111-1111-4111-8111-111111111111';
+    const v3Value = 'retired-secret';
+    const v3Marker = {
+      count: 1,
+      generation,
+      digest: createHash('sha256').update(v3Value).digest('hex'),
+    };
+    const v2ChunkKey = `clodex:${account}::chunk::${generation}::0`;
+    const v3ChunkKey = `clodex-chunks:${account}::chunk::${generation}::0`;
+    keyring.values.set(mainKey, `__relay_chunked__:v2:${generation}:1`);
+    keyring.values.set(v2ChunkKey, 'published-secret');
+    keyring.values.set(v3ChunkKey, v3Value);
+    keyring.values.set(
+      journalKey,
+      `__relay_chunk_journal__:v1:${JSON.stringify({
+        mode: 'delete',
+        generations: [v3Marker],
+      })}`,
+    );
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+
+    expect(keyring.values.has(mainKey)).toBe(false);
+    expect(keyring.values.has(v2ChunkKey)).toBe(false);
+    expect(keyring.values.has(v3ChunkKey)).toBe(false);
+    expect(keyring.values.has(journalKey)).toBe(false);
+  });
+
+  it('compacts a full deletion journal before adding newly observed generations', async () => {
+    const currentGenerations = [
+      '11111111-1111-4111-8111-111111111111',
+      '22222222-2222-4222-8222-222222222222',
+      '33333333-3333-4333-8333-333333333333',
+      '44444444-4444-4444-8444-444444444444',
+      '55555555-5555-4555-8555-555555555555',
+      '66666666-6666-4666-8666-666666666666',
+    ];
+    const legacyGenerations = [
+      '77777777-7777-4777-8777-777777777777',
+      '88888888-8888-4888-8888-888888888888',
+      '99999999-9999-4999-8999-999999999999',
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    ];
+    const currentPublished = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+    const legacyPublished = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+    for (const generation of currentGenerations) {
+      keyring.values.set(`clodex:${account}::chunk::${generation}::0`, generation);
+    }
+    for (const generation of legacyGenerations) {
+      keyring.values.set(`relay-ai:${account}::chunk::${generation}::0`, generation);
+    }
+    keyring.values.set(mainKey, `__relay_chunked__:v2:${currentPublished}:1`);
+    keyring.values.set(`clodex:${account}::chunk::${currentPublished}::0`, 'current');
+    keyring.values.set(`relay-ai:${account}`, `__relay_chunked__:v2:${legacyPublished}:1`);
+    keyring.values.set(`relay-ai:${account}::chunk::${legacyPublished}::0`, 'legacy');
+    const journal = `${journalPrefix}${JSON.stringify({
+      mode: 'delete',
+      generations: currentGenerations.map(generation => ({ count: 1, generation })),
+      legacyGenerations: legacyGenerations.map(generation => ({ count: 1, generation })),
+    })}`;
+    keyring.values.set(journalKey, journal);
+    keyring.failDeleteKey = mainKey;
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
+
+    const expandedJournal = keyring.values.get(journalKey)!;
+    expect(expandedJournal.startsWith(journalPrefix)).toBe(true);
+    const expanded = JSON.parse(expandedJournal.slice(journalPrefix.length)) as {
+      generations: unknown[];
+      legacyGenerations: unknown[];
+    };
+    expect(expanded.generations).toHaveLength(1);
+    expect(expanded.legacyGenerations).toHaveLength(1);
+    expect(currentChunkKeys()).toHaveLength(2);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+    keyring.failDeleteKey = '';
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    expect(currentChunkKeys()).toEqual([]);
+    expect(keyring.values.has(journalKey)).toBe(false);
+  });
+
+  it('compacts a size-bound v3 journal even when its generation counts fit', async () => {
+    const currentGenerations = [
+      '11111111-1111-4111-8111-111111111111',
+      '22222222-2222-4222-8222-222222222222',
+      '33333333-3333-4333-8333-333333333333',
+      '44444444-4444-4444-8444-444444444444',
+    ];
+    const legacyGenerations = [
+      '55555555-5555-4555-8555-555555555555',
+      '66666666-6666-4666-8666-666666666666',
+      '77777777-7777-4777-8777-777777777777',
+    ];
+    const currentPublished = '88888888-8888-4888-8888-888888888888';
+    const legacyPublished = '99999999-9999-4999-8999-999999999999';
+    const markerFor = (generation: string) => {
+      const value = `secret-${generation}`;
+      return {
+        marker: {
+          count: 1,
+          generation,
+          digest: createHash('sha256').update(value).digest('hex'),
+        },
+        value,
+      };
+    };
+    const currentMarkers = currentGenerations.map(markerFor);
+    const legacyMarkers = legacyGenerations.map(markerFor);
+    const current = markerFor(currentPublished);
+    const legacy = markerFor(legacyPublished);
+    for (const { marker, value } of [...currentMarkers, ...legacyMarkers, current, legacy]) {
+      keyring.values.set(`clodex-chunks:${account}::chunk::${marker.generation}::0`, value);
+    }
+    keyring.values.set(
+      mainKey,
+      `__relay_chunked__:v3:${currentPublished}:1:${current.marker.digest}`,
+    );
+    keyring.values.set(
+      `relay-ai:${account}`,
+      `__relay_chunked__:v3:${legacyPublished}:1:${legacy.marker.digest}`,
+    );
+    const journal = `${journalPrefix}${JSON.stringify({
+      mode: 'delete',
+      generations: currentMarkers.map(({ marker }) => marker),
+      legacyGenerations: legacyMarkers.map(({ marker }) => marker),
+    })}`;
+    expect(journal.length).toBeLessThanOrEqual(1_200);
+    keyring.values.set(journalKey, journal);
+    keyring.failDeleteKey = mainKey;
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
+
+    const compactedJournal = keyring.values.get(journalKey)!;
+    const compacted = JSON.parse(compactedJournal.slice(journalPrefix.length)) as {
+      generations: unknown[];
+      legacyGenerations: unknown[];
+    };
+    expect(compacted.generations).toHaveLength(1);
+    expect(compacted.legacyGenerations).toHaveLength(1);
+    expect(currentChunkKeys()).toHaveLength(2);
+    keyring.failDeleteKey = '';
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    expect(currentChunkKeys()).toEqual([]);
+    expect(keyring.values.has(journalKey)).toBe(false);
+  });
+
+  it('preserves main markers when a deletion-journal expansion cannot be written', async () => {
+    const generation = '11111111-1111-4111-8111-111111111111';
+    const chunkKey = `clodex:${account}::chunk::${generation}::0`;
+    const journal = `${journalPrefix}${JSON.stringify({
+      mode: 'delete',
+      generations: [],
+    })}`;
+    keyring.values.set(mainKey, `__relay_chunked__:v2:${generation}:1`);
+    keyring.values.set(chunkKey, 'pending-secret');
+    keyring.values.set(journalKey, journal);
+    keyring.failSetKey = journalKey;
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
+
+    expect(keyring.values.get(mainKey)).toBe(`__relay_chunked__:v2:${generation}:1`);
+    expect(keyring.values.get(chunkKey)).toBe('pending-secret');
+    expect(keyring.values.get(journalKey)).toBe(journal);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+    keyring.failSetKey = '';
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    expect(keyring.values.has(mainKey)).toBe(false);
+    expect(keyring.values.has(chunkKey)).toBe(false);
+    expect(keyring.values.has(journalKey)).toBe(false);
+  });
+
+  it('does not replace a valid journal after a transient journal read failure', async () => {
+    const generation = '11111111-1111-4111-8111-111111111111';
+    const marker = `__relay_chunked__:v2:${generation}:1`;
+    const chunkKey = `clodex:${account}::chunk::${generation}::0`;
+    const journal = `${journalPrefix}${JSON.stringify({
+      mode: 'delete',
+      generations: [],
+    })}`;
+    keyring.values.set(mainKey, marker);
+    keyring.values.set(chunkKey, 'pending-secret');
+    keyring.values.set(journalKey, journal);
+    let journalReads = 0;
+    keyring.onGet = (key) => {
+      if (key !== journalKey || ++journalReads !== 2) return;
+      keyring.onGet = null;
+      throw new Error('injected keyring read failure');
+    };
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
+
+    expect(keyring.values.get(journalKey)).toBe(journal);
+    expect(keyring.values.get(mainKey)).toBe(marker);
+    expect(keyring.values.get(chunkKey)).toBe('pending-secret');
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    expect(keyring.values.has(journalKey)).toBe(false);
+    expect(keyring.values.has(mainKey)).toBe(false);
+    expect(keyring.values.has(chunkKey)).toBe(false);
+  });
+
+  it('does not unpublish chunks after a transient main-entry read failure', async () => {
+    const generation = '11111111-1111-4111-8111-111111111111';
+    const marker = `__relay_chunked__:v2:${generation}:1`;
+    const chunkKey = `clodex:${account}::chunk::${generation}::0`;
+    const journal = `${journalPrefix}${JSON.stringify({
+      mode: 'delete',
+      generations: [],
+    })}`;
+    keyring.values.set(mainKey, marker);
+    keyring.values.set(chunkKey, 'pending-secret');
+    keyring.values.set(journalKey, journal);
+    let mainReads = 0;
+    keyring.onGet = (key) => {
+      if (key !== mainKey || ++mainReads !== 2) return;
+      keyring.onGet = null;
+      throw new Error('injected keyring read failure');
+    };
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
+
+    expect(keyring.values.get(journalKey)).toBe(journal);
+    expect(keyring.values.get(mainKey)).toBe(marker);
+    expect(keyring.values.get(chunkKey)).toBe('pending-secret');
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    expect(keyring.values.has(journalKey)).toBe(false);
+    expect(keyring.values.has(mainKey)).toBe(false);
+    expect(keyring.values.has(chunkKey)).toBe(false);
+  });
+
+  it('does not replace a valid write journal after a transient read failure', async () => {
+    const generation = '11111111-1111-4111-8111-111111111111';
+    const marker = { count: 1, generation };
+    const encodedMarker = `__relay_chunked__:v2:${generation}:1`;
+    const chunkKey = `clodex:${account}::chunk::${generation}::0`;
+    const journal = `${journalPrefix}${JSON.stringify({
+      mode: 'write',
+      generations: [marker],
+    })}`;
+    keyring.values.set(mainKey, encodedMarker);
+    keyring.values.set(chunkKey, 'published-secret');
+    keyring.values.set(journalKey, journal);
+    keyring.onGet = (key) => {
+      if (key !== journalKey) return;
+      keyring.onGet = null;
+      throw new Error('injected keyring read failure');
+    };
+
+    await expect(saveProviderCredential(authRef, 'replacement-secret')).resolves.toBe(false);
+
+    expect(keyring.values.get(journalKey)).toBe(journal);
+    expect(keyring.values.get(mainKey)).toBe(encodedMarker);
+    expect(keyring.values.get(chunkKey)).toBe('published-secret');
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe('published-secret');
+    expect(keyring.values.has(journalKey)).toBe(false);
+  });
+
+  it('fails closed with a durable tombstone after a malformed journal', async () => {
+    keyring.values.set(mainKey, 'existing-secret');
+    keyring.values.set(journalKey, '__relay_chunk_journal__:v1:{');
+
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+    await expect(saveProviderCredential(authRef, 'replacement-secret')).resolves.toBe(false);
+    const writeTombstone = expectUnverifiableTombstone();
+    await expect(saveProviderCredential(authRef, 'replacement-secret')).resolves.toBe(false);
+    expect(keyring.values.get(journalKey)).toBe(writeTombstone);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+
+    keyring.values.set(`relay-ai:${account}`, 'legacy-secret');
+    keyring.values.set(journalKey, '__relay_chunk_journal__:v1:{');
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
+    expect(keyring.values.has(mainKey)).toBe(false);
+    expect(keyring.values.get(`relay-ai:${account}`)).toBe('legacy-secret');
+    const deleteTombstone = expectUnverifiableTombstone();
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
+    expect(keyring.values.has(`relay-ai:${account}`)).toBe(false);
+    expect(keyring.values.get(journalKey)).toBe(deleteTombstone);
+  });
+
+  it.each([
+    { failedKey: mainKey, survivor: 'current-secret' },
+    { failedKey: `relay-ai:${account}`, survivor: 'legacy-secret' },
+  ])('keeps a tombstone while $failedKey cannot be unpublished', async ({ failedKey, survivor }) => {
+    const legacyMainKey = `relay-ai:${account}`;
+    const malformedJournal = '__relay_chunk_journal__:v1:{';
+    keyring.values.set(mainKey, 'current-secret');
+    keyring.values.set(legacyMainKey, 'legacy-secret');
+    keyring.values.set(journalKey, malformedJournal);
+    keyring.failDeleteKey = failedKey;
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
+
+    expect(keyring.values.get(mainKey)).toBe('current-secret');
+    expect(keyring.values.get(legacyMainKey)).toBe('legacy-secret');
+    const tombstone = expectUnverifiableTombstone();
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+    expect(keyring.values.get(failedKey)).toBe(survivor);
+    if (failedKey === mainKey) expect(keyring.values.get(legacyMainKey)).toBe('legacy-secret');
+    else expect(keyring.values.has(mainKey)).toBe(false);
+    expect(keyring.values.get(journalKey)).toBe(tombstone);
+
+    keyring.failDeleteKey = '';
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
+    expect(keyring.values.has(mainKey)).toBe(false);
+    expect(keyring.values.has(legacyMainKey)).toBe(false);
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
+    expect(keyring.values.get(journalKey)).toBe(tombstone);
+  });
+
+  it('preserves chunk markers before replacing a malformed journal', async () => {
+    const currentGeneration = '11111111-1111-4111-8111-111111111111';
+    const legacyGeneration = '22222222-2222-4222-8222-222222222222';
+    const currentChunk = `clodex:${account}::chunk::${currentGeneration}::0`;
+    const legacyChunk = `relay-ai:${account}::chunk::${legacyGeneration}::0`;
+    keyring.values.set(mainKey, `__relay_chunked__:v2:${currentGeneration}:1`);
+    keyring.values.set(`relay-ai:${account}`, `__relay_chunked__:v2:${legacyGeneration}:1`);
+    keyring.values.set(currentChunk, 'current-secret');
+    keyring.values.set(legacyChunk, 'legacy-secret');
+    keyring.values.set(journalKey, '__relay_chunk_journal__:v1:{');
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
+
+    expect(keyring.values.has(mainKey)).toBe(true);
+    expect(keyring.values.has(`relay-ai:${account}`)).toBe(true);
+    expect(keyring.values.has(currentChunk)).toBe(true);
+    expect(keyring.values.has(legacyChunk)).toBe(true);
+    const tombstone = expectUnverifiableTombstone();
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
+    expect(keyring.values.has(mainKey)).toBe(false);
+    expect(keyring.values.has(`relay-ai:${account}`)).toBe(false);
+    expect(keyring.values.has(currentChunk)).toBe(false);
+    expect(keyring.values.has(legacyChunk)).toBe(false);
+    const expandedTombstone = keyring.values.get(journalKey)!;
+    expect(expandedTombstone).not.toBe(tombstone);
+    expect(JSON.parse(expandedTombstone.slice(journalPrefix.length))).toEqual({
+      mode: 'delete',
+      generations: [{ count: 1, generation: currentGeneration }],
+      legacyGenerations: [{ count: 1, generation: legacyGeneration }],
+      unverifiable: true,
+    });
+  });
+
+  it('isolates the journal namespace from credential accounts', async () => {
+    const journalCollisionAccount = `${account}::chunk-journal`;
+    const journalCollisionRef = `keyring:${journalCollisionAccount}`;
+    await expect(saveProviderCredential(journalCollisionRef, 'journal-account-secret')).resolves.toBe(true);
+    await expect(saveProviderCredential(authRef, 'a'.repeat(2_500))).resolves.toBe(true);
+    await expect(resolveProviderCredential('test', journalCollisionRef)).resolves.toBe('journal-account-secret');
+  });
+
+  it('reserves legacy chunk account forms from credential references', async () => {
+    const generation = '11111111-1111-4111-8111-111111111111';
+    keyring.values.set(mainKey, `__relay_chunked__:v2:${generation}:1`);
+    keyring.values.set(`clodex:${account}::chunk::${generation}::0`, 'legacy-secret');
+    const chunkCollisionAccount = `${account}::chunk::${generation}::0`;
+    const chunkCollisionRef = `keyring:${chunkCollisionAccount}`;
+
+    await expect(saveProviderCredential(chunkCollisionRef, 'collision-secret')).resolves.toBe(false);
+    await expect(resolveProviderCredential('test', chunkCollisionRef)).resolves.toBeNull();
+    await expect(deleteProviderCredential(chunkCollisionRef)).resolves.toBe(false);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe('legacy-secret');
+  });
+
+  it('allows non-canonical chunk-like account names that cannot collide', async () => {
+    const generation = '11111111-1111-4111-8111-111111111111';
+    const safeRefs = [
+      `keyring:${account}::chunk::00`,
+      `keyring:${account}::chunk::${generation}::00`,
+    ];
+
+    for (const [index, safeRef] of safeRefs.entries()) {
+      const value = `safe-secret-${index}`;
+      await expect(saveProviderCredential(safeRef, value)).resolves.toBe(true);
+      await expect(resolveProviderCredential('test', safeRef)).resolves.toBe(value);
+    }
+  });
+
+  it('does not reinterpret malformed structured values as bearer credentials', async () => {
+    keyring.values.set(mainKey, '{"type":"oauth","access":');
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+  });
+});

--- a/tests/keyring-credentials.test.ts
+++ b/tests/keyring-credentials.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -10,16 +10,30 @@ const keyring = vi.hoisted(() => ({
   failSetKey: '' as string,
   failDeleteSuffix: '' as string,
   failDeleteKey: '' as string,
+  failFindService: '' as string,
+  failFindCount: 0,
+  omitFindKey: '' as string,
+  omitFindOnceKey: '' as string,
+  omitFindAccount: '' as string,
+  getCount: 0,
+  findCount: 0,
   onGet: null as ((key: string) => void) | null,
-  operations: [] as Array<{ type: 'set' | 'delete'; key: string; value?: string }>,
+  operations: [] as Array<{
+    type: 'set' | 'delete';
+    key: string;
+    value?: string;
+  }>,
   lockHome: '' as string,
 }));
 
-vi.mock('node:os', async (importOriginal) => {
+vi.mock('node:os', async importOriginal => {
   const actual = await importOriginal<typeof import('node:os')>();
   return {
     ...actual,
-    homedir: () => keyring.lockHome || actual.homedir(),
+    userInfo: () => ({
+      ...actual.userInfo(),
+      homedir: keyring.lockHome || actual.userInfo().homedir,
+    }),
   };
 });
 
@@ -32,7 +46,12 @@ vi.mock('@napi-rs/keyring', () => ({
     }
 
     getPassword(): string | null {
-      keyring.onGet?.(this.key);
+      keyring.getCount++;
+      try {
+        keyring.onGet?.(this.key);
+      } catch {
+        return null;
+      }
       return keyring.values.get(this.key) ?? null;
     }
 
@@ -43,62 +62,206 @@ vi.mock('@napi-rs/keyring', () => ({
       ) {
         throw new Error('injected keyring write failure');
       }
-      keyring.operations.push({ type: 'set', key: this.key, value });
-      keyring.values.set(this.key, value);
+      const nativeValue = Buffer.from(value, 'utf8').toString('utf8');
+      keyring.operations.push({
+        type: 'set',
+        key: this.key,
+        value: nativeValue,
+      });
+      keyring.values.set(this.key, nativeValue);
     }
 
-    deletePassword(): void {
+    deletePassword(): boolean {
       if (
         (keyring.failDeleteSuffix && this.key.endsWith(keyring.failDeleteSuffix))
         || (keyring.failDeleteKey && this.key === keyring.failDeleteKey)
       ) {
-        throw new Error('injected keyring delete failure');
+        return false;
       }
+      const deleted = keyring.values.delete(this.key);
+      if (!deleted) return false;
       keyring.operations.push({ type: 'delete', key: this.key });
-      keyring.values.delete(this.key);
+      return true;
     }
+  },
+  findCredentials: (service: string) => {
+    keyring.findCount++;
+    if (keyring.failFindService === service && keyring.failFindCount > 0) {
+      keyring.failFindCount--;
+      throw new Error('injected keyring enumeration failure');
+    }
+    const prefix = `${service}:`;
+    return [...keyring.values.entries()]
+      .filter(([key]) => {
+        if (!key.startsWith(prefix)) return false;
+        if (key === keyring.omitFindOnceKey) {
+          keyring.omitFindOnceKey = '';
+          return false;
+        }
+        const credentialAccount = key.slice(prefix.length);
+        if (
+          keyring.omitFindAccount &&
+          (credentialAccount === keyring.omitFindAccount ||
+            credentialAccount.startsWith(`${keyring.omitFindAccount}::`))
+        )
+          return false;
+        return key !== keyring.omitFindKey;
+      })
+      .map(([key, password]) => ({
+        account: key.slice(prefix.length),
+        password,
+      }));
   },
 }));
 
 import {
   deleteProviderCredential,
+  probeProviderCredentialStore,
+  provisionProviderCredential,
   resolveProviderCredential,
-  saveProviderCredential,
+  saveProviderCredential as replaceProviderCredential,
 } from '../src/env.js';
 
-const account = 'oauth:provider:test';
+const credentialInstance = `v1:${'1'.repeat(32)}`;
+const account = `oauth:provider:test::credential::${credentialInstance}`;
 const authRef = `keyring:${account}`;
 const mainKey = `clodex:${account}`;
 const journalKey = `clodex-journal:${account}`;
+const deletedKey = `clodex-deleted:${account}`;
 const journalPrefix = '__relay_chunk_journal__:v1:';
 const previousHome = process.env.CLODEX_HOME;
+const previousRuntimeDir = process.env.XDG_RUNTIME_DIR;
 let tempDir = '';
+
+function testCredentialAuthRef(accountBase: string): string {
+  return `keyring:${accountBase}::credential::${credentialInstance}`;
+}
+
+function managedStatePath(refAccount = account): string {
+  const accountDigest = createHash('sha256').update(refAccount).digest('hex');
+  return join(keyring.lockHome, '.clodex', 'keyring-state', `${accountDigest}.managed`);
+}
+
+function hasStoredCredentialState(ref: string): boolean {
+  const refAccount = ref.slice('keyring:'.length);
+  if (existsSync(managedStatePath(refAccount))) {
+    return true;
+  }
+  return [...keyring.values.keys()].some(key => {
+    const separatorIndex = key.indexOf(':');
+    const service = key.slice(0, separatorIndex);
+    const storedAccount = key.slice(separatorIndex + 1);
+    return (
+      ['clodex', 'clodex-chunks', 'clodex-journal', 'clodex-deleted'].includes(service) &&
+      (storedAccount === refAccount || storedAccount.startsWith(`${refAccount}::chunk::`))
+    );
+  });
+}
+
+function saveProviderCredential(
+  ref: string,
+  value: string,
+  diag?: (msg: string) => void,
+): Promise<boolean> {
+  return hasStoredCredentialState(ref)
+    ? replaceProviderCredential(ref, value, diag)
+    : provisionProviderCredential(ref, value, diag);
+}
 
 function currentChunkKeys(): string[] {
   return [...keyring.values.keys()].filter(key => key.includes(`${account}::chunk::`));
 }
 
-function expectUnverifiableTombstone(): string {
+function clearMockKeyringState(): void {
+  keyring.values.clear();
+  rmSync(join(keyring.lockHome, '.clodex', 'keyring-state'), { recursive: true, force: true });
+}
+
+function expectUnverifiableTombstone(blockLegacy = false): string {
   const raw = keyring.values.get(journalKey);
   expect(raw?.startsWith(journalPrefix)).toBe(true);
   expect(JSON.parse(raw!.slice(journalPrefix.length))).toEqual({
     mode: 'delete',
     generations: [],
+    ...(blockLegacy ? { blockLegacy: true } : {}),
     unverifiable: true,
   });
   return raw!;
+}
+
+function expectDeletionMarker(): void {
+  const raw = keyring.values.get(journalKey);
+  expect(raw?.startsWith(journalPrefix)).toBe(true);
+  expect(JSON.parse(raw!.slice(journalPrefix.length))).toEqual({
+    mode: 'deleted',
+    generations: [],
+  });
+  expectDeletionGuard();
+}
+
+function expectDeletionGuard(): void {
+  expect(keyring.values.has(mainKey)).toBe(false);
+  expect(keyring.values.get(deletedKey)).toBe('v1:deleted');
+}
+
+function publishedMarker(): {
+  count: number;
+  generation?: string;
+  digest?: string;
+} {
+  const raw = keyring.values.get(mainKey);
+  expect(raw?.startsWith('__relay_chunked__:')).toBe(true);
+  const encoded = raw!.slice('__relay_chunked__:'.length);
+  const current = /^v3:([^:]+):(\d+):([0-9a-f]{64})$/.exec(encoded);
+  const versioned = /^v2:([^:]+):(\d+)$/.exec(encoded);
+  const legacy = /^(\d+)$/.exec(encoded);
+  const count = Number(current?.[2] ?? versioned?.[2] ?? legacy?.[1]);
+  return {
+    count,
+    ...(current?.[1] || versioned?.[1] ? { generation: current?.[1] ?? versioned?.[1] } : {}),
+    ...(current?.[3] ? { digest: current[3] } : {}),
+  };
+}
+
+function expectActiveInventory(
+  marker: ReturnType<typeof publishedMarker> = publishedMarker(),
+): void {
+  const raw = keyring.values.get(journalKey);
+  expect(raw?.startsWith(journalPrefix)).toBe(true);
+  expect(JSON.parse(raw!.slice(journalPrefix.length))).toEqual({
+    mode: 'write',
+    generations: [marker],
+  });
+}
+
+function expectActiveShort(value: string): void {
+  const raw = keyring.values.get(journalKey);
+  expect(raw?.startsWith(journalPrefix)).toBe(true);
+  expect(JSON.parse(raw!.slice(journalPrefix.length))).toEqual({
+    mode: 'short',
+    generations: [],
+    shortDigest: createHash('sha256').update(value).digest('hex'),
+  });
 }
 
 describe('keyring credential chunks', () => {
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'clodex-keyring-'));
     process.env.CLODEX_HOME = tempDir;
+    process.env.XDG_RUNTIME_DIR = tempDir;
     keyring.lockHome = tempDir;
     keyring.values.clear();
     keyring.failSetSuffix = '';
     keyring.failSetKey = '';
     keyring.failDeleteSuffix = '';
     keyring.failDeleteKey = '';
+    keyring.failFindService = '';
+    keyring.failFindCount = 0;
+    keyring.omitFindKey = '';
+    keyring.omitFindOnceKey = '';
+    keyring.omitFindAccount = '';
+    keyring.getCount = 0;
+    keyring.findCount = 0;
     keyring.onGet = null;
     keyring.operations = [];
   });
@@ -106,7 +269,22 @@ describe('keyring credential chunks', () => {
   afterEach(() => {
     if (previousHome === undefined) delete process.env.CLODEX_HOME;
     else process.env.CLODEX_HOME = previousHome;
+    if (previousRuntimeDir === undefined) delete process.env.XDG_RUNTIME_DIR;
+    else process.env.XDG_RUNTIME_DIR = previousRuntimeDir;
     rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('requires a versioned account reference for provisioned credentials', async () => {
+    const diagnostics: string[] = [];
+
+    await expect(
+      provisionProviderCredential('keyring:provider:test', 'secret-value', message =>
+        diagnostics.push(message),
+      ),
+    ).resolves.toBe(false);
+
+    expect(diagnostics).toContain('provisioned credentials require a versioned account instance');
+    expect(keyring.values.size).toBe(0);
   });
 
   it('publishes a new chunk generation before removing the previous one', async () => {
@@ -141,22 +319,62 @@ describe('keyring credential chunks', () => {
       .map((operation, index) => ({ operation, index }))
       .filter(({ operation }) => operation.type === 'delete' && firstChunks.includes(operation.key))
       .map(({ index }) => index);
-    const journalSetIndex = keyring.operations.findIndex(operation =>
-      operation.type === 'set' && operation.key === journalKey,
-    );
-    const journalDeleteIndex = keyring.operations.findIndex(operation =>
-      operation.type === 'delete' && operation.key === journalKey,
-    );
+    const journalSetIndices = keyring.operations
+      .map((operation, index) => ({ operation, index }))
+      .filter(({ operation }) => operation.type === 'set' && operation.key === journalKey)
+      .map(({ index }) => index);
+    const initialJournalSetIndex = journalSetIndices.at(0)!;
+    const inventorySetIndex = journalSetIndices.at(-1)!;
     expect(markerSetIndex).toBeGreaterThanOrEqual(0);
-    expect(journalSetIndex).toBeGreaterThanOrEqual(0);
-    expect(journalDeleteIndex).toBeGreaterThanOrEqual(0);
+    expect(journalSetIndices).toHaveLength(2);
     expect(newChunkSetIndices).toHaveLength(2);
     expect(oldChunkDeleteIndices).toHaveLength(3);
-    expect(newChunkSetIndices.every(index => journalSetIndex < index)).toBe(true);
+    expect(newChunkSetIndices.every(index => initialJournalSetIndex < index)).toBe(true);
     expect(newChunkSetIndices.every(index => index < markerSetIndex)).toBe(true);
     expect(oldChunkDeleteIndices.every(index => index > markerSetIndex)).toBe(true);
-    expect(oldChunkDeleteIndices.every(index => index < journalDeleteIndex)).toBe(true);
+    expect(oldChunkDeleteIndices.every(index => index < inventorySetIndex)).toBe(true);
+    expectActiveInventory();
     await expect(resolveProviderCredential('test', authRef)).resolves.toBe(second);
+  });
+
+  it('does not split a surrogate pair across native keyring chunks', async () => {
+    const secret = `${'a'.repeat(1_199)}😀b`;
+
+    await expect(saveProviderCredential(authRef, secret)).resolves.toBe(true);
+
+    expect(currentChunkKeys()).toHaveLength(2);
+    expect([...keyring.values.values()].every(value => !value.includes('�'))).toBe(true);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe(secret);
+  });
+
+  it('does not multiply missing-entry scans for a steady short credential', async () => {
+    await expect(saveProviderCredential(authRef, 'short-secret')).resolves.toBe(true);
+    keyring.getCount = 0;
+    keyring.findCount = 0;
+
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe('short-secret');
+
+    expect(keyring.getCount).toBe(5);
+    expect(keyring.findCount).toBe(1);
+  });
+
+  it('places keyring coordination state under the native account home', async () => {
+    const defaultHome = mkdtempSync(join(tmpdir(), 'clodex-default-home-'));
+    const alternateRuntime = mkdtempSync(join(tmpdir(), 'clodex-runtime-'));
+    keyring.lockHome = defaultHome;
+    process.env.XDG_RUNTIME_DIR = alternateRuntime;
+    try {
+      await expect(saveProviderCredential(authRef, 'short-secret')).resolves.toBe(true);
+
+      expect(existsSync(join(defaultHome, '.clodex', 'credential-locks'))).toBe(true);
+      expect(existsSync(join(defaultHome, '.clodex', 'keyring-state'))).toBe(true);
+      expect(existsSync(join(tempDir, 'clodex-keyring-locks'))).toBe(false);
+      expect(existsSync(join(tempDir, 'keyring-state'))).toBe(false);
+      expect(existsSync(join(alternateRuntime, 'clodex-keyring-locks'))).toBe(false);
+    } finally {
+      rmSync(defaultHome, { recursive: true, force: true });
+      rmSync(alternateRuntime, { recursive: true, force: true });
+    }
   });
 
   it('keeps the published credential readable when a new generation fails', async () => {
@@ -170,9 +388,10 @@ describe('keyring credential chunks', () => {
 
     expect(keyring.values.get(mainKey)).toBe(firstMarker);
     expect(keyring.values.has(journalKey)).toBe(true);
+    keyring.failSetSuffix = '';
     await expect(resolveProviderCredential('test', authRef)).resolves.toBe(first);
     expect(currentChunkKeys().sort()).toEqual(firstChunks.sort());
-    expect(keyring.values.has(journalKey)).toBe(false);
+    expectActiveInventory();
   });
 
   it('recovers journaled chunks when publishing the new marker fails', async () => {
@@ -189,7 +408,221 @@ describe('keyring credential chunks', () => {
     keyring.failSetKey = '';
     await expect(resolveProviderCredential('test', authRef)).resolves.toBe(first);
     expect(currentChunkKeys().sort()).toEqual(firstChunks.sort());
+    expectActiveInventory();
+  });
+
+  it('retains a short fallback when its second read collapses before a failed long write', async () => {
+    const first = 'short-secret';
+    await expect(saveProviderCredential(authRef, first)).resolves.toBe(true);
+
+    let mainReads = 0;
+    keyring.omitFindOnceKey = mainKey;
+    keyring.onGet = key => {
+      if (key === mainKey && ++mainReads === 2) {
+        throw new Error('injected collapsed keyring read failure');
+      }
+    };
+    keyring.failSetSuffix = '::1';
+
+    await expect(saveProviderCredential(authRef, 'b'.repeat(2_500))).resolves.toBe(false);
+
+    keyring.onGet = null;
+    keyring.failSetSuffix = '';
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe(first);
+    expect(keyring.values.get(mainKey)).toBe(first);
+    expect(currentChunkKeys()).toEqual([]);
+    expectActiveShort(first);
+  });
+
+  it('retains a long fallback when its second read collapses before a failed short write', async () => {
+    const first = 'a'.repeat(2_500);
+    await expect(saveProviderCredential(authRef, first)).resolves.toBe(true);
+    const marker = publishedMarker();
+    const chunks = currentChunkKeys();
+
+    let mainReads = 0;
+    keyring.omitFindOnceKey = mainKey;
+    keyring.onGet = key => {
+      if (key === mainKey && ++mainReads === 2) {
+        throw new Error('injected collapsed keyring read failure');
+      }
+    };
+    keyring.failSetKey = mainKey;
+
+    await expect(saveProviderCredential(authRef, 'short-secret')).resolves.toBe(false);
+
+    keyring.onGet = null;
+    keyring.failSetKey = '';
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe(first);
+    expect(currentChunkKeys().sort()).toEqual(chunks.sort());
+    expectActiveInventory(marker);
+  });
+
+  it('recovers a short credential when publishing a long marker fails', async () => {
+    const first = 'short-secret';
+    await expect(saveProviderCredential(authRef, first)).resolves.toBe(true);
+    keyring.failSetKey = mainKey;
+
+    await expect(saveProviderCredential(authRef, 'b'.repeat(2_500))).resolves.toBe(false);
+
+    keyring.failSetKey = '';
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe(first);
+    expect(keyring.values.get(mainKey)).toBe(first);
+    expect(currentChunkKeys()).toEqual([]);
+    expectActiveShort(first);
+  });
+
+  it('recovers a long credential when publishing a short value fails', async () => {
+    const first = 'a'.repeat(2_500);
+    await expect(saveProviderCredential(authRef, first)).resolves.toBe(true);
+    const marker = publishedMarker();
+    const chunks = currentChunkKeys();
+    keyring.failSetKey = mainKey;
+
+    await expect(saveProviderCredential(authRef, 'short-secret')).resolves.toBe(false);
+
+    keyring.failSetKey = '';
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe(first);
+    expect(currentChunkKeys().sort()).toEqual(chunks.sort());
+    expectActiveInventory(marker);
+  });
+
+  it('retries an unpublished long credential after chunk or marker publication fails', async () => {
+    const secret = 'a'.repeat(2_500);
+    for (const failure of ['chunk', 'marker'] as const) {
+      clearMockKeyringState();
+      keyring.operations = [];
+      if (failure === 'chunk') keyring.failSetSuffix = '::1';
+      else keyring.failSetKey = mainKey;
+
+      await expect(saveProviderCredential(authRef, secret)).resolves.toBe(false);
+
+      keyring.failSetSuffix = '';
+      keyring.failSetKey = '';
+      await expect(saveProviderCredential(authRef, secret)).resolves.toBe(true);
+      await expect(resolveProviderCredential('test', authRef)).resolves.toBe(secret);
+      expectActiveInventory();
+    }
+  });
+
+  it('verifies a first long publication after a transient collapsed marker read', async () => {
+    const secret = 'a'.repeat(2_500);
+    let remainingCollapsedReads = 2;
+    keyring.onGet = key => {
+      const markerWasPublished = keyring.operations.some(
+        operation => operation.type === 'set' && operation.key === mainKey,
+      );
+      if (key === mainKey && markerWasPublished && remainingCollapsedReads > 0) {
+        remainingCollapsedReads--;
+        keyring.omitFindOnceKey = mainKey;
+        throw new Error('injected collapsed keyring read failure');
+      }
+    };
+
+    await expect(saveProviderCredential(authRef, secret)).resolves.toBe(false);
+
+    expect(remainingCollapsedReads).toBe(1);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe(secret);
+    expect(remainingCollapsedReads).toBe(0);
+    expect(currentChunkKeys()).toHaveLength(3);
+    expect(keyring.values.has(journalKey)).toBe(true);
+
+    keyring.onGet = null;
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe(secret);
+    expect(currentChunkKeys()).toHaveLength(3);
+    expectActiveInventory();
+  });
+
+  it('reuses the provisioned account after an ambiguous publication result', async () => {
+    const secret = 'a'.repeat(2_500);
+    let remainingCollapsedReads = 2;
+    keyring.onGet = key => {
+      const markerWasPublished = keyring.operations.some(
+        operation => operation.type === 'set' && operation.key === mainKey,
+      );
+      if (key === mainKey && markerWasPublished && remainingCollapsedReads > 0) {
+        remainingCollapsedReads--;
+        keyring.omitFindOnceKey = mainKey;
+        throw new Error('injected collapsed keyring read failure');
+      }
+    };
+
+    await expect(provisionProviderCredential(authRef, secret)).resolves.toBe(false);
+
+    keyring.onGet = null;
+    await expect(provisionProviderCredential(authRef, secret)).resolves.toBe(true);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe(secret);
+    expectActiveInventory();
+  });
+
+  it('retries an unpublished short credential after publication fails', async () => {
+    keyring.failSetKey = mainKey;
+    await expect(saveProviderCredential(authRef, 'first-secret')).resolves.toBe(false);
+
+    keyring.failSetKey = '';
+    await expect(saveProviderCredential(authRef, 'different-secret')).resolves.toBe(true);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe('different-secret');
+    expectActiveShort('different-secret');
+  });
+
+  it('replays the first journal write after publication fails', async () => {
+    keyring.failSetKey = journalKey;
+    await expect(provisionProviderCredential(authRef, 'short-secret')).resolves.toBe(false);
     expect(keyring.values.has(journalKey)).toBe(false);
+
+    keyring.failSetKey = '';
+    await expect(provisionProviderCredential(authRef, 'short-secret')).resolves.toBe(true);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe('short-secret');
+    expectActiveShort('short-secret');
+  });
+
+  it('shares interrupted journal intent across config homes', async () => {
+    const firstConfigHome = mkdtempSync(join(tmpdir(), 'clodex-config-a-'));
+    const secondConfigHome = mkdtempSync(join(tmpdir(), 'clodex-config-b-'));
+    try {
+      process.env.CLODEX_HOME = firstConfigHome;
+      keyring.failSetKey = journalKey;
+      await expect(provisionProviderCredential(authRef, 'first-secret')).resolves.toBe(false);
+      expect(existsSync(managedStatePath())).toBe(true);
+
+      process.env.CLODEX_HOME = secondConfigHome;
+      keyring.failSetKey = '';
+      await expect(provisionProviderCredential(authRef, 'second-secret')).resolves.toBe(true);
+
+      process.env.CLODEX_HOME = firstConfigHome;
+      await expect(resolveProviderCredential('test', authRef)).resolves.toBe('second-secret');
+      expect(existsSync(join(firstConfigHome, 'keyring-state'))).toBe(false);
+      expect(existsSync(join(secondConfigHome, 'keyring-state'))).toBe(false);
+    } finally {
+      rmSync(firstConfigHome, { recursive: true, force: true });
+      rmSync(secondConfigHome, { recursive: true, force: true });
+    }
+  });
+
+  it('replays a failed replacement journal without losing the active credential', async () => {
+    await expect(saveProviderCredential(authRef, 'first-secret')).resolves.toBe(true);
+
+    keyring.failSetKey = journalKey;
+    await expect(saveProviderCredential(authRef, 'a'.repeat(2_500))).resolves.toBe(false);
+
+    keyring.failSetKey = '';
+    await expect(saveProviderCredential(authRef, 'a'.repeat(2_500))).resolves.toBe(true);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe('a'.repeat(2_500));
+    expectActiveInventory();
+  });
+
+  it('fails closed when the local journal intent is malformed', async () => {
+    const diagnostics: string[] = [];
+    mkdirSync(join(keyring.lockHome, '.clodex', 'keyring-state'), { recursive: true });
+    writeFileSync(managedStatePath(), 'v1:preparing:not-valid!\n', { mode: 0o600 });
+
+    await expect(
+      provisionProviderCredential(authRef, 'short-secret', message => diagnostics.push(message)),
+    ).resolves.toBe(false);
+
+    expect(keyring.values.has(mainKey)).toBe(false);
+    expect(keyring.values.has(journalKey)).toBe(false);
+    expect(diagnostics).toContain('keyring error: keyring managed-state marker is invalid');
   });
 
   it('removes old chunks after replacing a long credential with a short one', async () => {
@@ -200,6 +633,45 @@ describe('keyring credential chunks', () => {
 
     expect(keyring.values.get(mainKey)).toBe('short-secret');
     expect(currentChunkKeys()).toEqual([]);
+    expectActiveShort('short-secret');
+  });
+
+  it('retains cleanup inventory until an older-release removal is confirmed', async () => {
+    const secret = 'a'.repeat(2_500);
+    await expect(saveProviderCredential(authRef, secret)).resolves.toBe(true);
+    const marker = publishedMarker();
+    const chunks = currentChunkKeys();
+    expect(chunks).toHaveLength(3);
+    expectActiveInventory(marker);
+
+    keyring.values.delete(mainKey);
+
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+    expect(chunks.every(key => keyring.values.has(key))).toBe(true);
+    expectActiveInventory(marker);
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    expect(chunks.every(key => !keyring.values.has(key))).toBe(true);
+    expectDeletionGuard();
+    expectDeletionMarker();
+  });
+
+  it('preserves active chunks when a collapsed main read omits the entry', async () => {
+    const secret = 'a'.repeat(2_500);
+    await expect(saveProviderCredential(authRef, secret)).resolves.toBe(true);
+    const marker = keyring.values.get(mainKey);
+    const journal = keyring.values.get(journalKey);
+    const chunks = currentChunkKeys();
+    keyring.omitFindKey = mainKey;
+    keyring.onGet = key => {
+      if (key === mainKey) throw new Error('injected collapsed keyring read failure');
+    };
+
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+
+    expect(keyring.values.get(mainKey)).toBe(marker);
+    expect(keyring.values.get(journalKey)).toBe(journal);
+    expect(chunks.every(key => keyring.values.has(key))).toBe(true);
   });
 
   it('reads and deletes valid legacy chunks', async () => {
@@ -209,7 +681,54 @@ describe('keyring credential chunks', () => {
 
     await expect(resolveProviderCredential('test', authRef)).resolves.toBe('legacy-secret');
     await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
-    expect(keyring.values.size).toBe(0);
+    expect(currentChunkKeys()).toEqual([]);
+    expectDeletionGuard();
+    expectDeletionMarker();
+  });
+
+  it('does not replace pre-journal chunks when keychain reads hide the account', async () => {
+    const marker = '__relay_chunked__:2';
+    const firstChunk = `clodex:${account}::chunk::0`;
+    const secondChunk = `clodex:${account}::chunk::1`;
+    keyring.values.set(mainKey, marker);
+    keyring.values.set(firstChunk, 'legacy-');
+    keyring.values.set(secondChunk, 'secret');
+    keyring.omitFindAccount = account;
+    keyring.onGet = key => {
+      if (key.endsWith(`:${account}`) || key.includes(`:${account}::chunk::`))
+        throw new Error('injected collapsed keyring read failure');
+    };
+
+    await expect(replaceProviderCredential(authRef, 'replacement-secret')).resolves.toBe(false);
+
+    expect(keyring.values.get(mainKey)).toBe(marker);
+    expect(keyring.values.get(firstChunk)).toBe('legacy-');
+    expect(keyring.values.get(secondChunk)).toBe('secret');
+    expect(keyring.values.has(journalKey)).toBe(false);
+    expect(keyring.operations).toEqual([]);
+  });
+
+  it('does not delete pre-journal chunks when keychain reads hide the account', async () => {
+    const marker = '__relay_chunked__:2';
+    const firstChunk = `clodex:${account}::chunk::0`;
+    const secondChunk = `clodex:${account}::chunk::1`;
+    keyring.values.set(mainKey, marker);
+    keyring.values.set(firstChunk, 'legacy-');
+    keyring.values.set(secondChunk, 'secret');
+    keyring.omitFindAccount = account;
+    keyring.onGet = key => {
+      if (key.endsWith(`:${account}`) || key.includes(`:${account}::chunk::`))
+        throw new Error('injected collapsed keyring read failure');
+    };
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
+
+    expect(keyring.values.get(mainKey)).toBe(marker);
+    expect(keyring.values.get(firstChunk)).toBe('legacy-');
+    expect(keyring.values.get(secondChunk)).toBe('secret');
+    expect(keyring.values.has(journalKey)).toBe(false);
+    expect(keyring.values.has(deletedKey)).toBe(false);
+    expect(keyring.operations).toEqual([]);
   });
 
   it('does not report deletion success while credential chunks remain', async () => {
@@ -218,13 +737,77 @@ describe('keyring credential chunks', () => {
 
     await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
 
-    expect(keyring.values.has(mainKey)).toBe(false);
+    expectDeletionGuard();
     expect(keyring.values.has(journalKey)).toBe(true);
     await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
     keyring.failDeleteSuffix = '';
     await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
     expect(currentChunkKeys()).toEqual([]);
-    expect(keyring.values.has(journalKey)).toBe(false);
+    expectDeletionGuard();
+    expectDeletionMarker();
+  });
+
+  it('preserves transition inventory when the first delete journal read collapses', async () => {
+    await expect(saveProviderCredential(authRef, 'a'.repeat(2_500))).resolves.toBe(true);
+    keyring.failDeleteSuffix = '::0';
+    await expect(saveProviderCredential(authRef, 'short-secret')).resolves.toBe(true);
+    expect(currentChunkKeys().length).toBeGreaterThan(0);
+    keyring.failDeleteSuffix = '';
+    let remainingCollapsedReads = 2;
+    keyring.onGet = key => {
+      if (key === journalKey && remainingCollapsedReads > 0) {
+        remainingCollapsedReads--;
+        keyring.omitFindOnceKey = journalKey;
+        throw new Error('injected collapsed keyring read failure');
+      }
+    };
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
+
+    expect(remainingCollapsedReads).toBe(0);
+    expect(currentChunkKeys().length).toBeGreaterThan(0);
+    expect(keyring.values.get(mainKey)).toBe('short-secret');
+    keyring.onGet = null;
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    expect(currentChunkKeys()).toEqual([]);
+    expectDeletionGuard();
+    expectDeletionMarker();
+  });
+
+  it('keeps a deletion journal when the final marker cannot be written', async () => {
+    await expect(saveProviderCredential(authRef, 'short-secret')).resolves.toBe(true);
+    keyring.values.set(
+      journalKey,
+      `${journalPrefix}${JSON.stringify({
+        mode: 'delete',
+        generations: [],
+        blockLegacy: true,
+      })}`,
+    );
+    keyring.failSetKey = journalKey;
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
+
+    expectDeletionGuard();
+    expect(keyring.values.get(journalKey)).toMatch(/^__relay_chunk_journal__:v1:/);
+    keyring.failSetKey = '';
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    expectDeletionGuard();
+    expectDeletionMarker();
+  });
+
+  it('keeps the credential published when the deletion guard cannot be written', async () => {
+    await expect(saveProviderCredential(authRef, 'short-secret')).resolves.toBe(true);
+    keyring.failSetKey = deletedKey;
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
+
+    expect(keyring.values.get(mainKey)).toBe('short-secret');
+    expect(keyring.values.has(journalKey)).toBe(true);
+    expect(keyring.values.has(deletedKey)).toBe(false);
+    keyring.failSetKey = '';
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    expectDeletionMarker();
   });
 
   it('persists an expanded same-generation count before unpublishing', async () => {
@@ -249,13 +832,14 @@ describe('keyring credential chunks', () => {
       generations: Array<{ count: number }>;
     };
     expect(pending.generations).toEqual([{ count: 2, generation }]);
-    expect(keyring.values.has(mainKey)).toBe(false);
+    expectDeletionGuard();
     expect(keyring.values.has(secondChunk)).toBe(true);
     keyring.failDeleteSuffix = '';
     await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
     expect(keyring.values.has(firstChunk)).toBe(false);
     expect(keyring.values.has(secondChunk)).toBe(false);
-    expect(keyring.values.has(journalKey)).toBe(false);
+    expectDeletionGuard();
+    expectDeletionMarker();
   });
 
   it('keeps a credential inaccessible while a deletion journal cannot unpublish it', async () => {
@@ -269,19 +853,26 @@ describe('keyring credential chunks', () => {
 
     await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
 
-    expect(keyring.values.get(mainKey)).toBe('pending-delete-secret');
+    const tombstone = keyring.values.get(mainKey)!;
+    expect(tombstone).toMatch(/^__clodex_delete__:/);
+    expect(keyring.values.get(mainKey)).not.toBe('pending-delete-secret');
     expect(keyring.values.get(journalKey)).toBe(journal);
+    keyring.values.delete(journalKey);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+    expect(keyring.values.get(mainKey)).toBe(tombstone);
+    keyring.values.set(journalKey, journal);
     keyring.failDeleteKey = '';
     await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
     expect(keyring.values.has(mainKey)).toBe(false);
     expect(keyring.values.has(journalKey)).toBe(false);
+    expect(keyring.values.has(deletedKey)).toBe(false);
   });
 
   it('retries from the published marker when rotation removes chunks mid-read', async () => {
     await expect(saveProviderCredential(authRef, 'a'.repeat(2_500))).resolves.toBe(true);
     const oldChunks = currentChunkKeys();
     const generation = '11111111-1111-4111-8111-111111111111';
-    keyring.onGet = (key) => {
+    keyring.onGet = key => {
       if (key !== oldChunks[0]) return;
       keyring.onGet = null;
       keyring.values.set(mainKey, `__relay_chunked__:v2:${generation}:2`);
@@ -298,33 +889,35 @@ describe('keyring credential chunks', () => {
     keyring.values.set(mainKey, '__relay_chunked__:Infinity');
     await expect(resolveProviderCredential('test', authRef, message => {
       diagnostics.push(message);
-    })).resolves.toBeNull();
+      }),
+    ).resolves.toBeNull();
     expect(diagnostics.join('\n')).toContain('invalid chunk marker');
     await expect(deleteProviderCredential(authRef, message => {
       diagnostics.push(message);
-    })).resolves.toBe(false);
-    expect(keyring.values.has(mainKey)).toBe(false);
+      }),
+    ).resolves.toBe(false);
+    expectDeletionGuard();
     expect(keyring.values.has(journalKey)).toBe(true);
     await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
     expect(keyring.values.has(journalKey)).toBe(true);
 
-    keyring.values.clear();
+    clearMockKeyringState();
     diagnostics.length = 0;
     keyring.values.set(mainKey, '__relay_chunked__:2');
     keyring.values.set(`clodex:${account}::chunk::0`, 'partial');
     await expect(resolveProviderCredential('test', authRef, message => {
       diagnostics.push(message);
-    })).resolves.toBeNull();
+      }),
+    ).resolves.toBeNull();
     expect(diagnostics.join('\n')).toContain('chunk 2 of 2 is missing');
 
     diagnostics.length = 0;
-    keyring.values.set(
-      mainKey,
-      `__relay_chunked__:v2:${'-'.repeat(36)}:2`,
-    );
-    await expect(resolveProviderCredential('test', authRef, message => {
+    keyring.values.set(mainKey, `__relay_chunked__:v2:${'-'.repeat(36)}:2`);
+    await expect(
+      resolveProviderCredential('test', authRef, message => {
       diagnostics.push(message);
-    })).resolves.toBeNull();
+      }),
+    ).resolves.toBeNull();
     expect(diagnostics.join('\n')).toContain('invalid chunk marker');
   });
 
@@ -371,7 +964,7 @@ describe('keyring credential chunks', () => {
     await expect(resolveProviderCredential('test', authRef)).resolves.toBe('old-secret');
     expect(newChunkKeys.every(key => !keyring.values.has(key))).toBe(true);
     expect(oldChunkKeys.every(key => keyring.values.has(key))).toBe(true);
-    expect(keyring.values.has(journalKey)).toBe(false);
+    expectActiveInventory({ count: 2, generation: oldGeneration });
 
     keyring.values.set(mainKey, newMarker);
     keyring.values.set(newChunkKeys[0]!, 'new-');
@@ -380,7 +973,39 @@ describe('keyring credential chunks', () => {
     await expect(resolveProviderCredential('test', authRef)).resolves.toBe('new-secret');
     expect(oldChunkKeys.every(key => !keyring.values.has(key))).toBe(true);
     expect(newChunkKeys.every(key => keyring.values.has(key))).toBe(true);
-    expect(keyring.values.has(journalKey)).toBe(false);
+    expectActiveInventory({ count: 2, generation: newGeneration });
+  });
+
+  it('fails closed when the published generation is absent from the write journal', async () => {
+    const publishedGeneration = '11111111-1111-4111-8111-111111111111';
+    const recoveryGeneration = '22222222-2222-4222-8222-222222222222';
+    const publishedMarker = `__relay_chunked__:v2:${publishedGeneration}:1`;
+    const publishedChunk = `clodex:${account}::chunk::${publishedGeneration}::0`;
+    const recoveryChunk = `clodex:${account}::chunk::${recoveryGeneration}::0`;
+    const journal = `${journalPrefix}${JSON.stringify({
+      mode: 'write',
+      generations: [{ count: 1, generation: recoveryGeneration }],
+    })}`;
+    const diagnostics: string[] = [];
+    keyring.values.set(mainKey, publishedMarker);
+    keyring.values.set(publishedChunk, 'published-secret');
+    keyring.values.set(recoveryChunk, 'recovery-secret');
+    keyring.values.set(journalKey, journal);
+
+    await expect(
+      resolveProviderCredential('test', authRef, message => {
+        diagnostics.push(message);
+      }),
+    ).resolves.toBeNull();
+
+    expect(diagnostics.join('\n')).toContain(
+      'published credential generation is not represented by cleanup journal',
+    );
+    expect(keyring.values.get(mainKey)).toBe(publishedMarker);
+    expect(keyring.values.get(publishedChunk)).toBe('published-secret');
+    expect(keyring.values.get(recoveryChunk)).toBe('recovery-secret');
+    expect(keyring.values.get(journalKey)).toBe(journal);
+    await expect(saveProviderCredential(authRef, 'replacement-secret')).resolves.toBe(false);
   });
 
   it('rolls back before retiring the last complete generation', async () => {
@@ -396,10 +1021,7 @@ describe('keyring credential chunks', () => {
       generation: newGeneration,
       digest: createHash('sha256').update(newValue).digest('hex'),
     };
-    keyring.values.set(
-      mainKey,
-      `__relay_chunked__:v3:${newGeneration}:2:${newMarker.digest}`,
-    );
+    keyring.values.set(mainKey, `__relay_chunked__:v3:${newGeneration}:2:${newMarker.digest}`);
     keyring.values.set(`clodex:${account}::chunk::${oldGeneration}::0`, 'old-');
     keyring.values.set(`clodex:${account}::chunk::${oldGeneration}::1`, 'secret');
     keyring.values.set(`clodex-chunks:${account}::chunk::${newGeneration}::0`, 'new-');
@@ -413,12 +1035,10 @@ describe('keyring credential chunks', () => {
 
     await expect(resolveProviderCredential('test', authRef)).resolves.toBe('old-secret');
 
-    expect(keyring.values.get(mainKey)).toBe(
-      `__relay_chunked__:v2:${oldGeneration}:2`,
-    );
+    expect(keyring.values.get(mainKey)).toBe(`__relay_chunked__:v2:${oldGeneration}:2`);
     expect(keyring.values.has(`clodex:${account}::chunk::${oldGeneration}::0`)).toBe(true);
     expect(keyring.values.has(`clodex-chunks:${account}::chunk::${newGeneration}::0`)).toBe(false);
-    expect(keyring.values.has(journalKey)).toBe(false);
+    expectActiveInventory(oldMarker);
   });
 
   it('trusts the published digest over a stale journal digest', async () => {
@@ -436,10 +1056,7 @@ describe('keyring credential chunks', () => {
       generation: newGeneration,
       digest: staleDigest,
     };
-    keyring.values.set(
-      mainKey,
-      `__relay_chunked__:v3:${newGeneration}:2:${publishedDigest}`,
-    );
+    keyring.values.set(mainKey, `__relay_chunked__:v3:${newGeneration}:2:${publishedDigest}`);
     keyring.values.set(`clodex-chunks:${account}::chunk::${newGeneration}::0`, 'new-');
     keyring.values.set(`clodex-chunks:${account}::chunk::${newGeneration}::1`, 'secret');
     keyring.values.set(`clodex:${account}::chunk::${oldGeneration}::0`, 'old-');
@@ -459,7 +1076,11 @@ describe('keyring credential chunks', () => {
     );
     expect(keyring.values.has(`clodex-chunks:${account}::chunk::${newGeneration}::0`)).toBe(true);
     expect(keyring.values.has(`clodex:${account}::chunk::${oldGeneration}::0`)).toBe(false);
-    expect(keyring.values.has(journalKey)).toBe(false);
+    expectActiveInventory({
+      count: 2,
+      generation: newGeneration,
+      digest: publishedDigest,
+    });
   });
 
   it('removes journal-only tail chunks from the published generation', async () => {
@@ -470,10 +1091,7 @@ describe('keyring credential chunks', () => {
     const journalDigest = createHash('sha256').update(journalValue).digest('hex');
     const firstChunk = `clodex-chunks:${account}::chunk::${generation}::0`;
     const secondChunk = `clodex-chunks:${account}::chunk::${generation}::1`;
-    keyring.values.set(
-      mainKey,
-      `__relay_chunked__:v3:${generation}:1:${publishedDigest}`,
-    );
+    keyring.values.set(mainKey, `__relay_chunked__:v3:${generation}:1:${publishedDigest}`);
     keyring.values.set(firstChunk, 'a');
     keyring.values.set(secondChunk, 'b');
     keyring.values.set(
@@ -491,7 +1109,7 @@ describe('keyring credential chunks', () => {
     );
     expect(keyring.values.has(firstChunk)).toBe(true);
     expect(keyring.values.has(secondChunk)).toBe(false);
-    expect(keyring.values.has(journalKey)).toBe(false);
+    expectActiveInventory({ count: 1, digest: publishedDigest, generation });
   });
 
   it('repairs a stale published digest from a valid journal copy', async () => {
@@ -505,10 +1123,7 @@ describe('keyring credential chunks', () => {
       generation: newGeneration,
       digest: currentDigest,
     };
-    keyring.values.set(
-      mainKey,
-      `__relay_chunked__:v3:${newGeneration}:2:${staleDigest}`,
-    );
+    keyring.values.set(mainKey, `__relay_chunked__:v3:${newGeneration}:2:${staleDigest}`);
     keyring.values.set(`clodex-chunks:${account}::chunk::${newGeneration}::0`, 'new-');
     keyring.values.set(`clodex-chunks:${account}::chunk::${newGeneration}::1`, 'secret');
     keyring.values.set(`clodex:${account}::chunk::${oldGeneration}::0`, 'old-');
@@ -517,10 +1132,7 @@ describe('keyring credential chunks', () => {
       journalKey,
       `__relay_chunk_journal__:v1:${JSON.stringify({
         mode: 'write',
-        generations: [
-          currentMarker,
-          { count: 2, generation: oldGeneration },
-        ],
+        generations: [currentMarker, { count: 2, generation: oldGeneration }],
       })}`,
     );
 
@@ -531,7 +1143,7 @@ describe('keyring credential chunks', () => {
     );
     expect(keyring.values.has(`clodex-chunks:${account}::chunk::${newGeneration}::0`)).toBe(true);
     expect(keyring.values.has(`clodex:${account}::chunk::${oldGeneration}::0`)).toBe(false);
-    expect(keyring.values.has(journalKey)).toBe(false);
+    expectActiveInventory(currentMarker);
   });
 
   it('removes published tail chunks before restoring a shorter journal marker', async () => {
@@ -541,10 +1153,7 @@ describe('keyring credential chunks', () => {
     const staleDigest = createHash('sha256').update('stale-value').digest('hex');
     const firstChunk = `clodex-chunks:${account}::chunk::${generation}::0`;
     const secondChunk = `clodex-chunks:${account}::chunk::${generation}::1`;
-    keyring.values.set(
-      mainKey,
-      `__relay_chunked__:v3:${generation}:2:${staleDigest}`,
-    );
+    keyring.values.set(mainKey, `__relay_chunked__:v3:${generation}:2:${staleDigest}`);
     keyring.values.set(firstChunk, 'a');
     keyring.values.set(secondChunk, 'b');
     keyring.values.set(
@@ -562,23 +1171,173 @@ describe('keyring credential chunks', () => {
     );
     expect(keyring.values.has(firstChunk)).toBe(true);
     expect(keyring.values.has(secondChunk)).toBe(false);
-    expect(keyring.values.has(journalKey)).toBe(false);
+    expectActiveInventory({ count: 1, digest: recoveredDigest, generation });
   });
 
-  it('migrates under one account lock and deletes both keyring services', async () => {
+  it('requires an explicit save before replacing a relay-ai source', async () => {
     const legacyMainKey = `relay-ai:${account}`;
     keyring.values.set(legacyMainKey, 'legacy-secret');
 
-    await expect(resolveProviderCredential('test', authRef)).resolves.toBe('legacy-secret');
-    expect(keyring.values.get(mainKey)).toBe('legacy-secret');
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+    expect(keyring.values.has(mainKey)).toBe(false);
+    expect(keyring.values.get(legacyMainKey)).toBe('legacy-secret');
+
+    await expect(saveProviderCredential(authRef, 'replacement-secret')).resolves.toBe(true);
+    expect(keyring.values.get(mainKey)).toBe('replacement-secret');
+    expectActiveShort('replacement-secret');
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe('replacement-secret');
     expect(keyring.values.get(legacyMainKey)).toBe('legacy-secret');
 
     await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
-    expect(keyring.values.has(mainKey)).toBe(false);
-    expect(keyring.values.has(legacyMainKey)).toBe(false);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+    expect(keyring.values.get(legacyMainKey)).toBe('legacy-secret');
   });
 
-  it('keeps deletion journaled until current and legacy chunks are gone', async () => {
+  it('backfills active metadata for a pre-journal short credential', async () => {
+    const legacyMainKey = `relay-ai:${account}`;
+    keyring.values.set(mainKey, 'current-secret');
+    keyring.values.set(legacyMainKey, 'stale-legacy-secret');
+
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe('current-secret');
+
+    expectActiveShort('current-secret');
+    expect(keyring.values.get(legacyMainKey)).toBe('stale-legacy-secret');
+  });
+
+  it('fails closed when the first pre-journal short read collapses', async () => {
+    const legacyMainKey = `relay-ai:${account}`;
+    keyring.values.set(mainKey, 'current-secret');
+    keyring.values.set(legacyMainKey, 'stale-legacy-secret');
+    keyring.omitFindKey = mainKey;
+    keyring.onGet = key => {
+      if (key === mainKey) throw new Error('injected collapsed keyring read failure');
+    };
+
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+
+    expect(keyring.values.get(mainKey)).toBe('current-secret');
+    expect(keyring.values.has(journalKey)).toBe(false);
+    expect(keyring.values.get(legacyMainKey)).toBe('stale-legacy-secret');
+
+    keyring.omitFindKey = '';
+    keyring.onGet = null;
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe('current-secret');
+    expectActiveShort('current-secret');
+  });
+
+  it('round-trips and deletes short credentials that resemble chunk markers', async () => {
+    for (const secret of ['__relay_chunked__:legitimate-provider-secret', '__relay_chunked__:2']) {
+      clearMockKeyringState();
+
+      await expect(saveProviderCredential(authRef, secret)).resolves.toBe(true);
+      expectActiveShort(secret);
+      await expect(resolveProviderCredential('test', authRef)).resolves.toBe(secret);
+      await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+      expectDeletionGuard();
+      expectDeletionMarker();
+    }
+  });
+
+  it('removes all durable state after a disposable keyring probe', async () => {
+    await expect(probeProviderCredentialStore(authRef)).resolves.toBe(true);
+
+    expect([...keyring.values.entries()]).toEqual([]);
+    const stateDirectory = join(keyring.lockHome, '.clodex', 'keyring-state');
+    expect(existsSync(stateDirectory) ? readdirSync(stateDirectory) : []).toEqual([]);
+  });
+
+  it('blocks legacy migration when a deleted journal read collapses to null', async () => {
+    const legacyMainKey = `relay-ai:${account}`;
+    keyring.values.set(legacyMainKey, 'legacy-secret');
+    await expect(saveProviderCredential(authRef, 'current-secret')).resolves.toBe(true);
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    const deletionJournal = keyring.values.get(journalKey);
+    keyring.omitFindKey = journalKey;
+    keyring.onGet = key => {
+      if (key === journalKey) throw new Error('injected collapsed keyring read failure');
+    };
+
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+
+    expectDeletionGuard();
+    expect(keyring.values.get(journalKey)).toBe(deletionJournal);
+    expect(keyring.values.get(legacyMainKey)).toBe('legacy-secret');
+  });
+
+  it('restores deleted state when the first guard snapshot collapses', async () => {
+    await expect(saveProviderCredential(authRef, 'current-secret')).resolves.toBe(true);
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    keyring.values.delete(journalKey);
+    let guardReads = 0;
+    keyring.omitFindOnceKey = deletedKey;
+    keyring.onGet = key => {
+      if (key === deletedKey && ++guardReads === 1) {
+        throw new Error('injected collapsed keyring read failure');
+      }
+    };
+
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+
+    expectDeletionGuard();
+    expect(keyring.values.has(journalKey)).toBe(false);
+    keyring.onGet = null;
+    keyring.omitFindOnceKey = '';
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+    expectDeletionMarker();
+  });
+
+  it('clears restored deletion metadata when a replacement is explicitly saved', async () => {
+    await expect(saveProviderCredential(authRef, 'current-secret')).resolves.toBe(true);
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    const collapsed = new Set([deletedKey, journalKey]);
+    keyring.onGet = key => {
+      if (collapsed.delete(key)) {
+        keyring.omitFindOnceKey = key;
+        throw new Error('injected collapsed keyring read failure');
+      }
+    };
+
+    await expect(saveProviderCredential(authRef, 'replacement-secret')).resolves.toBe(true);
+
+    keyring.onGet = null;
+    expect(keyring.values.has(deletedKey)).toBe(false);
+    expectActiveShort('replacement-secret');
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe('replacement-secret');
+  });
+
+  it('does not publish a replacement until the deletion guard is cleared', async () => {
+    await expect(saveProviderCredential(authRef, 'current-secret')).resolves.toBe(true);
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    keyring.failDeleteKey = deletedKey;
+
+    await expect(saveProviderCredential(authRef, 'replacement-secret')).resolves.toBe(false);
+
+    expect(keyring.values.has(mainKey)).toBe(false);
+    expectDeletionMarker();
+    keyring.values.delete(journalKey);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+    expectDeletionMarker();
+
+    keyring.failDeleteKey = '';
+    await expect(saveProviderCredential(authRef, 'replacement-secret')).resolves.toBe(true);
+    expect(keyring.values.has(deletedKey)).toBe(false);
+    expectActiveShort('replacement-secret');
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe('replacement-secret');
+  });
+
+  it('retires a credential recreated behind a deleted marker', async () => {
+    await expect(saveProviderCredential(authRef, 'first-secret')).resolves.toBe(true);
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    keyring.values.set(mainKey, 'credential-written-by-older-release');
+
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+
+    expectDeletionGuard();
+    expectDeletionMarker();
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+  });
+
+  it('deletes Clodex chunks without touching relay-ai chunks', async () => {
     const currentGeneration = '11111111-1111-4111-8111-111111111111';
     const legacyGeneration = '22222222-2222-4222-8222-222222222222';
     const currentChunk = `clodex:${account}::chunk::${currentGeneration}::0`;
@@ -591,14 +1350,18 @@ describe('keyring credential chunks', () => {
 
     await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
     expect(keyring.values.has(journalKey)).toBe(true);
-    expect(keyring.values.has(mainKey)).toBe(false);
-    expect(keyring.values.has(`relay-ai:${account}`)).toBe(false);
+    expectDeletionGuard();
+    expect(keyring.values.get(`relay-ai:${account}`)).toBe(
+      `__relay_chunked__:v2:${legacyGeneration}:1`,
+    );
+    expect(keyring.values.get(legacyChunk)).toBe('legacy-secret');
 
     keyring.failDeleteSuffix = '';
     await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
     expect(keyring.values.has(currentChunk)).toBe(false);
-    expect(keyring.values.has(legacyChunk)).toBe(false);
-    expect(keyring.values.has(journalKey)).toBe(false);
+    expect(keyring.values.get(legacyChunk)).toBe('legacy-secret');
+    expectDeletionGuard();
+    expectDeletionMarker();
   });
 
   it('captures a published generation missing from an existing deletion journal', async () => {
@@ -624,10 +1387,10 @@ describe('keyring credential chunks', () => {
 
     await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
 
-    expect(keyring.values.has(mainKey)).toBe(false);
+    expectDeletionGuard();
     expect(keyring.values.has(v2ChunkKey)).toBe(false);
     expect(keyring.values.has(v3ChunkKey)).toBe(false);
-    expect(keyring.values.has(journalKey)).toBe(false);
+    expectDeletionMarker();
   });
 
   it('compacts a full deletion journal before adding newly observed generations', async () => {
@@ -639,31 +1402,21 @@ describe('keyring credential chunks', () => {
       '55555555-5555-4555-8555-555555555555',
       '66666666-6666-4666-8666-666666666666',
     ];
-    const legacyGenerations = [
-      '77777777-7777-4777-8777-777777777777',
-      '88888888-8888-4888-8888-888888888888',
-      '99999999-9999-4999-8999-999999999999',
-      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
-    ];
     const currentPublished = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
-    const legacyPublished = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
     for (const generation of currentGenerations) {
       keyring.values.set(`clodex:${account}::chunk::${generation}::0`, generation);
     }
-    for (const generation of legacyGenerations) {
-      keyring.values.set(`relay-ai:${account}::chunk::${generation}::0`, generation);
-    }
     keyring.values.set(mainKey, `__relay_chunked__:v2:${currentPublished}:1`);
     keyring.values.set(`clodex:${account}::chunk::${currentPublished}::0`, 'current');
-    keyring.values.set(`relay-ai:${account}`, `__relay_chunked__:v2:${legacyPublished}:1`);
-    keyring.values.set(`relay-ai:${account}::chunk::${legacyPublished}::0`, 'legacy');
     const journal = `${journalPrefix}${JSON.stringify({
       mode: 'delete',
-      generations: currentGenerations.map(generation => ({ count: 1, generation })),
-      legacyGenerations: legacyGenerations.map(generation => ({ count: 1, generation })),
+      generations: currentGenerations.map(generation => ({
+        count: 1,
+        generation,
+      })),
     })}`;
     keyring.values.set(journalKey, journal);
-    keyring.failDeleteKey = mainKey;
+    keyring.failSetKey = mainKey;
 
     await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
 
@@ -671,32 +1424,27 @@ describe('keyring credential chunks', () => {
     expect(expandedJournal.startsWith(journalPrefix)).toBe(true);
     const expanded = JSON.parse(expandedJournal.slice(journalPrefix.length)) as {
       generations: unknown[];
-      legacyGenerations: unknown[];
     };
     expect(expanded.generations).toHaveLength(1);
-    expect(expanded.legacyGenerations).toHaveLength(1);
-    expect(currentChunkKeys()).toHaveLength(2);
+    expect(currentChunkKeys()).toHaveLength(1);
     await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
-    keyring.failDeleteKey = '';
+    keyring.failSetKey = '';
     await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
     expect(currentChunkKeys()).toEqual([]);
-    expect(keyring.values.has(journalKey)).toBe(false);
+    expectDeletionGuard();
+    expectDeletionMarker();
   });
 
-  it('compacts a size-bound v3 journal even when its generation counts fit', async () => {
+  it('compacts a full v3 deletion journal before adding the published generation', async () => {
     const currentGenerations = [
       '11111111-1111-4111-8111-111111111111',
       '22222222-2222-4222-8222-222222222222',
       '33333333-3333-4333-8333-333333333333',
       '44444444-4444-4444-8444-444444444444',
-    ];
-    const legacyGenerations = [
       '55555555-5555-4555-8555-555555555555',
       '66666666-6666-4666-8666-666666666666',
-      '77777777-7777-4777-8777-777777777777',
     ];
     const currentPublished = '88888888-8888-4888-8888-888888888888';
-    const legacyPublished = '99999999-9999-4999-8999-999999999999';
     const markerFor = (generation: string) => {
       const value = `secret-${generation}`;
       return {
@@ -709,43 +1457,35 @@ describe('keyring credential chunks', () => {
       };
     };
     const currentMarkers = currentGenerations.map(markerFor);
-    const legacyMarkers = legacyGenerations.map(markerFor);
     const current = markerFor(currentPublished);
-    const legacy = markerFor(legacyPublished);
-    for (const { marker, value } of [...currentMarkers, ...legacyMarkers, current, legacy]) {
+    for (const { marker, value } of [...currentMarkers, current]) {
       keyring.values.set(`clodex-chunks:${account}::chunk::${marker.generation}::0`, value);
     }
     keyring.values.set(
       mainKey,
       `__relay_chunked__:v3:${currentPublished}:1:${current.marker.digest}`,
     );
-    keyring.values.set(
-      `relay-ai:${account}`,
-      `__relay_chunked__:v3:${legacyPublished}:1:${legacy.marker.digest}`,
-    );
     const journal = `${journalPrefix}${JSON.stringify({
       mode: 'delete',
       generations: currentMarkers.map(({ marker }) => marker),
-      legacyGenerations: legacyMarkers.map(({ marker }) => marker),
     })}`;
     expect(journal.length).toBeLessThanOrEqual(1_200);
     keyring.values.set(journalKey, journal);
-    keyring.failDeleteKey = mainKey;
+    keyring.failSetKey = mainKey;
 
     await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
 
     const compactedJournal = keyring.values.get(journalKey)!;
     const compacted = JSON.parse(compactedJournal.slice(journalPrefix.length)) as {
       generations: unknown[];
-      legacyGenerations: unknown[];
     };
     expect(compacted.generations).toHaveLength(1);
-    expect(compacted.legacyGenerations).toHaveLength(1);
-    expect(currentChunkKeys()).toHaveLength(2);
-    keyring.failDeleteKey = '';
+    expect(currentChunkKeys()).toHaveLength(1);
+    keyring.failSetKey = '';
     await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
     expect(currentChunkKeys()).toEqual([]);
-    expect(keyring.values.has(journalKey)).toBe(false);
+    expectDeletionGuard();
+    expectDeletionMarker();
   });
 
   it('preserves main markers when a deletion-journal expansion cannot be written', async () => {
@@ -768,9 +1508,21 @@ describe('keyring credential chunks', () => {
     await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
     keyring.failSetKey = '';
     await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
-    expect(keyring.values.has(mainKey)).toBe(false);
+    expectDeletionGuard();
     expect(keyring.values.has(chunkKey)).toBe(false);
-    expect(keyring.values.has(journalKey)).toBe(false);
+    expectDeletionMarker();
+  });
+
+  it('falls back to credential enumeration when getPassword returns null', async () => {
+    keyring.values.set(mainKey, 'stored-secret');
+    keyring.onGet = key => {
+      if (key !== mainKey) return;
+      keyring.onGet = null;
+      throw new Error('injected collapsed keyring read failure');
+    };
+
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe('stored-secret');
+    expect(keyring.values.get(mainKey)).toBe('stored-secret');
   });
 
   it('does not replace a valid journal after a transient journal read failure', async () => {
@@ -784,8 +1536,10 @@ describe('keyring credential chunks', () => {
     keyring.values.set(mainKey, marker);
     keyring.values.set(chunkKey, 'pending-secret');
     keyring.values.set(journalKey, journal);
+    keyring.failFindService = 'clodex-journal';
+    keyring.failFindCount = 1;
     let journalReads = 0;
-    keyring.onGet = (key) => {
+    keyring.onGet = key => {
       if (key !== journalKey || ++journalReads !== 2) return;
       keyring.onGet = null;
       throw new Error('injected keyring read failure');
@@ -793,12 +1547,16 @@ describe('keyring credential chunks', () => {
 
     await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
 
-    expect(keyring.values.get(journalKey)).toBe(journal);
+    expect(JSON.parse(keyring.values.get(journalKey)!.slice(journalPrefix.length))).toEqual({
+      mode: 'delete',
+      generations: [],
+      blockLegacy: true,
+    });
     expect(keyring.values.get(mainKey)).toBe(marker);
     expect(keyring.values.get(chunkKey)).toBe('pending-secret');
     await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
-    expect(keyring.values.has(journalKey)).toBe(false);
-    expect(keyring.values.has(mainKey)).toBe(false);
+    expectDeletionMarker();
+    expectDeletionGuard();
     expect(keyring.values.has(chunkKey)).toBe(false);
   });
 
@@ -813,21 +1571,27 @@ describe('keyring credential chunks', () => {
     keyring.values.set(mainKey, marker);
     keyring.values.set(chunkKey, 'pending-secret');
     keyring.values.set(journalKey, journal);
+    keyring.failFindService = 'clodex';
+    keyring.failFindCount = 1;
     let mainReads = 0;
-    keyring.onGet = (key) => {
-      if (key !== mainKey || ++mainReads !== 2) return;
+    keyring.onGet = key => {
+      if (key !== mainKey || ++mainReads !== 1) return;
       keyring.onGet = null;
       throw new Error('injected keyring read failure');
     };
 
     await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
 
-    expect(keyring.values.get(journalKey)).toBe(journal);
+    expect(JSON.parse(keyring.values.get(journalKey)!.slice(journalPrefix.length))).toEqual({
+      mode: 'delete',
+      generations: [],
+      blockLegacy: true,
+    });
     expect(keyring.values.get(mainKey)).toBe(marker);
     expect(keyring.values.get(chunkKey)).toBe('pending-secret');
     await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
-    expect(keyring.values.has(journalKey)).toBe(false);
-    expect(keyring.values.has(mainKey)).toBe(false);
+    expectDeletionMarker();
+    expectDeletionGuard();
     expect(keyring.values.has(chunkKey)).toBe(false);
   });
 
@@ -843,7 +1607,9 @@ describe('keyring credential chunks', () => {
     keyring.values.set(mainKey, encodedMarker);
     keyring.values.set(chunkKey, 'published-secret');
     keyring.values.set(journalKey, journal);
-    keyring.onGet = (key) => {
+    keyring.failFindService = 'clodex-journal';
+    keyring.failFindCount = 1;
+    keyring.onGet = key => {
       if (key !== journalKey) return;
       keyring.onGet = null;
       throw new Error('injected keyring read failure');
@@ -855,7 +1621,7 @@ describe('keyring credential chunks', () => {
     expect(keyring.values.get(mainKey)).toBe(encodedMarker);
     expect(keyring.values.get(chunkKey)).toBe('published-secret');
     await expect(resolveProviderCredential('test', authRef)).resolves.toBe('published-secret');
-    expect(keyring.values.has(journalKey)).toBe(false);
+    expectActiveInventory(marker);
   });
 
   it('fails closed with a durable tombstone after a malformed journal', async () => {
@@ -874,38 +1640,35 @@ describe('keyring credential chunks', () => {
     await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
     expect(keyring.values.has(mainKey)).toBe(false);
     expect(keyring.values.get(`relay-ai:${account}`)).toBe('legacy-secret');
-    const deleteTombstone = expectUnverifiableTombstone();
+    const deleteTombstone = expectUnverifiableTombstone(true);
     await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
-    expect(keyring.values.has(`relay-ai:${account}`)).toBe(false);
+    expect(keyring.values.get(`relay-ai:${account}`)).toBe('legacy-secret');
     expect(keyring.values.get(journalKey)).toBe(deleteTombstone);
   });
 
-  it.each([
-    { failedKey: mainKey, survivor: 'current-secret' },
-    { failedKey: `relay-ai:${account}`, survivor: 'legacy-secret' },
-  ])('keeps a tombstone while $failedKey cannot be unpublished', async ({ failedKey, survivor }) => {
+  it('keeps a tombstone while the Clodex credential cannot be unpublished', async () => {
     const legacyMainKey = `relay-ai:${account}`;
     const malformedJournal = '__relay_chunk_journal__:v1:{';
     keyring.values.set(mainKey, 'current-secret');
     keyring.values.set(legacyMainKey, 'legacy-secret');
     keyring.values.set(journalKey, malformedJournal);
-    keyring.failDeleteKey = failedKey;
+    keyring.failDeleteKey = mainKey;
 
     await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
 
     expect(keyring.values.get(mainKey)).toBe('current-secret');
     expect(keyring.values.get(legacyMainKey)).toBe('legacy-secret');
-    const tombstone = expectUnverifiableTombstone();
+    const tombstone = expectUnverifiableTombstone(true);
     await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
-    expect(keyring.values.get(failedKey)).toBe(survivor);
-    if (failedKey === mainKey) expect(keyring.values.get(legacyMainKey)).toBe('legacy-secret');
-    else expect(keyring.values.has(mainKey)).toBe(false);
+    expect(keyring.values.get(mainKey)).toMatch(/^__clodex_delete__:/);
+    expect(keyring.values.get(mainKey)).not.toBe('current-secret');
+    expect(keyring.values.get(legacyMainKey)).toBe('legacy-secret');
     expect(keyring.values.get(journalKey)).toBe(tombstone);
 
     keyring.failDeleteKey = '';
     await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
-    expect(keyring.values.has(mainKey)).toBe(false);
-    expect(keyring.values.has(legacyMainKey)).toBe(false);
+    expectDeletionGuard();
+    expect(keyring.values.get(legacyMainKey)).toBe('legacy-secret');
     await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
     expect(keyring.values.get(journalKey)).toBe(tombstone);
   });
@@ -927,28 +1690,34 @@ describe('keyring credential chunks', () => {
     expect(keyring.values.has(`relay-ai:${account}`)).toBe(true);
     expect(keyring.values.has(currentChunk)).toBe(true);
     expect(keyring.values.has(legacyChunk)).toBe(true);
-    const tombstone = expectUnverifiableTombstone();
+    const tombstone = expectUnverifiableTombstone(true);
     await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
-    expect(keyring.values.has(mainKey)).toBe(false);
-    expect(keyring.values.has(`relay-ai:${account}`)).toBe(false);
+    expectDeletionGuard();
+    expect(keyring.values.get(`relay-ai:${account}`)).toBe(
+      `__relay_chunked__:v2:${legacyGeneration}:1`,
+    );
     expect(keyring.values.has(currentChunk)).toBe(false);
-    expect(keyring.values.has(legacyChunk)).toBe(false);
+    expect(keyring.values.get(legacyChunk)).toBe('legacy-secret');
     const expandedTombstone = keyring.values.get(journalKey)!;
     expect(expandedTombstone).not.toBe(tombstone);
     expect(JSON.parse(expandedTombstone.slice(journalPrefix.length))).toEqual({
       mode: 'delete',
       generations: [{ count: 1, generation: currentGeneration }],
-      legacyGenerations: [{ count: 1, generation: legacyGeneration }],
+      blockLegacy: true,
       unverifiable: true,
     });
   });
 
   it('isolates the journal namespace from credential accounts', async () => {
     const journalCollisionAccount = `${account}::chunk-journal`;
-    const journalCollisionRef = `keyring:${journalCollisionAccount}`;
-    await expect(saveProviderCredential(journalCollisionRef, 'journal-account-secret')).resolves.toBe(true);
+    const journalCollisionRef = testCredentialAuthRef(journalCollisionAccount);
+    await expect(
+      saveProviderCredential(journalCollisionRef, 'journal-account-secret'),
+    ).resolves.toBe(true);
     await expect(saveProviderCredential(authRef, 'a'.repeat(2_500))).resolves.toBe(true);
-    await expect(resolveProviderCredential('test', journalCollisionRef)).resolves.toBe('journal-account-secret');
+    await expect(resolveProviderCredential('test', journalCollisionRef)).resolves.toBe(
+      'journal-account-secret',
+    );
   });
 
   it('reserves legacy chunk account forms from credential references', async () => {
@@ -958,7 +1727,9 @@ describe('keyring credential chunks', () => {
     const chunkCollisionAccount = `${account}::chunk::${generation}::0`;
     const chunkCollisionRef = `keyring:${chunkCollisionAccount}`;
 
-    await expect(saveProviderCredential(chunkCollisionRef, 'collision-secret')).resolves.toBe(false);
+    await expect(saveProviderCredential(chunkCollisionRef, 'collision-secret')).resolves.toBe(
+      false,
+    );
     await expect(resolveProviderCredential('test', chunkCollisionRef)).resolves.toBeNull();
     await expect(deleteProviderCredential(chunkCollisionRef)).resolves.toBe(false);
     await expect(resolveProviderCredential('test', authRef)).resolves.toBe('legacy-secret');
@@ -967,8 +1738,8 @@ describe('keyring credential chunks', () => {
   it('allows non-canonical chunk-like account names that cannot collide', async () => {
     const generation = '11111111-1111-4111-8111-111111111111';
     const safeRefs = [
-      `keyring:${account}::chunk::00`,
-      `keyring:${account}::chunk::${generation}::00`,
+      testCredentialAuthRef(`${account}::chunk::00`),
+      testCredentialAuthRef(`${account}::chunk::${generation}::00`),
     ];
 
     for (const [index, safeRef] of safeRefs.entries()) {
@@ -976,6 +1747,36 @@ describe('keyring credential chunks', () => {
       await expect(saveProviderCredential(safeRef, value)).resolves.toBe(true);
       await expect(resolveProviderCredential('test', safeRef)).resolves.toBe(value);
     }
+  });
+
+  it('returns JSON-shaped non-OAuth credentials as opaque values', async () => {
+    const opaqueRef = testCredentialAuthRef('provider:test');
+    const opaqueValue = '{"type":"custom","access":"opaque"}';
+
+    await expect(saveProviderCredential(opaqueRef, opaqueValue)).resolves.toBe(true);
+    await expect(resolveProviderCredential('test', opaqueRef)).resolves.toBe(opaqueValue);
+  });
+
+  it('round-trips credentials that begin with the internal tombstone prefix', async () => {
+    const providerRef = testCredentialAuthRef('provider:test');
+    const opaqueValue = '__clodex_delete__:legitimate-provider-secret';
+
+    await expect(saveProviderCredential(providerRef, opaqueValue)).resolves.toBe(true);
+    await expect(resolveProviderCredential('test', providerRef)).resolves.toBe(opaqueValue);
+  });
+
+  it('decodes historical structured credentials for non-OAuth accounts', async () => {
+    const providerRef = testCredentialAuthRef('provider:test');
+
+    await expect(
+      saveProviderCredential(providerRef, '{"type":"wellknown","token":"wellknown-token"}'),
+    ).resolves.toBe(true);
+    await expect(resolveProviderCredential('test', providerRef)).resolves.toBe('wellknown-token');
+
+    await expect(
+      saveProviderCredential(providerRef, '{"type":"oauth","access":"oauth-access"}'),
+    ).resolves.toBe(true);
+    await expect(resolveProviderCredential('test', providerRef)).resolves.toBe('oauth-access');
   });
 
   it('does not reinterpret malformed structured values as bearer credentials', async () => {

--- a/tests/keyring-credentials.test.ts
+++ b/tests/keyring-credentials.test.ts
@@ -1,5 +1,13 @@
 import { createHash } from 'node:crypto';
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -128,7 +136,8 @@ const authRef = `keyring:${account}`;
 const mainKey = `clodex:${account}`;
 const journalKey = `clodex-journal:${account}`;
 const deletedKey = `clodex-deleted:${account}`;
-const journalPrefix = '__relay_chunk_journal__:v1:';
+const managedStateKey = `clodex-state-key:${account}`;
+const journalPrefix = '__clodex_chunk_journal__:v1:';
 const previousHome = process.env.CLODEX_HOME;
 const previousRuntimeDir = process.env.XDG_RUNTIME_DIR;
 let tempDir = '';
@@ -399,7 +408,7 @@ describe('keyring credential chunks', () => {
 
     await expect(resolveProviderCredential('test', authRef)).resolves.toBe('short-secret');
 
-    expect(keyring.getCount).toBe(5);
+    expect(keyring.getCount).toBe(6);
     expect(keyring.findCount).toBe(1);
   });
 
@@ -420,6 +429,63 @@ describe('keyring credential chunks', () => {
       rmSync(defaultHome, { recursive: true, force: true });
       rmSync(alternateRuntime, { recursive: true, force: true });
     }
+  });
+
+  it('encrypts managed cleanup metadata with a key kept in the keyring', async () => {
+    const secret = 'locally-chosen-secret';
+    const digest = createHash('sha256').update(secret).digest('hex');
+
+    await expect(saveProviderCredential(authRef, secret)).resolves.toBe(true);
+
+    const marker = readFileSync(managedStatePath(), 'utf8');
+    expect(marker).toMatch(/^v2:managed:[A-Za-z0-9_-]+\n$/);
+    const payload = marker.slice('v2:managed:'.length, -1);
+    const decodedPayload = Buffer.from(payload, 'base64url').toString('utf8');
+    expect(decodedPayload).not.toContain(secret);
+    expect(decodedPayload).not.toContain(digest);
+    expect(keyring.values.get(managedStateKey)).toMatch(/^v1:[A-Za-z0-9_-]{43}$/);
+  });
+
+  it('fails closed when encrypted metadata is changed on disk', async () => {
+    const diagnostics: string[] = [];
+    await expect(saveProviderCredential(authRef, 'current-secret')).resolves.toBe(true);
+    const marker = readFileSync(managedStatePath(), 'utf8');
+    const payloadOffset = 'v2:managed:'.length;
+    const replacement = marker[payloadOffset] === 'A' ? 'B' : 'A';
+    writeFileSync(
+      managedStatePath(),
+      `${marker.slice(0, payloadOffset)}${replacement}${marker.slice(payloadOffset + 1)}`,
+      'utf8',
+    );
+
+    await expect(
+      resolveProviderCredential('test', authRef, message => diagnostics.push(message)),
+    ).resolves.toBeNull();
+    await expect(
+      replaceProviderCredential(authRef, 'replacement-secret', message =>
+        diagnostics.push(message),
+      ),
+    ).resolves.toBe(false);
+
+    expect(keyring.values.get(mainKey)).toBe('current-secret');
+    expect(diagnostics).toContain('keyring error: keyring managed-state marker is invalid');
+  });
+
+  it('fails closed when the metadata key is missing but a credential remains', async () => {
+    const diagnostics: string[] = [];
+    await expect(saveProviderCredential(authRef, 'current-secret')).resolves.toBe(true);
+    keyring.values.delete(managedStateKey);
+
+    await expect(
+      replaceProviderCredential(authRef, 'replacement-secret', message =>
+        diagnostics.push(message),
+      ),
+    ).resolves.toBe(false);
+
+    expect(keyring.values.get(mainKey)).toBe('current-secret');
+    expect(diagnostics).toContain(
+      'keyring error: keyring managed-state encryption key is unavailable',
+    );
   });
 
   it('keeps the published credential readable when a new generation fails', async () => {
@@ -834,7 +900,7 @@ describe('keyring credential chunks', () => {
     await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
 
     expectDeletionGuard();
-    expect(keyring.values.get(journalKey)).toMatch(/^__relay_chunk_journal__:v1:/);
+    expect(keyring.values.get(journalKey)).toMatch(/^__clodex_chunk_journal__:v1:/);
     keyring.failSetKey = '';
     await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
     expectDeletionGuard();
@@ -986,7 +1052,7 @@ describe('keyring credential chunks', () => {
     const newGeneration = '22222222-2222-4222-8222-222222222222';
     const oldMarker = `__relay_chunked__:v2:${oldGeneration}:2`;
     const newMarker = `__relay_chunked__:v2:${newGeneration}:2`;
-    const journal = `__relay_chunk_journal__:v1:${JSON.stringify({
+    const journal = `__clodex_chunk_journal__:v1:${JSON.stringify({
       mode: 'write',
       generations: [
         { count: 2, generation: newGeneration },
@@ -1072,7 +1138,7 @@ describe('keyring credential chunks', () => {
     keyring.values.set(`clodex-chunks:${account}::chunk::${newGeneration}::0`, 'new-');
     keyring.values.set(
       journalKey,
-      `__relay_chunk_journal__:v1:${JSON.stringify({
+      `__clodex_chunk_journal__:v1:${JSON.stringify({
         mode: 'write',
         generations: [newMarker, oldMarker],
       })}`,
@@ -1108,7 +1174,7 @@ describe('keyring credential chunks', () => {
     keyring.values.set(`clodex:${account}::chunk::${oldGeneration}::1`, 'secret');
     keyring.values.set(
       journalKey,
-      `__relay_chunk_journal__:v1:${JSON.stringify({
+      `__clodex_chunk_journal__:v1:${JSON.stringify({
         mode: 'write',
         generations: [journalMarker, oldMarker],
       })}`,
@@ -1175,7 +1241,7 @@ describe('keyring credential chunks', () => {
     keyring.values.set(`clodex:${account}::chunk::${oldGeneration}::1`, 'secret');
     keyring.values.set(
       journalKey,
-      `__relay_chunk_journal__:v1:${JSON.stringify({
+      `__clodex_chunk_journal__:v1:${JSON.stringify({
         mode: 'write',
         generations: [currentMarker, { count: 2, generation: oldGeneration }],
       })}`,
@@ -1257,6 +1323,9 @@ describe('keyring credential chunks', () => {
     await expect(
       resolveProviderCredential('test', authRef, message => diagnostics.push(message)),
     ).resolves.toBe('current-secret');
+    await expect(
+      resolveProviderCredential('test', authRef, message => diagnostics.push(message)),
+    ).resolves.toBe('current-secret');
     expect(diagnostics).toContain('keyring error: injected keyring write failure');
 
     keyring.failSetKey = '';
@@ -1264,7 +1333,7 @@ describe('keyring credential chunks', () => {
     expectActiveShort('current-secret');
   });
 
-  it('recovers when managed metadata outlives the keyring entries', async () => {
+  it('re-provisions when managed metadata outlives an empty keyring', async () => {
     const diagnostics: string[] = [];
     await expect(saveProviderCredential(authRef, 'first-secret')).resolves.toBe(true);
     expect(existsSync(managedStatePath())).toBe(true);
@@ -1273,19 +1342,25 @@ describe('keyring credential chunks', () => {
     await expect(
       resolveProviderCredential('test', authRef, message => diagnostics.push(message)),
     ).resolves.toBeNull();
-    expect(diagnostics).toContain('restored keyring cleanup journal from managed state');
+    expect(diagnostics).toContain(
+      'keyring error: keyring managed-state encryption key is unavailable',
+    );
     expect(existsSync(managedStatePath())).toBe(true);
 
-    await expect(provisionProviderCredential(authRef, 'replacement-secret')).resolves.toBe(false);
-    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
-    expectDeletionMarker();
     await expect(provisionProviderCredential(authRef, 'replacement-secret')).resolves.toBe(true);
     await expect(resolveProviderCredential('test', authRef)).resolves.toBe('replacement-secret');
+  });
 
+  it('replaces an empty restored keyring with a chunked credential in one call', async () => {
+    const replacement = 'b'.repeat(2_500);
+    await expect(saveProviderCredential(authRef, 'first-secret')).resolves.toBe(true);
     keyring.values.clear();
-    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
-    expect(existsSync(managedStatePath())).toBe(true);
-    expectDeletionMarker();
+
+    await expect(replaceProviderCredential(authRef, replacement)).resolves.toBe(true);
+
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe(replacement);
+    expect(currentChunkKeys().length).toBeGreaterThan(1);
+    expectActiveInventory();
   });
 
   it('fails closed while a managed journal remains persistently hidden', async () => {
@@ -1379,6 +1454,21 @@ describe('keyring credential chunks', () => {
     expect(currentChunkKeys()).toEqual([]);
   });
 
+  it('deletes a journal-less long credential with a confirmed missing chunk', async () => {
+    const currentSecret = 'a'.repeat(2_500);
+    await expect(saveProviderCredential(authRef, currentSecret)).resolves.toBe(true);
+    const chunkKeys = currentChunkKeys().sort();
+    expect(chunkKeys.length).toBeGreaterThan(1);
+    writeFileSync(managedStatePath(), 'v1:managed\n', 'utf8');
+    keyring.values.delete(journalKey);
+    keyring.values.delete(chunkKeys[0]!);
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+
+    expectDeletionMarker();
+    expect(currentChunkKeys()).toEqual([]);
+  });
+
   it('removes an inventory sentinel when direct verification collapses', async () => {
     let collapsed = false;
     await expect(saveProviderCredential(authRef, 'current-secret')).resolves.toBe(true);
@@ -1408,6 +1498,21 @@ describe('keyring credential chunks', () => {
     keyring.omitFindOnceKey = '';
     await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
     expectDeletionMarker();
+  });
+
+  it('reports an inventory sentinel that cannot be removed during cleanup', async () => {
+    const diagnostics: string[] = [];
+    await expect(saveProviderCredential(authRef, 'current-secret')).resolves.toBe(true);
+    writeFileSync(managedStatePath(), 'v1:managed\n', 'utf8');
+    keyring.values.delete(journalKey);
+    keyring.omitFindAccount = account;
+    keyring.failDeleteSuffix = '::0';
+
+    await expect(
+      deleteProviderCredential(authRef, message => diagnostics.push(message)),
+    ).resolves.toBe(false);
+
+    expect(diagnostics).toContain('keyring credential inventory sentinel could not be removed');
   });
 
   it('does not trust an incomplete retired-chunk inventory for a short credential', async () => {
@@ -1645,7 +1750,7 @@ describe('keyring credential chunks', () => {
     keyring.values.set(v3ChunkKey, v3Value);
     keyring.values.set(
       journalKey,
-      `__relay_chunk_journal__:v1:${JSON.stringify({
+      `__clodex_chunk_journal__:v1:${JSON.stringify({
         mode: 'delete',
         generations: [v3Marker],
       })}`,
@@ -1892,7 +1997,7 @@ describe('keyring credential chunks', () => {
 
   it('fails closed with a durable tombstone after a malformed journal', async () => {
     keyring.values.set(mainKey, 'existing-secret');
-    keyring.values.set(journalKey, '__relay_chunk_journal__:v1:{');
+    keyring.values.set(journalKey, '__clodex_chunk_journal__:v1:{');
 
     await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
     await expect(saveProviderCredential(authRef, 'replacement-secret')).resolves.toBe(false);
@@ -1902,7 +2007,7 @@ describe('keyring credential chunks', () => {
     await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
 
     keyring.values.set(`relay-ai:${account}`, 'legacy-secret');
-    keyring.values.set(journalKey, '__relay_chunk_journal__:v1:{');
+    keyring.values.set(journalKey, '__clodex_chunk_journal__:v1:{');
     await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
     expect(keyring.values.has(mainKey)).toBe(false);
     expect(keyring.values.get(`relay-ai:${account}`)).toBe('legacy-secret');
@@ -1914,7 +2019,7 @@ describe('keyring credential chunks', () => {
 
   it('keeps a tombstone while the Clodex credential cannot be unpublished', async () => {
     const legacyMainKey = `relay-ai:${account}`;
-    const malformedJournal = '__relay_chunk_journal__:v1:{';
+    const malformedJournal = '__clodex_chunk_journal__:v1:{';
     keyring.values.set(mainKey, 'current-secret');
     keyring.values.set(legacyMainKey, 'legacy-secret');
     keyring.values.set(journalKey, malformedJournal);
@@ -1948,7 +2053,7 @@ describe('keyring credential chunks', () => {
     keyring.values.set(`relay-ai:${account}`, `__relay_chunked__:v2:${legacyGeneration}:1`);
     keyring.values.set(currentChunk, 'current-secret');
     keyring.values.set(legacyChunk, 'legacy-secret');
-    keyring.values.set(journalKey, '__relay_chunk_journal__:v1:{');
+    keyring.values.set(journalKey, '__clodex_chunk_journal__:v1:{');
 
     await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
 

--- a/tests/keyring-credentials.test.ts
+++ b/tests/keyring-credentials.test.ts
@@ -337,6 +337,28 @@ describe('keyring credential chunks', () => {
     await expect(resolveProviderCredential('test', authRef)).resolves.toBe(second);
   });
 
+  it('serializes concurrent public writes and retires the losing generation', async () => {
+    const first = 'a'.repeat(2_500);
+    const second = 'b'.repeat(3_700);
+
+    await expect(
+      Promise.all([
+        provisionProviderCredential(authRef, first),
+        provisionProviderCredential(authRef, second),
+      ]),
+    ).resolves.toEqual([true, true]);
+
+    const resolved = await resolveProviderCredential('test', authRef);
+    expect([first, second]).toContain(resolved);
+    const marker = publishedMarker();
+    const activeChunks = currentChunkKeys();
+    expect(activeChunks).toHaveLength(marker.count);
+    expect(
+      activeChunks.every(key => key.includes(`${account}::chunk::${marker.generation}::`)),
+    ).toBe(true);
+    expectActiveInventory(marker);
+  });
+
   it('does not split a surrogate pair across native keyring chunks', async () => {
     const secret = `${'a'.repeat(1_199)}😀b`;
 
@@ -345,6 +367,29 @@ describe('keyring credential chunks', () => {
     expect(currentChunkKeys()).toHaveLength(2);
     expect([...keyring.values.values()].every(value => !value.includes('�'))).toBe(true);
     await expect(resolveProviderCredential('test', authRef)).resolves.toBe(secret);
+  });
+
+  it('rejects credentials and markers above the chunk-count limit', async () => {
+    const diagnostics: string[] = [];
+    const oversized = 'a'.repeat(1_200 * 128 + 1);
+
+    await expect(
+      provisionProviderCredential(authRef, oversized, message => diagnostics.push(message)),
+    ).resolves.toBe(false);
+    expect(diagnostics.join('\n')).toContain(
+      'keyring credential exceeds the supported chunk count',
+    );
+    expect(currentChunkKeys()).toEqual([]);
+    expect(keyring.values.has(mainKey)).toBe(false);
+
+    diagnostics.length = 0;
+    const generation = '11111111-1111-4111-8111-111111111111';
+    const digest = createHash('sha256').update('oversized-marker').digest('hex');
+    keyring.values.set(mainKey, `__relay_chunked__:v3:${generation}:129:${digest}`);
+    await expect(
+      resolveProviderCredential('test', authRef, message => diagnostics.push(message)),
+    ).resolves.toBeNull();
+    expect(diagnostics.join('\n')).toContain('invalid chunk marker');
   });
 
   it('does not multiply missing-entry scans for a steady short credential', async () => {
@@ -1202,6 +1247,41 @@ describe('keyring credential chunks', () => {
 
     expectActiveShort('current-secret');
     expect(keyring.values.get(legacyMainKey)).toBe('stale-legacy-secret');
+  });
+
+  it('returns a pre-journal credential when metadata adoption is temporarily unavailable', async () => {
+    const diagnostics: string[] = [];
+    keyring.values.set(mainKey, 'current-secret');
+    keyring.failSetKey = journalKey;
+
+    await expect(
+      resolveProviderCredential('test', authRef, message => diagnostics.push(message)),
+    ).resolves.toBe('current-secret');
+    expect(diagnostics).toContain('keyring error: injected keyring write failure');
+
+    keyring.failSetKey = '';
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe('current-secret');
+    expectActiveShort('current-secret');
+  });
+
+  it('recovers when managed metadata outlives the keyring entries', async () => {
+    const diagnostics: string[] = [];
+    await expect(saveProviderCredential(authRef, 'first-secret')).resolves.toBe(true);
+    expect(existsSync(managedStatePath())).toBe(true);
+
+    keyring.values.clear();
+    await expect(
+      resolveProviderCredential('test', authRef, message => diagnostics.push(message)),
+    ).resolves.toBeNull();
+    expect(diagnostics).toContain('removed stale keyring managed-state marker');
+    expect(existsSync(managedStatePath())).toBe(false);
+
+    await expect(provisionProviderCredential(authRef, 'replacement-secret')).resolves.toBe(true);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe('replacement-secret');
+
+    keyring.values.clear();
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    expect(existsSync(managedStatePath())).toBe(false);
   });
 
   it('fails closed when the first pre-journal short read collapses', async () => {

--- a/tests/keyring-credentials.test.ts
+++ b/tests/keyring-credentials.test.ts
@@ -528,6 +528,70 @@ describe('keyring credential chunks', () => {
     },
   );
 
+  it.each([
+    ['malformed current-format', 'v1:CORRUPT', 'current-secret'],
+    ['future-format', 'v2:future-key-material', 'a'.repeat(2_500)],
+  ])(
+    'allows explicit deletion when %s metadata key material is unsupported',
+    async (_keyKind, unsupportedKey, currentSecret) => {
+      await expect(saveProviderCredential(authRef, currentSecret)).resolves.toBe(true);
+      const originalManagedState = readFileSync(managedStatePath(), 'utf8');
+      const originalPublishedValue = keyring.values.get(mainKey);
+      const originalChunks = currentChunkKeys().sort();
+      keyring.values.set(managedStateKey, unsupportedKey);
+
+      await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+      await expect(provisionProviderCredential(authRef, 'replacement-secret')).resolves.toBe(false);
+      expect(keyring.values.get(mainKey)).toBe(originalPublishedValue);
+      expect(currentChunkKeys().sort()).toEqual(originalChunks);
+      expect(keyring.values.get(managedStateKey)).toBe(unsupportedKey);
+      expect(readFileSync(managedStatePath(), 'utf8')).toBe(originalManagedState);
+
+      await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+      expectDeletionMarker();
+      expect(currentChunkKeys()).toEqual([]);
+      await expect(provisionProviderCredential(authRef, 'replacement-secret')).resolves.toBe(true);
+      await expect(resolveProviderCredential('test', authRef)).resolves.toBe('replacement-secret');
+    },
+  );
+
+  it('allows explicit deletion when future metadata has no keyring journal', async () => {
+    const currentSecret = 'a'.repeat(2_500);
+    const futureKey = 'v2:future-key-material';
+    await expect(saveProviderCredential(authRef, currentSecret)).resolves.toBe(true);
+    const originalManagedState = readFileSync(managedStatePath(), 'utf8');
+    const originalMarker = keyring.values.get(mainKey);
+    const originalChunks = currentChunkKeys().sort();
+    keyring.values.set(managedStateKey, futureKey);
+    keyring.values.delete(journalKey);
+
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+    await expect(provisionProviderCredential(authRef, 'replacement-secret')).resolves.toBe(false);
+    expect(keyring.values.get(mainKey)).toBe(originalMarker);
+    expect(currentChunkKeys().sort()).toEqual(originalChunks);
+    expect(keyring.values.get(managedStateKey)).toBe(futureKey);
+    expect(readFileSync(managedStatePath(), 'utf8')).toBe(originalManagedState);
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    expectDeletionMarker();
+    expect(currentChunkKeys()).toEqual([]);
+    await expect(provisionProviderCredential(authRef, 'replacement-secret')).resolves.toBe(true);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe('replacement-secret');
+  });
+
+  it('resumes explicit deletion after opaque metadata retirement', async () => {
+    await expect(saveProviderCredential(authRef, 'current-secret')).resolves.toBe(true);
+    keyring.values.delete(journalKey);
+    keyring.values.delete(mainKey);
+    keyring.values.set(deletedKey, 'v1:deleted');
+    keyring.values.set(managedStateKey, 'v2:future-key-material');
+    rmSync(managedStatePath());
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+
+    expectDeletionMarker();
+  });
+
   it.each(['v1:CORRUPT', 'v2:future-key-material'])(
     'regenerates unsupported metadata key material %s after proving the keyring is empty',
     async unsupportedKey => {

--- a/tests/keyring-credentials.test.ts
+++ b/tests/keyring-credentials.test.ts
@@ -346,7 +346,7 @@ describe('keyring credential chunks', () => {
     await expect(resolveProviderCredential('test', authRef)).resolves.toBe(second);
   });
 
-  it('serializes concurrent public writes and retires the losing generation', async () => {
+  it('keeps concurrent public writes self-consistent and retires the losing generation', async () => {
     const first = 'a'.repeat(2_500);
     const second = 'b'.repeat(3_700);
 
@@ -408,7 +408,7 @@ describe('keyring credential chunks', () => {
 
     await expect(resolveProviderCredential('test', authRef)).resolves.toBe('short-secret');
 
-    expect(keyring.getCount).toBe(6);
+    expect(keyring.getCount).toBeLessThanOrEqual(6);
     expect(keyring.findCount).toBe(1);
   });
 
@@ -471,6 +471,25 @@ describe('keyring credential chunks', () => {
     expect(diagnostics).toContain('keyring error: keyring managed-state marker is invalid');
   });
 
+  it('binds encrypted managed state to its lifecycle mode', async () => {
+    const diagnostics: string[] = [];
+    await expect(saveProviderCredential(authRef, 'current-secret')).resolves.toBe(true);
+    const marker = readFileSync(managedStatePath(), 'utf8');
+    expect(marker.startsWith('v2:managed:')).toBe(true);
+    writeFileSync(
+      managedStatePath(),
+      marker.replace(/^v2:managed:/, 'v2:preparing:'),
+      'utf8',
+    );
+
+    await expect(
+      resolveProviderCredential('test', authRef, message => diagnostics.push(message)),
+    ).resolves.toBeNull();
+
+    expect(keyring.values.get(mainKey)).toBe('current-secret');
+    expect(diagnostics).toContain('keyring error: keyring managed-state marker is invalid');
+  });
+
   it('fails closed when the metadata key is missing but a credential remains', async () => {
     const diagnostics: string[] = [];
     await expect(saveProviderCredential(authRef, 'current-secret')).resolves.toBe(true);
@@ -487,6 +506,44 @@ describe('keyring credential chunks', () => {
       'keyring error: keyring managed-state encryption key is unavailable',
     );
   });
+
+  it.each(['v1:CORRUPT', 'v2:future-key-material'])(
+    'fails closed when metadata key material %s is unsupported and a credential remains',
+    async unsupportedKey => {
+      const diagnostics: string[] = [];
+      await expect(saveProviderCredential(authRef, 'current-secret')).resolves.toBe(true);
+      keyring.values.set(managedStateKey, unsupportedKey);
+
+      await expect(
+        replaceProviderCredential(authRef, 'replacement-secret', message =>
+          diagnostics.push(message),
+        ),
+      ).resolves.toBe(false);
+
+      expect(keyring.values.get(mainKey)).toBe('current-secret');
+      expect(keyring.values.get(managedStateKey)).toBe(unsupportedKey);
+      expect(diagnostics).toContain(
+        'keyring error: keyring managed-state encryption key is unavailable',
+      );
+    },
+  );
+
+  it.each(['v1:CORRUPT', 'v2:future-key-material'])(
+    'regenerates unsupported metadata key material %s after proving the keyring is empty',
+    async unsupportedKey => {
+      await expect(saveProviderCredential(authRef, 'current-secret')).resolves.toBe(true);
+      keyring.values.clear();
+      keyring.values.set(managedStateKey, unsupportedKey);
+
+      await expect(provisionProviderCredential(authRef, 'replacement-secret')).resolves.toBe(true);
+
+      expect(keyring.values.get(managedStateKey)).toMatch(/^v1:[A-Za-z0-9_-]{43}$/);
+      expect(keyring.values.get(managedStateKey)).not.toBe(unsupportedKey);
+      await expect(resolveProviderCredential('test', authRef)).resolves.toBe(
+        'replacement-secret',
+      );
+    },
+  );
 
   it('keeps the published credential readable when a new generation fails', async () => {
     const first = 'a'.repeat(2_500);
@@ -1006,11 +1063,8 @@ describe('keyring credential chunks', () => {
     await expect(deleteProviderCredential(authRef, message => {
       diagnostics.push(message);
       }),
-    ).resolves.toBe(false);
-    expectDeletionGuard();
-    expect(keyring.values.has(journalKey)).toBe(true);
-    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
-    expect(keyring.values.has(journalKey)).toBe(true);
+    ).resolves.toBe(true);
+    expectDeletionMarker();
 
     clearMockKeyringState();
     diagnostics.length = 0;
@@ -1045,6 +1099,39 @@ describe('keyring credential chunks', () => {
     expect(keyring.values.get(journalKey)).toBe(tombstone);
     await expect(saveProviderCredential(authRef, 'replacement-secret')).resolves.toBe(false);
     expect(keyring.values.get(journalKey)).toBe(tombstone);
+  });
+
+  it('retires an unverifiable delete after proving the credential namespace is empty', async () => {
+    keyring.values.set(mainKey, '__relay_chunked__:Infinity');
+
+    await expect(saveProviderCredential(authRef, 'replacement-secret')).resolves.toBe(false);
+    expectUnverifiableTombstone();
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+
+    expectDeletionMarker();
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+    await expect(provisionProviderCredential(authRef, 'replacement-secret')).resolves.toBe(true);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe('replacement-secret');
+  });
+
+  it('retains an unverifiable delete when credential inventory is not empty', async () => {
+    const retainedGeneration = '11111111-1111-4111-8111-111111111111';
+    const retainedChunk = `clodex-chunks:${account}::chunk::${retainedGeneration}::0`;
+    const diagnostics: string[] = [];
+    keyring.values.set(mainKey, '__relay_chunked__:Infinity');
+    keyring.values.set(retainedChunk, 'retained-secret');
+
+    await expect(saveProviderCredential(authRef, 'replacement-secret')).resolves.toBe(false);
+    expectUnverifiableTombstone();
+
+    await expect(
+      deleteProviderCredential(authRef, message => diagnostics.push(message)),
+    ).resolves.toBe(false);
+
+    expect(keyring.values.get(retainedChunk)).toBe('retained-secret');
+    expectUnverifiableTombstone(true);
+    expect(diagnostics).toContain('keyring credential inventory is not empty');
   });
 
   it('reconciles journaled generations on either side of marker publication', async () => {
@@ -1351,6 +1438,17 @@ describe('keyring credential chunks', () => {
     await expect(resolveProviderCredential('test', authRef)).resolves.toBe('replacement-secret');
   });
 
+  it('deletes managed metadata that outlives an empty keyring', async () => {
+    await expect(saveProviderCredential(authRef, 'first-secret')).resolves.toBe(true);
+    expect(existsSync(managedStatePath())).toBe(true);
+    keyring.values.clear();
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+
+    expectDeletionMarker();
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+  });
+
   it('replaces an empty restored keyring with a chunked credential in one call', async () => {
     const replacement = 'b'.repeat(2_500);
     await expect(saveProviderCredential(authRef, 'first-secret')).resolves.toBe(true);
@@ -1513,6 +1611,58 @@ describe('keyring credential chunks', () => {
     ).resolves.toBe(false);
 
     expect(diagnostics).toContain('keyring credential inventory sentinel could not be removed');
+  });
+
+  it('removes orphaned sentinel bookkeeping before retrying empty-keyring recovery', async () => {
+    await expect(saveProviderCredential(authRef, 'current-secret')).resolves.toBe(true);
+    keyring.values.clear();
+    keyring.failDeleteSuffix = '::0';
+
+    await expect(provisionProviderCredential(authRef, 'replacement-secret')).resolves.toBe(false);
+
+    const orphanedSentinels = [...keyring.values.entries()].filter(
+      ([key, value]) =>
+        key.includes(`${account}::chunk::`) &&
+        (value.startsWith('__clodex_inventory__:')
+          || value.startsWith('__clodex_delete__:')),
+    );
+    expect(orphanedSentinels.length).toBeGreaterThan(0);
+
+    keyring.failDeleteSuffix = '';
+    await expect(provisionProviderCredential(authRef, 'replacement-secret')).resolves.toBe(true);
+
+    expect(
+      [...keyring.values.entries()].filter(
+        ([key, value]) =>
+          key.includes(`${account}::chunk::`) &&
+          (value.startsWith('__clodex_inventory__:')
+            || value.startsWith('__clodex_delete__:')),
+      ),
+    ).toEqual([]);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe(
+      'replacement-secret',
+    );
+  });
+
+  it.each([
+    '__clodex_inventory__:22222222-2222-4222-8222-222222222222',
+    '__clodex_delete__:11111111-1111-4111-8111-111111111111',
+  ])('does not remove a credential chunk with bookkeeping-like value %s', async value => {
+    const diagnostics: string[] = [];
+    const generation = '11111111-1111-4111-8111-111111111111';
+    const retainedChunk = `clodex-chunks:${account}::chunk::${generation}::0`;
+    await expect(saveProviderCredential(authRef, 'current-secret')).resolves.toBe(true);
+    keyring.values.clear();
+    keyring.values.set(retainedChunk, value);
+
+    await expect(
+      provisionProviderCredential(authRef, 'replacement-secret', message =>
+        diagnostics.push(message),
+      ),
+    ).resolves.toBe(false);
+
+    expect(keyring.values.get(retainedChunk)).toBe(value);
+    expect(diagnostics).toContain('keyring credential inventory is not empty');
   });
 
   it('does not trust an incomplete retired-chunk inventory for a short credential', async () => {
@@ -1966,6 +2116,40 @@ describe('keyring credential chunks', () => {
     expect(keyring.values.has(chunkKey)).toBe(false);
   });
 
+  it('does not overwrite a credential after an ambiguous deletion read', async () => {
+    const pendingDelete = `${journalPrefix}${JSON.stringify({
+      mode: 'delete',
+      generations: [],
+    })}`;
+    let mainReads = 0;
+    keyring.values.set(mainKey, 'current-secret');
+    keyring.values.set(journalKey, pendingDelete);
+    keyring.omitFindKey = mainKey;
+    keyring.failDeleteKey = mainKey;
+    keyring.onGet = key => {
+      if (key !== mainKey || ++mainReads !== 2) return;
+      throw new Error('injected ambiguous deletion read');
+    };
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
+
+    expect(keyring.values.get(mainKey)).toBe('current-secret');
+    expect(
+      keyring.operations.some(
+        operation =>
+          operation.type === 'set'
+          && operation.key === mainKey
+          && operation.value?.startsWith('__clodex_delete__:'),
+      ),
+    ).toBe(false);
+
+    keyring.omitFindKey = '';
+    keyring.failDeleteKey = '';
+    keyring.onGet = null;
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    expectDeletionMarker();
+  });
+
   it('does not replace a valid write journal after a transient read failure', async () => {
     const generation = '11111111-1111-4111-8111-111111111111';
     const marker = { count: 1, generation };
@@ -1995,88 +2179,70 @@ describe('keyring credential chunks', () => {
     expectActiveInventory(marker);
   });
 
-  it('fails closed with a durable tombstone after a malformed journal', async () => {
-    keyring.values.set(mainKey, 'existing-secret');
-    keyring.values.set(journalKey, '__clodex_chunk_journal__:v1:{');
-
-    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
-    await expect(saveProviderCredential(authRef, 'replacement-secret')).resolves.toBe(false);
-    const writeTombstone = expectUnverifiableTombstone();
-    await expect(saveProviderCredential(authRef, 'replacement-secret')).resolves.toBe(false);
-    expect(keyring.values.get(journalKey)).toBe(writeTombstone);
-    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
-
-    keyring.values.set(`relay-ai:${account}`, 'legacy-secret');
-    keyring.values.set(journalKey, '__clodex_chunk_journal__:v1:{');
-    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
-    expect(keyring.values.has(mainKey)).toBe(false);
-    expect(keyring.values.get(`relay-ai:${account}`)).toBe('legacy-secret');
-    const deleteTombstone = expectUnverifiableTombstone(true);
-    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
-    expect(keyring.values.get(`relay-ai:${account}`)).toBe('legacy-secret');
-    expect(keyring.values.get(journalKey)).toBe(deleteTombstone);
-  });
-
-  it('keeps a tombstone while the Clodex credential cannot be unpublished', async () => {
+  it.each([
+    ['malformed current journal', `${journalPrefix}{`],
+    [
+      'future journal version',
+      `__clodex_chunk_journal__:v2:${JSON.stringify({
+        mode: 'short',
+        generations: [],
+        shortDigest: '0'.repeat(64),
+      })}`,
+    ],
+    [
+      'unknown journal mode',
+      `${journalPrefix}${JSON.stringify({
+        mode: 'rotate',
+        generations: [],
+      })}`,
+    ],
+    [
+      'unsupported current-version shape',
+      `${journalPrefix}${JSON.stringify({
+        mode: 'write',
+        generations: [],
+        blockLegacy: true,
+      })}`,
+    ],
+    [
+      'earlier branch prefix',
+      `__relay_chunk_journal__:v1:${JSON.stringify({
+        mode: 'short',
+        generations: [],
+        shortDigest: '0'.repeat(64),
+      })}`,
+    ],
+  ])('preserves the credential for an %s', async (_label, wireJournal) => {
+    const diagnostics: string[] = [];
+    const generation = '11111111-1111-4111-8111-111111111111';
+    const currentChunk = `clodex:${account}::chunk::${generation}::0`;
     const legacyMainKey = `relay-ai:${account}`;
-    const malformedJournal = '__clodex_chunk_journal__:v1:{';
-    keyring.values.set(mainKey, 'current-secret');
+    const legacyChunk = `relay-ai:${account}::chunk::${generation}::0`;
+    keyring.values.set(mainKey, 'existing-secret');
+    keyring.values.set(currentChunk, 'current-chunk');
     keyring.values.set(legacyMainKey, 'legacy-secret');
-    keyring.values.set(journalKey, malformedJournal);
-    keyring.failDeleteKey = mainKey;
+    keyring.values.set(legacyChunk, 'legacy-chunk');
+    keyring.values.set(journalKey, wireJournal);
 
-    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
+    await expect(
+      resolveProviderCredential('test', authRef, message => diagnostics.push(message)),
+    ).resolves.toBeNull();
+    await expect(
+      saveProviderCredential(authRef, 'replacement-secret', message =>
+        diagnostics.push(message),
+      ),
+    ).resolves.toBe(false);
+    await expect(
+      deleteProviderCredential(authRef, message => diagnostics.push(message)),
+    ).resolves.toBe(false);
 
-    expect(keyring.values.get(mainKey)).toBe('current-secret');
+    expect(keyring.values.get(mainKey)).toBe('existing-secret');
+    expect(keyring.values.get(currentChunk)).toBe('current-chunk');
     expect(keyring.values.get(legacyMainKey)).toBe('legacy-secret');
-    const tombstone = expectUnverifiableTombstone(true);
-    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
-    expect(keyring.values.get(mainKey)).toMatch(/^__clodex_delete__:/);
-    expect(keyring.values.get(mainKey)).not.toBe('current-secret');
-    expect(keyring.values.get(legacyMainKey)).toBe('legacy-secret');
-    expect(keyring.values.get(journalKey)).toBe(tombstone);
-
-    keyring.failDeleteKey = '';
-    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
-    expectDeletionGuard();
-    expect(keyring.values.get(legacyMainKey)).toBe('legacy-secret');
-    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
-    expect(keyring.values.get(journalKey)).toBe(tombstone);
-  });
-
-  it('preserves chunk markers before replacing a malformed journal', async () => {
-    const currentGeneration = '11111111-1111-4111-8111-111111111111';
-    const legacyGeneration = '22222222-2222-4222-8222-222222222222';
-    const currentChunk = `clodex:${account}::chunk::${currentGeneration}::0`;
-    const legacyChunk = `relay-ai:${account}::chunk::${legacyGeneration}::0`;
-    keyring.values.set(mainKey, `__relay_chunked__:v2:${currentGeneration}:1`);
-    keyring.values.set(`relay-ai:${account}`, `__relay_chunked__:v2:${legacyGeneration}:1`);
-    keyring.values.set(currentChunk, 'current-secret');
-    keyring.values.set(legacyChunk, 'legacy-secret');
-    keyring.values.set(journalKey, '__clodex_chunk_journal__:v1:{');
-
-    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
-
-    expect(keyring.values.has(mainKey)).toBe(true);
-    expect(keyring.values.has(`relay-ai:${account}`)).toBe(true);
-    expect(keyring.values.has(currentChunk)).toBe(true);
-    expect(keyring.values.has(legacyChunk)).toBe(true);
-    const tombstone = expectUnverifiableTombstone(true);
-    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
-    expectDeletionGuard();
-    expect(keyring.values.get(`relay-ai:${account}`)).toBe(
-      `__relay_chunked__:v2:${legacyGeneration}:1`,
-    );
-    expect(keyring.values.has(currentChunk)).toBe(false);
-    expect(keyring.values.get(legacyChunk)).toBe('legacy-secret');
-    const expandedTombstone = keyring.values.get(journalKey)!;
-    expect(expandedTombstone).not.toBe(tombstone);
-    expect(JSON.parse(expandedTombstone.slice(journalPrefix.length))).toEqual({
-      mode: 'delete',
-      generations: [{ count: 1, generation: currentGeneration }],
-      blockLegacy: true,
-      unverifiable: true,
-    });
+    expect(keyring.values.get(legacyChunk)).toBe('legacy-chunk');
+    expect(keyring.values.get(journalKey)).toBe(wireJournal);
+    expect(keyring.values.has(deletedKey)).toBe(false);
+    expect(diagnostics.join('\n')).toContain('invalid cleanup journal');
   });
 
   it('isolates the journal namespace from credential accounts', async () => {

--- a/tests/keyring-credentials.test.ts
+++ b/tests/keyring-credentials.test.ts
@@ -1273,15 +1273,201 @@ describe('keyring credential chunks', () => {
     await expect(
       resolveProviderCredential('test', authRef, message => diagnostics.push(message)),
     ).resolves.toBeNull();
-    expect(diagnostics).toContain('removed stale keyring managed-state marker');
-    expect(existsSync(managedStatePath())).toBe(false);
+    expect(diagnostics).toContain('restored keyring cleanup journal from managed state');
+    expect(existsSync(managedStatePath())).toBe(true);
 
+    await expect(provisionProviderCredential(authRef, 'replacement-secret')).resolves.toBe(false);
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    expectDeletionMarker();
     await expect(provisionProviderCredential(authRef, 'replacement-secret')).resolves.toBe(true);
     await expect(resolveProviderCredential('test', authRef)).resolves.toBe('replacement-secret');
 
     keyring.values.clear();
     await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
-    expect(existsSync(managedStatePath())).toBe(false);
+    expect(existsSync(managedStatePath())).toBe(true);
+    expectDeletionMarker();
+  });
+
+  it('fails closed while a managed journal remains persistently hidden', async () => {
+    const diagnostics: string[] = [];
+    await expect(saveProviderCredential(authRef, 'current-secret')).resolves.toBe(true);
+    const originalJournal = keyring.values.get(journalKey);
+    keyring.operations = [];
+    keyring.omitFindKey = journalKey;
+    keyring.onGet = key => {
+      if (key === journalKey) throw new Error('injected collapsed keyring read failure');
+    };
+
+    await expect(
+      resolveProviderCredential('test', authRef, message => diagnostics.push(message)),
+    ).resolves.toBeNull();
+    await expect(
+      provisionProviderCredential(authRef, 'replacement-secret', message =>
+        diagnostics.push(message),
+      ),
+    ).resolves.toBe(false);
+    await expect(
+      deleteProviderCredential(authRef, message => diagnostics.push(message)),
+    ).resolves.toBe(false);
+
+    expect(diagnostics.join('\n')).toContain('keyring cleanup journal verification failed');
+    expect(keyring.values.get(journalKey)).toBe(originalJournal);
+    expect(keyring.values.get(mainKey)).toBe('current-secret');
+    expect(existsSync(managedStatePath())).toBe(true);
+    expect(keyring.operations.every(operation => operation.key === journalKey)).toBe(true);
+
+    keyring.omitFindKey = '';
+    keyring.onGet = null;
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe('current-secret');
+  });
+
+  it('keeps a journal-less managed marker while the keyring journal is hidden', async () => {
+    const currentSecret = 'a'.repeat(2_500);
+    await expect(saveProviderCredential(authRef, currentSecret)).resolves.toBe(true);
+    const originalJournal = keyring.values.get(journalKey);
+    const originalMarker = keyring.values.get(mainKey);
+    const originalChunks = currentChunkKeys().sort();
+    writeFileSync(managedStatePath(), 'v1:managed\n', 'utf8');
+    keyring.omitFindKey = journalKey;
+    keyring.onGet = key => {
+      if (key === journalKey) throw new Error('injected collapsed keyring read failure');
+    };
+
+    await expect(provisionProviderCredential(authRef, 'replacement-secret')).resolves.toBe(false);
+    expect(keyring.values.get(journalKey)).toBe(originalJournal);
+    expect(keyring.values.get(mainKey)).toBe(originalMarker);
+    expect(currentChunkKeys().sort()).toEqual(originalChunks);
+    expect(existsSync(managedStatePath())).toBe(true);
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
+    expectDeletionMarker();
+    expect(currentChunkKeys()).toEqual([]);
+    expect(existsSync(managedStatePath())).toBe(true);
+
+    keyring.omitFindKey = '';
+    keyring.onGet = null;
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+  });
+
+  it('does not delete a journal-less long credential from an incomplete inventory', async () => {
+    const currentSecret = 'a'.repeat(2_500);
+    await expect(saveProviderCredential(authRef, currentSecret)).resolves.toBe(true);
+    const originalJournal = keyring.values.get(journalKey);
+    const originalMarker = keyring.values.get(mainKey);
+    const originalChunks = currentChunkKeys().sort();
+    writeFileSync(managedStatePath(), 'v1:managed\n', 'utf8');
+    keyring.omitFindKey = journalKey;
+    keyring.omitFindAccount = account;
+    keyring.onGet = key => {
+      if (key === journalKey) throw new Error('injected collapsed keyring read failure');
+    };
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
+
+    expect(keyring.values.get(journalKey)).toBe(originalJournal);
+    expect(keyring.values.get(mainKey)).toBe(originalMarker);
+    expect(currentChunkKeys().sort()).toEqual(originalChunks);
+    expect(keyring.values.has(deletedKey)).toBe(false);
+    expect(existsSync(managedStatePath())).toBe(true);
+
+    keyring.omitFindKey = '';
+    keyring.omitFindAccount = '';
+    keyring.onGet = null;
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    expectDeletionMarker();
+    expect(currentChunkKeys()).toEqual([]);
+  });
+
+  it('removes an inventory sentinel when direct verification collapses', async () => {
+    let collapsed = false;
+    await expect(saveProviderCredential(authRef, 'current-secret')).resolves.toBe(true);
+    writeFileSync(managedStatePath(), 'v1:managed\n', 'utf8');
+    keyring.values.delete(journalKey);
+    keyring.onGet = key => {
+      if (
+        !collapsed &&
+        keyring.values.get(key)?.startsWith('__clodex_inventory__:')
+      ) {
+        collapsed = true;
+        keyring.omitFindOnceKey = key;
+        throw new Error('injected collapsed sentinel read');
+      }
+    };
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
+
+    expect(collapsed).toBe(true);
+    expect(
+      [...keyring.values.values()].filter(value => value.startsWith('__clodex_inventory__:')),
+    ).toEqual([]);
+    expect(keyring.values.get(mainKey)).toBe('current-secret');
+    expect(keyring.values.has(deletedKey)).toBe(false);
+
+    keyring.onGet = null;
+    keyring.omitFindOnceKey = '';
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    expectDeletionMarker();
+  });
+
+  it('does not trust an incomplete retired-chunk inventory for a short credential', async () => {
+    const retiredGeneration = '11111111-1111-4111-8111-111111111111';
+    const retiredChunk = `clodex-chunks:${account}::chunk::${retiredGeneration}::0`;
+    await expect(saveProviderCredential(authRef, 'current-secret')).resolves.toBe(true);
+    keyring.values.set(retiredChunk, 'retired-secret');
+    writeFileSync(managedStatePath(), 'v1:managed\n', 'utf8');
+    keyring.values.delete(journalKey);
+    keyring.omitFindAccount = account;
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
+
+    expect(keyring.values.get(mainKey)).toBe('current-secret');
+    expect(keyring.values.get(retiredChunk)).toBe('retired-secret');
+    expect(keyring.values.has(deletedKey)).toBe(false);
+
+    keyring.omitFindAccount = '';
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    expectDeletionMarker();
+    expect(keyring.values.has(retiredChunk)).toBe(false);
+  });
+
+  it('does not trust an incomplete chunk inventory when the main entry is absent', async () => {
+    const currentSecret = 'a'.repeat(2_500);
+    await expect(saveProviderCredential(authRef, currentSecret)).resolves.toBe(true);
+    const orphanedChunks = currentChunkKeys().sort();
+    writeFileSync(managedStatePath(), 'v1:managed\n', 'utf8');
+    keyring.values.delete(journalKey);
+    keyring.values.delete(mainKey);
+    keyring.omitFindAccount = account;
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(false);
+
+    expect(currentChunkKeys().sort()).toEqual(orphanedChunks);
+    expect(keyring.values.has(deletedKey)).toBe(false);
+
+    keyring.omitFindAccount = '';
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    expectDeletionMarker();
+    expect(currentChunkKeys()).toEqual([]);
+  });
+
+  it('requires explicit deletion to recover a journal-less managed marker', async () => {
+    const currentSecret = 'a'.repeat(2_500);
+    await expect(saveProviderCredential(authRef, currentSecret)).resolves.toBe(true);
+    expect(currentChunkKeys().length).toBeGreaterThan(0);
+    writeFileSync(managedStatePath(), 'v1:managed\n', 'utf8');
+    keyring.values.delete(journalKey);
+
+    await expect(provisionProviderCredential(authRef, 'replacement-secret')).resolves.toBe(false);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
+    expect(keyring.values.get(mainKey)).toBeDefined();
+    expect(existsSync(managedStatePath())).toBe(true);
+
+    await expect(deleteProviderCredential(authRef)).resolves.toBe(true);
+    expectDeletionMarker();
+    expect(currentChunkKeys()).toEqual([]);
+    await expect(provisionProviderCredential(authRef, 'replacement-secret')).resolves.toBe(true);
+    await expect(resolveProviderCredential('test', authRef)).resolves.toBe('replacement-secret');
   });
 
   it('fails closed when the first pre-journal short read collapses', async () => {
@@ -1359,7 +1545,7 @@ describe('keyring credential chunks', () => {
     await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();
 
     expectDeletionGuard();
-    expect(keyring.values.has(journalKey)).toBe(false);
+    expectDeletionMarker();
     keyring.onGet = null;
     keyring.omitFindOnceKey = '';
     await expect(resolveProviderCredential('test', authRef)).resolves.toBeNull();

--- a/tests/provider-auth.test.ts
+++ b/tests/provider-auth.test.ts
@@ -10,6 +10,7 @@ const lockState = vi.hoisted(() => ({
   credentialActive: false,
   credentialTails: new Map<string, Promise<void>>(),
   afterRegistryUnlock: null as null | (() => void),
+  providerActive: false,
 }));
 const registryState = vi.hoisted(() => ({
   current: { schemaVersion: 1, providers: [] } as ProviderRegistry,
@@ -22,7 +23,14 @@ vi.mock('../src/ui.js', () => ({
   printOAuthStepsPanel: vi.fn(),
 }));
 vi.mock('../src/oauth/openai.js', () => ({
-  runOpenAiDeviceCodeFlow: vi.fn(),
+  runOpenAiDeviceCodeFlow: vi.fn(async () => ({
+    tokens: {
+      access_token: 'openai-access',
+      refresh_token: 'openai-refresh',
+      expires_in: 3600,
+    },
+    accountId: 'acct-123',
+  })),
 }));
 vi.mock('../src/env.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../src/env.js')>();
@@ -30,6 +38,7 @@ vi.mock('../src/env.js', async importOriginal => {
     ...actual,
     deleteProviderCredential: vi.fn(),
     probeProviderCredentialStore: vi.fn(),
+    provisionProviderCredential: vi.fn(),
     saveProviderCredential: vi.fn(),
   };
 });
@@ -95,6 +104,14 @@ vi.mock('../src/registry/lock.js', () => ({
       }
     }
   }),
+  withProviderMutationLock: vi.fn(async (_providerSlot: string, operation: () => unknown) => {
+    lockState.providerActive = true;
+    try {
+      return await operation();
+    } finally {
+      lockState.providerActive = false;
+    }
+  }),
 }));
 vi.mock('@clack/prompts', () => ({
   log: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), success: vi.fn() },
@@ -106,25 +123,27 @@ vi.mock('@clack/prompts', () => ({
 import {
   deleteProviderCredential,
   probeProviderCredentialStore,
+  provisionProviderCredential,
   saveProviderCredential,
 } from '../src/env.js';
-import { credentialAuthRef } from '../src/credential-helper.js';
 import { runOpenAiDeviceCodeFlow } from '../src/oauth/openai.js';
 import { reconcilePendingCredentialDeletes } from '../src/registry/credential-lifecycle.js';
 import * as cleanupJournal from '../src/registry/credential-cleanup-journal.js';
 import { loadRegistryStrict, saveRegistry } from '../src/registry/io.js';
 import { authenticateProvider } from '../src/registry/provider-auth.js';
 import { refreshProviderModels } from '../src/registry/refresh-models.js';
+import { credentialInstanceAuthRef } from '../src/credential-helper.js';
 import * as prompts from '@clack/prompts';
 
 describe('authenticateProvider', () => {
   const previousHelper = process.env.CLODEX_CREDENTIAL_HELPER;
   const previousHome = process.env.CLODEX_HOME;
   let home = '';
-
+  let credentialRef = '';
   beforeEach(() => {
     home = mkdtempSync(join(tmpdir(), 'clodex-provider-auth-'));
     process.env.CLODEX_HOME = home;
+    credentialRef = credentialInstanceAuthRef('oauth:provider:openai-oauth');
     registryState.current = { schemaVersion: 1, providers: [] };
     journalState.pending.clear();
     delete process.env.CLODEX_CREDENTIAL_HELPER;
@@ -135,6 +154,8 @@ describe('authenticateProvider', () => {
     lockState.credentialActive = false;
     lockState.credentialTails.clear();
     lockState.afterRegistryUnlock = null;
+    lockState.providerActive = false;
+    vi.mocked(provisionProviderCredential).mockReset().mockResolvedValue(true);
     vi.mocked(saveProviderCredential).mockReset().mockResolvedValue(true);
     vi.mocked(loadRegistryStrict).mockReset().mockImplementation(
       () => structuredClone(registryState.current),
@@ -174,9 +195,10 @@ describe('authenticateProvider', () => {
   });
 
   it('runs the OpenAI device-code flow and stores the openai-oauth registry entry', async () => {
-    vi.mocked(saveProviderCredential).mockImplementationOnce(async () => {
+    vi.mocked(provisionProviderCredential).mockImplementationOnce(async () => {
       expect(lockState.active).toBe(false);
       expect(lockState.credentialActive).toBe(true);
+      expect(lockState.providerActive).toBe(true);
       return true;
     });
     const result = await authenticateProvider('openai');
@@ -191,6 +213,7 @@ describe('authenticateProvider', () => {
     expect(result.providerId).toBe('openai-oauth');
     expect(result.credential.access).toBe('openai-access');
     expect(result.registryProvider.name).toBe('OpenAI (ChatGPT)');
+    expect(result.registryProvider.authRef).toBe(credentialRef);
   });
 
   it('stops before device authorization when the credential store preflight fails', async () => {
@@ -203,12 +226,13 @@ describe('authenticateProvider', () => {
       + 'Set CLODEX_CREDENTIAL_HELPER to an absolute path to an external credential helper and try again.',
     );
     expect(runOpenAiDeviceCodeFlow).not.toHaveBeenCalled();
+    expect(provisionProviderCredential).not.toHaveBeenCalled();
     expect(saveProviderCredential).not.toHaveBeenCalled();
     expect(saveRegistry).not.toHaveBeenCalled();
   });
 
   it('rejects before updating the registry or refreshing models when token persistence fails', async () => {
-    vi.mocked(saveProviderCredential).mockImplementationOnce(async (_authRef, _credential, diagnostic) => {
+    vi.mocked(provisionProviderCredential).mockImplementationOnce(async (_authRef, _credential, diagnostic) => {
       diagnostic?.('credential write failed');
       return false;
     });
@@ -216,13 +240,73 @@ describe('authenticateProvider', () => {
     await expect(authenticateProvider('openai')).rejects.toThrow(
       'Could not save OAuth tokens to the credential store',
     );
-    expect(saveProviderCredential).toHaveBeenCalled();
+    expect(provisionProviderCredential).toHaveBeenCalled();
     expect(registryState.current.providers).toHaveLength(0);
-    expect([...journalState.pending]).toEqual([
-      'keyring:oauth:provider:openai-oauth',
-    ]);
+    expect([...journalState.pending]).toEqual([credentialRef]);
     expect(deleteProviderCredential).not.toHaveBeenCalled();
     expect(refreshProviderModels).not.toHaveBeenCalled();
+  });
+
+  it('does not publish a provider when token persistence fails', async () => {
+    vi.mocked(provisionProviderCredential).mockResolvedValueOnce(false);
+
+    await expect(authenticateProvider('openai')).rejects.toThrow(
+      'Could not save OAuth tokens to the credential store',
+    );
+    expect(provisionProviderCredential).toHaveBeenCalled();
+    expect(saveRegistry).not.toHaveBeenCalled();
+  });
+
+  it('moves an older credential reference to the selected account instance', async () => {
+    const existingProvider = {
+      id: 'openai-oauth',
+      templateId: 'openai',
+      name: 'OpenAI (ChatGPT)',
+      enabled: true,
+      authType: 'oauth' as const,
+      authRef: 'keyring:oauth:provider:openai-oauth',
+      api: { npm: '@ai-sdk/openai', url: 'https://api.openai.com/v1' },
+      addedAt: '2026-01-01T00:00:00.000Z',
+    };
+    registryState.current.providers = [existingProvider];
+    vi.mocked(provisionProviderCredential).mockResolvedValue(true);
+
+    const result = await authenticateProvider('openai');
+
+    expect(provisionProviderCredential).toHaveBeenCalledWith(
+      credentialRef,
+      expect.any(String),
+      expect.any(Function),
+    );
+    expect(saveProviderCredential).not.toHaveBeenCalled();
+    expect(result.registryProvider.authRef).toBe(credentialRef);
+  });
+
+  it('replaces the credential when the selected account instance is current', async () => {
+    const authRef = credentialRef;
+    registryState.current.providers = [
+      {
+        id: 'openai-oauth',
+        templateId: 'openai',
+        name: 'OpenAI (ChatGPT)',
+        enabled: true,
+        authType: 'oauth' as const,
+        authRef,
+        api: { npm: '@ai-sdk/openai', url: 'https://api.openai.com/v1' },
+        addedAt: '2026-01-01T00:00:00.000Z',
+      },
+    ];
+    vi.mocked(saveProviderCredential).mockResolvedValue(true);
+
+    const result = await authenticateProvider('openai');
+
+    expect(saveProviderCredential).toHaveBeenCalledWith(
+      authRef,
+      expect.any(String),
+      expect.any(Function),
+    );
+    expect(provisionProviderCredential).not.toHaveBeenCalled();
+    expect(result.registryProvider.authRef).toBe(authRef);
   });
 
   it('does not persist credentials when the registry cannot be validated', async () => {
@@ -245,11 +329,15 @@ describe('authenticateProvider', () => {
     vi.mocked(runOpenAiDeviceCodeFlow).mockImplementationOnce(async () => {
       observations.push(['authorization', lockState.active, lockState.credentialActive]);
       return {
-        tokens: { access_token: 'access-token', refresh_token: 'refresh-token', expires_in: 3600 },
+        tokens: {
+          access_token: 'access-token',
+          refresh_token: 'refresh-token',
+          expires_in: 3600,
+        },
         accountId: 'account-id',
       };
     });
-    vi.mocked(saveProviderCredential).mockImplementationOnce(async () => {
+    vi.mocked(provisionProviderCredential).mockImplementationOnce(async () => {
       observations.push(['credential-write', lockState.active, lockState.credentialActive]);
       return true;
     });
@@ -279,11 +367,11 @@ describe('authenticateProvider', () => {
       addedAt: '2026-01-01T00:00:00.000Z',
     });
     process.env.CLODEX_CREDENTIAL_HELPER = process.execPath;
-    const helperAuthRef = credentialAuthRef('oauth:provider:openai-oauth');
+    const helperAuthRef = credentialInstanceAuthRef('oauth:provider:openai-oauth');
 
     await authenticateProvider('openai');
 
-    expect(saveProviderCredential).toHaveBeenCalledWith(
+    expect(provisionProviderCredential).toHaveBeenCalledWith(
       helperAuthRef,
       expect.any(String),
       expect.any(Function),
@@ -293,7 +381,7 @@ describe('authenticateProvider', () => {
   });
 
   it('reauthorizes the same OAuth reference without deleting the active credential', async () => {
-    const authRef = 'keyring:oauth:provider:openai-oauth';
+    const authRef = credentialRef;
     registryState.current.providers.push({
       id: 'openai-oauth',
       templateId: 'openai',
@@ -329,7 +417,7 @@ describe('authenticateProvider', () => {
       addedAt: '2026-01-01T00:00:00.000Z',
     });
     process.env.CLODEX_CREDENTIAL_HELPER = process.execPath;
-    const helperAuthRef = credentialAuthRef('oauth:provider:openai-oauth');
+    const helperAuthRef = credentialInstanceAuthRef('oauth:provider:openai-oauth');
     vi.mocked(deleteProviderCredential).mockResolvedValue(false);
 
     const result = await authenticateProvider('openai');
@@ -348,6 +436,7 @@ describe('authenticateProvider', () => {
     );
 
     await expect(authenticateProvider('openai')).rejects.toThrow('journal unavailable');
+    expect(provisionProviderCredential).not.toHaveBeenCalled();
     expect(saveProviderCredential).not.toHaveBeenCalled();
     expect(registryState.current.providers).toHaveLength(0);
   });
@@ -358,31 +447,29 @@ describe('authenticateProvider', () => {
     });
 
     await expect(authenticateProvider('openai')).rejects.toThrow('activation failed');
-    expect(saveProviderCredential).toHaveBeenCalled();
+    expect(provisionProviderCredential).toHaveBeenCalled();
     expect(registryState.current.providers).toHaveLength(0);
-    expect([...journalState.pending]).toEqual([
-      'keyring:oauth:provider:openai-oauth',
-    ]);
+    expect([...journalState.pending]).toEqual([credentialRef]);
     expect(deleteProviderCredential).not.toHaveBeenCalled();
   });
 
   it('does not let concurrent reconciliation delete a credential during activation', async () => {
     let releaseWrite!: () => void;
     const writeGate = new Promise<void>(resolve => { releaseWrite = resolve; });
-    vi.mocked(saveProviderCredential).mockImplementation(async () => {
+    vi.mocked(provisionProviderCredential).mockImplementation(async () => {
       await writeGate;
       return true;
     });
 
     const authentication = authenticateProvider('openai');
-    await vi.waitFor(() => expect(saveProviderCredential).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(provisionProviderCredential).toHaveBeenCalledTimes(1));
     const reconciliation = reconcilePendingCredentialDeletes();
     await new Promise(resolve => setTimeout(resolve, 25));
 
     expect(deleteProviderCredential).not.toHaveBeenCalled();
     releaseWrite();
     const [result, cleanup] = await Promise.all([authentication, reconciliation]);
-    expect(result.registryProvider.authRef).toBe('keyring:oauth:provider:openai-oauth');
+    expect(result.registryProvider.authRef).toBe(credentialRef);
     expect(cleanup.deleted).toEqual([]);
     expect(deleteProviderCredential).not.toHaveBeenCalled();
     expect(journalState.pending.size).toBe(0);
@@ -421,7 +508,7 @@ describe('authenticateProvider', () => {
     const replacementRef = result.registryProvider.authRef;
 
     expect(cancellationLockStates).toEqual([true]);
-    expect(replacementRef).toBe('keyring:oauth:provider:openai-oauth');
+    expect(replacementRef).toBe(credentialRef);
     expect(journalState.pending).toContain(replacementRef);
     expect(result.credentialCleanupPending).toBe(true);
   });

--- a/tests/registry-add-template.test.ts
+++ b/tests/registry-add-template.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { addProviderFromTemplate } from '../src/registry/add-template.js';
+import { credentialInstanceAuthRef } from '../src/credential-helper.js';
 import * as env from '../src/env.js';
 import * as providerFactory from '../src/provider-factory.js';
 import * as fetchTemplate from '../src/registry/fetch-template-models.js';
@@ -13,8 +14,10 @@ const lockState = vi.hoisted(() => ({
   active: false,
   registryTail: Promise.resolve(),
   credentialActive: false,
+  providerActive: false,
   credentialTails: new Map<string, Promise<void>>(),
   afterRegistryUnlock: null as null | (() => void),
+  providerTails: new Map<string, Promise<void>>(),
 }));
 const journalState = vi.hoisted(() => ({
   pending: new Set<string>(),
@@ -26,6 +29,7 @@ vi.mock('../src/env.js', async importOriginal => {
   return {
     ...actual,
     deleteProviderCredential: vi.fn(),
+    provisionProviderCredential: vi.fn(),
     saveProviderCredential: vi.fn(),
   };
 });
@@ -73,13 +77,10 @@ vi.mock('../src/registry/lock.js', () => ({
       afterUnlock?.();
     }
   }),
-  withCredentialMutationLock: vi.fn(async (
-    authRef: string,
-    operation: () => unknown,
-  ) => {
+  withCredentialMutationLock: vi.fn(async (authRef: string, operation: () => unknown) => {
     const previous = lockState.credentialTails.get(authRef) ?? Promise.resolve();
     let release!: () => void;
-    const gate = new Promise<void>((resolve) => {
+    const gate = new Promise<void>(resolve => {
       release = resolve;
     });
     const tail = previous.then(() => gate);
@@ -96,9 +97,30 @@ vi.mock('../src/registry/lock.js', () => ({
       }
     }
   }),
+  withProviderMutationLock: vi.fn(async (providerSlot: string, operation: () => unknown) => {
+    const previous = lockState.providerTails.get(providerSlot) ?? Promise.resolve();
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    const tail = previous.then(() => gate);
+    lockState.providerTails.set(providerSlot, tail);
+    await previous;
+    lockState.providerActive = true;
+    try {
+      return await operation();
+    } finally {
+      lockState.providerActive = false;
+      release();
+      if (lockState.providerTails.get(providerSlot) === tail) {
+        lockState.providerTails.delete(providerSlot);
+      }
+    }
+  }),
 }));
 
 describe('registry/add-template', () => {
+  const credentialRef = credentialInstanceAuthRef('provider:test-template');
   const dummyTemplate: ProviderTemplate = {
     id: 'test-template',
     name: 'Test Provider',
@@ -113,12 +135,15 @@ describe('registry/add-template', () => {
     lockState.active = false;
     lockState.registryTail = Promise.resolve();
     lockState.credentialActive = false;
+    lockState.providerActive = false;
     lockState.credentialTails.clear();
     lockState.afterRegistryUnlock = null;
     journalState.pending.clear();
+    lockState.providerTails.clear();
 
     vi.mocked(providerFactory.isSdkMigratedNpm).mockReturnValue(true);
     vi.mocked(env.deleteProviderCredential).mockResolvedValue(true);
+    vi.mocked(env.provisionProviderCredential).mockResolvedValue(true);
     vi.mocked(env.saveProviderCredential).mockResolvedValue(true);
     vi.mocked(cleanupJournal.loadPendingCredentialDeletes).mockReset()
       .mockImplementation(async () => [...journalState.pending]);
@@ -138,11 +163,20 @@ describe('registry/add-template', () => {
     });
     
     vi.mocked(fetchTemplate.fetchTemplateModels).mockResolvedValue({
-      models: [{ id: 'model-1', name: 'Model 1', upstreamModelId: 'model-1', family: 'fam', brand: 'brand', modelFormat: 'openai' }],
+      models: [
+        {
+          id: 'model-1',
+          name: 'Model 1',
+          upstreamModelId: 'model-1',
+          family: 'fam',
+          brand: 'brand',
+          modelFormat: 'openai',
+        },
+      ],
       baseUrl: 'https://api.example.com',
     });
 
-    vi.mocked(pricing.enrichModelsWithPricing).mockImplementation((models) => models);
+    vi.mocked(pricing.enrichModelsWithPricing).mockImplementation(models => models);
   });
 
   afterEach(() => {
@@ -150,7 +184,11 @@ describe('registry/add-template', () => {
   });
 
   it('fails if template is not supported', async () => {
-    const tpl = { ...dummyTemplate, supported: false, unsupportedReason: 'Coming soon' };
+    const tpl = {
+      ...dummyTemplate,
+      supported: false,
+      unsupportedReason: 'Coming soon',
+    };
     const res = await addProviderFromTemplate(tpl, 'key');
     expect(res.added).toBe(false);
     expect(res.error).toBe('Coming soon');
@@ -170,7 +208,7 @@ describe('registry/add-template', () => {
   });
 
   it('fails if provider already exists and replaceExisting is not set', async () => {
-    vi.mocked(io.loadRegistryStrict).mockReturnValue({
+    registryState = {
       schemaVersion: 1,
       providers: [{
         id: 'test-template',
@@ -182,7 +220,7 @@ describe('registry/add-template', () => {
         api: {},
         addedAt: '2026-01-01T00:00:00.000Z',
       }],
-    });
+    };
 
     const res = await addProviderFromTemplate(dummyTemplate, 'key');
     expect(res.added).toBe(false);
@@ -204,16 +242,26 @@ describe('registry/add-template', () => {
     vi.mocked(fetchTemplate.fetchTemplateModels).mockImplementation(async () => {
       expect(lockState.active).toBe(false);
       return {
-        models: [{ id: 'model-1', name: 'Model 1', upstreamModelId: 'model-1', family: 'fam', brand: 'brand', modelFormat: 'openai' }],
+        models: [
+          {
+            id: 'model-1',
+            name: 'Model 1',
+            upstreamModelId: 'model-1',
+            family: 'fam',
+            brand: 'brand',
+            modelFormat: 'openai',
+          },
+        ],
         baseUrl: 'https://api.example.com',
       };
     });
     vi.mocked(pricing.enrichPricingAsync).mockImplementation(() => {
       expect(lockState.active).toBe(false);
     });
-    vi.mocked(env.saveProviderCredential).mockImplementation(async () => {
+    vi.mocked(env.provisionProviderCredential).mockImplementation(async () => {
       expect(lockState.active).toBe(false);
       expect(lockState.credentialActive).toBe(true);
+      expect(lockState.providerActive).toBe(true);
       return true;
     });
 
@@ -239,9 +287,9 @@ describe('registry/add-template', () => {
 
     expect(results.filter(result => result.added)).toHaveLength(1);
     expect(results.filter(result => !result.added)).toHaveLength(1);
-    expect(env.saveProviderCredential).toHaveBeenCalledOnce();
-    const [savedAuthRef, savedKey] = vi.mocked(env.saveProviderCredential).mock.calls[0]!;
-    expect(savedAuthRef).toBe('keyring:provider:test-template');
+    expect(env.provisionProviderCredential).toHaveBeenCalledOnce();
+    const [savedAuthRef, savedKey] = vi.mocked(env.provisionProviderCredential).mock.calls[0]!;
+    expect(savedAuthRef).toBe(credentialRef);
     expect(['first-key', 'second-key']).toContain(savedKey);
     expect(registry.providers).toHaveLength(1);
   });
@@ -260,7 +308,8 @@ describe('registry/add-template', () => {
           authRef: 'keyring:provider:test-template',
           api: {},
           addedAt: '2026-01-01T00:00:00.000Z',
-        }],
+          },
+        ],
       });
 
     const res = await addProviderFromTemplate(dummyTemplate, 'key');
@@ -268,20 +317,21 @@ describe('registry/add-template', () => {
     expect(res.added).toBe(false);
     expect(res.error).toContain('is already configured');
     expect(fetchTemplate.fetchTemplateModels).toHaveBeenCalledOnce();
+    expect(env.provisionProviderCredential).not.toHaveBeenCalled();
     expect(env.saveProviderCredential).not.toHaveBeenCalled();
     expect(io.saveRegistry).not.toHaveBeenCalled();
   });
 
   it('fails if credential cannot be saved', async () => {
-    vi.mocked(env.saveProviderCredential).mockResolvedValue(false);
+    vi.mocked(env.provisionProviderCredential).mockResolvedValue(false);
 
     const res = await addProviderFromTemplate(dummyTemplate, 'key');
     expect(res.added).toBe(false);
     expect(res.error).toContain('Could not save API key');
     expect(cleanupJournal.queueCredentialDelete).toHaveBeenCalledWith(
-      'keyring:provider:test-template',
+      credentialRef,
     );
-    expect(env.deleteProviderCredential).toHaveBeenCalledWith('keyring:provider:test-template');
+    expect(env.deleteProviderCredential).toHaveBeenCalledWith(credentialRef);
     expect(journalState.pending.size).toBe(0);
   });
 
@@ -294,7 +344,10 @@ describe('registry/add-template', () => {
     expect(res.provider?.modelsCache?.models).toHaveLength(1);
     expect(res.modelCount).toBe(1);
 
-    expect(env.saveProviderCredential).toHaveBeenCalledWith('keyring:provider:test-template', 'key_123');
+    expect(env.provisionProviderCredential).toHaveBeenCalledWith(
+      credentialRef,
+      'key_123',
+    );
     expect(io.saveRegistry).toHaveBeenCalled();
   });
 
@@ -308,6 +361,7 @@ describe('registry/add-template', () => {
       authRef: 'none:anonymous',
       authType: 'none',
     });
+    expect(env.provisionProviderCredential).not.toHaveBeenCalled();
     expect(env.saveProviderCredential).not.toHaveBeenCalled();
     const savedRegistry = vi.mocked(io.saveRegistry).mock.calls.at(-1)?.[0] as ProviderRegistry;
     expect(savedRegistry.providers[0]?.authRef).toBe('none:anonymous');
@@ -338,7 +392,8 @@ describe('registry/add-template', () => {
         brand: 'brand',
         modelFormat: 'openai',
         isFree: true,
-      }],
+        },
+      ],
       baseUrl: 'https://api.example.com',
     });
 
@@ -353,7 +408,7 @@ describe('registry/add-template', () => {
     expect(res.modelCount).toBe(1);
   });
 
-  it('replaces existing provider if replaceExisting is true', async () => {
+  it('moves an existing provider to the selected credential backend', async () => {
     registryState = {
       schemaVersion: 1,
       providers: [{
@@ -368,16 +423,21 @@ describe('registry/add-template', () => {
       }],
     };
 
-    const res = await addProviderFromTemplate(dummyTemplate, 'key_123', { replaceExisting: true });
+    const res = await addProviderFromTemplate(dummyTemplate, 'key_123', {
+      replaceExisting: true,
+    });
 
     expect(res.added).toBe(true);
+    expect(env.provisionProviderCredential).toHaveBeenCalledWith(
+      credentialRef,
+      'key_123',
+    );
+    expect(env.saveProviderCredential).not.toHaveBeenCalled();
     
     const savedRegistry = vi.mocked(io.saveRegistry).mock.calls.at(-1)?.[0] as ProviderRegistry;
     expect(savedRegistry.providers).toHaveLength(1); // Replaced, not duplicated
     expect(savedRegistry.providers[0]?.name).toBe('Test Provider');
-    expect(savedRegistry.providers[0]?.authRef).toMatch(
-      /^keyring:provider:test-template:replacement:/,
-    );
+    expect(savedRegistry.providers[0]?.authRef).toBe(credentialRef);
     expect(env.deleteProviderCredential).toHaveBeenCalledWith('keyring:provider:test-template');
   });
 
@@ -419,9 +479,7 @@ describe('registry/add-template', () => {
     const replacementRef = result.provider?.authRef;
 
     expect(cancellationLockStates).toEqual([true]);
-    expect(replacementRef).toMatch(
-      /^keyring:provider:test-template:replacement:/,
-    );
+    expect(replacementRef).toBe(credentialRef);
     expect(journalState.pending).toContain(replacementRef);
     expect(result.credentialCleanupPending).toBe(true);
   });
@@ -452,7 +510,7 @@ describe('registry/add-template', () => {
 
     expect(registryState.providers[0]?.authRef).toBe('keyring:provider:test-template');
     expect([...journalState.pending]).toEqual([
-      expect.stringMatching(/^keyring:provider:test-template:replacement:/),
+      credentialRef,
       'keyring:provider:test-template',
     ]);
     expect(env.deleteProviderCredential).not.toHaveBeenCalled();
@@ -468,5 +526,69 @@ describe('registry/add-template', () => {
     expect(result.added).toBe(true);
     expect(result.credentialCleanupPending).toBe(true);
     expect(registryState.providers).toHaveLength(1);
+  });
+
+  it('replaces the selected account instance in place', async () => {
+    const authRef = credentialRef;
+    registryState = {
+      schemaVersion: 1,
+      providers: [
+        {
+          id: 'test-template',
+          templateId: 'test-template',
+          name: 'Existing',
+          enabled: true,
+          authType: 'api',
+          authRef,
+          api: {},
+          addedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+    };
+
+    const res = await addProviderFromTemplate(dummyTemplate, 'key_123', {
+      replaceExisting: true,
+    });
+
+    expect(res.added).toBe(true);
+    expect(env.saveProviderCredential).toHaveBeenCalledWith(authRef, 'key_123');
+    expect(env.provisionProviderCredential).not.toHaveBeenCalled();
+  });
+
+  it('serializes concurrent replacements before selecting write mode', async () => {
+    let registry: ProviderRegistry = {
+      schemaVersion: 1,
+      providers: [
+        {
+          id: 'test-template',
+          templateId: 'test-template',
+          name: 'Existing',
+          enabled: true,
+          authType: 'api',
+          authRef: 'keyring:provider:test-template',
+          api: {},
+          addedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+    };
+    vi.mocked(io.loadRegistryStrict).mockImplementation(() => structuredClone(registry));
+    vi.mocked(io.saveRegistry).mockImplementation(next => {
+      registry = structuredClone(next);
+    });
+
+    const results = await Promise.all([
+      addProviderFromTemplate(dummyTemplate, 'first-key', {
+        replaceExisting: true,
+      }),
+      addProviderFromTemplate(dummyTemplate, 'second-key', {
+        replaceExisting: true,
+      }),
+    ]);
+
+    expect(results.every(result => result.added)).toBe(true);
+    expect(env.provisionProviderCredential).toHaveBeenCalledOnce();
+    expect(env.saveProviderCredential).toHaveBeenCalledOnce();
+    expect(registry.providers).toHaveLength(1);
+    expect(registry.providers[0]?.authRef).toBe(credentialRef);
   });
 });

--- a/tests/registry-crud.test.ts
+++ b/tests/registry-crud.test.ts
@@ -8,7 +8,9 @@ const lockState = vi.hoisted(() => ({
   active: false,
   registryTail: Promise.resolve(),
   credentialActive: false,
+  providerActive: false,
   credentialTails: new Map<string, Promise<void>>(),
+  providerTails: new Map<string, Promise<void>>(),
 }));
 const journalState = vi.hoisted(() => ({
   pending: new Set<string>(),
@@ -78,6 +80,29 @@ vi.mock('../src/registry/lock.js', () => ({
       }
     }
   }),
+  withProviderMutationLock: vi.fn(async <T>(
+    providerSlot: string,
+    operation: () => Promise<T> | T,
+  ): Promise<T> => {
+    const previous = lockState.providerTails.get(providerSlot) ?? Promise.resolve();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = previous.then(() => gate);
+    lockState.providerTails.set(providerSlot, tail);
+    await previous;
+    lockState.providerActive = true;
+    try {
+      return await operation();
+    } finally {
+      lockState.providerActive = false;
+      release();
+      if (lockState.providerTails.get(providerSlot) === tail) {
+        lockState.providerTails.delete(providerSlot);
+      }
+    }
+  }),
   withRegistryWriteLockSync: vi.fn(),
 }));
 
@@ -85,6 +110,7 @@ import { deleteProviderCredential } from '../src/env.js';
 import { removeProviderFromRegistry } from '../src/registry/crud.js';
 import {
   withCredentialMutationLock,
+  withProviderMutationLock,
   withRegistryWriteLock,
 } from '../src/registry/lock.js';
 
@@ -93,7 +119,9 @@ describe('registry provider removal', () => {
     lockState.active = false;
     lockState.registryTail = Promise.resolve();
     lockState.credentialActive = false;
+    lockState.providerActive = false;
     lockState.credentialTails.clear();
+    lockState.providerTails.clear();
     journalState.pending.clear();
     registryState.current = {
       schemaVersion: 1,
@@ -114,6 +142,7 @@ describe('registry provider removal', () => {
       async () => {
         expect(lockState.active).toBe(false);
         expect(lockState.credentialActive).toBe(true);
+        expect(lockState.providerActive).toBe(true);
         return true;
       },
     );
@@ -137,6 +166,7 @@ describe('registry provider removal', () => {
     vi.mocked(deleteProviderCredential).mockImplementation(async () => {
       expect(lockState.active).toBe(false);
       expect(lockState.credentialActive).toBe(true);
+      expect(lockState.providerActive).toBe(true);
       return false;
     });
 
@@ -209,5 +239,48 @@ describe('registry provider removal', () => {
 
     expect(credentialValue).toBe('new-key');
     expect(registryState.current.providers).toHaveLength(1);
+  });
+
+  it('serializes removal against publishing a credential on another backend', async () => {
+    let startDelete!: () => void;
+    const deleteStarted = new Promise<void>(resolve => {
+      startDelete = resolve;
+    });
+    let finishDelete!: () => void;
+    const deleteGate = new Promise<void>(resolve => {
+      finishDelete = resolve;
+    });
+    vi.mocked(deleteProviderCredential).mockImplementation(async () => {
+      startDelete();
+      await deleteGate;
+      return true;
+    });
+
+    const removal = removeProviderFromRegistry('openai');
+    await deleteStarted;
+    let migrationEntered = false;
+    const migration = withProviderMutationLock('openai', async () => {
+      migrationEntered = true;
+      await withRegistryWriteLock(() => {
+        registryState.current.providers.push({
+          id: 'openai',
+          templateId: 'openai',
+          name: 'OpenAI',
+          enabled: true,
+          authRef: 'helper:v1:new-helper:provider:openai',
+          authType: 'api',
+          api: { npm: '@ai-sdk/openai', url: 'https://api.openai.com/v1' },
+          addedAt: '2026-07-21T01:00:00.000Z',
+        });
+      });
+    });
+
+    await Promise.resolve();
+    expect(migrationEntered).toBe(false);
+    finishDelete();
+    await Promise.all([removal, migration]);
+
+    expect(registryState.current.providers).toHaveLength(1);
+    expect(registryState.current.providers[0]?.authRef).toContain('new-helper');
   });
 });

--- a/tests/registry-lock.test.ts
+++ b/tests/registry-lock.test.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import {
   existsSync,
   mkdtempSync,
@@ -15,7 +16,9 @@ import { build } from 'tsup';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   RegistryLockLostError,
+  getCredentialLockRoot,
   getCredentialMutationLockPath,
+  getCredentialStateRoot,
   tryAcquireRegistryLock,
   withCredentialMutationLock,
   withRegistryWriteLock,
@@ -59,23 +62,20 @@ function temporaryLockPath(): string {
 function workerEnvironment(
   root: string,
   role: WorkerRole,
+  options: {
+    clodexHome?: string;
+    overrides?: NodeJS.ProcessEnv;
+  } = {},
 ): NodeJS.ProcessEnv {
   const environment: NodeJS.ProcessEnv = {
-    CLODEX_HOME: root,
+    CLODEX_HOME: options.clodexHome ?? root,
+    REGISTRY_LOCK_WORKER_ROOT: root,
     REGISTRY_LOCK_WORKER_ROLE: role,
   };
-  for (const key of [
-    'HOME',
-    'PATH',
-    'TMPDIR',
-    'TEMP',
-    'TMP',
-    'SystemRoot',
-    'ComSpec',
-    'PATHEXT',
-  ]) {
+  for (const key of ['HOME', 'PATH', 'TMPDIR', 'TEMP', 'TMP', 'SystemRoot', 'ComSpec', 'PATHEXT']) {
     if (process.env[key] !== undefined) environment[key] = process.env[key];
   }
+  Object.assign(environment, options.overrides);
   return environment;
 }
 
@@ -83,10 +83,14 @@ function spawnWorker(
   workerPath: string,
   root: string,
   role: WorkerRole,
+  options: {
+    clodexHome?: string;
+    overrides?: NodeJS.ProcessEnv;
+  } = {},
 ): WorkerProcess {
   const child = spawn(process.execPath, [workerPath], {
     cwd: process.cwd(),
-    env: workerEnvironment(root, role),
+    env: workerEnvironment(root, role, options),
     stdio: ['ignore', 'pipe', 'pipe'],
   });
   let stdout = '';
@@ -117,11 +121,7 @@ function spawnWorker(
 async function buildWorker(root: string): Promise<string> {
   const outDir = join(root, 'worker-build');
   await build({
-    entry: [
-      fileURLToPath(
-        new URL('./fixtures/registry-lock-worker.ts', import.meta.url),
-      ),
-    ],
+    entry: [fileURLToPath(new URL('./fixtures/registry-lock-worker.ts', import.meta.url))],
     outDir,
     outExtension: () => ({ js: '.mjs' }),
     format: ['esm'],
@@ -146,14 +146,14 @@ async function waitForJson<T>(path: string, timeoutMs = 5_000): Promise<T> {
         // Retry while the creating process finishes its synchronous write.
       }
     }
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await new Promise(resolve => setTimeout(resolve, 10));
   }
   throw new Error(`Timed out waiting for JSON result: ${path}`);
 }
 
 function lockArtifacts(root: string): string[] {
   return readdirSync(root)
-    .filter((name) => name.includes('.lock') || name.endsWith('.tmp'))
+    .filter(name => name.includes('.lock') || name.endsWith('.tmp'))
     .sort();
 }
 
@@ -163,9 +163,8 @@ afterEach(async () => {
       worker.child.kill('SIGTERM');
     }
   }
-  await Promise.allSettled([...workers].map((worker) => worker.exit));
-  for (const root of roots.splice(0))
-    rmSync(root, { recursive: true, force: true });
+  await Promise.allSettled([...workers].map(worker => worker.exit));
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
 describe('provider registry lock', () => {
@@ -184,22 +183,15 @@ describe('provider registry lock', () => {
   it('retains a fresh lock owned by a live process and reaps a dead owner', () => {
     const lockPath = temporaryLockPath();
     const now = Date.now();
-    writeFileSync(
-      lockPath,
-      JSON.stringify({ pid: 1234, startedAt: now, token: 'first-owner' }),
-    );
+    writeFileSync(lockPath, JSON.stringify({ pid: 1234, startedAt: now, token: 'first-owner' }));
 
-    expect(
-      tryAcquireRegistryLock(lockPath, { now: () => now, isAlive: () => true }),
-    ).toBeNull();
+    expect(tryAcquireRegistryLock(lockPath, { now: () => now, isAlive: () => true })).toBeNull();
     const lease = tryAcquireRegistryLock(lockPath, {
       now: () => now,
       isAlive: () => false,
     });
     expect(lease).toMatchObject({ active: true });
-    expect(JSON.parse(readFileSync(lockPath, 'utf8')).token).not.toBe(
-      'first-owner',
-    );
+    expect(JSON.parse(readFileSync(lockPath, 'utf8')).token).not.toBe('first-owner');
     lease?.release();
   });
 
@@ -221,9 +213,7 @@ describe('provider registry lock', () => {
         isAlive: () => true,
       }),
     ).toBeNull();
-    expect(JSON.parse(readFileSync(lockPath, 'utf8')).token).toBe(
-      'expired-owner',
-    );
+    expect(JSON.parse(readFileSync(lockPath, 'utf8')).token).toBe('expired-owner');
   });
 
   it('does not remove a replacement created during stale-lock reclamation', () => {
@@ -241,7 +231,7 @@ describe('provider registry lock', () => {
     let competingLease: ReturnType<typeof tryAcquireRegistryLock> = null;
     let interleaved = false;
     const lease = tryAcquireRegistryLock(lockPath, {
-      isAlive: (pid) => {
+      isAlive: pid => {
         if (pid === stalePid && !interleaved) {
           interleaved = true;
           competingLease = tryAcquireRegistryLock(lockPath, {
@@ -282,12 +272,10 @@ describe('provider registry lock', () => {
 
     expect(
       tryAcquireRegistryLock(lockPath, {
-        isAlive: (pid) => pid === process.pid,
+        isAlive: pid => pid === process.pid,
       }),
     ).toBeNull();
-    expect(JSON.parse(readFileSync(lockPath, 'utf8')).token).toBe(
-      'stale-owner',
-    );
+    expect(JSON.parse(readFileSync(lockPath, 'utf8')).token).toBe('stale-owner');
   });
 
   it('recovers when a dead process leaves the reaper guard behind', () => {
@@ -303,9 +291,7 @@ describe('provider registry lock', () => {
     const lease = tryAcquireRegistryLock(lockPath, { isAlive: () => false });
 
     expect(lease).toMatchObject({ active: true });
-    expect(JSON.parse(readFileSync(lockPath, 'utf8')).token).not.toBe(
-      'dead-owner',
-    );
+    expect(JSON.parse(readFileSync(lockPath, 'utf8')).token).not.toBe('dead-owner');
     lease?.release();
   });
 
@@ -334,7 +320,7 @@ describe('provider registry lock', () => {
     const lockPath = temporaryLockPath();
     const events: string[] = [];
     let releaseFirst!: () => void;
-    const firstGate = new Promise<void>((resolve) => {
+    const firstGate = new Promise<void>(resolve => {
       releaseFirst = resolve;
     });
 
@@ -346,14 +332,14 @@ describe('provider registry lock', () => {
       },
       { lockPath, waitMs: 1_000, retryMs: 5 },
     );
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await new Promise(resolve => setTimeout(resolve, 20));
     const second = withRegistryWriteLock(
       () => {
         events.push('second-enter');
       },
       { lockPath, waitMs: 1_000, retryMs: 5 },
     );
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await new Promise(resolve => setTimeout(resolve, 20));
 
     expect(events).toEqual(['first-enter']);
     releaseFirst();
@@ -367,7 +353,7 @@ describe('provider registry lock', () => {
     process.env.CLODEX_HOME = home;
     const events: string[] = [];
     let releaseFirst!: () => void;
-    const firstGate = new Promise<void>((resolve) => {
+    const firstGate = new Promise<void>(resolve => {
       releaseFirst = resolve;
     });
 
@@ -378,26 +364,53 @@ describe('provider registry lock', () => {
           events.push('first-enter');
           await firstGate;
           events.push('first-exit');
-        },
-      );
-      await new Promise((resolve) => setTimeout(resolve, 20));
-      const second = withCredentialMutationLock(
-        'keyring:provider:openai',
-        () => {
+      });
+      await new Promise(resolve => setTimeout(resolve, 20));
+      const second = withCredentialMutationLock('keyring:provider:openai', () => {
           events.push('second-enter');
-        },
-      );
-      await new Promise((resolve) => setTimeout(resolve, 20));
+      });
+      await new Promise(resolve => setTimeout(resolve, 20));
 
       expect(events).toEqual(['first-enter']);
-      expect(getCredentialMutationLockPath('keyring:provider:openai')).not
-        .toContain('provider:openai');
+      expect(getCredentialMutationLockPath('keyring:provider:openai')).not.toContain(
+        'provider:openai',
+      );
       releaseFirst();
       await Promise.all([first, second]);
       expect(events).toEqual(['first-enter', 'first-exit', 'second-enter']);
     } finally {
       if (previousHome === undefined) delete process.env.CLODEX_HOME;
       else process.env.CLODEX_HOME = previousHome;
+    }
+  });
+
+  it('keeps credential lock paths independent of process environment homes', () => {
+    const keys = [
+      'CLODEX_HOME',
+      'HOME',
+      'USERPROFILE',
+      'XDG_RUNTIME_DIR',
+      'TMPDIR',
+      'TEMP',
+      'TMP',
+    ] as const;
+    const previous = new Map(keys.map(key => [key, process.env[key]]));
+    const authRef = `keyring:test:${randomUUID()}`;
+
+    try {
+      for (const key of keys) process.env[key] = `/tmp/credential-lock-a/${key}`;
+      const first = getCredentialMutationLockPath(authRef);
+      for (const key of keys) process.env[key] = `/tmp/credential-lock-b/${key}`;
+      const second = getCredentialMutationLockPath(authRef);
+
+      expect(second).toBe(first);
+      expect(dirname(first)).toBe(getCredentialLockRoot());
+      expect(first).not.toContain(authRef);
+    } finally {
+      for (const [key, value] of previous) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
     }
   });
 
@@ -452,7 +465,7 @@ describe('provider registry lock', () => {
     const lockPath = temporaryLockPath();
     const events: string[] = [];
     let startDetached!: () => void;
-    const detachedGate = new Promise<void>((resolve) => {
+    const detachedGate = new Promise<void>(resolve => {
       startDetached = resolve;
     });
     let detached: Promise<void> | undefined;
@@ -473,11 +486,11 @@ describe('provider registry lock', () => {
     );
 
     let releaseSecond!: () => void;
-    const secondGate = new Promise<void>((resolve) => {
+    const secondGate = new Promise<void>(resolve => {
       releaseSecond = resolve;
     });
     let markSecondEntered!: () => void;
-    const secondEntered = new Promise<void>((resolve) => {
+    const secondEntered = new Promise<void>(resolve => {
       markSecondEntered = resolve;
     });
     const second = withRegistryWriteLock(
@@ -492,7 +505,7 @@ describe('provider registry lock', () => {
 
     await secondEntered;
     startDetached();
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await new Promise(resolve => setTimeout(resolve, 20));
     expect(events).toEqual(['second-enter']);
 
     releaseSecond();
@@ -505,7 +518,7 @@ describe('provider registry lock', () => {
     const events: string[] = [];
     let detachedError: unknown;
     let finishDetached!: () => void;
-    const detachedFinished = new Promise<void>((resolve) => {
+    const detachedFinished = new Promise<void>(resolve => {
       finishDetached = resolve;
     });
 
@@ -566,9 +579,7 @@ describe('provider registry lock', () => {
   it('rejects registry writes without an active matching lease', () => {
     const registryPath = temporaryLockPath().replace(/\.lock$/, '');
 
-    expect(() => saveRegistry(emptyRegistry(), registryPath)).toThrow(
-      RegistryLockLostError,
-    );
+    expect(() => saveRegistry(emptyRegistry(), registryPath)).toThrow(RegistryLockLostError);
   });
 
   it('does not use a lease to authorize a different registry path', () => {
@@ -577,9 +588,9 @@ describe('provider registry lock', () => {
 
     withRegistryWriteLockSync(
       () => {
-        expect(() =>
-          saveRegistry(emptyRegistry(), otherRegistryPath),
-        ).toThrow(RegistryLockLostError);
+        expect(() => saveRegistry(emptyRegistry(), otherRegistryPath)).toThrow(
+          RegistryLockLostError,
+        );
       },
       { lockPath },
     );
@@ -622,9 +633,7 @@ describe('provider registry lock', () => {
         error?: string;
       }>(join(root, 'contender-result.json'));
       expect(contenderResult.acquired).toBe(false);
-      expect(contenderResult.error).toContain(
-        'Timed out after 250ms waiting for lock',
-      );
+      expect(contenderResult.error).toContain('Timed out after 250ms waiting for lock');
       expect(contenderResult.error).toContain(String(ready.pid));
 
       const retainedOwner = JSON.parse(readFileSync(lockPath, 'utf8')) as {
@@ -632,9 +641,7 @@ describe('provider registry lock', () => {
         token: string;
       };
       expect(retainedOwner).toMatchObject(ready);
-      expect(JSON.parse(readFileSync(registryPath, 'utf8')).importedAt).toBe(
-        'holder-initial',
-      );
+      expect(JSON.parse(readFileSync(registryPath, 'utf8')).importedAt).toBe('holder-initial');
 
       writeFileSync(releasePath, 'release\n');
       const holderExit = await holder.exit;
@@ -645,9 +652,7 @@ describe('provider registry lock', () => {
       expect(await waitForJson(join(root, 'holder-result.json'))).toEqual({
         ok: true,
       });
-      expect(JSON.parse(readFileSync(registryPath, 'utf8')).importedAt).toBe(
-        'holder-final',
-      );
+      expect(JSON.parse(readFileSync(registryPath, 'utf8')).importedAt).toBe('holder-final');
       expect(lockArtifacts(root)).toEqual([]);
     } finally {
       if (!existsSync(releasePath)) writeFileSync(releasePath, 'release\n');
@@ -680,9 +685,7 @@ describe('provider registry lock', () => {
         workerExit.code,
         `worker stderr:\n${workerExit.stderr}\nstdout:\n${workerExit.stdout}`,
       ).toBe(0);
-      expect(
-        await waitForJson(join(root, 'atomic-acquire-result.json')),
-      ).toEqual({
+      expect(await waitForJson(join(root, 'atomic-acquire-result.json'))).toEqual({
         acquired: true,
         ownerPid: ready.pid,
         ownerToken: expect.any(String),
@@ -696,34 +699,58 @@ describe('provider registry lock', () => {
     }
   }, 10_000);
 
-  it('serializes the same credential reference across processes', async () => {
+  it('serializes a credential across processes with different environment homes', async () => {
     const root = temporaryRoot();
+    const holderHome = temporaryRoot();
+    const contenderHome = temporaryRoot();
+    const holderRuntime = temporaryRoot();
+    const contenderRuntime = temporaryRoot();
+    const credentialRef = `keyring:test:${randomUUID()}`;
     const workerPath = await buildWorker(root);
     const releasePath = join(root, 'release-credential-holder');
     const enteredPath = join(root, 'credential-contender-entered.json');
-    const holder = spawnWorker(workerPath, root, 'credential-holder');
+    const holder = spawnWorker(workerPath, root, 'credential-holder', {
+      clodexHome: holderHome,
+      overrides: {
+        HOME: holderHome,
+        XDG_RUNTIME_DIR: holderRuntime,
+        TMPDIR: holderRuntime,
+        REGISTRY_LOCK_CREDENTIAL_REF: credentialRef,
+      },
+    });
     let contender: WorkerProcess | undefined;
 
     try {
       const holderReady = await waitForJson<{
         pid: number;
         lockPath: string;
+        stateRoot: string;
       }>(join(root, 'credential-holder-ready.json'));
       expect(existsSync(holderReady.lockPath)).toBe(true);
 
-      contender = spawnWorker(workerPath, root, 'credential-contender');
-      const contenderReady = await waitForJson<{ pid: number }>(
-        join(root, 'credential-contender-ready.json'),
-      );
-      await new Promise((resolve) => setTimeout(resolve, 125));
+      contender = spawnWorker(workerPath, root, 'credential-contender', {
+        clodexHome: contenderHome,
+        overrides: {
+          HOME: contenderHome,
+          XDG_RUNTIME_DIR: contenderRuntime,
+          TMPDIR: contenderRuntime,
+          REGISTRY_LOCK_CREDENTIAL_REF: credentialRef,
+        },
+      });
+      const contenderReady = await waitForJson<{
+        pid: number;
+        lockPath: string;
+        stateRoot: string;
+      }>(join(root, 'credential-contender-ready.json'));
+      expect(contenderReady.lockPath).toBe(holderReady.lockPath);
+      expect(contenderReady.stateRoot).toBe(holderReady.stateRoot);
+      expect(contenderReady.stateRoot).toBe(getCredentialStateRoot());
+      await new Promise(resolve => setTimeout(resolve, 125));
       expect(existsSync(enteredPath)).toBe(false);
       expect(contender.child.exitCode).toBeNull();
 
       writeFileSync(releasePath, 'release\n');
-      const [holderExit, contenderExit] = await Promise.all([
-        holder.exit,
-        contender.exit,
-      ]);
+      const [holderExit, contenderExit] = await Promise.all([holder.exit, contender.exit]);
       expect(
         holderExit.code,
         `holder stderr:\n${holderExit.stderr}\nstdout:\n${holderExit.stdout}`,
@@ -735,12 +762,11 @@ describe('provider registry lock', () => {
       expect(await waitForJson(enteredPath)).toEqual({
         pid: contenderReady.pid,
       });
-      expect(
-        await waitForJson(join(root, 'credential-holder-result.json')),
-      ).toEqual({ ok: true });
-      expect(
-        await waitForJson(join(root, 'credential-contender-result.json')),
-      ).toEqual({ ok: true });
+      expect(await waitForJson(join(root, 'credential-holder-result.json'))).toEqual({ ok: true });
+      expect(await waitForJson(join(root, 'credential-contender-result.json'))).toEqual({
+        ok: true,
+      });
+      expect(existsSync(holderReady.lockPath)).toBe(false);
       expect(lockArtifacts(root)).toEqual([]);
     } finally {
       if (!existsSync(releasePath)) writeFileSync(releasePath, 'release\n');

--- a/tests/registry-lock.test.ts
+++ b/tests/registry-lock.test.ts
@@ -64,11 +64,14 @@ function workerEnvironment(
   role: WorkerRole,
   options: {
     clodexHome?: string;
+    nativeHome?: string;
     overrides?: NodeJS.ProcessEnv;
   } = {},
 ): NodeJS.ProcessEnv {
   const environment: NodeJS.ProcessEnv = {
     CLODEX_HOME: options.clodexHome ?? root,
+    REGISTRY_LOCK_WORKER_NATIVE_HOME:
+      options.nativeHome ?? dirname(dirname(getCredentialStateRoot())),
     REGISTRY_LOCK_WORKER_ROOT: root,
     REGISTRY_LOCK_WORKER_ROLE: role,
   };
@@ -85,6 +88,7 @@ function spawnWorker(
   role: WorkerRole,
   options: {
     clodexHome?: string;
+    nativeHome?: string;
     overrides?: NodeJS.ProcessEnv;
   } = {},
 ): WorkerProcess {
@@ -705,12 +709,14 @@ describe('provider registry lock', () => {
     const contenderHome = temporaryRoot();
     const holderRuntime = temporaryRoot();
     const contenderRuntime = temporaryRoot();
+    const nativeHome = dirname(dirname(getCredentialStateRoot()));
     const credentialRef = `keyring:test:${randomUUID()}`;
     const workerPath = await buildWorker(root);
     const releasePath = join(root, 'release-credential-holder');
     const enteredPath = join(root, 'credential-contender-entered.json');
     const holder = spawnWorker(workerPath, root, 'credential-holder', {
       clodexHome: holderHome,
+      nativeHome,
       overrides: {
         HOME: holderHome,
         XDG_RUNTIME_DIR: holderRuntime,
@@ -730,6 +736,7 @@ describe('provider registry lock', () => {
 
       contender = spawnWorker(workerPath, root, 'credential-contender', {
         clodexHome: contenderHome,
+        nativeHome,
         overrides: {
           HOME: contenderHome,
           XDG_RUNTIME_DIR: contenderRuntime,
@@ -745,6 +752,7 @@ describe('provider registry lock', () => {
       expect(contenderReady.lockPath).toBe(holderReady.lockPath);
       expect(contenderReady.stateRoot).toBe(holderReady.stateRoot);
       expect(contenderReady.stateRoot).toBe(getCredentialStateRoot());
+      expect(contenderReady.stateRoot).toBe(join(nativeHome, '.clodex', 'keyring-state'));
       await new Promise(resolve => setTimeout(resolve, 125));
       expect(existsSync(enteredPath)).toBe(false);
       expect(contender.child.exitCode).toBeNull();

--- a/tests/test-sandbox-floor.test.ts
+++ b/tests/test-sandbox-floor.test.ts
@@ -2,6 +2,22 @@ import { tmpdir, userInfo } from 'node:os';
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { getAppHome } from '../src/paths.js';
+import {
+  getCredentialLockRoot,
+  getCredentialMutationLockPath,
+  getCredentialStateRoot,
+} from '../src/registry/lock.js';
+
+function expectInsideVitestSandbox(candidate: string): void {
+  const relativeToTemp = relative(resolve(tmpdir()), resolve(candidate));
+
+  expect(relativeToTemp).not.toBe('');
+  expect(relativeToTemp).not.toMatch(/^\.\.(?:[/\\]|$)/);
+  expect(isAbsolute(relativeToTemp)).toBe(false);
+  expect(relativeToTemp.split(/[/\\]/)).toContainEqual(
+    expect.stringMatching(/^clodex-vitest-sandbox-/),
+  );
+}
 
 describe('test sandbox floor', () => {
   it('keeps the default app home inside a Vitest temp sandbox', () => {
@@ -16,5 +32,11 @@ describe('test sandbox floor', () => {
     expect(basename(dirname(clodexHome))).toMatch(/^clodex-vitest-sandbox-/);
     expect(getAppHome()).toBe(clodexHome);
     expect(getAppHome()).not.toBe(join(userInfo().homedir, '.clodex'));
+  });
+
+  it('keeps native credential coordination state inside the Vitest sandbox', () => {
+    expectInsideVitestSandbox(getCredentialLockRoot());
+    expectInsideVitestSandbox(getCredentialMutationLockPath('keyring:test-account'));
+    expectInsideVitestSandbox(getCredentialStateRoot());
   });
 });

--- a/tests/test-sandbox-floor.test.ts
+++ b/tests/test-sandbox-floor.test.ts
@@ -1,6 +1,6 @@
 import { tmpdir, userInfo } from 'node:os';
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { getAppHome, getCredentialCleanupPath } from '../src/paths.js';
 import {
   getCredentialLockRoot,
@@ -19,6 +19,15 @@ function expectInsideVitestSandbox(candidate: string): void {
   );
 }
 
+function expectOutsideDirectory(candidate: string, directory: string): void {
+  const relativeToDirectory = relative(resolve(directory), resolve(candidate));
+  const insideOrEqual =
+    relativeToDirectory === ''
+    || (!relativeToDirectory.match(/^\.\.(?:[/\\]|$)/) && !isAbsolute(relativeToDirectory));
+
+  expect(insideOrEqual).toBe(false);
+}
+
 describe('test sandbox floor', () => {
   it('keeps the default app home inside a Vitest temp sandbox', () => {
     expect(process.env.CLODEX_HOME).toBeDefined();
@@ -34,10 +43,20 @@ describe('test sandbox floor', () => {
     expect(getAppHome()).not.toBe(join(userInfo().homedir, '.clodex'));
   });
 
-  it('keeps credential coordination and cleanup state inside the Vitest sandbox', () => {
-    expectInsideVitestSandbox(getCredentialLockRoot());
-    expectInsideVitestSandbox(getCredentialMutationLockPath('keyring:test-account'));
-    expectInsideVitestSandbox(getCredentialStateRoot());
-    expectInsideVitestSandbox(getCredentialCleanupPath());
+  it('keeps credential coordination and cleanup state away from the real home', async () => {
+    const actualOs = await vi.importActual<typeof import('node:os')>('node:os');
+    const realUserHome = actualOs.userInfo().homedir;
+    const coordinationPaths = [
+      getCredentialLockRoot(),
+      getCredentialMutationLockPath('keyring:test-account'),
+      getCredentialStateRoot(),
+      getCredentialCleanupPath(),
+    ];
+
+    expect(realUserHome).not.toBe(userInfo().homedir);
+    for (const path of coordinationPaths) {
+      expectInsideVitestSandbox(path);
+      expectOutsideDirectory(path, realUserHome);
+    }
   });
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,10 +1,24 @@
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { beforeEach } from 'vitest';
+import { beforeEach, vi } from 'vitest';
+
+const sandbox = vi.hoisted(() => ({ root: '' }));
+
+vi.mock('node:os', async importOriginal => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return {
+    ...actual,
+    userInfo: () => ({
+      ...actual.userInfo(),
+      homedir: sandbox.root || actual.userInfo().homedir,
+    }),
+  };
+});
 
 const sandboxRoot = mkdtempSync(join(tmpdir(), 'clodex-vitest-sandbox-'));
 const sandboxHome = join(sandboxRoot, 'clodex-home');
+sandbox.root = sandboxRoot;
 
 function establishSandboxFloor(): void {
   process.env.CLODEX_HOME = sandboxHome;


### PR DESCRIPTION
## Summary

- journal chunk generations and deletion state before publishing credential markers
- use stable config-scoped credential accounts for retryable provider ownership
- serialize provider, credential, and registry mutations across processes
- encrypt filesystem recovery intent with a random per-account key kept in the OS credential store
- allow direct reauthorization after sentinel checks prove the main and chunk namespaces are empty
- preserve opaque, malformed, older, and newer journal data without modifying credentials or chunks
- retire known unverifiable deletion state only after a complete empty-inventory proof
- regenerate unsupported managed-state key material only after proving the credential namespace empty
- link sentinel account and value identities before recognizing removable bookkeeping
- keep credential coordination tests inside temporary native-home sandboxes

## Unreleased branch note

Anyone who ran a commit from this PR before `97c766f` should remove only the unreleased branch's old `clodex-journal:*` entries using the `__relay_chunk_journal__:v1:` prefix before moving to the current branch. Released versions did not write these journals. The current code intentionally treats unknown journal formats as opaque and does not alter their credential state.

## Test plan

- [x] focused keyring regression suite: 101 tests
- [x] complete suite on current `main`: 80 files, 1011 tests
- [x] type checking
- [x] production build
- [x] diff hygiene
- [x] staged secret scan
- [x] focused review of recovery, encryption, deletion, and test isolation
