### PR TITLE
fix(logging): attribute proxy transport failures

### DIFF
--- a/src/http-proxy/server.ts
+++ b/src/http-proxy/server.ts
@@ -271,6 +271,7 @@ function forwardRawAnthropicRequest(
     provider: string;
     progressIntervalMs: number;
   },
+  isLocalShutdown: () => boolean = () => false,
 ): Promise<void> {
   return new Promise(resolve => {
     const startedAt = Date.now();
@@ -378,6 +379,7 @@ function forwardRawAnthropicRequest(
           bytes,
           chunks,
           errorType: errorType(err),
+          terminationSource: 'upstream_failure',
         });
         done();
       });
@@ -407,7 +409,7 @@ function forwardRawAnthropicRequest(
         idleMs: now - lastActivityAt,
         bytes,
         chunks,
-        disconnectSource: 'downstream_client',
+        terminationSource: isLocalShutdown() ? 'local_shutdown' : 'downstream_client',
       });
       upstream.destroy(new Error('Client disconnected'));
       done();
@@ -428,6 +430,7 @@ function forwardRawAnthropicRequest(
         bytes,
         chunks,
         errorType: errorType(err),
+        terminationSource: 'upstream_failure',
       });
       onErrorResponse?.(502, `Anthropic upstream unreachable: ${err.message}`);
       if (!res.headersSent) res.writeHead(502, { 'Content-Type': 'text/plain' });
@@ -451,6 +454,7 @@ function forwardToAdapter(
     provider: string;
     progressIntervalMs: number;
   },
+  isLocalShutdown: () => boolean = () => false,
 ): Promise<void> {
   return new Promise(resolve => {
     const startedAt = Date.now();
@@ -530,7 +534,7 @@ function forwardToAdapter(
         idleMs: now - lastActivityAt,
         bytes,
         chunks,
-        disconnectSource: 'downstream_client',
+        terminationSource: isLocalShutdown() ? 'local_shutdown' : 'downstream_client',
       });
       adapterResponse?.destroy(new Error('Client disconnected'));
       upstream?.destroy(new Error('Client disconnected'));
@@ -554,6 +558,7 @@ function forwardToAdapter(
         bytes,
         chunks,
         errorType: err.name,
+        terminationSource: 'upstream_failure',
       });
       if (!res.headersSent) res.writeHead(502, { 'Content-Type': 'text/plain' });
       res.end(`Relay adapter unreachable: ${err.message}`);
@@ -614,6 +619,7 @@ function forwardToAdapter(
           bytes,
           chunks,
           errorType: err.name,
+          terminationSource: 'upstream_failure',
         });
         if (!res.writableEnded) res.destroy(err);
         resolve();
@@ -688,6 +694,7 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
       options.modelAliases,
     );
   }
+  let shuttingDown = false;
 
   const mitmServer = https.createServer({
     key: certificates.serverKey,
@@ -758,16 +765,23 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
         // Claude Code resolves context windows from the response model field, so
         // substituting the canonical route id here breaks its window lookup for
         // patched/alias model ids (wrong auto-compact threshold → agent death).
-        await forwardToAdapter(req, res, rawBody, adapter, messagesEndpoint === 'messages' && options.inferenceLogPath
-          ? {
-              logPath: options.inferenceLogPath,
-              requestId,
-              claudeSessionId,
-              modelId: typeof parsed?.model === 'string' ? parsed.model : 'unknown',
-              provider: route.providerId ?? route.aliasId.split(':')[1] ?? 'unknown',
-              progressIntervalMs: options.responseProgressIntervalMs ?? INFERENCE_PROGRESS_INTERVAL_MS,
-            }
-          : undefined);
+        await forwardToAdapter(
+          req,
+          res,
+          rawBody,
+          adapter,
+          messagesEndpoint === 'messages' && options.inferenceLogPath
+            ? {
+                logPath: options.inferenceLogPath,
+                requestId,
+                claudeSessionId,
+                modelId: typeof parsed?.model === 'string' ? parsed.model : 'unknown',
+                provider: route.providerId ?? route.aliasId.split(':')[1] ?? 'unknown',
+                progressIntervalMs: options.responseProgressIntervalMs ?? INFERENCE_PROGRESS_INTERVAL_MS,
+              }
+            : undefined,
+          () => shuttingDown,
+        );
         return;
       }
 
@@ -808,6 +822,7 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
               progressIntervalMs: options.responseProgressIntervalMs ?? INFERENCE_PROGRESS_INTERVAL_MS,
             }
           : undefined,
+        () => shuttingDown,
       );
       return;
     }
@@ -893,6 +908,7 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
     inferenceLogPath: options.inferenceLogPath,
     webSocketDiagnosticsLogPath: options.webSocketDiagnosticsLogPath,
     close: async () => {
+      shuttingDown = true;
       for (const socket of sockets) socket.destroy();
       await new Promise<void>(resolve => proxyServer.close(() => resolve()));
       mitmServer.close();

--- a/src/http-proxy/server.ts
+++ b/src/http-proxy/server.ts
@@ -20,6 +20,7 @@ import {
   writeInferenceResponseLifecycleLog,
   writeInferenceResponseErrorLog,
   writeWebSocketDiagnosticRequestLog,
+  type InferenceFailureSource,
   type InferenceResponsePhase,
 } from '../trace-log.js';
 
@@ -156,6 +157,8 @@ export interface HttpProxyOptions {
   anthropicRejectUnauthorized?: boolean;
   /** Test hook for observing relay-route isolation without calling an AI provider. */
   adapterHandle?: ProxyHandle;
+  /** Test hook for exercising adapter request transport failures. */
+  adapterRequest?: typeof http.request;
   /** Test hook; production emits a progress record every 30 seconds. */
   responseProgressIntervalMs?: number;
 }
@@ -446,6 +449,7 @@ function forwardToAdapter(
   res: http.ServerResponse,
   rawBody: Buffer,
   adapter: ProxyHandle,
+  adapterRequest: typeof http.request = http.request,
   lifecycle?: {
     logPath: string;
     requestId: string;
@@ -541,7 +545,10 @@ function forwardToAdapter(
       resolve();
     });
 
-    const failAdapterRequest = (err: Error) => {
+    const failAdapterRequest = (
+      err: Error,
+      failureSource: InferenceFailureSource,
+    ) => {
       if (clientDisconnected) {
         resolve();
         return;
@@ -558,6 +565,8 @@ function forwardToAdapter(
         bytes,
         chunks,
         errorType: err.name,
+        errorCode: (err as NodeJS.ErrnoException).code,
+        failureSource,
         terminationSource: 'upstream_failure',
       });
       if (!res.headersSent) res.writeHead(502, { 'Content-Type': 'text/plain' });
@@ -565,7 +574,7 @@ function forwardToAdapter(
       resolve();
     };
 
-    upstream = http.request({
+    upstream = adapterRequest({
       hostname: '127.0.0.1',
       port: adapter.port,
       method: 'POST',
@@ -601,7 +610,10 @@ function forwardToAdapter(
       copyResponse(upstreamRes, res, undefined, lifecycle
         ? usage => writeLifecycle('response_usage', usage)
         : undefined);
-      const failAdapterResponse = (err: Error) => {
+      const failAdapterResponse = (
+        err: Error,
+        failureSource: InferenceFailureSource,
+      ) => {
         if (clientDisconnected) {
           resolve();
           return;
@@ -619,6 +631,8 @@ function forwardToAdapter(
           bytes,
           chunks,
           errorType: err.name,
+          errorCode: (err as NodeJS.ErrnoException).code,
+          failureSource,
           terminationSource: 'upstream_failure',
         });
         if (!res.writableEnded) res.destroy(err);
@@ -629,16 +643,27 @@ function forwardToAdapter(
         lastActivityAt = Date.now();
         resolve();
       });
-      upstreamRes.once('error', failAdapterResponse);
-      upstreamRes.once('aborted', () => failAdapterResponse(new Error('Relay adapter response aborted')));
+      upstreamRes.once('error', err => failAdapterResponse(err, 'adapter_response_error'));
+      upstreamRes.once('aborted', () => failAdapterResponse(
+        new Error('Relay adapter response aborted'),
+        'adapter_response_aborted',
+      ));
       upstreamRes.once('close', () => {
-        if (!upstreamRes.complete) failAdapterResponse(new Error('Relay adapter response closed before completion'));
+        if (!upstreamRes.complete) {
+          failAdapterResponse(
+            new Error('Relay adapter response closed before completion'),
+            'adapter_response_close',
+          );
+        }
       });
     });
-    upstream.once('error', failAdapterRequest);
+    upstream.once('error', err => failAdapterRequest(err, 'adapter_request_error'));
     upstream.once('close', () => {
       if (!headersReceived && !failed) {
-        failAdapterRequest(new Error('Relay adapter connection closed before a response'));
+        failAdapterRequest(
+          new Error('Relay adapter connection closed before a response'),
+          'adapter_request_close',
+        );
       }
     });
     upstream.end(rawBody);
@@ -770,6 +795,7 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
           res,
           rawBody,
           adapter,
+          options.adapterRequest,
           messagesEndpoint === 'messages' && options.inferenceLogPath
             ? {
                 logPath: options.inferenceLogPath,

--- a/src/http-proxy/server.ts
+++ b/src/http-proxy/server.ts
@@ -266,6 +266,7 @@ function forwardRawAnthropicRequest(
   lifecycle?: {
     logPath: string;
     requestId: string;
+    claudeSessionId?: string;
     modelId: string;
     provider: string;
     progressIntervalMs: number;
@@ -291,6 +292,7 @@ function forwardRawAnthropicRequest(
       writeInferenceResponseLifecycleLog(lifecycle.logPath, {
         event,
         requestId: lifecycle.requestId,
+        claudeSessionId: lifecycle.claudeSessionId,
         modelId: lifecycle.modelId,
         provider: lifecycle.provider,
         route: 'passthrough',
@@ -405,6 +407,7 @@ function forwardRawAnthropicRequest(
         idleMs: now - lastActivityAt,
         bytes,
         chunks,
+        disconnectSource: 'downstream_client',
       });
       upstream.destroy(new Error('Client disconnected'));
       done();
@@ -443,6 +446,7 @@ function forwardToAdapter(
   lifecycle?: {
     logPath: string;
     requestId: string;
+    claudeSessionId?: string;
     modelId: string;
     provider: string;
     progressIntervalMs: number;
@@ -470,6 +474,7 @@ function forwardToAdapter(
       writeInferenceResponseLifecycleLog(lifecycle.logPath, {
         event,
         requestId: lifecycle.requestId,
+        claudeSessionId: lifecycle.claudeSessionId,
         modelId: lifecycle.modelId,
         provider: lifecycle.provider,
         route: 'translated',
@@ -525,6 +530,7 @@ function forwardToAdapter(
         idleMs: now - lastActivityAt,
         bytes,
         chunks,
+        disconnectSource: 'downstream_client',
       });
       adapterResponse?.destroy(new Error('Client disconnected'));
       upstream?.destroy(new Error('Client disconnected'));
@@ -756,6 +762,7 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
           ? {
               logPath: options.inferenceLogPath,
               requestId,
+              claudeSessionId,
               modelId: typeof parsed?.model === 'string' ? parsed.model : 'unknown',
               provider: route.providerId ?? route.aliasId.split(':')[1] ?? 'unknown',
               progressIntervalMs: options.responseProgressIntervalMs ?? INFERENCE_PROGRESS_INTERVAL_MS,
@@ -784,6 +791,7 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
           ? usage => writeInferenceResponseLifecycleLog(options.inferenceLogPath!, {
               event: 'response_usage',
               requestId,
+              claudeSessionId,
               modelId: typeof parsed?.model === 'string' ? parsed.model : 'unknown',
               provider: 'anthropic',
               route: 'passthrough',
@@ -794,6 +802,7 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
           ? {
               logPath: options.inferenceLogPath,
               requestId,
+              claudeSessionId,
               modelId: typeof parsed?.model === 'string' ? parsed.model : 'unknown',
               provider: 'anthropic',
               progressIntervalMs: options.responseProgressIntervalMs ?? INFERENCE_PROGRESS_INTERVAL_MS,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -155,11 +155,16 @@ function createTranslationLifecycle(
       clearInterval(timer);
       write('translation_cancelled', snapshot(Date.now()));
     },
-    fail(errorType: string, errorSignature?: string) {
+    fail(errorType: string, errorSignature?: string, errorCode?: string) {
       if (stopped) return;
       stopped = true;
       clearInterval(timer);
-      write('translation_failed', { ...snapshot(Date.now()), errorType, errorSignature });
+      write('translation_failed', {
+        ...snapshot(Date.now()),
+        errorType,
+        errorSignature,
+        errorCode,
+      });
     },
   };
 }
@@ -660,6 +665,7 @@ export async function startProxyCatalog(
           translationLifecycle?.fail(
             err instanceof Error ? err.name : 'UpstreamError',
             sdkTranslationErrorSignature(err),
+            details?.transportCode,
           );
           const contextLengthExceeded = upstreamStatus === 400
             && isContextLengthExceededError(err, message);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -70,6 +70,7 @@ const STREAM_KEEPALIVE_PING = 'event: ping\ndata: {"type":"ping"}\n\n';
 function createTranslationLifecycle(
   logPath: string | undefined,
   requestId: string | undefined,
+  claudeSessionId: string | undefined,
   modelId: string,
   provider: string,
 ) {
@@ -92,6 +93,7 @@ function createTranslationLifecycle(
   ) => writeInferenceResponseLifecycleLog(logPath, {
     event,
     requestId,
+    claudeSessionId,
     modelId,
     provider,
     route: 'translated',
@@ -498,17 +500,18 @@ export async function startProxyCatalog(
       // format, endpoint selection, and provider quirks.
       if (usesSdkAdapter) {
         const openAiOAuth = route.npm === '@ai-sdk/openai' && route.authType === 'oauth';
+        const claudeSessionIdHeader = Array.isArray(req.headers['x-claude-code-session-id'])
+          ? req.headers['x-claude-code-session-id'][0]
+          : req.headers['x-claude-code-session-id'];
+        const claudeSessionId = extractClaudeSessionId(anthropicBody, claudeSessionIdHeader);
         const translationLifecycle = createTranslationLifecycle(
           inferenceLogPath,
           relayRequestId,
+          claudeSessionId,
           originalModel,
           route.providerId ?? route.aliasId.split(':')[1] ?? 'unknown',
         );
         const runSdkRequest = async (): Promise<void> => {
-          const claudeSessionIdHeader = Array.isArray(req.headers['x-claude-code-session-id'])
-            ? req.headers['x-claude-code-session-id'][0]
-            : req.headers['x-claude-code-session-id'];
-          const claudeSessionId = extractClaudeSessionId(anthropicBody, claudeSessionIdHeader);
           const params = sdkTranslateRequest(anthropicBody, route.npm!, {
             openAiOAuth,
             claudeSessionId,

--- a/src/trace-log.ts
+++ b/src/trace-log.ts
@@ -231,6 +231,7 @@ export type InferenceResponsePhase =
 export interface InferenceResponseLifecycleLogEntry {
   event: InferenceResponseLifecycleEvent;
   requestId: string;
+  claudeSessionId?: string;
   modelId: string;
   provider: string;
   route: 'passthrough' | 'translated';
@@ -254,6 +255,7 @@ export interface InferenceResponseLifecycleLogEntry {
   lastPartType?: string;
   errorType?: string;
   errorSignature?: string;
+  disconnectSource?: 'downstream_client';
 }
 
 export type ProxyLifecycleEvent =
@@ -409,6 +411,7 @@ export function writeInferenceResponseLifecycleLog(
   path: string,
   entry: InferenceResponseLifecycleLogEntry,
 ): void {
+  const claudeSessionId = safeClaudeSessionId(entry.claudeSessionId);
   const statusCode = nonNegativeInteger(entry.statusCode);
   const durationMs = nonNegativeInteger(entry.durationMs);
   const timeToFirstByteMs = nonNegativeInteger(entry.timeToFirstByteMs);
@@ -428,6 +431,7 @@ export function writeInferenceResponseLifecycleLog(
     timestamp: new Date().toISOString(),
     event: entry.event,
     requestId: compactLogValue(entry.requestId, 100),
+    ...(claudeSessionId ? { claudeSessionId } : {}),
     modelId: compactLogValue(entry.modelId),
     provider: compactLogValue(entry.provider, 200),
     route: entry.route,
@@ -451,6 +455,9 @@ export function writeInferenceResponseLifecycleLog(
     ...(entry.lastPartType ? { lastPartType: compactLogValue(entry.lastPartType, 100) } : {}),
     ...(entry.errorType ? { errorType: compactLogValue(entry.errorType, 200) } : {}),
     ...(entry.errorSignature ? { errorSignature: compactLogValue(entry.errorSignature, 100) } : {}),
+    ...(entry.event === 'response_client_disconnected' && entry.disconnectSource
+      ? { disconnectSource: entry.disconnectSource }
+      : {}),
   }));
 }
 

--- a/src/trace-log.ts
+++ b/src/trace-log.ts
@@ -228,6 +228,13 @@ export type InferenceResponsePhase =
   | 'streaming'
   | 'delivering';
 
+export type InferenceFailureSource =
+  | 'adapter_request_error'
+  | 'adapter_request_close'
+  | 'adapter_response_error'
+  | 'adapter_response_aborted'
+  | 'adapter_response_close';
+
 export type InferenceTerminationSource =
   | 'downstream_client'
   | 'local_shutdown'
@@ -259,7 +266,9 @@ export interface InferenceResponseLifecycleLogEntry {
   cacheReadInputTokens?: number;
   lastPartType?: string;
   errorType?: string;
+  errorCode?: string;
   errorSignature?: string;
+  failureSource?: InferenceFailureSource;
   terminationSource?: InferenceTerminationSource;
 }
 
@@ -459,7 +468,9 @@ export function writeInferenceResponseLifecycleLog(
     ...(cacheReadInputTokens !== undefined ? { cacheReadInputTokens } : {}),
     ...(entry.lastPartType ? { lastPartType: compactLogValue(entry.lastPartType, 100) } : {}),
     ...(entry.errorType ? { errorType: compactLogValue(entry.errorType, 200) } : {}),
+    ...(entry.errorCode ? { errorCode: compactLogValue(entry.errorCode, 100) } : {}),
     ...(entry.errorSignature ? { errorSignature: compactLogValue(entry.errorSignature, 100) } : {}),
+    ...(entry.failureSource ? { failureSource: entry.failureSource } : {}),
     ...(entry.terminationSource ? { terminationSource: entry.terminationSource } : {}),
   }));
 }

--- a/src/trace-log.ts
+++ b/src/trace-log.ts
@@ -228,6 +228,11 @@ export type InferenceResponsePhase =
   | 'streaming'
   | 'delivering';
 
+export type InferenceTerminationSource =
+  | 'downstream_client'
+  | 'local_shutdown'
+  | 'upstream_failure';
+
 export interface InferenceResponseLifecycleLogEntry {
   event: InferenceResponseLifecycleEvent;
   requestId: string;
@@ -255,7 +260,7 @@ export interface InferenceResponseLifecycleLogEntry {
   lastPartType?: string;
   errorType?: string;
   errorSignature?: string;
-  disconnectSource?: 'downstream_client';
+  terminationSource?: InferenceTerminationSource;
 }
 
 export type ProxyLifecycleEvent =
@@ -455,9 +460,7 @@ export function writeInferenceResponseLifecycleLog(
     ...(entry.lastPartType ? { lastPartType: compactLogValue(entry.lastPartType, 100) } : {}),
     ...(entry.errorType ? { errorType: compactLogValue(entry.errorType, 200) } : {}),
     ...(entry.errorSignature ? { errorSignature: compactLogValue(entry.errorSignature, 100) } : {}),
-    ...(entry.event === 'response_client_disconnected' && entry.disconnectSource
-      ? { disconnectSource: entry.disconnectSource }
-      : {}),
+    ...(entry.terminationSource ? { terminationSource: entry.terminationSource } : {}),
   }));
 }
 

--- a/src/upstream-error.ts
+++ b/src/upstream-error.ts
@@ -18,6 +18,7 @@ export interface SdkUpstreamErrorDetails {
   attemptCount: number;
   /** Client backoff hint (seconds); only present on rate-limit (429) failures. */
   retryAfterSeconds?: number;
+  transportCode?: 'websocket_transport_error';
 }
 
 /** Default downstream backoff hint when the upstream throttle gives none. */
@@ -53,6 +54,15 @@ function numericRetryAfterSeconds(inner: InstanceType<typeof APICallError>): num
   return undefined;
 }
 
+function boundedTransportCode(data: unknown): 'websocket_transport_error' | undefined {
+  if (!data || typeof data !== 'object') return undefined;
+  const error = (data as { error?: unknown }).error;
+  if (!error || typeof error !== 'object') return undefined;
+  return (error as { code?: unknown }).code === 'websocket_transport_error'
+    ? 'websocket_transport_error'
+    : undefined;
+}
+
 /** Extract the real HTTP failure from an AI SDK retry wrapper without relying on instanceof. */
 export function sdkUpstreamErrorDetails(err: unknown): SdkUpstreamErrorDetails | undefined {
   const retry = RetryError.isInstance(err) ? err : undefined;
@@ -79,6 +89,7 @@ export function sdkUpstreamErrorDetails(err: unknown): SdkUpstreamErrorDetails |
     isRetryable: inner.isRetryable,
     attemptCount: retry?.errors.length ?? 1,
     ...(retryAfterSeconds !== undefined ? { retryAfterSeconds } : {}),
+    transportCode: boundedTransportCode(inner.data),
   };
 }
 

--- a/tests/http-proxy-server.test.ts
+++ b/tests/http-proxy-server.test.ts
@@ -410,6 +410,7 @@ describe('selective HTTP proxy', () => {
         event: 'response_failed',
         requestId: entries[0].requestId,
         statusCode: 503,
+        terminationSource: 'upstream_failure',
       }));
     } finally {
       if (previousRequestPreview === undefined) delete process.env['CLODEX_LOG_REQUEST_PREVIEW'];
@@ -465,6 +466,7 @@ describe('selective HTTP proxy', () => {
         statusCode: 502,
         phase: 'waiting_for_headers',
         errorType: expect.stringMatching(/^ECONN(?:REFUSED|RESET)$/),
+        terminationSource: 'upstream_failure',
       }));
       expect(entries).toContainEqual(expect.objectContaining({
         event: 'upstream_error',
@@ -820,12 +822,90 @@ describe('selective HTTP proxy', () => {
         requestId: requestEntry.requestId,
         claudeSessionId,
         phase: 'waiting_for_headers',
-        disconnectSource: 'downstream_client',
+        terminationSource: 'downstream_client',
       }));
       expect(entries.some(entry => entry.event === 'response_completed')).toBe(false);
       expect(entries.some(entry => entry.event === 'response_failed')).toBe(false);
     } finally {
       await proxy.close();
+    }
+  }, 20_000);
+
+  it('attributes an in-flight response termination to local proxy shutdown', async () => {
+    const certificates = ensureHttpProxyCertificates();
+    const inferenceLogPath = join(testHome, 'local-shutdown-inference.jsonl');
+    let adapterReceivedResolve!: () => void;
+    const adapterReceived = new Promise<void>(resolve => {
+      adapterReceivedResolve = resolve;
+    });
+    let adapterClosedResolve!: () => void;
+    const adapterClosed = new Promise<void>(resolve => {
+      adapterClosedResolve = resolve;
+    });
+    const adapterServer = http.createServer(req => {
+      req.resume();
+      req.once('end', adapterReceivedResolve);
+      req.socket.once('close', adapterClosedResolve);
+    });
+    const adapterPort = await listen(adapterServer);
+    const route = {
+      aliasId: 'clodex:test:translated-model',
+      realModelId: 'translated-model',
+      displayName: 'Translated Model',
+      upstreamUrl: '',
+      apiKey: 'provider-key',
+      modelFormat: 'openai' as const,
+      npm: '@ai-sdk/openai-compatible',
+      providerId: 'test-provider',
+    };
+    const proxy = await startHttpProxy({
+      routes: [route],
+      adapterHandle: {
+        port: adapterPort,
+        token: 'adapter-local-token',
+        close: () => {
+          adapterServer.closeAllConnections();
+          adapterServer.close();
+        },
+      },
+      inferenceLogPath,
+    });
+    let proxyClosed = false;
+
+    try {
+      const body = JSON.stringify({
+        model: route.aliasId,
+        messages: [{ role: 'user', content: 'wait for local shutdown' }],
+        stream: false,
+      });
+      const secure = await connectMitm(proxy.port, certificates.caCert);
+      secure.on('error', () => {});
+      secure.resume();
+      secure.write([
+        'POST /v1/messages HTTP/1.1',
+        'Host: api.anthropic.com',
+        'Content-Type: application/json',
+        `Content-Length: ${Buffer.byteLength(body)}`,
+        '',
+        '',
+      ].join('\r\n') + body);
+      await adapterReceived;
+      await proxy.close();
+      proxyClosed = true;
+      await adapterClosed;
+      await new Promise(resolve => setImmediate(resolve));
+
+      const entries = readFileSync(inferenceLogPath, 'utf8').trim().split('\n').map(line => JSON.parse(line));
+      const requestEntry = entries.find(entry => !entry.event);
+      expect(entries).toContainEqual(expect.objectContaining({
+        event: 'response_client_disconnected',
+        requestId: requestEntry.requestId,
+        phase: 'waiting_for_headers',
+        terminationSource: 'local_shutdown',
+      }));
+      expect(entries.some(entry => entry.terminationSource === 'downstream_client')).toBe(false);
+    } finally {
+      if (!proxyClosed) await proxy.close();
     }
   }, 20_000);
 
@@ -898,6 +978,7 @@ describe('selective HTTP proxy', () => {
         requestId: requestEntry.requestId,
         statusCode: 200,
         phase: 'streaming',
+        terminationSource: 'upstream_failure',
       }));
       expect(entries.some(entry => entry.event === 'response_completed')).toBe(false);
     } finally {

--- a/tests/http-proxy-server.test.ts
+++ b/tests/http-proxy-server.test.ts
@@ -115,6 +115,7 @@ describe('selective HTTP proxy', () => {
     const certificates = ensureHttpProxyCertificates();
     const inferenceLogPath = join(testHome, 'anthropic-inference.jsonl');
     const webSocketDiagnosticsLogPath = join(testHome, 'websocket-diagnostics.jsonl');
+    const claudeSessionId = '00000000-0000-4000-8000-000000000004';
     const previousRequestPreview = process.env['CLODEX_LOG_REQUEST_PREVIEW'];
     process.env['CLODEX_LOG_REQUEST_PREVIEW'] = '1';
     let receivedBody = Buffer.alloc(0);
@@ -166,6 +167,7 @@ describe('selective HTTP proxy', () => {
         'POST /v1/messages?beta=true HTTP/1.1',
         'Host: api.anthropic.com',
         'Authorization: Bearer subscription-oauth-token',
+        `x-claude-code-session-id: ${claudeSessionId}`,
         'Content-Type: application/json',
         `Content-Length: ${body.length}`,
         'Connection: close',
@@ -199,6 +201,7 @@ describe('selective HTTP proxy', () => {
         effort: 'high',
         provider: 'anthropic',
         route: 'passthrough',
+        claudeSessionId,
         requestPreview: 'user: identify this Sonnet request',
       });
       const responseStarted = entries.find(entry => entry.event === 'response_started');
@@ -209,6 +212,7 @@ describe('selective HTTP proxy', () => {
         requestId: entries[0].requestId,
         statusCode: 200,
         route: 'passthrough',
+        claudeSessionId,
       });
       expect(messageStartUsage).toMatchObject({
         event: 'response_usage',
@@ -216,6 +220,7 @@ describe('selective HTTP proxy', () => {
         modelId: 'claude-sonnet-4-6',
         provider: 'anthropic',
         route: 'passthrough',
+        claudeSessionId,
         usageStage: 'message_start',
         inputTokens: 321,
         outputTokens: 1,
@@ -228,6 +233,7 @@ describe('selective HTTP proxy', () => {
         modelId: 'claude-sonnet-4-6',
         provider: 'anthropic',
         route: 'passthrough',
+        claudeSessionId,
         usageStage: 'message_delta',
         inputTokens: 19,
         outputTokens: 8,
@@ -238,6 +244,7 @@ describe('selective HTTP proxy', () => {
         requestId: entries[0].requestId,
         statusCode: 200,
         route: 'passthrough',
+        claudeSessionId,
       });
       expect(inferenceLog).not.toContain('private-image-data');
       expect(inferenceLog).not.toContain('private response text');
@@ -749,6 +756,7 @@ describe('selective HTTP proxy', () => {
   it('closes the adapter request and logs a terminal client disconnect', async () => {
     const certificates = ensureHttpProxyCertificates();
     const inferenceLogPath = join(testHome, 'client-disconnect-inference.jsonl');
+    const claudeSessionId = '00000000-0000-4000-8000-000000000002';
     let adapterReceivedResolve!: () => void;
     const adapterReceived = new Promise<void>(resolve => { adapterReceivedResolve = resolve; });
     let adapterClosedResolve!: () => void;
@@ -794,6 +802,7 @@ describe('selective HTTP proxy', () => {
         'POST /v1/messages HTTP/1.1',
         'Host: api.anthropic.com',
         'Content-Type: application/json',
+        `x-claude-code-session-id: ${claudeSessionId}`,
         `Content-Length: ${Buffer.byteLength(body)}`,
         '',
         '',
@@ -805,10 +814,13 @@ describe('selective HTTP proxy', () => {
 
       const entries = readFileSync(inferenceLogPath, 'utf8').trim().split('\n').map(line => JSON.parse(line));
       const requestEntry = entries.find(entry => !entry.event);
+      expect(requestEntry.claudeSessionId).toBe(claudeSessionId);
       expect(entries).toContainEqual(expect.objectContaining({
         event: 'response_client_disconnected',
         requestId: requestEntry.requestId,
+        claudeSessionId,
         phase: 'waiting_for_headers',
+        disconnectSource: 'downstream_client',
       }));
       expect(entries.some(entry => entry.event === 'response_completed')).toBe(false);
       expect(entries.some(entry => entry.event === 'response_failed')).toBe(false);

--- a/tests/http-proxy-server.test.ts
+++ b/tests/http-proxy-server.test.ts
@@ -6,7 +6,7 @@ import * as https from 'node:https';
 import * as http from 'node:http';
 import * as net from 'node:net';
 import * as tls from 'node:tls';
-import { once } from 'node:events';
+import { EventEmitter, once } from 'node:events';
 import { gzipSync } from 'node:zlib';
 import { ensureHttpProxyCaBundle, ensureHttpProxyCertificates } from '../src/http-proxy/ca.js';
 import { shouldInterceptConnect, startHttpProxy } from '../src/http-proxy/server.js';
@@ -40,6 +40,33 @@ async function connectMitm(proxyPort: number, ca: string): Promise<tls.TLSSocket
   const secure = tls.connect({ socket, servername: 'api.anthropic.com', ca });
   await once(secure, 'secureConnect');
   return secure;
+}
+
+async function requestMitm(
+  proxyPort: number,
+  ca: string,
+  path: string,
+  body: string,
+): Promise<string> {
+  const secure = await connectMitm(proxyPort, ca);
+  let response = '';
+  secure.on('data', chunk => {
+    response += chunk.toString();
+  });
+  secure.write([
+    `POST ${path} HTTP/1.1`,
+    'Host: api.anthropic.com',
+    'Content-Type: application/json',
+    `Content-Length: ${Buffer.byteLength(body)}`,
+    'Connection: close',
+    '',
+    '',
+  ].join('\r\n') + body);
+  await new Promise<void>(resolve => {
+    secure.once('close', resolve);
+    secure.once('error', resolve);
+  });
+  return response;
 }
 
 function activeProxySockets(proxyPort: number): net.Socket[] {
@@ -909,6 +936,126 @@ describe('selective HTTP proxy', () => {
     }
   }, 20_000);
 
+  it('logs adapter request errno and source when the adapter is unavailable before headers', async () => {
+    const certificates = ensureHttpProxyCertificates();
+    const inferenceLogPath = join(testHome, 'adapter-request-error-inference.jsonl');
+    const unavailableAdapter = http.createServer();
+    const unavailableAdapterPort = await listen(unavailableAdapter);
+    await new Promise<void>(resolve => unavailableAdapter.close(() => resolve()));
+    const route = {
+      aliasId: 'clodex:test:translated-model',
+      realModelId: 'translated-model',
+      displayName: 'Translated Model',
+      upstreamUrl: '',
+      apiKey: 'provider-key',
+      modelFormat: 'openai' as const,
+      npm: '@ai-sdk/openai-compatible',
+      providerId: 'test-provider',
+    };
+    const proxy = await startHttpProxy({
+      routes: [route],
+      adapterHandle: {
+        port: unavailableAdapterPort,
+        token: 'adapter-local-token',
+        close: () => {},
+      },
+      inferenceLogPath,
+    });
+
+    try {
+      const response = await requestMitm(
+        proxy.port,
+        certificates.caCert,
+        '/v1/messages',
+        JSON.stringify({
+          model: route.aliasId,
+          messages: [{ role: 'user', content: 'test unavailable adapter' }],
+          stream: true,
+        }),
+      );
+
+      expect(response).toContain('502');
+      const entries = readFileSync(inferenceLogPath, 'utf8').trim().split('\n').map(line => JSON.parse(line));
+      const requestEntry = entries.find(entry => !entry.event);
+      expect(entries).toContainEqual(expect.objectContaining({
+        event: 'response_failed',
+        requestId: requestEntry.requestId,
+        route: 'translated',
+        statusCode: 502,
+        phase: 'waiting_for_headers',
+        errorType: 'Error',
+        errorCode: expect.stringMatching(/^ECONN(?:REFUSED|RESET)$/),
+        failureSource: 'adapter_request_error',
+        terminationSource: 'upstream_failure',
+      }));
+    } finally {
+      await proxy.close();
+    }
+  }, 20_000);
+
+  it('logs a distinct source when the adapter request closes before headers', async () => {
+    const certificates = ensureHttpProxyCertificates();
+    const inferenceLogPath = join(testHome, 'adapter-request-close-inference.jsonl');
+    const route = {
+      aliasId: 'clodex:test:translated-model',
+      realModelId: 'translated-model',
+      displayName: 'Translated Model',
+      upstreamUrl: '',
+      apiKey: 'provider-key',
+      modelFormat: 'openai' as const,
+      npm: '@ai-sdk/openai-compatible',
+      providerId: 'test-provider',
+    };
+    const adapterRequest = () => {
+      const request = new EventEmitter() as EventEmitter & {
+        end(body: Buffer): void;
+        destroy(error?: Error): void;
+      };
+      request.end = () => queueMicrotask(() => request.emit('close'));
+      request.destroy = () => {};
+      return request;
+    };
+    const proxy = await startHttpProxy({
+      routes: [route],
+      adapterHandle: {
+        port: 1,
+        token: 'adapter-local-token',
+        close: () => {},
+      },
+      inferenceLogPath,
+      adapterRequest,
+    } as Parameters<typeof startHttpProxy>[0]);
+
+    try {
+      const response = await requestMitm(
+        proxy.port,
+        certificates.caCert,
+        '/v1/messages',
+        JSON.stringify({
+          model: route.aliasId,
+          messages: [{ role: 'user', content: 'test closed adapter request' }],
+          stream: true,
+        }),
+      );
+
+      expect(response).toContain('502');
+      const entries = readFileSync(inferenceLogPath, 'utf8').trim().split('\n').map(line => JSON.parse(line));
+      const requestEntry = entries.find(entry => !entry.event);
+      expect(entries).toContainEqual(expect.objectContaining({
+        event: 'response_failed',
+        requestId: requestEntry.requestId,
+        route: 'translated',
+        statusCode: 502,
+        phase: 'waiting_for_headers',
+        errorType: 'Error',
+        failureSource: 'adapter_request_close',
+        terminationSource: 'upstream_failure',
+      }));
+    } finally {
+      await proxy.close();
+    }
+  }, 20_000);
+
   it('terminates and logs a translated response when the adapter closes before end', async () => {
     const certificates = ensureHttpProxyCertificates();
     const inferenceLogPath = join(testHome, 'adapter-abort-inference.jsonl');
@@ -978,6 +1125,7 @@ describe('selective HTTP proxy', () => {
         requestId: requestEntry.requestId,
         statusCode: 200,
         phase: 'streaming',
+        failureSource: 'adapter_response_aborted',
         terminationSource: 'upstream_failure',
       }));
       expect(entries.some(entry => entry.event === 'response_completed')).toBe(false);

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -15,6 +15,7 @@ function postToProxy(
   body: unknown,
   relayRequestId?: string,
   path = '/v1/messages',
+  claudeSessionId?: string,
 ): Promise<{ status: number; body: string; headers: http.IncomingHttpHeaders }> {
   return new Promise((resolve, reject) => {
     const payload = JSON.stringify(body);
@@ -30,6 +31,7 @@ function postToProxy(
           'anthropic-version': '2023-06-01',
           'Content-Length': Buffer.byteLength(payload),
           ...(relayRequestId ? { 'x-relay-request-id': relayRequestId } : {}),
+          ...(claudeSessionId ? { 'x-claude-code-session-id': claudeSessionId } : {}),
         },
       },
       (res) => {
@@ -779,7 +781,15 @@ describe('SDK translated error logging', () => {
         '/v1/messages/count_tokens',
       );
       const expectedInputTokens = JSON.parse(countResponse.body).input_tokens;
-      const res = await postToProxy(handle.port, handle.token, requestBody, 'req-success-1');
+      const claudeSessionId = '00000000-0000-4000-8000-000000000003';
+      const res = await postToProxy(
+        handle.port,
+        handle.token,
+        requestBody,
+        'req-success-1',
+        '/v1/messages',
+        claudeSessionId,
+      );
 
       expect(res.status).toBe(200);
       expect(res.body).toContain('event: message_stop');
@@ -797,15 +807,18 @@ describe('SDK translated error logging', () => {
       expect(entries).toContainEqual(expect.objectContaining({
         event: 'translation_dispatched',
         requestId: 'req-success-1',
+        claudeSessionId,
         phase: 'waiting_for_sdk',
       }));
       expect(entries).toContainEqual(expect.objectContaining({
         event: 'translation_started',
         requestId: 'req-success-1',
+        claudeSessionId,
       }));
       expect(entries).toContainEqual(expect.objectContaining({
         event: 'translation_completed',
         requestId: 'req-success-1',
+        claudeSessionId,
         lastPartType: 'finish',
       }));
       const completed = entries.find(entry => entry.event === 'translation_completed');

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -672,6 +672,65 @@ describe('SDK translated error logging', () => {
     }
   }, 20_000);
 
+  it('records the bounded WebSocket transport code in the translation lifecycle', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'clodex-sdk-transport-error-'));
+    const inferenceLogPath = join(dir, 'inference.jsonl');
+    const upstream = http.createServer((req, res) => {
+      req.resume();
+      res.writeHead(400, {
+        'Content-Type': 'application/json',
+        'Connection': 'close',
+      });
+      res.end(JSON.stringify({
+        error: {
+          type: 'transport_error',
+          code: 'websocket_transport_error',
+          message: 'transport unavailable',
+        },
+      }));
+    });
+    await new Promise<void>((resolve, reject) => {
+      upstream.once('error', reject);
+      upstream.listen(0, '127.0.0.1', () => resolve());
+    });
+    const address = upstream.address();
+    if (!address || typeof address === 'string') throw new Error('test upstream did not bind');
+
+    const route: ProxyRoute = {
+      aliasId: 'clodex:test:translated-model',
+      realModelId: 'gpt-5.6-test',
+      displayName: 'Translated Model',
+      upstreamUrl: '',
+      apiKey: 'provider-key',
+      modelFormat: 'openai',
+      npm: '@ai-sdk/openai-compatible',
+      baseURL: `http://127.0.0.1:${address.port}/v1`,
+      providerId: 'test-provider',
+    };
+    const handle = await startProxyCatalog([route], route.aliasId, false, inferenceLogPath);
+
+    try {
+      const res = await postToProxy(handle.port, handle.token, {
+        model: route.aliasId,
+        max_tokens: 100,
+        messages: [{ role: 'user', content: 'test transport failure' }],
+        stream: true,
+      }, 'req-transport-error');
+
+      expect(res.status).toBe(400);
+      const entries = readFileSync(inferenceLogPath, 'utf8').trim().split('\n').map(line => JSON.parse(line));
+      expect(entries).toContainEqual(expect.objectContaining({
+        event: 'translation_failed',
+        requestId: 'req-transport-error',
+        errorCode: 'websocket_transport_error',
+      }));
+    } finally {
+      handle.close();
+      await new Promise<void>(resolve => upstream.close(() => resolve()));
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 20_000);
+
   it('translates an OpenAI context overflow into an Anthropic prompt-too-long error', async () => {
     const upstream = http.createServer((req, res) => {
       req.resume();

--- a/tests/trace-log.test.ts
+++ b/tests/trace-log.test.ts
@@ -314,7 +314,9 @@ describe('inference request log', () => {
         provider: 'openai',
         route: 'translated',
         errorType: 'Error',
+        errorCode: 'ECONNRESET',
         errorSignature: 'reasoning_part_not_found',
+        failureSource: 'adapter_response_error',
         terminationSource: 'upstream_failure',
       });
       writeInferenceResponseLifecycleLog(path, {
@@ -356,7 +358,9 @@ describe('inference request log', () => {
       expect(failure).toMatchObject({
         event: 'response_failed',
         errorType: 'Error',
+        errorCode: 'ECONNRESET',
         errorSignature: 'reasoning_part_not_found',
+        failureSource: 'adapter_response_error',
         terminationSource: 'upstream_failure',
       });
       expect(failure).not.toHaveProperty('claudeSessionId');

--- a/tests/trace-log.test.ts
+++ b/tests/trace-log.test.ts
@@ -307,7 +307,7 @@ describe('inference request log', () => {
         lastPartType: 'text-delta',
       });
       writeInferenceResponseLifecycleLog(path, {
-        event: 'translation_failed',
+        event: 'response_failed',
         requestId: 'req-123',
         claudeSessionId: 'not-a-session-id',
         modelId: 'clodex:openai:gpt-test',
@@ -315,7 +315,7 @@ describe('inference request log', () => {
         route: 'translated',
         errorType: 'Error',
         errorSignature: 'reasoning_part_not_found',
-        disconnectSource: 'downstream_client',
+        terminationSource: 'upstream_failure',
       });
       writeInferenceResponseLifecycleLog(path, {
         event: 'response_client_disconnected',
@@ -324,10 +324,18 @@ describe('inference request log', () => {
         modelId: 'clodex:openai:gpt-test',
         provider: 'openai',
         route: 'translated',
-        disconnectSource: 'downstream_client',
+        terminationSource: 'downstream_client',
+      });
+      writeInferenceResponseLifecycleLog(path, {
+        event: 'response_client_disconnected',
+        requestId: 'req-456',
+        modelId: 'clodex:openai:gpt-test',
+        provider: 'openai',
+        route: 'translated',
+        terminationSource: 'local_shutdown',
       });
 
-      const [entry, failure, disconnect] = readFileSync(path, 'utf8').trim().split('\n').map(line => JSON.parse(line));
+      const [entry, failure, disconnect, shutdown] = readFileSync(path, 'utf8').trim().split('\n').map(line => JSON.parse(line));
       expect(entry).toMatchObject({
         event: 'translation_progress',
         requestId: 'req-123',
@@ -346,16 +354,21 @@ describe('inference request log', () => {
       });
       expect(entry).not.toHaveProperty('responseContent');
       expect(failure).toMatchObject({
-        event: 'translation_failed',
+        event: 'response_failed',
         errorType: 'Error',
         errorSignature: 'reasoning_part_not_found',
+        terminationSource: 'upstream_failure',
       });
       expect(failure).not.toHaveProperty('claudeSessionId');
-      expect(failure).not.toHaveProperty('disconnectSource');
       expect(disconnect).toMatchObject({
         event: 'response_client_disconnected',
         claudeSessionId: '00000000-0000-4000-8000-000000000001',
-        disconnectSource: 'downstream_client',
+        terminationSource: 'downstream_client',
+      });
+      expect(shutdown).toMatchObject({
+        event: 'response_client_disconnected',
+        requestId: 'req-456',
+        terminationSource: 'local_shutdown',
       });
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/tests/trace-log.test.ts
+++ b/tests/trace-log.test.ts
@@ -293,6 +293,7 @@ describe('inference request log', () => {
       writeInferenceResponseLifecycleLog(path, {
         event: 'translation_progress',
         requestId: 'req-123',
+        claudeSessionId: '00000000-0000-4000-8000-000000000001',
         modelId: 'clodex:openai:gpt-test',
         provider: 'openai',
         route: 'translated',
@@ -308,17 +309,29 @@ describe('inference request log', () => {
       writeInferenceResponseLifecycleLog(path, {
         event: 'translation_failed',
         requestId: 'req-123',
+        claudeSessionId: 'not-a-session-id',
         modelId: 'clodex:openai:gpt-test',
         provider: 'openai',
         route: 'translated',
         errorType: 'Error',
         errorSignature: 'reasoning_part_not_found',
+        disconnectSource: 'downstream_client',
+      });
+      writeInferenceResponseLifecycleLog(path, {
+        event: 'response_client_disconnected',
+        requestId: 'req-123',
+        claudeSessionId: '00000000-0000-4000-8000-000000000001',
+        modelId: 'clodex:openai:gpt-test',
+        provider: 'openai',
+        route: 'translated',
+        disconnectSource: 'downstream_client',
       });
 
-      const [entry, failure] = readFileSync(path, 'utf8').trim().split('\n').map(line => JSON.parse(line));
+      const [entry, failure, disconnect] = readFileSync(path, 'utf8').trim().split('\n').map(line => JSON.parse(line));
       expect(entry).toMatchObject({
         event: 'translation_progress',
         requestId: 'req-123',
+        claudeSessionId: '00000000-0000-4000-8000-000000000001',
         modelId: 'clodex:openai:gpt-test',
         provider: 'openai',
         route: 'translated',
@@ -336,6 +349,13 @@ describe('inference request log', () => {
         event: 'translation_failed',
         errorType: 'Error',
         errorSignature: 'reasoning_part_not_found',
+      });
+      expect(failure).not.toHaveProperty('claudeSessionId');
+      expect(failure).not.toHaveProperty('disconnectSource');
+      expect(disconnect).toMatchObject({
+        event: 'response_client_disconnected',
+        claudeSessionId: '00000000-0000-4000-8000-000000000001',
+        disconnectSource: 'downstream_client',
       });
     } finally {
       rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- distinguish adapter request, early close, response error, response abort, and response close failures
- retain bounded transport error codes on response lifecycle records
- carry the recognized transport failure code into translated-response lifecycle records
- add deterministic transport-failure coverage through injectable request handling

## Privacy

Diagnostics retain only bounded error types, bounded error codes, and fixed failure-source values. Request and response content is not added to lifecycle records.

## Dependency

This draft is stacked on #26. Until that branch lands, the final commit is the topic-specific review scope.

## Validation

- type checking passes
- focused transport and lifecycle logging tests pass
- complete suite: 79 files and 881 tests
- production build passes
- diff hygiene and secret scanning pass
