### PR TITLE
ci: run tests on pull requests, add CONTRIBUTING.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+# Runs on every pull request and every push to main. Deliberately NOT gated behind
+# CLODEX_PUBLISH_ENABLED: that variable exists to keep the *release* machinery dormant
+# outside the dedicated repo, but typecheck/test/build publish nothing and should always
+# run — a PR with no CI signal is the failure mode this workflow exists to prevent.
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+# A new push to a PR branch cancels the in-flight run for that branch; main is never
+# cancelled so every landed commit keeps its own result.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      # Corepack reads the pinned pnpm version from package.json's packageManager field.
+      - run: corepack enable
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck
+      - run: pnpm test
+      - run: pnpm build

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -11,9 +11,13 @@ permissions:
 
 jobs:
   commitlint:
-    # Keep this inert in relay-ai; enable it with the rest of the release system
-    # after migration by setting CLODEX_PUBLISH_ENABLED=true.
-    if: vars.CLODEX_PUBLISH_ENABLED == 'true'
+    # Deliberately ungated. This previously carried
+    # `if: vars.CLODEX_PUBLISH_ENABLED == 'true'` to stay inert in relay-ai before
+    # the migration to a dedicated repo. That gate silently broke the check for the
+    # contributors who need it most: repository variables do not resolve for
+    # `pull_request` runs from a fork, so `vars.CLODEX_PUBLISH_ENABLED` was empty
+    # there and the job reported "skipped" — a green check that never ran. Linting
+    # commit messages publishes nothing, so there is nothing to gate.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,180 @@
+# Contributing to clodex
+
+Contributions are welcome — bug reports, fixes, and features all.
+
+clodex bridges Claude Code to OpenAI models. A lot of its behavior encodes real production
+failures that aren't obvious from reading the code, so this guide is mostly about the
+context you can't infer from the diff. Please skim it before opening a PR; it should save
+you rework.
+
+## Before you start
+
+**Small changes** — bug fixes, docs, tests, a focused improvement — just open a PR. No
+ceremony needed.
+
+**Larger changes** — anything touching a subsystem, spanning several files, or changing
+behavior users depend on — please open an issue first. This isn't a gate, and you won't be
+turned away for skipping it. It's to protect your time: clodex has invariants that look
+arbitrary until you know the failure they came from, and it's much cheaper to sort that out
+in an issue than after you've written the code.
+
+**Read [`CLAUDE.md`](./CLAUDE.md).** Despite the name it's the architecture document for the
+whole repo, and it's the single best thing to read before changing anything. It explains
+what each module does and, more importantly, *why* several of them are shaped the way they
+are.
+
+## Scoping your PR
+
+This is the guidance most worth following, because it's the one that's hard to see from
+inside a single PR.
+
+**One coherent change per PR — but keep a coherent change together.** If a fix requires
+touching four files, that's one PR with four files, not four PRs. The unit is the change,
+not the file.
+
+**Don't split one subsystem across parallel PRs.** This is the big one. Several
+independent PRs that each rework the same area will each look reasonable in isolation
+and still collide badly in aggregate: whoever merges first wins, and everyone else
+rebases into a conflict they couldn't have predicted. Worse, reviewing them separately
+hides design disagreements — two PRs can extend the same type in two incompatible
+directions and neither review will catch it, because the conflict doesn't exist in either
+diff.
+
+If you find yourself opening a third PR against the same subsystem, that's a signal the
+work wanted to be one PR (or an issue first).
+
+**Prefer a few well-scoped PRs over many micro-PRs.** Three or four substantial,
+self-contained PRs are easier to review and land than six or more fine-grained ones
+that share files. Splitting has real costs — reviewer context, merge conflicts,
+integration risk — and they're paid per-PR.
+
+**If your changes genuinely must stack, say so.** Note the dependency and intended merge
+order in the PR description, and target each PR at the branch it builds on rather than
+`main`. That makes the diffs readable and the order explicit.
+
+## Quality bar
+
+These are the standards that matter most here, in rough order of how often they're missed:
+
+**Verify the code path you're changing is actually reachable.** Before fixing behavior,
+confirm that the path can execute in a real configuration. clodex is a trimmed fork of a
+broader project, and some code is vestigial — it supports providers and options that no
+longer ship. A fix to an unreachable path passes review and CI while the real bug survives
+untouched.
+
+**Tests must be behavioral.** The test for a fix should fail if you revert the fix. Tests
+that assert structure, restate the implementation, or exercise fixtures that can't occur
+in practice give false confidence — they pass whether or not the bug is fixed. If you add
+a lot of tests, make sure at least one of them actually pins the behavior you changed.
+
+**Follow existing patterns rather than introducing parallel ones.** Where the codebase
+already solves a problem — file locking, credential resolution, stale-state detection —
+match the established approach. `CLAUDE.md` documents several of these explicitly. A new
+mechanism that's subtly weaker than the existing one is harder to spot than an obvious bug.
+
+**Don't leave no-op edits behind.** A conditional whose branches are identical, an option
+that's parsed but never read, a helper that's implemented but never called — these read as
+finished work and quietly aren't. If you started a change and decided against it, revert it
+rather than leaving the scaffolding.
+
+**Update every consumer.** When you change a representation — a type, a stored format, a
+sentinel value — search the tree for existing readers of the old form. A missed consumer is
+where the real bug hides, especially in auth code, where the failure mode is silent rather
+than loud.
+
+**Consider the upgrade path.** If a change affects data persisted in `~/.clodex` or the
+system keychain, make sure an existing install still works after upgrading, or add a
+migration.
+
+## Development
+
+```bash
+corepack enable          # activates the pinned pnpm version
+pnpm install
+pnpm build               # compile TypeScript → dist/
+pnpm test                # vitest
+pnpm typecheck           # tsc --noEmit
+pnpm dev                 # watch mode
+
+pnpm vitest run tests/patcher.test.ts    # a single test file
+```
+
+Development targets **Node 24** (`.nvmrc` pins the version; CI runs 24). The published
+package supports **Node >= 22**, so don't use APIs newer than Node 22 in `src/`.
+
+The package manager is **pnpm**, pinned via `packageManager` in `package.json` and
+activated through corepack. Dependencies are **exact-pinned** — no `^` or `~`. Note that
+`pnpm-workspace.yaml` sets `minimumReleaseAge`, so a dependency version younger than ten
+days can't be resolved; already-locked versions install normally.
+
+Before opening a PR, run:
+
+```bash
+pnpm typecheck && pnpm test && pnpm build
+```
+
+CI runs exactly these three on every pull request.
+
+## Commits
+
+This repo uses [Conventional Commits](https://www.conventionalcommits.org/) — releases and
+the changelog are generated from commit messages, so the format is enforced by commitlint
+both locally (a Husky `commit-msg` hook) and in CI.
+
+| Prefix | Use for |
+| --- | --- |
+| `feat:` | adds a feature |
+| `fix:` | fixes behavior |
+| `docs:` | documentation only |
+| `test:` | tests only |
+| `refactor:` | no behavior change |
+| `build:` / `ci:` / `chore:` | maintenance |
+
+Add `!` after the type (`feat!:`) or a `BREAKING CHANGE:` footer for an incompatible change.
+
+A scope is encouraged where it's obvious — `fix(auth):`, `feat(wrapper):`.
+
+## Manual testing
+
+Much of clodex can't be covered by the automated suite, because it involves launching
+Claude Code against a real provider. The tests cover pure functions; interactive launch
+flows and real-provider behavior are verified by hand.
+
+If your change touches a launch path, please say in the PR description what you exercised
+manually. Useful commands:
+
+```bash
+clodex claude --dry-run     # full wizard, preview instead of launch, no writes
+clodex claude --trace       # debug logs to ~/.clodex/logs/
+clodex models --list        # print model names + aliases
+clodex server               # foreground gateway
+```
+
+Use `CLODEX_HOME=$(mktemp -d)` to exercise the CLI against throwaway config instead of your
+real `~/.clodex`.
+
+## A few hard rules
+
+- **Never commit `dist/`.** It's gitignored and rebuilt by CI.
+- **Never run `npm publish`.** Releases are automated; publishing is staged via CI and
+  approved by a maintainer.
+- **Never hardcode a version string.** `package.json` is the single source of truth.
+- **Never add `claude -p` end-to-end tests to the automated suite.** They're manual only.
+- **Don't restructure `src/oauth/responses-websocket.ts`.** The OAuth WebSocket
+  continuation logic took extensive real-world testing. Surgical changes only.
+- **Don't touch `~/.claude/settings.json`** from clodex code, and never mutate a legacy
+  `~/.relay-ai` directory.
+
+More context for all of these is in `CLAUDE.md`.
+
+## Review
+
+PRs are reviewed manually, and review may include running the change locally. Expect
+questions about reachability, test coverage of the actual fix, and interaction with other
+in-flight PRs — those are the three things that most often need another pass.
+
+If a review asks for changes, that's normal and not a rejection. If you disagree with a
+review comment, say so; the reasoning behind an invariant is sometimes wrong or no longer
+applies, and that's worth knowing.
+
+Thanks for contributing.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ You can also run clodex as a local OpenAI-compatible endpoint in front of your C
 
 > clodex is derived from the original [relay-ai](https://github.com/jacob-bd/relay-ai) project, heavily modified and streamlined for this one use case, with the full commit history preserved.
 
+Contributions are welcome — see [CONTRIBUTING.md](./CONTRIBUTING.md) for how to scope a PR and what the quality bar is.
+
 ## Quick Start (ChatGPT/Codex plan)
 
 ```bash


### PR DESCRIPTION
## Summary

Pull requests currently run no tests. The `test` job (typecheck + test + build) lives in `release-please.yml`, which triggers only on `push` to `main`, so the only check a PR gets today is commitlint — and that just validates commit message format. Recent PRs merged with no automated verification of their claims.

This adds a dedicated `CI` workflow running the same three commands on every pull request and every push to `main`.

Two deliberate choices:

- **Not gated behind `CLODEX_PUBLISH_ENABLED`.** That variable keeps the *release* machinery dormant outside the dedicated repo. Typecheck, test, and build publish nothing, and a PR without CI signal is precisely what this prevents.
- **Concurrency cancels superseded PR runs**, but never cancels `main`, so every landed commit keeps its own result.

Also adds `CONTRIBUTING.md`, covering:

- PR scoping — keep a coherent change together, and don't split one subsystem across parallel PRs (several recent PRs each reworked `src/registry/` independently; each looked fine alone and they collided on merge)
- Quality bar — verify the path you're changing is reachable, tests must fail if the fix is reverted, follow existing patterns, update every consumer of a changed representation
- Toolchain, conventional commits, manual testing, and the hard rules already documented in `CLAUDE.md`

Plus a one-line pointer from the README.

## Test plan

- [x] `pnpm typecheck`, `pnpm test` (629 tests / 64 files), `pnpm build` all green locally
- [x] Both workflow files parse as valid YAML; the new job mirrors the existing 7-step job
- [ ] This PR's own CI run is the live check — a `pull_request` workflow added in a PR runs on that PR