### PR TITLE
fix(oauth): map upstream 403 throttle to retryable 429

### DIFF
--- a/src/oauth/responses-websocket.ts
+++ b/src/oauth/responses-websocket.ts
@@ -12,7 +12,7 @@ import type { FetchFunction } from '@ai-sdk/provider-utils';
 import type { RawData, WebSocket as WsWebSocket } from 'ws';
 import { CODEX_RESPONSES_WEBSOCKETS_BETA } from '../constants.js';
 import { outboundWsProxyAgent } from '../outbound-proxy.js';
-import { anthropicErrorType } from '../upstream-error.js';
+import { anthropicErrorType, clampRetryAfterSeconds } from '../upstream-error.js';
 
 const RESPONSES_LITE_HEADER = 'x-openai-internal-codex-responses-lite';
 const TERMINAL_EVENT_TYPES = new Set(['response.completed', 'response.failed', 'response.incomplete']);
@@ -814,6 +814,7 @@ function failContext(
   message: string,
   diagnosticDetails: Record<string, unknown>,
   statusCode?: number,
+  retryAfterSeconds?: number,
 ): void {
   if (ctx.closed || entry.current !== ctx) return;
   entry.debug(`fail: ${message}`);
@@ -830,6 +831,7 @@ function failContext(
       code: statusCode === undefined ? 'websocket_transport_error' : String(statusCode),
       message,
       param: null,
+      ...(retryAfterSeconds !== undefined ? { retry_after_seconds: retryAfterSeconds } : {}),
     },
   });
   deleteEntry(entry);
@@ -1117,6 +1119,13 @@ function handleSocketMessage(entry: ConnectionEntry, data: RawData): void {
   }
 }
 
+function numericRetryAfterHeader(value: string | string[] | undefined): number | undefined {
+  const single = Array.isArray(value) ? value[0] : value;
+  return typeof single === 'string' && /^\d+$/.test(single.trim())
+    ? Number(single.trim())
+    : undefined;
+}
+
 function createConnection(
   WebSocket: WebSocketConstructor,
   wsUrl: string,
@@ -1160,16 +1169,41 @@ function createConnection(
   socket.on('unexpected-response', (_request, response) => {
     const statusCode = response.statusCode ?? 502;
     debug(`unexpected-response status=${statusCode}`);
+    // Fire-and-forget drain. Upgrade failures are classified by status alone —
+    // the body is never read, so nothing here is deferred into a callback.
     response.resume();
     const ctx = entry.current;
-    if (ctx && !ctx.closed) {
-      failContext(entry, ctx, `WebSocket upgrade failed (HTTP ${statusCode})`, {
+    if (!ctx || ctx.closed) {
+      deleteEntry(entry);
+      return;
+    }
+    if (statusCode === 403) {
+      // OpenAI's edge/WAF rejects the upgrade with HTTP 403 when the ChatGPT
+      // account's concurrency/usage throttle trips, before the request ever
+      // reaches the application. Terminal conditions are 401 (re-auth) or a
+      // 429 with a JSON body; the only application 403 is a geo restriction,
+      // and the official codex client retries ALL 403s. Map every upgrade 403
+      // to a retryable Anthropic 429 synchronously; failContext closes the
+      // context here, so the socket error/close transport-retry path sees a
+      // finished request and cannot double-handle this failure.
+      const retryAfterSeconds = clampRetryAfterSeconds(
+        numericRetryAfterHeader(response.headers['retry-after']),
+      );
+      // "retry after Ns" is load-bearing: the AI SDK strips unknown frame
+      // fields, so sdkUpstreamErrorDetails recovers the hint from this text.
+      failContext(entry, ctx, 'OpenAI edge throttled the Responses WebSocket upgrade '
+        + `(HTTP 403); retry after ${retryAfterSeconds}s`, {
         source: 'unexpected_response',
         httpStatusCode: statusCode,
-      }, statusCode);
-    } else {
-      deleteEntry(entry);
+        mappedStatusCode: 429,
+        retryAfterSeconds,
+      }, 429, retryAfterSeconds);
+      return;
     }
+    failContext(entry, ctx, `WebSocket upgrade failed (HTTP ${statusCode})`, {
+      source: 'unexpected_response',
+      httpStatusCode: statusCode,
+    }, statusCode);
   });
   socket.on('message', (data: RawData) => handleSocketMessage(entry, data));
   socket.on('error', (error: Error) => {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -680,6 +680,9 @@ export async function startProxyCatalog(
             });
           }
           if (!res.headersSent) {
+            if (details?.retryAfterSeconds !== undefined) {
+              res.setHeader('retry-after', String(details.retryAfterSeconds));
+            }
             anthropicError(
               res,
               upstreamStatus === 500 ? 502 : upstreamStatus,

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -148,7 +148,7 @@ function auditSdkError(
   model: ServerModelInfo,
   err: unknown,
   message: string,
-): number {
+): { statusCode: number; retryAfterSeconds?: number } {
   const details = sdkUpstreamErrorDetails(err);
   const statusCode = details?.statusCode ?? upstreamHttpStatus(err, message);
   if (options.inferenceLogPath && statusCode >= 400) {
@@ -162,7 +162,7 @@ function auditSdkError(
       attemptCount: details?.attemptCount,
     });
   }
-  return statusCode;
+  return { statusCode, retryAfterSeconds: details?.retryAfterSeconds };
 }
 
 function openAiEffort(body: JsonBody): string | undefined {
@@ -477,7 +477,7 @@ async function handleAnthropicMessages(
           plog('sdk oauth credential replaced after 401; retrying once');
           continue;
         }
-        const status = auditSdkError(options, body.model, model, err, message);
+        const { statusCode: status, retryAfterSeconds } = auditSdkError(options, body.model, model, err, message);
         const contextLengthExceeded = status === 400
           && isContextLengthExceededError(err, message);
         const clientMessage = contextLengthExceeded
@@ -495,6 +495,7 @@ async function handleAnthropicMessages(
               request_id: requestId,
             });
           } else {
+            if (retryAfterSeconds !== undefined) res.setHeader('retry-after', String(retryAfterSeconds));
             sendJson(res, status === 500 ? 502 : status, { error: { message: clientMessage } });
           }
         } else {
@@ -667,9 +668,10 @@ async function handleOpenAIChatCompletions(
         plog('sdk oauth credential replaced after 401; retrying once');
         continue;
       }
-      const status = auditSdkError(options, body.model, model, err, message);
+      const { statusCode: status, retryAfterSeconds } = auditSdkError(options, body.model, model, err, message);
       plog(`sdk error npm=${model.npm} upstream=${upstreamModelId(model)}: ${message}`);
       if (!res.headersSent) {
+        if (retryAfterSeconds !== undefined) res.setHeader('retry-after', String(retryAfterSeconds));
         sendJson(res, status === 500 ? 502 : status, { error: { message } });
       } else {
         res.write(`data: ${JSON.stringify({ error: { message, type: 'upstream_error', code: status } })}\n\n`);

--- a/src/upstream-error.ts
+++ b/src/upstream-error.ts
@@ -16,6 +16,41 @@ export interface SdkUpstreamErrorDetails {
   errorContent: string;
   isRetryable: boolean;
   attemptCount: number;
+  /** Client backoff hint (seconds); only present on rate-limit (429) failures. */
+  retryAfterSeconds?: number;
+}
+
+/** Default downstream backoff hint when the upstream throttle gives none. */
+export const DEFAULT_RETRY_AFTER_SECONDS = 5;
+/**
+ * Upper bound for any retry-after hint clodex produces or forwards. Keeps the
+ * AI SDK's bounded backoff (default maxRetries=2) and downstream clients well
+ * clear of clodex's 120s no-event stream abort.
+ */
+export const MAX_RETRY_AFTER_SECONDS = 60;
+
+/** Clamp a retry-after hint to [0, 60]s; missing/invalid values become the 5s default. */
+export function clampRetryAfterSeconds(value?: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    return DEFAULT_RETRY_AFTER_SECONDS;
+  }
+  return Math.min(Math.round(value), MAX_RETRY_AFTER_SECONDS);
+}
+
+function numericRetryAfterSeconds(inner: InstanceType<typeof APICallError>): number | undefined {
+  const data = inner.data as { error?: { retry_after_seconds?: unknown; message?: unknown } } | undefined;
+  const fromBody = data?.error?.retry_after_seconds;
+  if (typeof fromBody === 'number' && Number.isFinite(fromBody) && fromBody >= 0) return fromBody;
+  const fromHeader = inner.responseHeaders?.['retry-after'];
+  if (typeof fromHeader === 'string' && /^\d+$/.test(fromHeader.trim())) return Number(fromHeader.trim());
+  // The OAuth WebSocket transport's synthetic error frames can only carry the
+  // hint in message text — the AI SDK's chunk schema strips unknown fields.
+  for (const message of [data?.error?.message, inner.message]) {
+    if (typeof message !== 'string') continue;
+    const match = /retry after (\d+)s\b/i.exec(message);
+    if (match) return Number(match[1]);
+  }
+  return undefined;
 }
 
 /** Extract the real HTTP failure from an AI SDK retry wrapper without relying on instanceof. */
@@ -33,11 +68,17 @@ export function sdkUpstreamErrorDetails(err: unknown): SdkUpstreamErrorDetails |
     }
   }
 
+  const rawRetryAfter = inner.statusCode === 429 ? numericRetryAfterSeconds(inner) : undefined;
+  const retryAfterSeconds = rawRetryAfter === undefined
+    ? undefined
+    : clampRetryAfterSeconds(rawRetryAfter);
+
   return {
     statusCode: inner.statusCode,
     errorContent: errorContent || inner.message,
     isRetryable: inner.isRetryable,
     attemptCount: retry?.errors.length ?? 1,
+    ...(retryAfterSeconds !== undefined ? { retryAfterSeconds } : {}),
   };
 }
 

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -15,7 +15,7 @@ function postToProxy(
   body: unknown,
   relayRequestId?: string,
   path = '/v1/messages',
-): Promise<{ status: number; body: string }> {
+): Promise<{ status: number; body: string; headers: http.IncomingHttpHeaders }> {
   return new Promise((resolve, reject) => {
     const payload = JSON.stringify(body);
     const req = http.request(
@@ -35,7 +35,7 @@ function postToProxy(
       (res) => {
         let data = '';
         res.on('data', (chunk) => { data += chunk; });
-        res.on('end', () => resolve({ status: res.statusCode ?? 0, body: data }));
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, body: data, headers: res.headers }));
       },
     );
     req.on('error', reject);
@@ -580,6 +580,7 @@ describe('SDK translated error logging', () => {
       }, 'req-error-1');
 
       expect(res.status).toBe(400);
+      expect(res.headers['retry-after']).toBeUndefined();
       expect(res.body).toContain('translated request rejected');
       const entries = readFileSync(inferenceLogPath, 'utf8').trim().split('\n').map(line => JSON.parse(line));
       const errorEntry = entries.find(entry => entry.event === 'upstream_error');
@@ -615,6 +616,57 @@ describe('SDK translated error logging', () => {
       handle.close();
       await new Promise<void>(resolve => upstream.close(() => resolve()));
       rmSync(dir, { recursive: true, force: true });
+    }
+  }, 20_000);
+
+  it('returns HTTP 429 with a clamped retry-after header after upstream rate limiting', async () => {
+    const upstream = http.createServer((req, res) => {
+      req.resume();
+      res.writeHead(429, {
+        'Content-Type': 'application/json',
+        // retry-after-ms drives the AI SDK's internal backoff (1ms keeps the
+        // SDK's own retries fast); retry-after is what clodex forwards to the
+        // client, and 3600 must come out clamped to 60.
+        'retry-after-ms': '1',
+        'retry-after': '3600',
+        'Connection': 'close',
+      });
+      res.end(JSON.stringify({ error: { message: 'rate limited, slow down', type: 'rate_limit_error' } }));
+    });
+    await new Promise<void>((resolve, reject) => {
+      upstream.once('error', reject);
+      upstream.listen(0, '127.0.0.1', () => resolve());
+    });
+    const address = upstream.address();
+    if (!address || typeof address === 'string') throw new Error('test upstream did not bind');
+
+    const route: ProxyRoute = {
+      aliasId: 'clodex:test:rate-limited-model',
+      realModelId: 'rate-limited-model',
+      displayName: 'Rate Limited Model',
+      upstreamUrl: '',
+      apiKey: 'provider-key',
+      modelFormat: 'openai',
+      npm: '@ai-sdk/openai-compatible',
+      baseURL: `http://127.0.0.1:${address.port}/v1`,
+      providerId: 'test-provider',
+    };
+    const handle = await startProxyCatalog([route], route.aliasId, false);
+
+    try {
+      const res = await postToProxy(handle.port, handle.token, {
+        model: route.aliasId,
+        max_tokens: 100,
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: true,
+      });
+
+      expect(res.status).toBe(429);
+      expect(res.headers['retry-after']).toBe('60');
+      expect(res.body).toContain('rate limited');
+    } finally {
+      handle.close();
+      await new Promise<void>(resolve => upstream.close(() => resolve()));
     }
   }, 20_000);
 

--- a/tests/responses-websocket.test.ts
+++ b/tests/responses-websocket.test.ts
@@ -60,6 +60,54 @@ const sessionPayload = (input: unknown[], extra: Record<string, unknown> = {}) =
   ...extra,
 });
 
+/** Drive a failed WebSocket upgrade by emitting `unexpected-response`. */
+function rejectUpgrade(
+  socket: FakeWebSocket,
+  statusCode: number,
+  opts: { headers?: Record<string, string>; statusMessage?: string } = {},
+): { resume: ReturnType<typeof vi.fn> } {
+  const response = Object.assign(new EventEmitter(), {
+    statusCode,
+    statusMessage: opts.statusMessage ?? '',
+    headers: opts.headers ?? {},
+    resume: vi.fn(),
+  });
+  socket.emit('unexpected-response', {}, response);
+  return response;
+}
+
+/** Parse the single SSE error frame produced by a failed request. */
+async function readErrorFrame(res: Response): Promise<{
+  type: string;
+  sequence_number: number;
+  error: Record<string, unknown>;
+}> {
+  const body = await readAll(res);
+  return JSON.parse(body.replace(/^data: /, '').trim());
+}
+
+/** Run the SSE error body through the real AI SDK and classify the surfaced error. */
+async function classifyThroughSdk(sseBody: string): Promise<ReturnType<typeof sdkUpstreamErrorDetails>> {
+  const provider = createOpenAI({
+    apiKey: 'test-only',
+    fetch: async () => new Response(sseBody, {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    }),
+  });
+  const streamed = streamText({
+    model: provider.responses('gpt-5.6-sol'),
+    prompt: 'test',
+    maxRetries: 0,
+    onError: () => {},
+  });
+  let upstreamError: unknown;
+  for await (const part of streamed.stream) {
+    if (part.type === 'error') upstreamError = part.error;
+  }
+  return sdkUpstreamErrorDetails(upstreamError);
+}
+
 function emitTextResponse(socket: FakeWebSocket, responseId: string, text: string): void {
   socket.emit('message', Buffer.from(JSON.stringify({
     type: 'response.created', response: { id: responseId },
@@ -604,17 +652,10 @@ describe('createResponsesWebSocketFetch', () => {
       }),
     );
     const socket = lastSocket();
-    const resume = vi.fn();
-    socket.emit(
-      'unexpected-response',
-      {},
-      {
-        statusCode: 401,
-        statusMessage: 'private response status',
-        headers: { 'x-private': 'private response header' },
-        resume,
-      },
-    );
+    const { resume } = rejectUpgrade(socket, 401, {
+      statusMessage: 'private response status',
+      headers: { 'x-private': 'private response header' },
+    });
 
     const body = await readAll(res);
     const frame = JSON.parse(body.replace(/^data: /, '').trim());
@@ -628,23 +669,7 @@ describe('createResponsesWebSocketFetch', () => {
         param: null,
       },
     });
-    const provider = createOpenAI({
-      apiKey: 'test-only',
-      fetch: async () => new Response(body, {
-        status: 200,
-        headers: { 'content-type': 'text/event-stream' },
-      }),
-    });
-    const streamed = streamText({
-      model: provider.responses('gpt-5.6-sol'),
-      prompt: 'test',
-      onError: () => {},
-    });
-    let upstreamError: unknown;
-    for await (const part of streamed.stream) {
-      if (part.type === 'error') upstreamError = part.error;
-    }
-    expect(sdkUpstreamErrorDetails(upstreamError)?.statusCode).toBe(401);
+    expect((await classifyThroughSdk(body))?.statusCode).toBe(401);
     expect(resume).toHaveBeenCalledOnce();
     expect(socket.close).toHaveBeenCalledOnce();
     expect(diagnostics).toContainEqual(
@@ -679,6 +704,116 @@ describe('createResponsesWebSocketFetch', () => {
     replacement.emit('open');
     emitTextResponse(replacement, 'resp_after_401', 'recovered');
     await readAll(next);
+  });
+
+  it('maps a 403 upgrade rejection (edge throttle) to a retryable 429 rate limit without reading the body', async () => {
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
+      onDiagnostic: event => diagnostics.push(event),
+    });
+    const res = await withResponsesWebSocketDiagnosticContext(
+      { requestId: 'req-upgrade-403' },
+      () => wsFetch('https://x', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer tok' },
+        body: JSON.stringify(sessionPayload([
+          { role: 'user', content: [{ type: 'input_text', text: 'hello' }] },
+        ])),
+      }),
+    );
+    // Emit only `unexpected-response` — never body data or `end`. The mapping
+    // must be synchronous and status-only.
+    const { resume } = rejectUpgrade(lastSocket(), 403);
+
+    const body = await readAll(res);
+    const frame = JSON.parse(body.replace(/^data: /, '').trim());
+    expect(frame.error.type).toBe('rate_limit_error');
+    expect(frame.error.code).toBe('429');
+    expect(frame.error.retry_after_seconds).toBe(5);
+    expect(frame.error.message).toMatch(/retry after 5s/i);
+    expect(resume).toHaveBeenCalledOnce();
+
+    // Through the real AI SDK the failure surfaces as a retryable 429 with the
+    // backoff hint — never as the permission error hosts relabel "Please run
+    // /login".
+    const details = await classifyThroughSdk(body);
+    expect(details).toMatchObject({
+      statusCode: 429,
+      isRetryable: true,
+      retryAfterSeconds: 5,
+    });
+
+    // Diagnostics keep the real upstream status alongside the mapping.
+    expect(diagnostics).toContainEqual(expect.objectContaining({
+      event: 'ws_response_error',
+      requestId: 'req-upgrade-403',
+      source: 'unexpected_response',
+      httpStatusCode: 403,
+      mappedStatusCode: 429,
+      retryAfterSeconds: 5,
+    }));
+  });
+
+  it('honors an upstream retry-after header on a 403 rejection', async () => {
+    const wsFetch = createResponsesWebSocketFetch(WS_URL);
+    const res = await wsFetch('https://x', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer tok' },
+      body: JSON.stringify({ model: 'gpt-5.6-luna', input: [] }),
+    });
+    rejectUpgrade(lastSocket(), 403, { headers: { 'retry-after': '12' } });
+
+    const frame = await readErrorFrame(res);
+    expect(frame.error.type).toBe('rate_limit_error');
+    expect(frame.error.retry_after_seconds).toBe(12);
+  });
+
+  it('clamps an oversized retry-after header and defaults a malformed one', async () => {
+    const wsFetch = createResponsesWebSocketFetch(WS_URL);
+
+    const oversized = await wsFetch('https://x', {
+      method: 'POST',
+      headers: {},
+      body: JSON.stringify({ model: 'gpt-5.6-luna', input: [] }),
+    });
+    rejectUpgrade(lastSocket(), 403, { headers: { 'retry-after': '3600' } });
+    expect((await readErrorFrame(oversized)).error.retry_after_seconds).toBe(60);
+
+    const malformed = await wsFetch('https://x', {
+      method: 'POST',
+      headers: {},
+      body: JSON.stringify({ model: 'gpt-5.6-luna', input: [] }),
+    });
+    rejectUpgrade(lastSocket(), 403, { headers: { 'retry-after': 'Wed, 21 Oct 2026 07:28:00 GMT' } });
+    expect((await readErrorFrame(malformed)).error.retry_after_seconds).toBe(5);
+  });
+
+  it('handles the 403 synchronously so later socket error/close events cannot retry or double-handle', async () => {
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
+      onDiagnostic: event => diagnostics.push(event),
+    });
+    const res = await wsFetch('https://x', {
+      method: 'POST',
+      headers: {},
+      body: JSON.stringify(sessionPayload([
+        { role: 'user', content: [{ type: 'input_text', text: 'throttled' }] },
+      ])),
+    });
+    const socket = lastSocket();
+    rejectUpgrade(socket, 403);
+    // ws surfaces transport teardown after a failed upgrade; the pre-frame
+    // transport retry (PR #29) must see a finished request and stand down.
+    socket.emit('error', Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' }));
+    socket.emit('close', 1006, Buffer.from(''));
+
+    expect(fakeSockets).toHaveLength(1);
+    const frames = (await readAll(res)).split('\n\n').filter(Boolean);
+    expect(frames).toHaveLength(1);
+    expect(JSON.parse(frames[0]!.replace(/^data: /, '')).error.type).toBe('rate_limit_error');
+    expect(diagnostics).not.toContainEqual(expect.objectContaining({
+      event: 'ws_transport_retry',
+    }));
   });
 
   it('logs sanitized upstream response failure details after partial output', async () => {

--- a/tests/responses-websocket.test.ts
+++ b/tests/responses-websocket.test.ts
@@ -777,7 +777,11 @@ describe('createResponsesWebSocketFetch', () => {
       body: JSON.stringify({ model: 'gpt-5.6-luna', input: [] }),
     });
     rejectUpgrade(lastSocket(), 403, { headers: { 'retry-after': '3600' } });
-    expect((await readErrorFrame(oversized)).error.retry_after_seconds).toBe(60);
+    const oversizedFrame = await readErrorFrame(oversized);
+    expect(oversizedFrame.error.retry_after_seconds).toBe(60);
+    // The message text is the only channel that survives the AI SDK's chunk
+    // schema stripping, so the CLAMPED value must appear there too.
+    expect(oversizedFrame.error.message).toMatch(/retry after 60s\b/i);
 
     const malformed = await wsFetch('https://x', {
       method: 'POST',
@@ -785,7 +789,9 @@ describe('createResponsesWebSocketFetch', () => {
       body: JSON.stringify({ model: 'gpt-5.6-luna', input: [] }),
     });
     rejectUpgrade(lastSocket(), 403, { headers: { 'retry-after': 'Wed, 21 Oct 2026 07:28:00 GMT' } });
-    expect((await readErrorFrame(malformed)).error.retry_after_seconds).toBe(5);
+    const malformedFrame = await readErrorFrame(malformed);
+    expect(malformedFrame.error.retry_after_seconds).toBe(5);
+    expect(malformedFrame.error.message).toMatch(/retry after 5s\b/i);
   });
 
   it('handles the 403 synchronously so later socket error/close events cannot retry or double-handle', async () => {
@@ -815,6 +821,42 @@ describe('createResponsesWebSocketFetch', () => {
       event: 'ws_transport_retry',
     }));
   });
+
+  it('lets the AI SDK transparently retry a 403-throttled upgrade and recover', async () => {
+    // The design premise of the 403->429 mapping: because the synthetic error
+    // frame arrives BEFORE any output chunk, @ai-sdk/openai's
+    // throwIfOpenAIStreamErrorBeforeOutput rejects doStream with a retryable
+    // 429 APICallError, so the AI SDK's own retry loop re-attempts the whole
+    // request — including a fresh WebSocket upgrade. This drives that loop for
+    // real: attempt 1 gets a 403 upgrade rejection, attempt 2 succeeds.
+    const wsFetch = createResponsesWebSocketFetch(WS_URL);
+    const provider = createOpenAI({ apiKey: 'test-only', fetch: wsFetch });
+    const streamed = streamText({
+      model: provider.responses('gpt-5.6-sol'),
+      prompt: 'retry me',
+      maxRetries: 1,
+      onError: () => {},
+    });
+    const collected = (async () => {
+      let out = '';
+      for await (const chunk of streamed.textStream) out += chunk;
+      return out;
+    })();
+
+    await vi.waitFor(() => expect(fakeSockets).toHaveLength(1));
+    rejectUpgrade(lastSocket(), 403);
+
+    // The SDK backs off (no retry-after header on the synthetic SSE response,
+    // so its default ~2s exponential delay) and opens a SECOND upgrade.
+    await vi.waitFor(() => expect(fakeSockets).toHaveLength(2), { timeout: 10_000 });
+    const replacement = lastSocket();
+    replacement.emit('open');
+    emitTextResponse(replacement, 'resp_retry_recovered', 'recovered');
+
+    // Transparent recovery: the caller sees only the successful text.
+    await expect(collected).resolves.toBe('recovered');
+    expect(fakeSockets).toHaveLength(2);
+  }, 20_000);
 
   it('logs sanitized upstream response failure details after partial output', async () => {
     const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];

--- a/tests/server-router.test.ts
+++ b/tests/server-router.test.ts
@@ -1,5 +1,6 @@
 import { createServer, type Server } from 'node:http';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { APICallError } from 'ai';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -596,6 +597,88 @@ describe('server router', () => {
     expect(body.error.type).toBe('invalid_request_error');
     expect(body.error.message).toMatch(/^prompt is too long: \d+ tokens > 10 maximum$/);
     expect(body.request_id).toEqual(expect.any(String));
+  });
+
+  it('sets a clamped retry-after header on translated 429s from both endpoints', async () => {
+    const sdkCatalog = createGatewayModelCatalog([{
+      id: 'sdk-model',
+      name: 'SDK Model',
+      isFree: false,
+      brand: 'Test',
+      providerId: 'test-provider',
+      sourceBackend: 'test-provider',
+      modelFormat: 'openai',
+      npm: '@ai-sdk/openai',
+      apiKey: 'provider-key',
+    }]);
+    const rateLimitError = (retryAfter: string) => new APICallError({
+      message: 'rate limited',
+      url: 'https://upstream/v1/responses',
+      requestBodyValues: {},
+      statusCode: 429,
+      responseHeaders: { 'retry-after': retryAfter },
+      responseBody: JSON.stringify({ error: { message: 'rate limited' } }),
+    });
+    const server = await startTestServer({ catalog: sdkCatalog });
+
+    // Anthropic-format endpoint: an oversized upstream hint comes out clamped.
+    vi.mocked(generateAnthropicResponse).mockRejectedValueOnce(rateLimitError('3600'));
+    const anthropicResponse = await fetch(`${server.url}/anthropic/v1/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'anthropic-test-provider__sdk-model',
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+    });
+    expect(anthropicResponse.status).toBe(429);
+    expect(anthropicResponse.headers.get('retry-after')).toBe('60');
+
+    // OpenAI-format endpoint: an in-range hint is forwarded as-is.
+    vi.mocked(generateOpenAiResponse).mockRejectedValueOnce(rateLimitError('7'));
+    const openAiResponse = await fetch(`${server.url}/openai/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'sdk-model', messages: [{ role: 'user', content: 'hi' }] }),
+    });
+    expect(openAiResponse.status).toBe(429);
+    expect(openAiResponse.headers.get('retry-after')).toBe('7');
+  });
+
+  it('omits the retry-after header on non-429 upstream errors', async () => {
+    const sdkCatalog = createGatewayModelCatalog([{
+      id: 'sdk-model',
+      name: 'SDK Model',
+      isFree: false,
+      brand: 'Test',
+      providerId: 'test-provider',
+      sourceBackend: 'test-provider',
+      modelFormat: 'openai',
+      npm: '@ai-sdk/openai',
+      apiKey: 'provider-key',
+    }]);
+    // Even with a retry-after header present upstream, a non-429 stays terminal
+    // with no backoff hint.
+    vi.mocked(generateAnthropicResponse).mockRejectedValueOnce(new APICallError({
+      message: 'forbidden',
+      url: 'https://upstream/v1/responses',
+      requestBodyValues: {},
+      statusCode: 403,
+      responseHeaders: { 'retry-after': '30' },
+      responseBody: JSON.stringify({ error: { message: 'forbidden' } }),
+    }));
+    const server = await startTestServer({ catalog: sdkCatalog });
+
+    const response = await fetch(`${server.url}/anthropic/v1/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'anthropic-test-provider__sdk-model',
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+    });
+    expect(response.status).toBe(403);
+    expect(response.headers.get('retry-after')).toBeNull();
   });
 
   it('forces internal streaming for non-streaming requests on OpenAI OAuth routes', async () => {

--- a/tests/upstream-error.test.ts
+++ b/tests/upstream-error.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { APICallError } from 'ai';
+import { anthropicErrorType, clampRetryAfterSeconds, sdkUpstreamErrorDetails } from '../src/upstream-error.js';
+
+function apiCallError(overrides: {
+  statusCode: number;
+  message?: string;
+  responseBody?: string;
+  responseHeaders?: Record<string, string>;
+  data?: unknown;
+}): APICallError {
+  return new APICallError({
+    message: `HTTP ${overrides.statusCode} failure`,
+    url: 'https://chatgpt.com/backend-api/codex/responses',
+    requestBodyValues: {},
+    ...overrides,
+  });
+}
+
+describe('sdkUpstreamErrorDetails retry-after extraction', () => {
+  it('keeps every non-WebSocket 403 a terminal permission error (WS layer owns the throttle mapping)', () => {
+    const details = sdkUpstreamErrorDetails(apiCallError({
+      statusCode: 403,
+      responseBody: JSON.stringify({
+        error: { type: 'invalid_request_error', message: 'Your account may not use this model.' },
+      }),
+    }));
+    expect(details).toMatchObject({ statusCode: 403, isRetryable: false });
+    expect(details?.retryAfterSeconds).toBeUndefined();
+    expect(anthropicErrorType(details!.statusCode!)).toBe('permission_error');
+  });
+
+  it('extracts the backoff hint on 429s from the error payload or retry-after header', () => {
+    const fromPayload = sdkUpstreamErrorDetails(apiCallError({
+      statusCode: 429,
+      data: { error: { message: 'rate limited', retry_after_seconds: 5 } },
+    }));
+    expect(fromPayload).toMatchObject({ statusCode: 429, isRetryable: true, retryAfterSeconds: 5 });
+
+    const fromHeader = sdkUpstreamErrorDetails(apiCallError({
+      statusCode: 429,
+      responseBody: JSON.stringify({ error: { message: 'rate limited' } }),
+      responseHeaders: { 'retry-after': '12' },
+    }));
+    expect(fromHeader).toMatchObject({ statusCode: 429, retryAfterSeconds: 12 });
+  });
+
+  it('recovers the hint from message text on 429s (the WS synthetic frame path)', () => {
+    const details = sdkUpstreamErrorDetails(apiCallError({
+      statusCode: 429,
+      message: 'OpenAI edge throttled the Responses WebSocket upgrade (HTTP 403); retry after 5s',
+    }));
+    expect(details).toMatchObject({ statusCode: 429, isRetryable: true, retryAfterSeconds: 5 });
+  });
+
+  it('clamps an oversized extracted hint to 60s', () => {
+    const details = sdkUpstreamErrorDetails(apiCallError({
+      statusCode: 429,
+      responseBody: JSON.stringify({ error: { message: 'rate limited' } }),
+      responseHeaders: { 'retry-after': '3600' },
+    }));
+    expect(details?.retryAfterSeconds).toBe(60);
+  });
+
+  it('carries no backoff hint on non-rate-limit failures', () => {
+    const details = sdkUpstreamErrorDetails(apiCallError({
+      statusCode: 500,
+      responseBody: 'internal error',
+      responseHeaders: { 'retry-after': '30' },
+    }));
+    expect(details?.statusCode).toBe(500);
+    expect(details?.retryAfterSeconds).toBeUndefined();
+  });
+});
+
+describe('clampRetryAfterSeconds', () => {
+  it('defaults missing or invalid values to 5s and caps at 60s', () => {
+    expect(clampRetryAfterSeconds(undefined)).toBe(5);
+    expect(clampRetryAfterSeconds(Number.NaN)).toBe(5);
+    expect(clampRetryAfterSeconds(-1)).toBe(5);
+    expect(clampRetryAfterSeconds(0)).toBe(0);
+    expect(clampRetryAfterSeconds(12)).toBe(12);
+    expect(clampRetryAfterSeconds(3600)).toBe(60);
+  });
+});

--- a/tests/upstream-error.test.ts
+++ b/tests/upstream-error.test.ts
@@ -30,6 +30,18 @@ describe('sdkUpstreamErrorDetails retry-after extraction', () => {
     expect(anthropicErrorType(details!.statusCode!)).toBe('permission_error');
   });
 
+  it('keeps a bodyless 403 terminal — the removed WS-throttle heuristic must not return here', () => {
+    // OpenAI's edge rejects the WebSocket upgrade with an HTTP 403 carrying NO
+    // body. That exact shape maps to a retryable 429 in the WebSocket layer
+    // ONLY; reintroducing a bodyless-403 -> 429 heuristic in this HTTP
+    // classifier would make every plain 403 (real permission failures) retryable.
+    const details = sdkUpstreamErrorDetails(apiCallError({ statusCode: 403 }));
+    expect(details).toMatchObject({ statusCode: 403, isRetryable: false });
+    expect(details?.statusCode).not.toBe(429);
+    expect(details?.retryAfterSeconds).toBeUndefined();
+    expect(anthropicErrorType(details!.statusCode!)).toBe('permission_error');
+  });
+
   it('extracts the backoff hint on 429s from the error payload or retry-after header', () => {
     const fromPayload = sdkUpstreamErrorDetails(apiCallError({
       statusCode: 429,


### PR DESCRIPTION
## Problem

Under concurrent ChatGPT/Codex OAuth Responses traffic, OpenAI's edge returns **HTTP 403 with an empty body** at the WebSocket upgrade — a WAF/edge concurrency throttle, not an application error. The transport classified that 403 as a terminal `permission_error`, so a transient throttle surfaced as a hard failure; worse, surrounding tooling reads a 403 as an auth problem and tells the user to re-login, which is misleading (the credentials are fine).

## Why a bodyless 403 here is transient

- **OpenAI's documented error codes** reserve **403 for regional restrictions** (served *with* a body); authentication failures are **401** and rate-limit/quota are **429** (both with bodies). A **bodyless** 403 is therefore not a documented application error — it's the edge/WAF layer.
- The official **codex** client treats **all** 403s as retryable (`UnexpectedStatus`) and reserves re-authentication **strictly for 401**. Mapping a WS-upgrade 403 to a retryable rate limit matches the reference client.

## Change

At the WebSocket `unexpected-response` handler, map every 403 **synchronously** to a retryable Anthropic **429 `rate_limit_error`** with a **clamped `retry-after`** (default 5s, max 60s). The body is drained but never read, so nothing is deferred into a callback.

Because the synthetic error is delivered before any output chunk, the AI SDK's built-in retry (default `maxRetries`) transparently re-attempts the upgrade with backoff — a genuine throttle clears on retry, and only a persistent one surfaces downstream, now as a proper `429` that retries gracefully instead of looking like an auth failure. The `retry-after` clamp keeps that backoff comfortably under the transport's 120s idle-abort.

The mapping is single-sourced at the transport layer; **plain HTTP 403s stay terminal `permission_error`** (regional restriction, API-key model-access denials, etc.).

## Tests

- 403 at the WS upgrade → retryable `429` + clamped `retry-after`, driven through the real AI SDK.
- **Transparent recovery**: a 403 upgrade followed by SDK backoff opens a second upgrade attempt and completes successfully (proves the retry premise end-to-end).
- A plain/bodyless 403 into the SDK error classifier **stays terminal** `permission_error` (guards against re-introducing a body-based heuristic).
- Client-facing `retry-after` header is set on 429 responses (proxy + server paths) and omitted otherwise; clamp boundaries covered.
- Composes with the existing pre-frame transport retry: the 403 is handled synchronously (`ctx.closed`), so later socket `error`/`close` events cannot double-handle or consume the retry budget.
