### PR TITLE
test(proxy): wait for complete usage logs

### DIFF
--- a/tests/http-proxy-server.test.ts
+++ b/tests/http-proxy-server.test.ts
@@ -178,14 +178,18 @@ describe('selective HTTP proxy', () => {
       expect(receivedPath).toBe('/v1/messages?beta=true');
       expect(receivedAuth).toBe('Bearer subscription-oauth-token');
       expect(receivedBody.equals(body)).toBe(true);
-      // The proxy flushes response_usage/response_completed log lines as it drains
-      // the upstream SSE stream, which can lag slightly behind the client socket
-      // close (reliable locally, flaky in CI). Wait for the terminal event before
-      // asserting instead of reading the log once right after close.
+      // Usage decoding and downstream completion are logged by independent
+      // asynchronous paths. Wait for every asserted lifecycle event instead of
+      // assuming that response_completed is always recorded last.
       const logDeadline = Date.now() + 5000;
       let inferenceLog = readFileSync(inferenceLogPath, 'utf8');
       let entries = inferenceLog.trim().split('\n').map(line => JSON.parse(line));
-      while (!entries.some(entry => entry.event === 'response_completed') && Date.now() < logDeadline) {
+      while (
+        (!entries.some(entry => entry.event === 'response_completed') ||
+          !entries.some(entry => entry.event === 'response_usage' && entry.usageStage === 'message_start') ||
+          !entries.some(entry => entry.event === 'response_usage' && entry.usageStage === 'message_delta')) &&
+        Date.now() < logDeadline
+      ) {
         await new Promise(resolve => setTimeout(resolve, 20));
         inferenceLog = readFileSync(inferenceLogPath, 'utf8');
         entries = inferenceLog.trim().split('\n').map(line => JSON.parse(line));


### PR DESCRIPTION
## Summary

- wait for completion plus both streamed usage records before asserting the request log
- remove the ordering assumption between independent asynchronous lifecycle paths

## Verification

- `pnpm typecheck`
- `pnpm build`
- focused proxy test composed with #23: 1 passed
- full suite composed with #23: 70 files passed, 699 tests passed

## Note

On unstacked `main`, the focused test can hit the independent listener startup race addressed by #23 before reaching these assertions.
