### PR TITLE
fix(server): wait for listener readiness

### DIFF
--- a/src/http-proxy/server.ts
+++ b/src/http-proxy/server.ts
@@ -1,7 +1,7 @@
 import * as http from 'node:http';
 import * as https from 'node:https';
 import * as net from 'node:net';
-import type { Socket } from 'node:net';
+import type { AddressInfo, Socket } from 'node:net';
 import { randomUUID } from 'node:crypto';
 import { URL } from 'node:url';
 import { createBrotliDecompress, createGunzip, createInflate } from 'node:zlib';
@@ -10,6 +10,7 @@ import { startProxyCatalog } from '../proxy.js';
 import { ensureHttpProxyCertificates } from './ca.js';
 import { routeLookupIds } from '../context-model-id.js';
 import type { ResolvedHttpProxyAlias } from './routes.js';
+import { listenTcpServer } from '../listener-ready.js';
 import { anthropicEffortFromRequest, extractClaudeSessionId, type AnthropicRequest } from '../sdk-adapter.js';
 import { anthropicMessagesEndpoint } from '../anthropic-endpoints.js';
 import {
@@ -860,23 +861,16 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
     });
   });
 
+  let address: AddressInfo;
   try {
-    await new Promise<void>((resolve, reject) => {
-      proxyServer.once('error', reject);
-      proxyServer.listen(options.port ?? 0, options.host ?? '127.0.0.1', () => {
-        proxyServer.off('error', reject);
-        resolve();
-      });
-    });
+    address = await listenTcpServer(
+      proxyServer,
+      options.port ?? 0,
+      options.host ?? '127.0.0.1',
+    );
   } catch (err) {
     adapter?.close();
     throw err;
-  }
-
-  const address = proxyServer.address();
-  if (!address || typeof address === 'string') {
-    adapter?.close();
-    throw new Error('HTTP proxy did not bind to a TCP port');
   }
 
   return {

--- a/src/listener-ready.ts
+++ b/src/listener-ready.ts
@@ -1,0 +1,85 @@
+import { connect, type AddressInfo, type Server } from 'node:net';
+import { setTimeout as delay } from 'node:timers/promises';
+
+const LISTENER_READY_TIMEOUT_MS = 1_000;
+const LISTENER_READY_RETRY_MS = 5;
+
+function connectHost(address: string): string {
+  if (address === '0.0.0.0') return '127.0.0.1';
+  if (address === '::') return '::1';
+  return address;
+}
+
+/** Return a reachable host formatted for use in an HTTP URL. */
+export function tcpListenerUrlHost(address: string): string {
+  const host = connectHost(address);
+  return host.includes(':') ? `[${host}]` : host;
+}
+
+function probeTcpListener(host: string, port: number, timeoutMs: number): Promise<boolean> {
+  return new Promise(resolve => {
+    const socket = connect({ host, port });
+    let settled = false;
+    const finish = (ready: boolean) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(ready);
+    };
+    socket.once('connect', () => finish(true));
+    socket.once('error', () => finish(false));
+    socket.setTimeout(timeoutMs, () => finish(false));
+  });
+}
+
+async function closeAfterReadinessFailure(server: Server): Promise<void> {
+  if (!server.listening) return;
+  await new Promise<void>(resolve => server.close(() => resolve()));
+}
+
+/** Bind a TCP server and wait until the bound socket accepts connections. */
+export async function listenTcpServer(
+  server: Server,
+  port: number,
+  host: string,
+): Promise<AddressInfo> {
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = () => server.off('error', onError);
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    server.once('error', onError);
+    try {
+      server.listen(port, host, () => {
+        cleanup();
+        resolve();
+      });
+    } catch (error) {
+      cleanup();
+      reject(error);
+    }
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    await closeAfterReadinessFailure(server);
+    throw new Error('TCP server did not bind to a network address');
+  }
+
+  const probeHost = connectHost(address.address);
+  const deadline = Date.now() + LISTENER_READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const remaining = deadline - Date.now();
+    if (await probeTcpListener(probeHost, address.port, Math.min(remaining, 50))) {
+      return address;
+    }
+    await delay(Math.min(LISTENER_READY_RETRY_MS, Math.max(1, deadline - Date.now())));
+  }
+
+  await closeAfterReadinessFailure(server);
+  throw new Error(
+    `TCP listener did not become reachable within ${LISTENER_READY_TIMEOUT_MS}ms: `
+      + `${probeHost}:${address.port}`,
+  );
+}

--- a/src/oauth/callback-server.ts
+++ b/src/oauth/callback-server.ts
@@ -3,6 +3,7 @@
 // This is only used when running `clodex providers auth <provider>` without the GUI.
 
 import http from 'node:http';
+import { listenTcpServer } from '../listener-ready.js';
 
 export interface CallbackParams {
   code: string;
@@ -25,44 +26,37 @@ const SUCCESS_HTML = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Au
 <p style="color:#666">You can close this tab and return to the terminal.</p>
 </div></body></html>`;
 
-export function startCallbackServer(): Promise<CallbackServer> {
-  return new Promise((resolve, reject) => {
-    let codeResolve: ((p: CallbackParams) => void) | undefined;
-    let codeReject: ((e: Error) => void) | undefined;
+export async function startCallbackServer(): Promise<CallbackServer> {
+  let codeResolve: ((p: CallbackParams) => void) | undefined;
+  let codeReject: ((e: Error) => void) | undefined;
 
-    const server = http.createServer((req, res) => {
-      const u = new URL(req.url ?? '/', 'http://localhost');
-      if (u.pathname !== '/callback' && u.pathname !== '/oauth/callback') {
-        res.writeHead(404); res.end(); return;
-      }
-      const code = u.searchParams.get('code') ?? '';
-      const state = u.searchParams.get('state') ?? '';
-      const error = u.searchParams.get('error') ?? '';
-      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
-      res.end(SUCCESS_HTML);
-      codeResolve?.({ code, state, error: error || undefined });
-    });
-
-    server.listen(0, '127.0.0.1', () => {
-      const addr = server.address() as { port: number };
-      const port = addr.port;
-      resolve({
-        port,
-        redirectUri: `http://127.0.0.1:${port}/callback`,
-        waitForCallback(timeoutMs = 300_000) {
-          return new Promise<CallbackParams>((res, rej) => {
-            codeResolve = res;
-            codeReject = rej;
-            setTimeout(
-              () => rej(new Error('OAuth timeout — browser closed without completing sign-in')),
-              timeoutMs,
-            );
-          });
-        },
-        close() { server.close(); codeReject?.(new Error('Server closed')); },
-      });
-    });
-
-    server.on('error', reject);
+  const server = http.createServer((req, res) => {
+    const u = new URL(req.url ?? '/', 'http://localhost');
+    if (u.pathname !== '/callback' && u.pathname !== '/oauth/callback') {
+      res.writeHead(404); res.end(); return;
+    }
+    const code = u.searchParams.get('code') ?? '';
+    const state = u.searchParams.get('state') ?? '';
+    const error = u.searchParams.get('error') ?? '';
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end(SUCCESS_HTML);
+    codeResolve?.({ code, state, error: error || undefined });
   });
+
+  const address = await listenTcpServer(server, 0, '127.0.0.1');
+  return {
+    port: address.port,
+    redirectUri: `http://127.0.0.1:${address.port}/callback`,
+    waitForCallback(timeoutMs = 300_000) {
+      return new Promise<CallbackParams>((resolve, reject) => {
+        codeResolve = resolve;
+        codeReject = reject;
+        setTimeout(
+          () => reject(new Error('OAuth timeout — browser closed without completing sign-in')),
+          timeoutMs,
+        );
+      });
+    },
+    close() { server.close(); codeReject?.(new Error('Server closed')); },
+  };
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2,6 +2,7 @@
 // Adapted from cucoleadan/opencode-cowork-proxy (MIT)
 import { createServer } from 'node:http';
 import type { ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import { appendFileSync, openSync, writeSync, closeSync } from 'node:fs';
 import { readBody, extractApiKey, sendJson } from './http-utils.js';
 import { formatAnthropicModelEntry, formatAnthropicModelList } from './server/models.js';
@@ -46,6 +47,7 @@ import {
 } from './anthropic-endpoints.js';
 import { withResponsesWebSocketDiagnosticContext } from './oauth/responses-websocket.js';
 import { resolveContextWindow } from './context-window.js';
+import { listenTcpServer } from './listener-ready.js';
 
 type ProxyLog = (message: string | (() => string)) => void;
 
@@ -261,7 +263,7 @@ export interface ProxyModelAlias {
 }
 
 /** Multi-model proxy: routes each request by body.model to the correct upstream. */
-export function startProxyCatalog(
+export async function startProxyCatalog(
   routes: ProxyRoute[],
   defaultAliasId: string,
   debug = false,
@@ -274,7 +276,7 @@ export function startProxyCatalog(
   silenceSdkWarnings();
 
   if (routes.length === 0) {
-    return Promise.reject(new Error('Proxy catalog requires at least one route'));
+    throw new Error('Proxy catalog requires at least one route');
   }
 
   const byAlias = new Map(routes.map(r => [r.aliasId, r]));
@@ -667,26 +669,26 @@ export function startProxyCatalog(
     anthropicError(res, 404, `Unknown endpoint: ${req.method} ${req.url}`);
   });
 
-  return new Promise((resolve, reject) => {
-    server.on('error', reject);
-    server.listen(0, '127.0.0.1', () => {
-      const addr = server.address();
-      if (!addr || typeof addr === 'string') {
-        reject(new Error('Failed to bind proxy'));
-        return;
-      }
-      plog(() => `started on port ${addr.port}, catalog=${routes.length} model(s), default=${defaultRoute.aliasId}`);
-      resolve({
-        port: addr.port,
-        token: proxyToken,
-        close: () => {
-          process.off('unhandledRejection', onRejection);
-          process.off('uncaughtException', onException);
-          server.close();
-        },
-      });
-    });
-  });
+  let address: AddressInfo;
+  try {
+    address = await listenTcpServer(server, 0, '127.0.0.1');
+  } catch (error) {
+    process.off('unhandledRejection', onRejection);
+    process.off('uncaughtException', onException);
+    throw error;
+  }
+  plog(() =>
+    `started on port ${address.port}, catalog=${routes.length} model(s), default=${defaultRoute.aliasId}`,
+  );
+  return {
+    port: address.port,
+    token: proxyToken,
+    close: () => {
+      process.off('unhandledRejection', onRejection);
+      process.off('uncaughtException', onException);
+      server.close();
+    },
+  };
 }
 
 /** Single-model proxy — backward-compatible wrapper around startProxyCatalog. */

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -60,6 +60,7 @@ import {
   type AnthropicRequest,
 } from '../sdk-adapter.js';
 import { withResponsesWebSocketDiagnosticContext } from '../oauth/responses-websocket.js';
+import { listenTcpServer, tcpListenerUrlHost } from '../listener-ready.js';
 
 export interface ServerOptions {
   host: string;
@@ -153,23 +154,12 @@ export async function startServer(options: ServerOptions): Promise<ServerHandle>
     void routeRequest(req, res, options, languageModelCache, plog);
   });
 
-  await new Promise<void>((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(options.port, options.host, () => {
-      server.off('error', reject);
-      resolve();
-    });
-  });
-
-  const address = server.address();
-  if (!address || typeof address === 'string') {
-    throw new Error('Server did not bind to a TCP port');
-  }
+  const address = await listenTcpServer(server, options.port, options.host);
 
   return {
     host: options.host,
     port: address.port,
-    url: `http://${options.host}:${address.port}`,
+    url: `http://${tcpListenerUrlHost(address.address)}:${address.port}`,
     server,
     inferenceLogPath: options.inferenceLogPath,
     close: () => new Promise<void>((resolve, reject) => {

--- a/tests/http-proxy-server.test.ts
+++ b/tests/http-proxy-server.test.ts
@@ -408,7 +408,7 @@ describe('selective HTTP proxy', () => {
     }
   }, 20_000);
 
-  it('logs an Anthropic connection refusal as an upstream response failure', async () => {
+  it('logs an Anthropic connection failure as an upstream response failure', async () => {
     const certificates = ensureHttpProxyCertificates();
     const inferenceLogPath = join(testHome, 'connection-refused-inference.jsonl');
     const unavailableOrigin = https.createServer({
@@ -453,7 +453,7 @@ describe('selective HTTP proxy', () => {
         route: 'passthrough',
         statusCode: 502,
         phase: 'waiting_for_headers',
-        errorType: 'ECONNREFUSED',
+        errorType: expect.stringMatching(/^ECONN(?:REFUSED|RESET)$/),
       }));
       expect(entries).toContainEqual(expect.objectContaining({
         event: 'upstream_error',

--- a/tests/listener-ready.test.ts
+++ b/tests/listener-ready.test.ts
@@ -1,0 +1,37 @@
+import { createServer } from 'node:net';
+import { describe, expect, it } from 'vitest';
+import { listenTcpServer, tcpListenerUrlHost } from '../src/listener-ready.js';
+
+describe('tcp listener readiness', () => {
+  it.each([
+    ['127.0.0.1', '127.0.0.1'],
+    ['0.0.0.0', '127.0.0.1'],
+    ['::1', '[::1]'],
+    ['::', '[::1]'],
+  ])('formats %s as a reachable URL host', (address, expected) => {
+    expect(tcpListenerUrlHost(address)).toBe(expected);
+  });
+
+  it('removes its bind error listener after a synchronous listen failure', async () => {
+    const server = createServer();
+
+    await expect(listenTcpServer(server, 65_536, '127.0.0.1')).rejects.toThrow();
+
+    expect(server.listenerCount('error')).toBe(0);
+  });
+
+  it('removes its bind error listener after an asynchronous listen failure', async () => {
+    const boundServer = createServer();
+    const address = await listenTcpServer(boundServer, 0, '127.0.0.1');
+    const conflictingServer = createServer();
+
+    try {
+      await expect(
+        listenTcpServer(conflictingServer, address.port, '127.0.0.1'),
+      ).rejects.toMatchObject({ code: 'EADDRINUSE' });
+      expect(conflictingServer.listenerCount('error')).toBe(0);
+    } finally {
+      await new Promise<void>(resolve => boundServer.close(() => resolve()));
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- wait until bound TCP listeners accept connections before returning server handles
- normalize wildcard and IPv6 listener addresses when forming local URLs
- remove temporary listeners on startup failure and accept both common connection-failure codes in the transport regression

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run --maxWorkers=1 --no-file-parallelism` (70 files, 699 tests)
- [x] `pnpm build`
- [x] `pnpm pack --dry-run`
- [x] staged secret scan
