### PR TITLE
fix(auth): enforce anonymous credential boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,10 @@ clodex --version    # version
   FAT, exFAT, or a network mount that rejects hard links. An abrupt process kill
   during lock publication can leave a `providers.json.lock.*.tmp` file; it does
   not block later lock acquisition and can be removed when no Clodex process is
-  running.
+  running. If `providers.json.lock` remains after a crash, stop every Clodex
+  process and verify that the recorded PID is not a running Clodex process before
+  removing the lock. Never remove the canonical lock while a Clodex process is
+  active.
 - Credentials live in the OS credential store (Keychain / Windows Credential Manager / Secret Service) under the `clodex` service. Set `CLODEX_CREDENTIAL_HELPER` to an absolute executable path to use an external secure store instead; see [credential helpers](docs/credential-helpers.md).
 - `CLODEX_CLAUDE_PATH` overrides Claude Code binary discovery.
 - **Outbound proxy:** when `HTTP_PROXY`/`HTTPS_PROXY` (and optionally `NO_PROXY`) are set in clodex's environment, all clodex-originated network calls honor them — OAuth sign-in and token refresh, model-list and models.dev refreshes, upstream OpenAI API calls, and the ChatGPT/Codex OAuth WebSocket transport (tunneled via HTTP CONNECT).

--- a/README.md
+++ b/README.md
@@ -219,11 +219,13 @@ clodex --version    # version
   FAT, exFAT, or a network mount that rejects hard links. An abrupt process kill
   during lock publication can leave a `providers.json.lock.*.tmp` file; it does
   not block later lock acquisition and can be removed when no Clodex process is
-  running. If `providers.json.lock` remains after a crash, stop every Clodex
-  process and verify that the recorded PID is not a running Clodex process before
-  removing the lock. Never remove the canonical lock while a Clodex process is
-  active.
+  running. A canonical `providers.json.lock` whose recorded PID is no longer
+  running is reclaimed automatically on the next lock acquisition. If it remains
+  while that PID is active, stop every Clodex process and verify the recorded PID
+  before removing the lock manually. Never remove the canonical lock while a
+  Clodex process is active.
 - Credentials live in the OS credential store (Keychain / Windows Credential Manager / Secret Service) under the `clodex` service. Set `CLODEX_CREDENTIAL_HELPER` to an absolute executable path to use an external secure store instead; see [credential helpers](docs/credential-helpers.md).
+- Proxied routes forward configured provider headers for API-key and OAuth authentication. Anonymous routes preserve non-credential headers while removing authorization, API-key, cookie, token, secret, and credential-bearing header names before dispatch.
 - `CLODEX_CLAUDE_PATH` overrides Claude Code binary discovery.
 - **Outbound proxy:** when `HTTP_PROXY`/`HTTPS_PROXY` (and optionally `NO_PROXY`) are set in clodex's environment, all clodex-originated network calls honor them — OAuth sign-in and token refresh, model-list and models.dev refreshes, upstream OpenAI API calls, and the ChatGPT/Codex OAuth WebSocket transport (tunneled via HTTP CONNECT).
 

--- a/docs/credential-helpers.md
+++ b/docs/credential-helpers.md
@@ -18,8 +18,9 @@ OS keyring or an environment variable.
 
 Changing `CLODEX_CREDENTIAL_HELPER` to a different path does not redirect old
 references. Clodex refuses the operation before starting the new helper. Restore
-the prior path to read or delete the old credential, or reauthenticate to create
-a reference owned by the new helper.
+the prior path to read or delete the old credential. Reauthentication creates a
+reference owned by the new helper, but does not delete the credential from the
+previous store; remove that credential with the previous backend's tooling.
 
 Clodex verifies the selected store with a disposable write, read, and delete
 before starting device authorization. It also reads back real credential
@@ -71,5 +72,6 @@ executable wrapper. Clodex intentionally does not evaluate a shell command from
 this setting.
 
 Existing `keyring:` and `env:` provider references retain their original
-behavior. Enabling a helper affects newly saved credentials; reauthenticate a
-provider to move it to the helper-backed store.
+behavior. Enabling a helper affects newly saved credentials. Reauthentication
+stores future credentials in the helper-backed store while the previous store
+remains unchanged until its credential is explicitly removed.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1264,6 +1264,9 @@ export async function runClaudeCommand(parsed: ParsedArgs): Promise<number> {
   const usesAnthropicProxy = selectedModel.modelFormat === 'anthropic' &&
     (isOAuthAnthropic || anonymousProvider);
 
+  // Static provider headers remain part of the proxied endpoint contract,
+  // including OAuth routes. Anonymous dispatch filters credential-bearing
+  // names at the final boundary while retaining non-credential metadata.
   if (usesAnthropicProxy) {
     // The passthrough proxy owns upstream authentication for OAuth and strips it
     // entirely for explicitly anonymous Anthropic endpoints.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1249,7 +1249,8 @@ export async function runClaudeCommand(parsed: ParsedArgs): Promise<number> {
   }
 
   const launchApiKey = await resolveLocalProviderApiKey(activeProvider);
-  if (!launchApiKey?.trim()) {
+  const anonymousProvider = activeProvider.authType === 'none';
+  if (!anonymousProvider && !launchApiKey?.trim()) {
     p.log.error(
       `No credential found for ${activeProvider.name}. Add a key or sign in with clodex providers.`,
     );
@@ -1260,9 +1261,12 @@ export async function runClaudeCommand(parsed: ParsedArgs): Promise<number> {
   let childEnv: NodeJS.ProcessEnv;
 
   const isOAuthAnthropic = selectedModel.modelFormat === 'anthropic' && activeProvider.authType === 'oauth';
+  const usesAnthropicProxy = selectedModel.modelFormat === 'anthropic' &&
+    (isOAuthAnthropic || anonymousProvider);
 
-  if (isOAuthAnthropic) {
-    // Anthropic OAuth passthrough — proxy injects compatibility metadata and Bearer auth.
+  if (usesAnthropicProxy) {
+    // The passthrough proxy owns upstream authentication for OAuth and strips it
+    // entirely for explicitly anonymous Anthropic endpoints.
     try {
       proxyHandle = await startProxy(
         selectedModel.baseUrl ?? 'https://api.anthropic.com',
@@ -1271,16 +1275,17 @@ export async function runClaudeCommand(parsed: ParsedArgs): Promise<number> {
         selectedModel.contextWindow,
         {
           providerId: activeProvider.id,
-          authType: 'oauth',
+          authType: activeProvider.authType,
           oauthAccountId: activeProvider.oauthAccountId,
           providerData: activeProvider.providerData,
           modelFormat: 'anthropic',
+          headers: activeProvider.headers,
         },
-        launchApiKey,
+        launchApiKey ?? '',
       );
-      if (!isAgentStdoutMode()) p.log.info(`OAuth proxy started on port ${proxyHandle.port}`);
+      if (!isAgentStdoutMode()) p.log.info(`Anthropic proxy started on port ${proxyHandle.port}`);
     } catch (err) {
-      p.log.error(`Failed to start OAuth proxy: ${err instanceof Error ? err.message : String(err)}`);
+      p.log.error(`Failed to start Anthropic proxy: ${err instanceof Error ? err.message : String(err)}`);
       return 1;
     }
     childEnv = buildChildEnv(
@@ -1294,7 +1299,7 @@ export async function runClaudeCommand(parsed: ParsedArgs): Promise<number> {
     childEnv = buildChildEnv(
       selectedModel.baseUrl!,
       selectedModel.id,
-      launchApiKey,
+      launchApiKey ?? '',
       undefined,
       selectedModel.contextWindow,
     );
@@ -1317,8 +1322,9 @@ export async function runClaudeCommand(parsed: ParsedArgs): Promise<number> {
           interleavedReasoningField: selectedModel.interleavedReasoningField,
           useResponsesLite: selectedModel.useResponsesLite,
           preferWebSockets: selectedModel.preferWebSockets,
+          headers: activeProvider.headers,
         },
-        launchApiKey,
+        launchApiKey ?? '',
       );
       if (!isAgentStdoutMode()) {
         p.log.info(
@@ -1339,7 +1345,7 @@ export async function runClaudeCommand(parsed: ParsedArgs): Promise<number> {
     );
   }
 
-  if (selectedModel.modelFormat === 'anthropic' && !isOAuthAnthropic) {
+  if (selectedModel.modelFormat === 'anthropic' && !usesAnthropicProxy) {
     childEnv['CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS'] = '1';
   }
 

--- a/src/credential-headers.ts
+++ b/src/credential-headers.ts
@@ -1,0 +1,6 @@
+const CREDENTIAL_BEARING_HEADER =
+  /(?:^|[-_])(?:authorization|api[-_]?key|cookie|token|secret|credential)(?:$|[-_])/i;
+
+export function isCredentialBearingHeader(name: string): boolean {
+  return CREDENTIAL_BEARING_HEADER.test(name);
+}

--- a/src/favorites-resolver.ts
+++ b/src/favorites-resolver.ts
@@ -99,7 +99,11 @@ export async function buildFavoritesList(
   const capacitySkippedFavorites: FavoriteModel[] = [];
   for (let i = 0; i < uniqueFavorites.length; i++) {
     const resolved = resolutions[i];
-    if (!resolved || (options.dropEmptyApiKey && !resolved.apiKey.trim())) {
+    if (!resolved || (
+      options.dropEmptyApiKey &&
+      !resolved.apiKey.trim() &&
+      resolved.authType !== 'none'
+    )) {
       droppedFavorites.push(uniqueFavorites[i]!);
       continue;
     }

--- a/src/http-proxy/routes.ts
+++ b/src/http-proxy/routes.ts
@@ -66,7 +66,7 @@ export function buildHttpProxyRoutes(
       continue;
     }
     const route = localModelToRoute(provider, model);
-    if (!route || !route.apiKey.trim()) {
+    if (!route || (!route.apiKey.trim() && route.authType !== 'none')) {
       unavailable.push(favorite);
       continue;
     }

--- a/src/provider-catalog.ts
+++ b/src/provider-catalog.ts
@@ -28,16 +28,14 @@ export function providersForPicker(providers: LocalProvider[]): LocalProvider[] 
 
 /** Resolve API key when provider.apiKey is empty (registry authRef or OAuth credential store). */
 export async function resolveLocalProviderApiKey(provider: LocalProvider): Promise<string | null> {
-  if (provider.authRef === 'none:anonymous') return 'anonymous';
+  if (provider.authRef === 'none:anonymous' || provider.authType === 'none') return '';
 
   const direct = provider.apiKey?.trim();
   if (direct) return direct;
-  
-  if (provider.authType === 'none') return 'anonymous';
 
   const template = getTemplateById(provider.id);
   if (template?.apiKeyOptional || template?.anonymousFreeModels) {
-    return 'anonymous';
+    return '';
   }
 
   const reg = loadRegistry().providers.find(p => p.id === provider.id);

--- a/src/provider-factory.ts
+++ b/src/provider-factory.ts
@@ -13,6 +13,7 @@ import {
   CLAUDE_CODE_USER_AGENT,
   injectClaudeIdentity,
 } from './oauth/claude-identity.js';
+import { isCredentialBearingHeader } from './credential-headers.js';
 
 /** Models that must use /v1/responses instead of /v1/chat/completions. */
 const RESPONSES_ONLY_PREFIXES = [
@@ -41,8 +42,9 @@ const fetchWithoutCredentialHeaders: typeof fetch = (input, init) => {
   const headers = new Headers(
     init?.headers ?? (input instanceof Request ? input.headers : undefined),
   );
-  headers.delete('authorization');
-  headers.delete('x-api-key');
+  for (const name of [...headers.keys()]) {
+    if (isCredentialBearingHeader(name)) headers.delete(name);
+  }
   return fetch(input, { ...init, headers });
 };
 

--- a/src/provider-factory.ts
+++ b/src/provider-factory.ts
@@ -23,13 +23,28 @@ const RESPONSES_ONLY_PREFIXES = [
   'o4',
 ];
 
-type SdkProviderFactory = (options: { apiKey: string; baseURL?: string; name?: string; headers?: Record<string, string> }) => {
+type SdkProviderFactory = (options: {
+  apiKey: string;
+  baseURL?: string;
+  name?: string;
+  headers?: Record<string, string>;
+  fetch?: typeof fetch;
+}) => {
   (modelId: string): LanguageModel;
   chat: (modelId: string) => LanguageModel;
   responses: (modelId: string) => LanguageModel;
 };
 
 const factoryCache = new Map<string, Promise<SdkProviderFactory>>();
+
+const fetchWithoutCredentialHeaders: typeof fetch = (input, init) => {
+  const headers = new Headers(
+    init?.headers ?? (input instanceof Request ? input.headers : undefined),
+  );
+  headers.delete('authorization');
+  headers.delete('x-api-key');
+  return fetch(input, { ...init, headers });
+};
 
 /**
  * True when a model id must use the OpenAI/xAI Responses API instead of
@@ -177,7 +192,9 @@ export async function createLanguageModel(spec: ProviderModelSpec): Promise<Lang
               }
             : {}),
         }
-      : { apiKey };
+      : spec.authType === 'none'
+        ? { apiKey: '', fetch: fetchWithoutCredentialHeaders }
+        : { apiKey };
     const openai = createOpenAI(oauthOptions);
     return useResponsesEndpoint ? openai.responses(modelId) : openai.chat(modelId);
   }
@@ -203,7 +220,9 @@ export async function createLanguageModel(spec: ProviderModelSpec): Promise<Lang
               }
             : {}),
         }
-      : { apiKey };
+      : spec.authType === 'none'
+        ? { apiKey: '', fetch: fetchWithoutCredentialHeaders }
+        : { apiKey };
     if (spec.headers) {
       anthropicOptions.headers = { ...anthropicOptions.headers, ...spec.headers };
     }
@@ -220,7 +239,8 @@ export async function createLanguageModel(spec: ProviderModelSpec): Promise<Lang
     const options = {
       name: spec.providerId ?? 'openai-compatible',
       baseURL: baseURL ?? '',
-      ...(apiKey.trim() ? { apiKey } : {}),
+      ...(spec.authType !== 'none' && apiKey.trim() ? { apiKey } : {}),
+      ...(spec.authType === 'none' ? { fetch: fetchWithoutCredentialHeaders } : {}),
       ...(spec.headers ? { headers: spec.headers } : {}),
     };
     model = createOpenAICompatible({
@@ -229,7 +249,8 @@ export async function createLanguageModel(spec: ProviderModelSpec): Promise<Lang
   } else {
     const create = await loadSdkProviderFactory(npm);
     const provider = create({
-      apiKey,
+      apiKey: spec.authType === 'none' ? '' : apiKey,
+      ...(spec.authType === 'none' ? { fetch: fetchWithoutCredentialHeaders } : {}),
       ...(baseURL ? { baseURL } : {}),
       ...(spec.headers ? { headers: spec.headers } : {}),
     });

--- a/src/provider-factory.ts
+++ b/src/provider-factory.ts
@@ -172,6 +172,7 @@ export async function createLanguageModel(spec: ProviderModelSpec): Promise<Lang
           apiKey,
           baseURL: 'https://chatgpt.com/backend-api/codex',
           headers: {
+            ...spec.headers,
             ...(accountId ? { 'ChatGPT-Account-Id': accountId } : {}),
             originator: 'clodex',
             // Responses-Lite models (backend prefer_websockets/use_responses_lite,
@@ -195,8 +196,12 @@ export async function createLanguageModel(spec: ProviderModelSpec): Promise<Lang
             : {}),
         }
       : spec.authType === 'none'
-        ? { apiKey: '', fetch: fetchWithoutCredentialHeaders }
-        : { apiKey };
+        ? {
+            apiKey: '',
+            ...(spec.headers ? { headers: spec.headers } : {}),
+            fetch: fetchWithoutCredentialHeaders,
+          }
+        : { apiKey, ...(spec.headers ? { headers: spec.headers } : {}) };
     const openai = createOpenAI(oauthOptions);
     return useResponsesEndpoint ? openai.responses(modelId) : openai.chat(modelId);
   }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -368,9 +368,10 @@ export function startProxyCatalog(
       const route = lookupRoute(byAlias, originalModel) ?? defaultRoute;
       const apiKey = route.apiKey;
       const upstreamUrl = route.upstreamUrl;
+      const routeAuthType = route.authType ?? 'api';
 
       plog(() =>
-        `POST /v1/messages - alias=${originalModel} route=${route.realModelId} format=${route.modelFormat} key=${apiKey ? `len:${apiKey.length}` : 'MISSING'}`,
+        `POST /v1/messages - alias=${originalModel} route=${route.realModelId} format=${route.modelFormat} key=${routeAuthType === 'none' ? 'none' : apiKey ? `len:${apiKey.length}` : 'MISSING'}`,
       );
 
       const usesSdkAdapter = isSdkMigratedNpm(route.npm);
@@ -384,7 +385,7 @@ export function startProxyCatalog(
           return;
         }
 
-        if (!apiKey) {
+        if (!apiKey && routeAuthType !== 'none') {
           anthropicError(res, 401, 'Missing API key');
           return;
         }
@@ -393,11 +394,11 @@ export function startProxyCatalog(
         const inboundBeta = Array.isArray(betaHeaderRaw) ? betaHeaderRaw.join(',') : betaHeaderRaw;
         const forwardBody = { ...anthropicBody, model: route.realModelId };
         const targetUrl = `${upstreamUrl}/v1/messages/count_tokens`;
-        const isOAuth = route.authType === 'oauth';
+        const isOAuth = routeAuthType === 'oauth';
         try {
           await relayAnthropicMessages(res, targetUrl, forwardBody, apiKey, false, {
             inboundBeta,
-            authType: isOAuth ? 'oauth' : 'api',
+            authType: routeAuthType,
             log: message => plog(message),
             extraHeaders: route.headers,
             refreshToken: route.refreshToken,
@@ -413,7 +414,7 @@ export function startProxyCatalog(
         return;
       }
 
-      if (!apiKey && !usesSdkAdapter) {
+      if (!apiKey && routeAuthType !== 'none' && !usesSdkAdapter) {
         anthropicError(res, 401, 'Missing API key');
         return;
       }
@@ -426,7 +427,7 @@ export function startProxyCatalog(
         const inboundBeta = Array.isArray(betaHeaderRaw) ? betaHeaderRaw.join(',') : betaHeaderRaw;
         const forwardBody = { ...anthropicBody, model: route.realModelId };
         const targetUrl = `${upstreamUrl}/v1/messages`;
-        const isOAuth = route.authType === 'oauth';
+        const isOAuth = routeAuthType === 'oauth';
 
         let effectiveBeta = inboundBeta;
         let claudeCodeSessionId: string | undefined;
@@ -446,7 +447,7 @@ export function startProxyCatalog(
         try {
           await relayAnthropicMessages(res, targetUrl, forwardBody, apiKey, clientWantsStream, {
             inboundBeta: effectiveBeta,
-            authType: isOAuth ? 'oauth' : 'api',
+            authType: routeAuthType,
             log: message => plog(message),
             claudeCodeSessionId,
             extraHeaders: route.headers,
@@ -709,6 +710,7 @@ export function startProxy(
     interleavedReasoningField?: string;
     useResponsesLite?: boolean;
     preferWebSockets?: boolean;
+    headers?: Record<string, string>;
   },
   apiKey?: string,
 ): Promise<ProxyHandle> {
@@ -733,5 +735,6 @@ export function startProxy(
     interleavedReasoningField: sdk?.interleavedReasoningField,
     useResponsesLite: sdk?.useResponsesLite,
     preferWebSockets: sdk?.preferWebSockets,
+    headers: sdk?.headers,
   }], clientModelId, debug);
 }

--- a/src/registry/crud.ts
+++ b/src/registry/crud.ts
@@ -26,6 +26,10 @@ function credentialStillReferenced(authRef: string, remaining: RegistryProvider[
   return remaining.some(p => p.authRef === authRef);
 }
 
+function isStoredCredentialRef(authRef: string): boolean {
+  return authRef.startsWith('keyring:') || authRef.startsWith('helper:');
+}
+
 /** Remove a provider from the registry; delete per-provider keychain entry when safe. */
 export async function removeProviderFromRegistry(
   id: string,
@@ -58,6 +62,7 @@ export async function removeProviderFromRegistry(
       },
       authRefToDelete:
         opts?.deleteCredential !== false &&
+        isStoredCredentialRef(removedProvider.authRef) &&
         !credentialStillReferenced(removedProvider.authRef, registry.providers)
           ? removedProvider.authRef
           : null,

--- a/src/registry/provider-auth.ts
+++ b/src/registry/provider-auth.ts
@@ -176,16 +176,18 @@ export async function authenticateProvider(
       oauthCredentialToKeychainJson(cred),
       (msg) => { nativeDiagMsg = msg; },
     );
+    if (!saved) {
+      throw new Error(
+        `Could not save OAuth tokens to the credential store${nativeDiagMsg ? ` — ${nativeDiagMsg}` : ' — check access and try again'}`,
+      );
+    }
     const registryProvider = await upsertOAuthProvider(
       providerId,
       cred,
       authRef,
     );
-    return { saved, nativeDiagMsg, registryProvider };
+    return { registryProvider };
   });
-  if (!persisted.saved) {
-    p.log.warn(`Could not save OAuth tokens to the credential store — ${persisted.nativeDiagMsg || 'session may not persist.'}`);
-  }
   const { registryProvider } = persisted;
 
   const refreshSpinner = p.spinner();

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -275,7 +275,8 @@ async function handleAnthropicMessages(
     const inboundBeta = Array.isArray(betaHeaderRaw) ? betaHeaderRaw.join(',') : betaHeaderRaw;
     const clientWantsStream = Boolean(body.stream);
     const forwardBody: Record<string, unknown> = { ...body, model: upstreamModelId(model) };
-    const isOAuth = model.authType === 'oauth';
+    const authType = model.authType ?? 'api';
+    const isOAuth = authType === 'oauth';
 
     auditInference(options, {
       requestId,
@@ -304,7 +305,7 @@ async function handleAnthropicMessages(
     plog(() => `anthropic-passthrough → ${messagesUrl} oauth=${isOAuth} stream=${clientWantsStream}`);
     await relayAnthropicMessages(res, messagesUrl, forwardBody, apiKey, clientWantsStream, {
       inboundBeta: effectiveBeta,
-      authType: isOAuth ? 'oauth' : 'api',
+      authType,
       log: message => plog(message),
       claudeCodeSessionId,
       extraHeaders: model.headers,
@@ -481,6 +482,7 @@ async function handleOpenAIChatCompletions(
       requestPreview: getLatestMessagePreview(body.messages, body.system),
     });
     await relayAnthropicMessages(res, completionsUrl, forwardBody, apiKey, Boolean(body.stream), {
+      authType: model.authType ?? 'api',
       onUpstreamError: options.inferenceLogPath
         ? (statusCode, errorContent) => writeInferenceResponseErrorLog(options.inferenceLogPath!, {
             modelId: body.model,

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -483,6 +483,7 @@ async function handleOpenAIChatCompletions(
     });
     await relayAnthropicMessages(res, completionsUrl, forwardBody, apiKey, Boolean(body.stream), {
       authType: model.authType ?? 'api',
+      extraHeaders: model.headers,
       onUpstreamError: options.inferenceLogPath
         ? (statusCode, errorContent) => writeInferenceResponseErrorLog(options.inferenceLogPath!, {
             modelId: body.model,

--- a/src/trace-log.ts
+++ b/src/trace-log.ts
@@ -12,6 +12,7 @@ import { createHash } from 'node:crypto';
 import { join } from 'node:path';
 import pc from 'picocolors';
 import { getLogsPath } from './paths.js';
+import { isCredentialBearingHeader } from './credential-headers.js';
 
 const DIR_MODE = 0o700;
 const FILE_MODE = 0o600;
@@ -283,7 +284,6 @@ export interface WebSocketDiagnosticRequestLogEntry {
 }
 
 const REDACTED_DIAGNOSTIC_HEADER = '[REDACTED]';
-const SENSITIVE_DIAGNOSTIC_HEADER = /(?:^|[-_])(?:authorization|api[-_]?key|cookie|token|secret|credential)(?:$|[-_])/i;
 const CONVERSATION_BODY_FIELDS = new Set(['system', 'messages', 'tools']);
 
 function canonicalDiagnosticValue(value: unknown): unknown {
@@ -315,7 +315,7 @@ export function sanitizeDiagnosticHeaders(
   const out: Record<string, string | string[]> = {};
   for (const [name, value] of Object.entries(headers).sort(([left], [right]) => left.localeCompare(right))) {
     if (value === undefined) continue;
-    out[name.toLowerCase()] = SENSITIVE_DIAGNOSTIC_HEADER.test(name)
+    out[name.toLowerCase()] = isCredentialBearingHeader(name)
       ? REDACTED_DIAGNOSTIC_HEADER
       : value;
   }

--- a/src/upstream-forward.ts
+++ b/src/upstream-forward.ts
@@ -2,6 +2,7 @@ import { Readable } from 'node:stream';
 import type { ServerResponse } from 'node:http';
 import { sanitizeCredential } from './server/auth.js';
 import { CLAUDE_CODE_USER_AGENT } from './oauth/claude-identity.js';
+import { isCredentialBearingHeader } from './credential-headers.js';
 
 export function anthropicUpstreamHeaders(
   apiKey: string,
@@ -17,7 +18,7 @@ export function anthropicUpstreamHeaders(
   const forwardedExtraHeaders = resolvedAuthType === 'none'
     ? Object.fromEntries(
         Object.entries(extraHeaders ?? {}).filter(
-          ([name]) => !['authorization', 'x-api-key'].includes(name.toLowerCase()),
+          ([name]) => !isCredentialBearingHeader(name),
         ),
       )
     : extraHeaders;

--- a/src/upstream-forward.ts
+++ b/src/upstream-forward.ts
@@ -7,18 +7,30 @@ export function anthropicUpstreamHeaders(
   apiKey: string,
   stream = false,
   inboundBeta?: string,
-  authType?: 'api' | 'oauth',
+  authType?: 'api' | 'oauth' | 'none',
   claudeCodeSessionId?: string,
   extraHeaders?: Record<string, string>,
 ): Record<string, string> {
   const key = sanitizeCredential(apiKey) ?? apiKey.trim();
-  const isOAuth = authType === 'oauth';
+  const resolvedAuthType = authType ?? 'api';
+  const isOAuth = resolvedAuthType === 'oauth';
+  const forwardedExtraHeaders = resolvedAuthType === 'none'
+    ? Object.fromEntries(
+        Object.entries(extraHeaders ?? {}).filter(
+          ([name]) => !['authorization', 'x-api-key'].includes(name.toLowerCase()),
+        ),
+      )
+    : extraHeaders;
   const headers: Record<string, string> = {
-    ...extraHeaders,
+    ...forwardedExtraHeaders,
     'Content-Type': 'application/json',
     'anthropic-version': '2023-06-01',
-    Authorization: `Bearer ${key}`,
-    ...(isOAuth ? {} : { 'x-api-key': key }),
+    ...(resolvedAuthType === 'none'
+      ? {}
+      : {
+          Authorization: `Bearer ${key}`,
+          ...(isOAuth ? {} : { 'x-api-key': key }),
+        }),
     ...(isOAuth ? { 'User-Agent': CLAUDE_CODE_USER_AGENT, 'x-app': 'cli' } : {}),
     ...(isOAuth && claudeCodeSessionId ? { 'X-Claude-Code-Session-Id': claudeCodeSessionId } : {}),
     ...(stream ? { Accept: 'text/event-stream' } : {}),
@@ -58,7 +70,7 @@ export async function fetchWithOAuthRetry<TResponse extends { status: number }>(
 /** Relay an Anthropic /v1/messages response (JSON or SSE) to the client. */
 export interface RelayAnthropicOptions {
   inboundBeta?: string;
-  authType?: 'api' | 'oauth';
+  authType?: 'api' | 'oauth' | 'none';
   log?: (message: string) => void;
   claudeCodeSessionId?: string;
   extraHeaders?: Record<string, string>;

--- a/tests/credential-headers.test.ts
+++ b/tests/credential-headers.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { isCredentialBearingHeader } from '../src/credential-headers.js';
+
+describe('isCredentialBearingHeader', () => {
+  it.each([
+    'Authorization',
+    'Proxy-Authorization',
+    'X-API-Key',
+    'Cookie',
+    'Set-Cookie',
+    'X-Auth-Token',
+    'X-Client-Secret',
+    'X-Credential-Id',
+  ])('identifies %s as credential-bearing', (name) => {
+    expect(isCredentialBearingHeader(name)).toBe(true);
+  });
+
+  it.each([
+    'Accept',
+    'Content-Type',
+    'User-Agent',
+    'X-Plan',
+    'X-Request-Id',
+  ])('preserves non-credential header %s', (name) => {
+    expect(isCredentialBearingHeader(name)).toBe(false);
+  });
+});

--- a/tests/favorites-resolver.test.ts
+++ b/tests/favorites-resolver.test.ts
@@ -197,6 +197,68 @@ describe('buildFavoritesList', () => {
     expect(resolved).toHaveLength(0);
     expect(droppedFavorites).toEqual(favorites);
   });
+
+  it('retains anonymous favorites while dropping ordinary empty-key providers', async () => {
+    const anonymousProvider: LocalProvider = {
+      id: 'anonymous',
+      name: 'Anonymous',
+      apiKey: '',
+      authType: 'none',
+      models: [{
+        id: 'anonymous-model',
+        name: 'Anonymous Model',
+        family: 'test',
+        brand: 'Test',
+        modelFormat: 'openai',
+        upstreamModelId: 'anonymous-model',
+      }],
+    };
+    const emptyKeyProvider: LocalProvider = {
+      id: 'empty-key',
+      name: 'Empty Key',
+      apiKey: '',
+      authType: 'api',
+      models: [{
+        id: 'empty-key-model',
+        name: 'Empty Key Model',
+        family: 'test',
+        brand: 'Test',
+        modelFormat: 'openai',
+        upstreamModelId: 'empty-key-model',
+      }],
+    };
+    const localProviders = [anonymousProvider, emptyKeyProvider];
+    const favorites: FavoriteModel[] = [
+      { providerId: 'anonymous', modelId: 'anonymous-model' },
+      { providerId: 'empty-key', modelId: 'empty-key-model' },
+    ];
+    const mixedCtx: ResolveContext = {
+      localProviders,
+      findLocalModel: (providerId, modelId) => {
+        const provider = localProviders.find(candidate => candidate.id === providerId);
+        const model = provider?.models.find(candidate => candidate.id === modelId);
+        return provider && model ? { provider, model } : undefined;
+      },
+    };
+
+    const { resolved, droppedFavorites } = await buildFavoritesList(
+      undefined,
+      favorites,
+      mixedCtx,
+      20,
+      { dropEmptyApiKey: true },
+    );
+
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]).toMatchObject({
+      providerId: 'anonymous',
+      apiKey: '',
+      authType: 'none',
+    });
+    expect(droppedFavorites).toEqual([
+      { providerId: 'empty-key', modelId: 'empty-key-model' },
+    ]);
+  });
 });
 
 describe('resolveFirstAvailableFavorite', () => {

--- a/tests/http-proxy-routes.test.ts
+++ b/tests/http-proxy-routes.test.ts
@@ -61,6 +61,22 @@ describe('HTTP proxy routes', () => {
     expect(result.unavailable).toHaveLength(1);
   });
 
+  it('retains an explicitly anonymous route with an empty credential', () => {
+    const anonymous = [{ ...providers[0]!, apiKey: '', authType: 'none' as const }];
+    const favorite = { providerId: 'groq', modelId: 'llama-3.3-70b' };
+
+    const result = buildHttpProxyRoutes(anonymous, [favorite]);
+
+    expect(result.routes).toHaveLength(1);
+    expect(result.routes[0]).toMatchObject({
+      aliasId: 'clodex:groq:llama-3.3-70b[1m]',
+      apiKey: '',
+      authType: 'none',
+    });
+    expect(result.unavailable).toEqual([]);
+    expect(result.unsupported).toEqual([]);
+  });
+
   it('formats the exact freeform Claude model id', () => {
     expect(httpProxyModelId('openrouter', 'deepseek/deepseek-v3')).toBe('clodex:openrouter:deepseek/deepseek-v3');
   });

--- a/tests/provider-auth.test.ts
+++ b/tests/provider-auth.test.ts
@@ -65,7 +65,7 @@ describe('authenticateProvider', () => {
     vi.mocked(probeProviderCredentialStore).mockReset().mockResolvedValue(true);
     lockState.active = false;
     lockState.credentialActive = false;
-    vi.mocked(saveProviderCredential).mockClear();
+    vi.mocked(saveProviderCredential).mockReset().mockResolvedValue(false);
     vi.mocked(saveRegistry).mockClear();
     vi.mocked(runOpenAiDeviceCodeFlow).mockClear();
     vi.mocked(refreshProviderModels).mockClear();
@@ -106,15 +106,23 @@ describe('authenticateProvider', () => {
     expect(saveRegistry).not.toHaveBeenCalled();
   });
 
-  it('warns and continues when token persistence fails (graceful degradation)', async () => {
-    const result = await authenticateProvider('openai');
+  it('rejects before updating the registry or refreshing models when token persistence fails', async () => {
+    vi.mocked(saveProviderCredential).mockImplementationOnce(async (_authRef, _credential, diagnostic) => {
+      diagnostic?.('credential write failed');
+      return false;
+    });
+
+    await expect(authenticateProvider('openai')).rejects.toThrow(
+      'Could not save OAuth tokens to the credential store',
+    );
     expect(saveProviderCredential).toHaveBeenCalled();
-    expect(saveRegistry).toHaveBeenCalled();
-    expect(result.providerId).toBe('openai-oauth');
+    expect(saveRegistry).not.toHaveBeenCalled();
+    expect(refreshProviderModels).not.toHaveBeenCalled();
   });
 
   it('holds the registry lock only while persisting the provider entry', async () => {
     const observations: Array<[string, boolean]> = [];
+    vi.mocked(saveProviderCredential).mockResolvedValueOnce(true);
     vi.mocked(runOpenAiDeviceCodeFlow).mockImplementationOnce(async () => {
       observations.push(['authorization', lockState.active]);
       return {

--- a/tests/provider-catalog-display.test.ts
+++ b/tests/provider-catalog-display.test.ts
@@ -72,9 +72,9 @@ describe('provider-catalog-display', () => {
       expect(env.resolveProviderCredential).toHaveBeenCalledWith('groq', 'keyring:provider:groq');
     });
 
-    it('returns "anonymous" for providers declared authType none', async () => {
+    it('returns an empty credential for providers declared authType none', async () => {
       const provider = { id: 'local', name: 'Local', apiKey: '', authType: 'none', models: [] } as any;
-      expect(await resolveLocalProviderApiKey(provider)).toBe('anonymous');
+      expect(await resolveLocalProviderApiKey(provider)).toBe('');
     });
 
     it('does not resurrect a direct key for an explicitly anonymous provider', async () => {
@@ -86,7 +86,7 @@ describe('provider-catalog-display', () => {
         authType: 'none',
         models: [],
       } as any;
-      expect(await resolveLocalProviderApiKey(provider)).toBe('anonymous');
+      expect(await resolveLocalProviderApiKey(provider)).toBe('');
     });
 
     it('falls back to the OAuth keyring ref when there is no registry authRef and no zen/go/anonymous special case', async () => {

--- a/tests/provider-factory.test.ts
+++ b/tests/provider-factory.test.ts
@@ -259,6 +259,28 @@ describe('createLanguageModel', () => {
     vi.doUnmock('@ai-sdk/openai');
   });
 
+  it('installs credential-header stripping for anonymous OpenAI providers', async () => {
+    const responses = vi.fn((modelId: string) => ({ modelId, provider: 'openai-responses' }));
+    const chat = vi.fn((modelId: string) => ({ modelId, provider: 'openai-chat' }));
+    const createOpenAI = vi.fn(() => ({ responses, chat }));
+    vi.doMock('@ai-sdk/openai', () => ({ createOpenAI }));
+
+    const { createLanguageModel: create } = await import('../src/provider-factory.js');
+    await create({
+      npm: '@ai-sdk/openai',
+      modelId: 'anonymous-model',
+      apiKey: '',
+      authType: 'none',
+    });
+
+    expect(createOpenAI).toHaveBeenCalledWith({
+      apiKey: '',
+      fetch: expect.any(Function),
+    });
+    expect(responses).toHaveBeenCalledWith('anonymous-model');
+    vi.doUnmock('@ai-sdk/openai');
+  });
+
   it('ignores discovery baseURL for @ai-sdk/anthropic (SDK default includes /v1)', async () => {
     const anthropicFactory = vi.fn((modelId: string) => ({ modelId, provider: 'anthropic' }));
     const createAnthropic = vi.fn(() => anthropicFactory);
@@ -363,6 +385,7 @@ describe('createLanguageModel', () => {
       npm: '@ai-sdk/openai-compatible',
       modelId: 'tencent/hy3:free',
       apiKey: '',
+      authType: 'none',
       baseURL: 'https://api.kilo.ai/api/gateway',
       providerId: 'kilo',
     });
@@ -370,8 +393,52 @@ describe('createLanguageModel', () => {
     expect(createOpenAICompatible).toHaveBeenCalledWith({
       name: 'kilo',
       baseURL: 'https://api.kilo.ai/api/gateway',
+      fetch: expect.any(Function),
     });
     vi.doUnmock('@ai-sdk/openai-compatible');
+  });
+
+  it('strips generated credential headers for anonymous Anthropic providers', async () => {
+    const anthropicFactory = vi.fn((modelId: string) => ({ modelId }));
+    const createAnthropic = vi.fn(() => anthropicFactory);
+    vi.doMock('@ai-sdk/anthropic', () => ({ createAnthropic }));
+
+    const { createLanguageModel: create } = await import('../src/provider-factory.js');
+    await create({
+      npm: '@ai-sdk/anthropic',
+      modelId: 'anonymous-model',
+      apiKey: '',
+      authType: 'none',
+      baseURL: 'https://anonymous.example',
+    });
+
+    expect(createAnthropic).toHaveBeenCalledWith({
+      apiKey: '',
+      baseURL: 'https://anonymous.example/v1',
+      fetch: expect.any(Function),
+    });
+    expect(anthropicFactory).toHaveBeenCalledWith('anonymous-model');
+
+    const options = createAnthropic.mock.calls[0]?.[0] as { fetch: typeof fetch };
+    const transport = vi.fn(async () => new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', transport);
+    await options.fetch(new Request('https://anonymous.example/v1/messages', {
+      headers: {
+        Authorization: 'Bearer environment-secret',
+        'x-api-key': 'environment-secret',
+        'Content-Type': 'application/json',
+        'X-Custom': 'preserved',
+      },
+    }));
+
+    const [, init] = transport.mock.calls[0] as unknown as [string, RequestInit];
+    const headers = new Headers(init.headers);
+    expect(headers.has('authorization')).toBe(false);
+    expect(headers.has('x-api-key')).toBe(false);
+    expect(headers.get('content-type')).toBe('application/json');
+    expect(headers.get('x-custom')).toBe('preserved');
+    vi.unstubAllGlobals();
+    vi.doUnmock('@ai-sdk/anthropic');
   });
 
   it('merges custom headers into a non-OAuth custom anthropic endpoint', async () => {

--- a/tests/provider-factory.test.ts
+++ b/tests/provider-factory.test.ts
@@ -12,7 +12,10 @@ import {
 } from '../src/provider-factory.js';
 import { VERTEX_ANTHROPIC_NPM } from '../src/constants.js';
 
-async function expectCredentialHeadersStripped(fetchImpl: typeof fetch): Promise<void> {
+async function expectCredentialHeadersStripped(
+  fetchImpl: typeof fetch,
+  extraHeaders: Record<string, string> = {},
+): Promise<void> {
   const transport = vi.fn(async () => new Response(null, { status: 204 }));
   vi.stubGlobal('fetch', transport);
   try {
@@ -27,6 +30,7 @@ async function expectCredentialHeadersStripped(fetchImpl: typeof fetch): Promise
         'X-Credential-Id': 'configured-value',
         'Content-Type': 'application/json',
         'X-Custom': 'preserved',
+        ...extraHeaders,
       },
     });
 
@@ -45,6 +49,19 @@ async function expectCredentialHeadersStripped(fetchImpl: typeof fetch): Promise
     }
     expect(headers.get('content-type')).toBe('application/json');
     expect(headers.get('x-custom')).toBe('preserved');
+    for (const [name, value] of Object.entries(extraHeaders)) {
+      if (![
+        'authorization',
+        'x-api-key',
+        'cookie',
+        'proxy-authorization',
+        'x-auth-token',
+        'x-client-secret',
+        'x-credential-id',
+      ].includes(name.toLowerCase())) {
+        expect(headers.get(name)).toBe(value);
+      }
+    }
   } finally {
     vi.unstubAllGlobals();
   }
@@ -309,15 +326,49 @@ describe('createLanguageModel', () => {
       modelId: 'anonymous-model',
       apiKey: '',
       authType: 'none',
+      headers: {
+        Authorization: 'Bearer configured-value',
+        'X-Plan': 'free',
+      },
     });
 
     expect(createOpenAI).toHaveBeenCalledWith({
       apiKey: '',
+      headers: {
+        Authorization: 'Bearer configured-value',
+        'X-Plan': 'free',
+      },
       fetch: expect.any(Function),
     });
     expect(responses).toHaveBeenCalledWith('anonymous-model');
-    const options = createOpenAI.mock.calls[0]?.[0] as { fetch: typeof fetch };
-    await expectCredentialHeadersStripped(options.fetch);
+    const options = createOpenAI.mock.calls[0]?.[0] as {
+      fetch: typeof fetch;
+      headers: Record<string, string>;
+    };
+    await expectCredentialHeadersStripped(options.fetch, options.headers);
+    vi.doUnmock('@ai-sdk/openai');
+  });
+
+  it('forwards configured headers for authenticated OpenAI providers', async () => {
+    const responses = vi.fn((modelId: string) => ({ modelId, provider: 'openai-responses' }));
+    const chat = vi.fn((modelId: string) => ({ modelId, provider: 'openai-chat' }));
+    const createOpenAI = vi.fn(() => ({ responses, chat }));
+    vi.doMock('@ai-sdk/openai', () => ({ createOpenAI }));
+
+    const { createLanguageModel: create } = await import('../src/provider-factory.js');
+    await create({
+      npm: '@ai-sdk/openai',
+      modelId: 'authenticated-model',
+      apiKey: 'provider-key',
+      authType: 'api',
+      headers: { 'X-Plan': 'paid' },
+    });
+
+    expect(createOpenAI).toHaveBeenCalledWith({
+      apiKey: 'provider-key',
+      headers: { 'X-Plan': 'paid' },
+    });
+    expect(responses).toHaveBeenCalledWith('authenticated-model');
     vi.doUnmock('@ai-sdk/openai');
   });
 

--- a/tests/provider-factory.test.ts
+++ b/tests/provider-factory.test.ts
@@ -12,6 +12,44 @@ import {
 } from '../src/provider-factory.js';
 import { VERTEX_ANTHROPIC_NPM } from '../src/constants.js';
 
+async function expectCredentialHeadersStripped(fetchImpl: typeof fetch): Promise<void> {
+  const transport = vi.fn(async () => new Response(null, { status: 204 }));
+  vi.stubGlobal('fetch', transport);
+  try {
+    await fetchImpl('https://anonymous.example/v1/messages', {
+      headers: {
+        Authorization: 'Bearer configured-value',
+        'X-API-Key': 'configured-value',
+        Cookie: 'session=configured-value',
+        'Proxy-Authorization': 'Bearer configured-value',
+        'X-Auth-Token': 'configured-value',
+        'X-Client-Secret': 'configured-value',
+        'X-Credential-Id': 'configured-value',
+        'Content-Type': 'application/json',
+        'X-Custom': 'preserved',
+      },
+    });
+
+    const [, init] = transport.mock.calls[0] as unknown as [string, RequestInit];
+    const headers = new Headers(init.headers);
+    for (const name of [
+      'authorization',
+      'x-api-key',
+      'cookie',
+      'proxy-authorization',
+      'x-auth-token',
+      'x-client-secret',
+      'x-credential-id',
+    ]) {
+      expect(headers.has(name)).toBe(false);
+    }
+    expect(headers.get('content-type')).toBe('application/json');
+    expect(headers.get('x-custom')).toBe('preserved');
+  } finally {
+    vi.unstubAllGlobals();
+  }
+}
+
 describe('isSdkMigratedNpm', () => {
   it('returns true for any OpenCode-assigned npm except anthropic', () => {
     expect(isSdkMigratedNpm('@ai-sdk/openai')).toBe(true);
@@ -278,6 +316,8 @@ describe('createLanguageModel', () => {
       fetch: expect.any(Function),
     });
     expect(responses).toHaveBeenCalledWith('anonymous-model');
+    const options = createOpenAI.mock.calls[0]?.[0] as { fetch: typeof fetch };
+    await expectCredentialHeadersStripped(options.fetch);
     vi.doUnmock('@ai-sdk/openai');
   });
 
@@ -395,6 +435,8 @@ describe('createLanguageModel', () => {
       baseURL: 'https://api.kilo.ai/api/gateway',
       fetch: expect.any(Function),
     });
+    const options = createOpenAICompatible.mock.calls[0]?.[0] as { fetch: typeof fetch };
+    await expectCredentialHeadersStripped(options.fetch);
     vi.doUnmock('@ai-sdk/openai-compatible');
   });
 
@@ -420,24 +462,7 @@ describe('createLanguageModel', () => {
     expect(anthropicFactory).toHaveBeenCalledWith('anonymous-model');
 
     const options = createAnthropic.mock.calls[0]?.[0] as { fetch: typeof fetch };
-    const transport = vi.fn(async () => new Response(null, { status: 204 }));
-    vi.stubGlobal('fetch', transport);
-    await options.fetch(new Request('https://anonymous.example/v1/messages', {
-      headers: {
-        Authorization: 'Bearer environment-secret',
-        'x-api-key': 'environment-secret',
-        'Content-Type': 'application/json',
-        'X-Custom': 'preserved',
-      },
-    }));
-
-    const [, init] = transport.mock.calls[0] as unknown as [string, RequestInit];
-    const headers = new Headers(init.headers);
-    expect(headers.has('authorization')).toBe(false);
-    expect(headers.has('x-api-key')).toBe(false);
-    expect(headers.get('content-type')).toBe('application/json');
-    expect(headers.get('x-custom')).toBe('preserved');
-    vi.unstubAllGlobals();
+    await expectCredentialHeadersStripped(options.fetch);
     vi.doUnmock('@ai-sdk/anthropic');
   });
 

--- a/tests/providers-command.test.ts
+++ b/tests/providers-command.test.ts
@@ -7,6 +7,7 @@ import {
   providerHubChoiceValue,
   providersHelpText,
   runProvidersAdd,
+  runProvidersAuth,
   runProvidersRemove,
 } from '../src/providers-command.js';
 import {
@@ -22,6 +23,7 @@ import * as env from '../src/env.js';
 const selectMock = vi.hoisted(() => vi.fn());
 const logErrorMock = vi.hoisted(() => vi.fn());
 const logSuccessMock = vi.hoisted(() => vi.fn());
+const authenticateProviderMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@clack/prompts', async importOriginal => {
   const actual = await importOriginal<typeof import('@clack/prompts')>();
@@ -33,6 +35,14 @@ vi.mock('@clack/prompts', async importOriginal => {
       error: logErrorMock,
       success: logSuccessMock,
     },
+  };
+});
+
+vi.mock('../src/registry/provider-auth.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/registry/provider-auth.js')>();
+  return {
+    ...actual,
+    authenticateProvider: authenticateProviderMock,
   };
 });
 
@@ -189,6 +199,45 @@ describe('registry crud', () => {
     expect(result.credentialDeleted).toBe(false);
     expect(deleteSpy).not.toHaveBeenCalled();
     expect(loadRegistry().providers).toHaveLength(1);
+  });
+
+  it.each([
+    { authRef: 'none:anonymous', authType: 'none' as const },
+    { authRef: 'env:LOCAL_PROVIDER_API_KEY', authType: 'api' as const },
+  ])('removes a provider using $authRef without attempting credential deletion', async ({ authRef, authType }) => {
+    const registry = emptyRegistry();
+    registry.providers.push(openaiEntry({ authRef, authType }));
+    withRegistryWriteLockSync(() => saveRegistry(registry));
+
+    const deleteSpy = vi.spyOn(env, 'deleteProviderCredential').mockResolvedValue(false);
+    const code = await runProvidersRemove('openai');
+
+    expect(code).toBe(0);
+    expect(loadRegistry().providers).toHaveLength(0);
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(logErrorMock).not.toHaveBeenCalled();
+    expect(logSuccessMock).toHaveBeenCalledWith('Removed OpenAI.');
+  });
+});
+
+describe('providers auth command', () => {
+  beforeEach(() => {
+    authenticateProviderMock.mockReset();
+    logErrorMock.mockReset();
+    logSuccessMock.mockReset();
+  });
+
+  it('does not report success when credential persistence rejects authentication', async () => {
+    authenticateProviderMock.mockRejectedValueOnce(
+      new Error('Could not save OAuth tokens to the credential store: credential write failed'),
+    );
+
+    await expect(runProvidersAuth('openai')).resolves.toBe(1);
+
+    expect(logErrorMock).toHaveBeenCalledWith(
+      'Could not save OAuth tokens to the credential store: credential write failed',
+    );
+    expect(logSuccessMock).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -4,7 +4,7 @@ import http from 'node:http';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { aliasModelId, startProxyCatalog, type ProxyRoute } from '../src/proxy.js';
+import { aliasModelId, startProxy, startProxyCatalog, type ProxyRoute } from '../src/proxy.js';
 import { getProxyDebugLogPath } from '../src/trace-log.js';
 import { anthropicMessagesEndpoint, estimateAnthropicInputTokens } from '../src/anthropic-endpoints.js';
 
@@ -82,6 +82,10 @@ describe('aliasModelId', () => {
 });
 
 describe('SDK anonymous route handling', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('does not reject empty upstream keys before SDK routing', async () => {
     const route: ProxyRoute = {
       aliasId: 'anthropic-kilo__tencent/hy3:free',
@@ -147,6 +151,83 @@ describe('SDK anonymous route handling', () => {
       const headers = new Headers(init.headers);
       expect(headers.has('authorization')).toBe(false);
       expect(headers.has('x-api-key')).toBe(false);
+    } finally {
+      handle.close();
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('forwards single-route anonymous messages and token counts without credential headers', async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/v1/messages/count_tokens')) {
+        return new Response('{"input_tokens":17}', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(
+        JSON.stringify({
+          id: 'msg_anonymous',
+          type: 'message',
+          role: 'assistant',
+          model: 'anonymous-model',
+          content: [],
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const handle = await startProxy(
+      'https://anonymous.example',
+      'anonymous-model',
+      false,
+      undefined,
+      {
+        providerId: 'local',
+        authType: 'none',
+        modelFormat: 'anthropic',
+        headers: {
+          Authorization: 'Bearer configured-value',
+          Cookie: 'session=configured-value',
+          'X-Auth-Token': 'configured-value',
+          'X-Custom': 'preserved',
+        },
+      },
+      '',
+    );
+
+    try {
+      const messages = await postToProxy(handle.port, handle.token, {
+        model: 'anonymous-model',
+        max_tokens: 100,
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: false,
+      });
+      const tokens = await postToProxy(handle.port, handle.token, {
+        model: 'anonymous-model',
+        messages: [{ role: 'user', content: 'count this' }],
+      }, undefined, '/v1/messages/count_tokens');
+
+      expect(messages.status).toBe(200);
+      expect(tokens.status).toBe(200);
+      expect(JSON.parse(tokens.body)).toEqual({ input_tokens: 17 });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      const calls = fetchMock.mock.calls as unknown as Array<[string, RequestInit]>;
+      expect(calls.map(([url]) => url)).toEqual([
+        'https://anonymous.example/v1/messages',
+        'https://anonymous.example/v1/messages/count_tokens',
+      ]);
+      for (const [, init] of calls) {
+        const headers = new Headers(init.headers);
+        expect(headers.has('authorization')).toBe(false);
+        expect(headers.has('x-api-key')).toBe(false);
+        expect(headers.has('cookie')).toBe(false);
+        expect(headers.has('x-auth-token')).toBe(false);
+        expect(headers.get('x-custom')).toBe('preserved');
+      }
     } finally {
       handle.close();
       vi.unstubAllGlobals();

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -107,6 +107,51 @@ describe('SDK anonymous route handling', () => {
     expect(res.status).toBe(502);
     expect(res.body).not.toContain('Missing API key');
   });
+
+  it('forwards anonymous Anthropic routes without authentication headers', async () => {
+    const route: ProxyRoute = {
+      aliasId: 'anthropic-local__anonymous-model',
+      realModelId: 'anonymous-model',
+      displayName: 'Anonymous Model',
+      upstreamUrl: 'https://anonymous.example',
+      apiKey: '',
+      authType: 'none',
+      modelFormat: 'anthropic',
+      providerId: 'local',
+    };
+    const fetchMock = vi.fn(async () => new Response(
+      JSON.stringify({
+        id: 'msg_anonymous',
+        type: 'message',
+        role: 'assistant',
+        model: route.realModelId,
+        content: [],
+        usage: { input_tokens: 1, output_tokens: 1 },
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const handle = await startProxyCatalog([route], route.aliasId, false);
+    try {
+      const res = await postToProxy(handle.port, handle.token, {
+        model: route.aliasId,
+        max_tokens: 100,
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: false,
+      });
+
+      expect(res.status).toBe(200);
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+      const headers = new Headers(init.headers);
+      expect(headers.has('authorization')).toBe(false);
+      expect(headers.has('x-api-key')).toBe(false);
+    } finally {
+      handle.close();
+      vi.unstubAllGlobals();
+    }
+  });
 });
 
 describe('catalog model aliases', () => {

--- a/tests/server-router.test.ts
+++ b/tests/server-router.test.ts
@@ -52,6 +52,7 @@ interface UpstreamRequest {
   url: string;
   authorization: string | undefined;
   xApiKey: string | undefined;
+  xPlan?: string;
   body: any;
 }
 
@@ -74,6 +75,9 @@ async function startUpstream(responseBody: any): Promise<{ baseUrl: string; requ
       xApiKey: Array.isArray(req.headers['x-api-key'])
         ? req.headers['x-api-key'][0]
         : req.headers['x-api-key'],
+      xPlan: Array.isArray(req.headers['x-plan'])
+        ? req.headers['x-plan'][0]
+        : req.headers['x-plan'],
       body: await readRequestBody(req),
     });
 
@@ -342,6 +346,10 @@ describe('server router', () => {
         completionsUrl: `${upstream.baseUrl}/v1/chat/completions`,
         apiKey: '',
         authType: 'none',
+        headers: {
+          Authorization: 'Bearer configured-value',
+          'X-Plan': 'free',
+        },
       }]),
     });
 
@@ -362,6 +370,7 @@ describe('server router', () => {
       url: '/v1/chat/completions',
       authorization: undefined,
       xApiKey: undefined,
+      xPlan: 'free',
     });
   });
 

--- a/tests/server-router.test.ts
+++ b/tests/server-router.test.ts
@@ -51,6 +51,7 @@ interface UpstreamRequest {
   method: string;
   url: string;
   authorization: string | undefined;
+  xApiKey: string | undefined;
   body: any;
 }
 
@@ -70,6 +71,9 @@ async function startUpstream(responseBody: any): Promise<{ baseUrl: string; requ
       authorization: Array.isArray(req.headers.authorization)
         ? req.headers.authorization[0]
         : req.headers.authorization,
+      xApiKey: Array.isArray(req.headers['x-api-key'])
+        ? req.headers['x-api-key'][0]
+        : req.headers['x-api-key'],
       body: await readRequestBody(req),
     });
 
@@ -274,6 +278,49 @@ describe('server router', () => {
       url: '/v1/messages',
       authorization: 'Bearer real-opencode-key',
       body: { model: 'claude-native', messages: [{ role: 'user', content: 'hi' }] },
+    });
+  });
+
+  it('forwards anonymous Anthropic-native messages without authentication headers', async () => {
+    const upstream = await startUpstream({
+      id: 'msg-anonymous',
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'text', text: 'anonymous ok' }],
+    });
+    handles.push(upstream);
+    const server = await startTestServer({
+      catalog: createGatewayModelCatalog([{
+        id: 'anonymous-model',
+        name: 'Anonymous Model',
+        isFree: true,
+        brand: 'Other',
+        providerId: 'local',
+        sourceBackend: 'local',
+        modelFormat: 'anthropic',
+        baseUrl: upstream.baseUrl,
+        apiKey: '',
+        authType: 'none',
+      }]),
+    });
+
+    const response = await fetch(`${server.url}/anthropic/v1/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'anonymous-model',
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ id: 'msg-anonymous' });
+    expect(upstream.requests).toHaveLength(1);
+    expect(upstream.requests[0]).toMatchObject({
+      method: 'POST',
+      url: '/v1/messages',
+      authorization: undefined,
+      xApiKey: undefined,
     });
   });
 

--- a/tests/server-router.test.ts
+++ b/tests/server-router.test.ts
@@ -324,6 +324,47 @@ describe('server router', () => {
     });
   });
 
+  it('forwards anonymous OpenAI chat completions without authentication headers', async () => {
+    const upstream = await startUpstream({
+      id: 'chatcmpl-anonymous',
+      choices: [{ message: { content: 'anonymous ok' }, finish_reason: 'stop' }],
+    });
+    handles.push(upstream);
+    const server = await startTestServer({
+      catalog: createGatewayModelCatalog([{
+        id: 'anonymous-chat-model',
+        name: 'Anonymous Chat Model',
+        isFree: true,
+        brand: 'Other',
+        providerId: 'local',
+        sourceBackend: 'go',
+        modelFormat: 'openai',
+        completionsUrl: `${upstream.baseUrl}/v1/chat/completions`,
+        apiKey: '',
+        authType: 'none',
+      }]),
+    });
+
+    const response = await fetch(`${server.url}/openai/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'anonymous-chat-model',
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ id: 'chatcmpl-anonymous' });
+    expect(upstream.requests).toHaveLength(1);
+    expect(upstream.requests[0]).toMatchObject({
+      method: 'POST',
+      url: '/v1/chat/completions',
+      authorization: undefined,
+      xApiKey: undefined,
+    });
+  });
+
   // OpenAI-format Anthropic translation now routes through the Vercel AI SDK adapter
   // (createLanguageModel + streamAnthropicResponse/generateAnthropicResponse), which
   // requires an SDK `npm` on the model. Translation correctness is covered by

--- a/tests/upstream-forward.test.ts
+++ b/tests/upstream-forward.test.ts
@@ -34,17 +34,45 @@ describe('anthropicUpstreamHeaders', () => {
     const headers = anthropicUpstreamHeaders('', false, undefined, 'none', undefined, {
       authorization: 'Bearer configured-secret',
       'X-API-Key': 'configured-secret',
+      Cookie: 'session=configured-secret',
+      'Proxy-Authorization': 'Bearer configured-secret',
+      'X-Auth-Token': 'configured-secret',
+      'X-Client-Secret': 'configured-secret',
+      'X-Credential-Id': 'configured-secret',
       'X-Custom': 'preserved',
     });
 
-    expect(headers).not.toHaveProperty('Authorization');
-    expect(headers).not.toHaveProperty('authorization');
-    expect(headers).not.toHaveProperty('x-api-key');
-    expect(headers).not.toHaveProperty('X-API-Key');
+    for (const name of [
+      'Authorization',
+      'authorization',
+      'x-api-key',
+      'X-API-Key',
+      'Cookie',
+      'Proxy-Authorization',
+      'X-Auth-Token',
+      'X-Client-Secret',
+      'X-Credential-Id',
+    ]) {
+      expect(headers).not.toHaveProperty(name);
+    }
     expect(headers).toMatchObject({
       'Content-Type': 'application/json',
       'anthropic-version': '2023-06-01',
       'X-Custom': 'preserved',
+    });
+  });
+
+  it('preserves configured provider headers for authenticated requests', () => {
+    expect(anthropicUpstreamHeaders(
+      'oauth-token',
+      false,
+      undefined,
+      'oauth',
+      undefined,
+      { 'X-Plan': 'coding' },
+    )).toMatchObject({
+      Authorization: 'Bearer oauth-token',
+      'X-Plan': 'coding',
     });
   });
 });

--- a/tests/upstream-forward.test.ts
+++ b/tests/upstream-forward.test.ts
@@ -29,6 +29,24 @@ describe('anthropicUpstreamHeaders', () => {
       'X-Claude-Code-Session-Id': 'session-123',
     });
   });
+
+  it('omits authentication headers for anonymous requests', () => {
+    const headers = anthropicUpstreamHeaders('', false, undefined, 'none', undefined, {
+      authorization: 'Bearer configured-secret',
+      'X-API-Key': 'configured-secret',
+      'X-Custom': 'preserved',
+    });
+
+    expect(headers).not.toHaveProperty('Authorization');
+    expect(headers).not.toHaveProperty('authorization');
+    expect(headers).not.toHaveProperty('x-api-key');
+    expect(headers).not.toHaveProperty('X-API-Key');
+    expect(headers).toMatchObject({
+      'Content-Type': 'application/json',
+      'anthropic-version': '2023-06-01',
+      'X-Custom': 'preserved',
+    });
+  });
 });
 
 describe('fetchWithOAuthRetry', () => {


### PR DESCRIPTION
## Summary

- represent explicitly anonymous providers without sentinel credentials throughout catalog resolution and routing
- enforce one credential-header classifier across SDK forwarding, native forwarding, and diagnostic redaction
- remove authorization, API-key, cookie, token, secret, and credential-bearing headers from anonymous dispatch while preserving ordinary metadata
- intentionally retain configured provider headers on authenticated API-key and OAuth proxy routes
- fail credential activation before registry updates when secure persistence fails
- clarify automatic dead-PID lock reclamation and the narrow manual-removal case

## Boundary guarantees

- process-level credential defaults cannot attach to anonymous upstream requests
- configured credential-bearing headers cannot cross an anonymous dispatch boundary
- URL-plus-init request headers are filtered for each supported provider family
- single-route messages, token counting, and alternate chat forwarding preserve the anonymous boundary on the wire
- diagnostic redaction and outbound filtering cannot drift to different header-name rules

## Test plan

- [x] focused header, provider, proxy, and route suite (104 tests across 6 files)
- [x] full Node 24 container suite (717 tests across 70 files)
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `git diff --cached --check`
- [x] staged secret and personal-identifier scans
