### PR TITLE
feat(logging): correlate response lifecycles

### DIFF
--- a/src/http-proxy/server.ts
+++ b/src/http-proxy/server.ts
@@ -271,6 +271,7 @@ function forwardRawAnthropicRequest(
     provider: string;
     progressIntervalMs: number;
   },
+  isLocalShutdown: () => boolean = () => false,
 ): Promise<void> {
   return new Promise(resolve => {
     const startedAt = Date.now();
@@ -378,6 +379,7 @@ function forwardRawAnthropicRequest(
           bytes,
           chunks,
           errorType: errorType(err),
+          terminationSource: 'upstream_failure',
         });
         done();
       });
@@ -407,7 +409,7 @@ function forwardRawAnthropicRequest(
         idleMs: now - lastActivityAt,
         bytes,
         chunks,
-        disconnectSource: 'downstream_client',
+        terminationSource: isLocalShutdown() ? 'local_shutdown' : 'downstream_client',
       });
       upstream.destroy(new Error('Client disconnected'));
       done();
@@ -428,6 +430,7 @@ function forwardRawAnthropicRequest(
         bytes,
         chunks,
         errorType: errorType(err),
+        terminationSource: 'upstream_failure',
       });
       onErrorResponse?.(502, `Anthropic upstream unreachable: ${err.message}`);
       if (!res.headersSent) res.writeHead(502, { 'Content-Type': 'text/plain' });
@@ -451,6 +454,7 @@ function forwardToAdapter(
     provider: string;
     progressIntervalMs: number;
   },
+  isLocalShutdown: () => boolean = () => false,
 ): Promise<void> {
   return new Promise(resolve => {
     const startedAt = Date.now();
@@ -530,7 +534,7 @@ function forwardToAdapter(
         idleMs: now - lastActivityAt,
         bytes,
         chunks,
-        disconnectSource: 'downstream_client',
+        terminationSource: isLocalShutdown() ? 'local_shutdown' : 'downstream_client',
       });
       adapterResponse?.destroy(new Error('Client disconnected'));
       upstream?.destroy(new Error('Client disconnected'));
@@ -554,6 +558,7 @@ function forwardToAdapter(
         bytes,
         chunks,
         errorType: err.name,
+        terminationSource: 'upstream_failure',
       });
       if (!res.headersSent) res.writeHead(502, { 'Content-Type': 'text/plain' });
       res.end(`Relay adapter unreachable: ${err.message}`);
@@ -614,6 +619,7 @@ function forwardToAdapter(
           bytes,
           chunks,
           errorType: err.name,
+          terminationSource: 'upstream_failure',
         });
         if (!res.writableEnded) res.destroy(err);
         resolve();
@@ -688,6 +694,7 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
       options.modelAliases,
     );
   }
+  let shuttingDown = false;
 
   const mitmServer = https.createServer({
     key: certificates.serverKey,
@@ -758,16 +765,23 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
         // Claude Code resolves context windows from the response model field, so
         // substituting the canonical route id here breaks its window lookup for
         // patched/alias model ids (wrong auto-compact threshold → agent death).
-        await forwardToAdapter(req, res, rawBody, adapter, messagesEndpoint === 'messages' && options.inferenceLogPath
-          ? {
-              logPath: options.inferenceLogPath,
-              requestId,
-              claudeSessionId,
-              modelId: typeof parsed?.model === 'string' ? parsed.model : 'unknown',
-              provider: route.providerId ?? route.aliasId.split(':')[1] ?? 'unknown',
-              progressIntervalMs: options.responseProgressIntervalMs ?? INFERENCE_PROGRESS_INTERVAL_MS,
-            }
-          : undefined);
+        await forwardToAdapter(
+          req,
+          res,
+          rawBody,
+          adapter,
+          messagesEndpoint === 'messages' && options.inferenceLogPath
+            ? {
+                logPath: options.inferenceLogPath,
+                requestId,
+                claudeSessionId,
+                modelId: typeof parsed?.model === 'string' ? parsed.model : 'unknown',
+                provider: route.providerId ?? route.aliasId.split(':')[1] ?? 'unknown',
+                progressIntervalMs: options.responseProgressIntervalMs ?? INFERENCE_PROGRESS_INTERVAL_MS,
+              }
+            : undefined,
+          () => shuttingDown,
+        );
         return;
       }
 
@@ -808,6 +822,7 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
               progressIntervalMs: options.responseProgressIntervalMs ?? INFERENCE_PROGRESS_INTERVAL_MS,
             }
           : undefined,
+        () => shuttingDown,
       );
       return;
     }
@@ -893,6 +908,7 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
     inferenceLogPath: options.inferenceLogPath,
     webSocketDiagnosticsLogPath: options.webSocketDiagnosticsLogPath,
     close: async () => {
+      shuttingDown = true;
       for (const socket of sockets) socket.destroy();
       await new Promise<void>(resolve => proxyServer.close(() => resolve()));
       mitmServer.close();

--- a/src/http-proxy/server.ts
+++ b/src/http-proxy/server.ts
@@ -266,6 +266,7 @@ function forwardRawAnthropicRequest(
   lifecycle?: {
     logPath: string;
     requestId: string;
+    claudeSessionId?: string;
     modelId: string;
     provider: string;
     progressIntervalMs: number;
@@ -291,6 +292,7 @@ function forwardRawAnthropicRequest(
       writeInferenceResponseLifecycleLog(lifecycle.logPath, {
         event,
         requestId: lifecycle.requestId,
+        claudeSessionId: lifecycle.claudeSessionId,
         modelId: lifecycle.modelId,
         provider: lifecycle.provider,
         route: 'passthrough',
@@ -405,6 +407,7 @@ function forwardRawAnthropicRequest(
         idleMs: now - lastActivityAt,
         bytes,
         chunks,
+        disconnectSource: 'downstream_client',
       });
       upstream.destroy(new Error('Client disconnected'));
       done();
@@ -443,6 +446,7 @@ function forwardToAdapter(
   lifecycle?: {
     logPath: string;
     requestId: string;
+    claudeSessionId?: string;
     modelId: string;
     provider: string;
     progressIntervalMs: number;
@@ -470,6 +474,7 @@ function forwardToAdapter(
       writeInferenceResponseLifecycleLog(lifecycle.logPath, {
         event,
         requestId: lifecycle.requestId,
+        claudeSessionId: lifecycle.claudeSessionId,
         modelId: lifecycle.modelId,
         provider: lifecycle.provider,
         route: 'translated',
@@ -525,6 +530,7 @@ function forwardToAdapter(
         idleMs: now - lastActivityAt,
         bytes,
         chunks,
+        disconnectSource: 'downstream_client',
       });
       adapterResponse?.destroy(new Error('Client disconnected'));
       upstream?.destroy(new Error('Client disconnected'));
@@ -756,6 +762,7 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
           ? {
               logPath: options.inferenceLogPath,
               requestId,
+              claudeSessionId,
               modelId: typeof parsed?.model === 'string' ? parsed.model : 'unknown',
               provider: route.providerId ?? route.aliasId.split(':')[1] ?? 'unknown',
               progressIntervalMs: options.responseProgressIntervalMs ?? INFERENCE_PROGRESS_INTERVAL_MS,
@@ -784,6 +791,7 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
           ? usage => writeInferenceResponseLifecycleLog(options.inferenceLogPath!, {
               event: 'response_usage',
               requestId,
+              claudeSessionId,
               modelId: typeof parsed?.model === 'string' ? parsed.model : 'unknown',
               provider: 'anthropic',
               route: 'passthrough',
@@ -794,6 +802,7 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
           ? {
               logPath: options.inferenceLogPath,
               requestId,
+              claudeSessionId,
               modelId: typeof parsed?.model === 'string' ? parsed.model : 'unknown',
               provider: 'anthropic',
               progressIntervalMs: options.responseProgressIntervalMs ?? INFERENCE_PROGRESS_INTERVAL_MS,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -70,6 +70,7 @@ const STREAM_KEEPALIVE_PING = 'event: ping\ndata: {"type":"ping"}\n\n';
 function createTranslationLifecycle(
   logPath: string | undefined,
   requestId: string | undefined,
+  claudeSessionId: string | undefined,
   modelId: string,
   provider: string,
 ) {
@@ -92,6 +93,7 @@ function createTranslationLifecycle(
   ) => writeInferenceResponseLifecycleLog(logPath, {
     event,
     requestId,
+    claudeSessionId,
     modelId,
     provider,
     route: 'translated',
@@ -498,17 +500,18 @@ export async function startProxyCatalog(
       // format, endpoint selection, and provider quirks.
       if (usesSdkAdapter) {
         const openAiOAuth = route.npm === '@ai-sdk/openai' && route.authType === 'oauth';
+        const claudeSessionIdHeader = Array.isArray(req.headers['x-claude-code-session-id'])
+          ? req.headers['x-claude-code-session-id'][0]
+          : req.headers['x-claude-code-session-id'];
+        const claudeSessionId = extractClaudeSessionId(anthropicBody, claudeSessionIdHeader);
         const translationLifecycle = createTranslationLifecycle(
           inferenceLogPath,
           relayRequestId,
+          claudeSessionId,
           originalModel,
           route.providerId ?? route.aliasId.split(':')[1] ?? 'unknown',
         );
         const runSdkRequest = async (): Promise<void> => {
-          const claudeSessionIdHeader = Array.isArray(req.headers['x-claude-code-session-id'])
-            ? req.headers['x-claude-code-session-id'][0]
-            : req.headers['x-claude-code-session-id'];
-          const claudeSessionId = extractClaudeSessionId(anthropicBody, claudeSessionIdHeader);
           const params = sdkTranslateRequest(anthropicBody, route.npm!, {
             openAiOAuth,
             claudeSessionId,

--- a/src/trace-log.ts
+++ b/src/trace-log.ts
@@ -231,6 +231,7 @@ export type InferenceResponsePhase =
 export interface InferenceResponseLifecycleLogEntry {
   event: InferenceResponseLifecycleEvent;
   requestId: string;
+  claudeSessionId?: string;
   modelId: string;
   provider: string;
   route: 'passthrough' | 'translated';
@@ -254,6 +255,7 @@ export interface InferenceResponseLifecycleLogEntry {
   lastPartType?: string;
   errorType?: string;
   errorSignature?: string;
+  disconnectSource?: 'downstream_client';
 }
 
 export type ProxyLifecycleEvent =
@@ -409,6 +411,7 @@ export function writeInferenceResponseLifecycleLog(
   path: string,
   entry: InferenceResponseLifecycleLogEntry,
 ): void {
+  const claudeSessionId = safeClaudeSessionId(entry.claudeSessionId);
   const statusCode = nonNegativeInteger(entry.statusCode);
   const durationMs = nonNegativeInteger(entry.durationMs);
   const timeToFirstByteMs = nonNegativeInteger(entry.timeToFirstByteMs);
@@ -428,6 +431,7 @@ export function writeInferenceResponseLifecycleLog(
     timestamp: new Date().toISOString(),
     event: entry.event,
     requestId: compactLogValue(entry.requestId, 100),
+    ...(claudeSessionId ? { claudeSessionId } : {}),
     modelId: compactLogValue(entry.modelId),
     provider: compactLogValue(entry.provider, 200),
     route: entry.route,
@@ -451,6 +455,9 @@ export function writeInferenceResponseLifecycleLog(
     ...(entry.lastPartType ? { lastPartType: compactLogValue(entry.lastPartType, 100) } : {}),
     ...(entry.errorType ? { errorType: compactLogValue(entry.errorType, 200) } : {}),
     ...(entry.errorSignature ? { errorSignature: compactLogValue(entry.errorSignature, 100) } : {}),
+    ...(entry.event === 'response_client_disconnected' && entry.disconnectSource
+      ? { disconnectSource: entry.disconnectSource }
+      : {}),
   }));
 }
 

--- a/src/trace-log.ts
+++ b/src/trace-log.ts
@@ -228,6 +228,11 @@ export type InferenceResponsePhase =
   | 'streaming'
   | 'delivering';
 
+export type InferenceTerminationSource =
+  | 'downstream_client'
+  | 'local_shutdown'
+  | 'upstream_failure';
+
 export interface InferenceResponseLifecycleLogEntry {
   event: InferenceResponseLifecycleEvent;
   requestId: string;
@@ -255,7 +260,7 @@ export interface InferenceResponseLifecycleLogEntry {
   lastPartType?: string;
   errorType?: string;
   errorSignature?: string;
-  disconnectSource?: 'downstream_client';
+  terminationSource?: InferenceTerminationSource;
 }
 
 export type ProxyLifecycleEvent =
@@ -455,9 +460,7 @@ export function writeInferenceResponseLifecycleLog(
     ...(entry.lastPartType ? { lastPartType: compactLogValue(entry.lastPartType, 100) } : {}),
     ...(entry.errorType ? { errorType: compactLogValue(entry.errorType, 200) } : {}),
     ...(entry.errorSignature ? { errorSignature: compactLogValue(entry.errorSignature, 100) } : {}),
-    ...(entry.event === 'response_client_disconnected' && entry.disconnectSource
-      ? { disconnectSource: entry.disconnectSource }
-      : {}),
+    ...(entry.terminationSource ? { terminationSource: entry.terminationSource } : {}),
   }));
 }
 

--- a/tests/http-proxy-server.test.ts
+++ b/tests/http-proxy-server.test.ts
@@ -410,6 +410,7 @@ describe('selective HTTP proxy', () => {
         event: 'response_failed',
         requestId: entries[0].requestId,
         statusCode: 503,
+        terminationSource: 'upstream_failure',
       }));
     } finally {
       if (previousRequestPreview === undefined) delete process.env['CLODEX_LOG_REQUEST_PREVIEW'];
@@ -465,6 +466,7 @@ describe('selective HTTP proxy', () => {
         statusCode: 502,
         phase: 'waiting_for_headers',
         errorType: expect.stringMatching(/^ECONN(?:REFUSED|RESET)$/),
+        terminationSource: 'upstream_failure',
       }));
       expect(entries).toContainEqual(expect.objectContaining({
         event: 'upstream_error',
@@ -820,12 +822,90 @@ describe('selective HTTP proxy', () => {
         requestId: requestEntry.requestId,
         claudeSessionId,
         phase: 'waiting_for_headers',
-        disconnectSource: 'downstream_client',
+        terminationSource: 'downstream_client',
       }));
       expect(entries.some(entry => entry.event === 'response_completed')).toBe(false);
       expect(entries.some(entry => entry.event === 'response_failed')).toBe(false);
     } finally {
       await proxy.close();
+    }
+  }, 20_000);
+
+  it('attributes an in-flight response termination to local proxy shutdown', async () => {
+    const certificates = ensureHttpProxyCertificates();
+    const inferenceLogPath = join(testHome, 'local-shutdown-inference.jsonl');
+    let adapterReceivedResolve!: () => void;
+    const adapterReceived = new Promise<void>(resolve => {
+      adapterReceivedResolve = resolve;
+    });
+    let adapterClosedResolve!: () => void;
+    const adapterClosed = new Promise<void>(resolve => {
+      adapterClosedResolve = resolve;
+    });
+    const adapterServer = http.createServer(req => {
+      req.resume();
+      req.once('end', adapterReceivedResolve);
+      req.socket.once('close', adapterClosedResolve);
+    });
+    const adapterPort = await listen(adapterServer);
+    const route = {
+      aliasId: 'clodex:test:translated-model',
+      realModelId: 'translated-model',
+      displayName: 'Translated Model',
+      upstreamUrl: '',
+      apiKey: 'provider-key',
+      modelFormat: 'openai' as const,
+      npm: '@ai-sdk/openai-compatible',
+      providerId: 'test-provider',
+    };
+    const proxy = await startHttpProxy({
+      routes: [route],
+      adapterHandle: {
+        port: adapterPort,
+        token: 'adapter-local-token',
+        close: () => {
+          adapterServer.closeAllConnections();
+          adapterServer.close();
+        },
+      },
+      inferenceLogPath,
+    });
+    let proxyClosed = false;
+
+    try {
+      const body = JSON.stringify({
+        model: route.aliasId,
+        messages: [{ role: 'user', content: 'wait for local shutdown' }],
+        stream: false,
+      });
+      const secure = await connectMitm(proxy.port, certificates.caCert);
+      secure.on('error', () => {});
+      secure.resume();
+      secure.write([
+        'POST /v1/messages HTTP/1.1',
+        'Host: api.anthropic.com',
+        'Content-Type: application/json',
+        `Content-Length: ${Buffer.byteLength(body)}`,
+        '',
+        '',
+      ].join('\r\n') + body);
+      await adapterReceived;
+      await proxy.close();
+      proxyClosed = true;
+      await adapterClosed;
+      await new Promise(resolve => setImmediate(resolve));
+
+      const entries = readFileSync(inferenceLogPath, 'utf8').trim().split('\n').map(line => JSON.parse(line));
+      const requestEntry = entries.find(entry => !entry.event);
+      expect(entries).toContainEqual(expect.objectContaining({
+        event: 'response_client_disconnected',
+        requestId: requestEntry.requestId,
+        phase: 'waiting_for_headers',
+        terminationSource: 'local_shutdown',
+      }));
+      expect(entries.some(entry => entry.terminationSource === 'downstream_client')).toBe(false);
+    } finally {
+      if (!proxyClosed) await proxy.close();
     }
   }, 20_000);
 
@@ -898,6 +978,7 @@ describe('selective HTTP proxy', () => {
         requestId: requestEntry.requestId,
         statusCode: 200,
         phase: 'streaming',
+        terminationSource: 'upstream_failure',
       }));
       expect(entries.some(entry => entry.event === 'response_completed')).toBe(false);
     } finally {

--- a/tests/http-proxy-server.test.ts
+++ b/tests/http-proxy-server.test.ts
@@ -115,6 +115,7 @@ describe('selective HTTP proxy', () => {
     const certificates = ensureHttpProxyCertificates();
     const inferenceLogPath = join(testHome, 'anthropic-inference.jsonl');
     const webSocketDiagnosticsLogPath = join(testHome, 'websocket-diagnostics.jsonl');
+    const claudeSessionId = '00000000-0000-4000-8000-000000000004';
     const previousRequestPreview = process.env['CLODEX_LOG_REQUEST_PREVIEW'];
     process.env['CLODEX_LOG_REQUEST_PREVIEW'] = '1';
     let receivedBody = Buffer.alloc(0);
@@ -166,6 +167,7 @@ describe('selective HTTP proxy', () => {
         'POST /v1/messages?beta=true HTTP/1.1',
         'Host: api.anthropic.com',
         'Authorization: Bearer subscription-oauth-token',
+        `x-claude-code-session-id: ${claudeSessionId}`,
         'Content-Type: application/json',
         `Content-Length: ${body.length}`,
         'Connection: close',
@@ -199,6 +201,7 @@ describe('selective HTTP proxy', () => {
         effort: 'high',
         provider: 'anthropic',
         route: 'passthrough',
+        claudeSessionId,
         requestPreview: 'user: identify this Sonnet request',
       });
       const responseStarted = entries.find(entry => entry.event === 'response_started');
@@ -209,6 +212,7 @@ describe('selective HTTP proxy', () => {
         requestId: entries[0].requestId,
         statusCode: 200,
         route: 'passthrough',
+        claudeSessionId,
       });
       expect(messageStartUsage).toMatchObject({
         event: 'response_usage',
@@ -216,6 +220,7 @@ describe('selective HTTP proxy', () => {
         modelId: 'claude-sonnet-4-6',
         provider: 'anthropic',
         route: 'passthrough',
+        claudeSessionId,
         usageStage: 'message_start',
         inputTokens: 321,
         outputTokens: 1,
@@ -228,6 +233,7 @@ describe('selective HTTP proxy', () => {
         modelId: 'claude-sonnet-4-6',
         provider: 'anthropic',
         route: 'passthrough',
+        claudeSessionId,
         usageStage: 'message_delta',
         inputTokens: 19,
         outputTokens: 8,
@@ -238,6 +244,7 @@ describe('selective HTTP proxy', () => {
         requestId: entries[0].requestId,
         statusCode: 200,
         route: 'passthrough',
+        claudeSessionId,
       });
       expect(inferenceLog).not.toContain('private-image-data');
       expect(inferenceLog).not.toContain('private response text');
@@ -749,6 +756,7 @@ describe('selective HTTP proxy', () => {
   it('closes the adapter request and logs a terminal client disconnect', async () => {
     const certificates = ensureHttpProxyCertificates();
     const inferenceLogPath = join(testHome, 'client-disconnect-inference.jsonl');
+    const claudeSessionId = '00000000-0000-4000-8000-000000000002';
     let adapterReceivedResolve!: () => void;
     const adapterReceived = new Promise<void>(resolve => { adapterReceivedResolve = resolve; });
     let adapterClosedResolve!: () => void;
@@ -794,6 +802,7 @@ describe('selective HTTP proxy', () => {
         'POST /v1/messages HTTP/1.1',
         'Host: api.anthropic.com',
         'Content-Type: application/json',
+        `x-claude-code-session-id: ${claudeSessionId}`,
         `Content-Length: ${Buffer.byteLength(body)}`,
         '',
         '',
@@ -805,10 +814,13 @@ describe('selective HTTP proxy', () => {
 
       const entries = readFileSync(inferenceLogPath, 'utf8').trim().split('\n').map(line => JSON.parse(line));
       const requestEntry = entries.find(entry => !entry.event);
+      expect(requestEntry.claudeSessionId).toBe(claudeSessionId);
       expect(entries).toContainEqual(expect.objectContaining({
         event: 'response_client_disconnected',
         requestId: requestEntry.requestId,
+        claudeSessionId,
         phase: 'waiting_for_headers',
+        disconnectSource: 'downstream_client',
       }));
       expect(entries.some(entry => entry.event === 'response_completed')).toBe(false);
       expect(entries.some(entry => entry.event === 'response_failed')).toBe(false);

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -15,6 +15,7 @@ function postToProxy(
   body: unknown,
   relayRequestId?: string,
   path = '/v1/messages',
+  claudeSessionId?: string,
 ): Promise<{ status: number; body: string; headers: http.IncomingHttpHeaders }> {
   return new Promise((resolve, reject) => {
     const payload = JSON.stringify(body);
@@ -30,6 +31,7 @@ function postToProxy(
           'anthropic-version': '2023-06-01',
           'Content-Length': Buffer.byteLength(payload),
           ...(relayRequestId ? { 'x-relay-request-id': relayRequestId } : {}),
+          ...(claudeSessionId ? { 'x-claude-code-session-id': claudeSessionId } : {}),
         },
       },
       (res) => {
@@ -779,7 +781,15 @@ describe('SDK translated error logging', () => {
         '/v1/messages/count_tokens',
       );
       const expectedInputTokens = JSON.parse(countResponse.body).input_tokens;
-      const res = await postToProxy(handle.port, handle.token, requestBody, 'req-success-1');
+      const claudeSessionId = '00000000-0000-4000-8000-000000000003';
+      const res = await postToProxy(
+        handle.port,
+        handle.token,
+        requestBody,
+        'req-success-1',
+        '/v1/messages',
+        claudeSessionId,
+      );
 
       expect(res.status).toBe(200);
       expect(res.body).toContain('event: message_stop');
@@ -797,15 +807,18 @@ describe('SDK translated error logging', () => {
       expect(entries).toContainEqual(expect.objectContaining({
         event: 'translation_dispatched',
         requestId: 'req-success-1',
+        claudeSessionId,
         phase: 'waiting_for_sdk',
       }));
       expect(entries).toContainEqual(expect.objectContaining({
         event: 'translation_started',
         requestId: 'req-success-1',
+        claudeSessionId,
       }));
       expect(entries).toContainEqual(expect.objectContaining({
         event: 'translation_completed',
         requestId: 'req-success-1',
+        claudeSessionId,
         lastPartType: 'finish',
       }));
       const completed = entries.find(entry => entry.event === 'translation_completed');

--- a/tests/trace-log.test.ts
+++ b/tests/trace-log.test.ts
@@ -307,7 +307,7 @@ describe('inference request log', () => {
         lastPartType: 'text-delta',
       });
       writeInferenceResponseLifecycleLog(path, {
-        event: 'translation_failed',
+        event: 'response_failed',
         requestId: 'req-123',
         claudeSessionId: 'not-a-session-id',
         modelId: 'clodex:openai:gpt-test',
@@ -315,7 +315,7 @@ describe('inference request log', () => {
         route: 'translated',
         errorType: 'Error',
         errorSignature: 'reasoning_part_not_found',
-        disconnectSource: 'downstream_client',
+        terminationSource: 'upstream_failure',
       });
       writeInferenceResponseLifecycleLog(path, {
         event: 'response_client_disconnected',
@@ -324,10 +324,18 @@ describe('inference request log', () => {
         modelId: 'clodex:openai:gpt-test',
         provider: 'openai',
         route: 'translated',
-        disconnectSource: 'downstream_client',
+        terminationSource: 'downstream_client',
+      });
+      writeInferenceResponseLifecycleLog(path, {
+        event: 'response_client_disconnected',
+        requestId: 'req-456',
+        modelId: 'clodex:openai:gpt-test',
+        provider: 'openai',
+        route: 'translated',
+        terminationSource: 'local_shutdown',
       });
 
-      const [entry, failure, disconnect] = readFileSync(path, 'utf8').trim().split('\n').map(line => JSON.parse(line));
+      const [entry, failure, disconnect, shutdown] = readFileSync(path, 'utf8').trim().split('\n').map(line => JSON.parse(line));
       expect(entry).toMatchObject({
         event: 'translation_progress',
         requestId: 'req-123',
@@ -346,16 +354,21 @@ describe('inference request log', () => {
       });
       expect(entry).not.toHaveProperty('responseContent');
       expect(failure).toMatchObject({
-        event: 'translation_failed',
+        event: 'response_failed',
         errorType: 'Error',
         errorSignature: 'reasoning_part_not_found',
+        terminationSource: 'upstream_failure',
       });
       expect(failure).not.toHaveProperty('claudeSessionId');
-      expect(failure).not.toHaveProperty('disconnectSource');
       expect(disconnect).toMatchObject({
         event: 'response_client_disconnected',
         claudeSessionId: '00000000-0000-4000-8000-000000000001',
-        disconnectSource: 'downstream_client',
+        terminationSource: 'downstream_client',
+      });
+      expect(shutdown).toMatchObject({
+        event: 'response_client_disconnected',
+        requestId: 'req-456',
+        terminationSource: 'local_shutdown',
       });
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/tests/trace-log.test.ts
+++ b/tests/trace-log.test.ts
@@ -293,6 +293,7 @@ describe('inference request log', () => {
       writeInferenceResponseLifecycleLog(path, {
         event: 'translation_progress',
         requestId: 'req-123',
+        claudeSessionId: '00000000-0000-4000-8000-000000000001',
         modelId: 'clodex:openai:gpt-test',
         provider: 'openai',
         route: 'translated',
@@ -308,17 +309,29 @@ describe('inference request log', () => {
       writeInferenceResponseLifecycleLog(path, {
         event: 'translation_failed',
         requestId: 'req-123',
+        claudeSessionId: 'not-a-session-id',
         modelId: 'clodex:openai:gpt-test',
         provider: 'openai',
         route: 'translated',
         errorType: 'Error',
         errorSignature: 'reasoning_part_not_found',
+        disconnectSource: 'downstream_client',
+      });
+      writeInferenceResponseLifecycleLog(path, {
+        event: 'response_client_disconnected',
+        requestId: 'req-123',
+        claudeSessionId: '00000000-0000-4000-8000-000000000001',
+        modelId: 'clodex:openai:gpt-test',
+        provider: 'openai',
+        route: 'translated',
+        disconnectSource: 'downstream_client',
       });
 
-      const [entry, failure] = readFileSync(path, 'utf8').trim().split('\n').map(line => JSON.parse(line));
+      const [entry, failure, disconnect] = readFileSync(path, 'utf8').trim().split('\n').map(line => JSON.parse(line));
       expect(entry).toMatchObject({
         event: 'translation_progress',
         requestId: 'req-123',
+        claudeSessionId: '00000000-0000-4000-8000-000000000001',
         modelId: 'clodex:openai:gpt-test',
         provider: 'openai',
         route: 'translated',
@@ -336,6 +349,13 @@ describe('inference request log', () => {
         event: 'translation_failed',
         errorType: 'Error',
         errorSignature: 'reasoning_part_not_found',
+      });
+      expect(failure).not.toHaveProperty('claudeSessionId');
+      expect(failure).not.toHaveProperty('disconnectSource');
+      expect(disconnect).toMatchObject({
+        event: 'response_client_disconnected',
+        claudeSessionId: '00000000-0000-4000-8000-000000000001',
+        disconnectSource: 'downstream_client',
       });
     } finally {
       rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- carry the validated session identifier onto response lifecycle records
- classify abnormal response endings as `downstream_client`, `local_shutdown`, or `upstream_failure`
- mark local shutdown before tracked sockets are destroyed so records keep the correct source
- cover pass-through usage, translated completion, upstream failures, downstream disconnects, local shutdown, and invalid identifiers

## Privacy

Only canonical UUID-shaped session identifiers are retained. Invalid values are omitted, and no request or response content is added to lifecycle records.

## Validation

- type checking passes
- focused lifecycle logging tests pass
- complete suite: 79 files and 878 tests
- production build passes
- diff hygiene and secret scanning pass
