### PR TITLE
test: sandbox CLODEX_HOME so the suite can never touch real user state

### DIFF
--- a/tests/test-sandbox-floor.test.ts
+++ b/tests/test-sandbox-floor.test.ts
@@ -1,0 +1,20 @@
+import { tmpdir, userInfo } from 'node:os';
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { getAppHome } from '../src/paths.js';
+
+describe('test sandbox floor', () => {
+  it('keeps the default app home inside a Vitest temp sandbox', () => {
+    expect(process.env.CLODEX_HOME).toBeDefined();
+    const clodexHome = process.env.CLODEX_HOME!;
+    const relativeToTemp = relative(resolve(tmpdir()), resolve(clodexHome));
+
+    expect(relativeToTemp).not.toBe('');
+    expect(relativeToTemp).not.toMatch(/^\.\.(?:[/\\]|$)/);
+    expect(isAbsolute(relativeToTemp)).toBe(false);
+    expect(basename(clodexHome)).toBe('clodex-home');
+    expect(basename(dirname(clodexHome))).toMatch(/^clodex-vitest-sandbox-/);
+    expect(getAppHome()).toBe(clodexHome);
+    expect(getAppHome()).not.toBe(join(userInfo().homedir, '.clodex'));
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    setupFiles: ['./vitest.setup.ts'],
+  },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,16 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach } from 'vitest';
+
+const sandboxRoot = mkdtempSync(join(tmpdir(), 'clodex-vitest-sandbox-'));
+const sandboxHome = join(sandboxRoot, 'clodex-home');
+
+function establishSandboxFloor(): void {
+  process.env.CLODEX_HOME = sandboxHome;
+  // HOME is sandboxed too: the full suite supports this stronger floor for direct homedir() reads.
+  process.env.HOME = sandboxRoot;
+}
+
+establishSandboxFloor();
+beforeEach(establishSandboxFloor);


### PR DESCRIPTION
## Summary

- create a per-worker temporary `CLODEX_HOME` before test modules load
- reapply that sandbox before every test so teardown in one test cannot expose real user state
- add a behavioral test proving path resolution stays under the OS temporary directory

This prevents an unisolated registry, journal, or config write from modifying or erasing a
developer's real `~/.clodex` data.

## Verification

- `CLODEX_HOME="$(mktemp -d)" pnpm typecheck`
- `CLODEX_HOME="$(mktemp -d)" pnpm test`
- `CLODEX_HOME="$(mktemp -d)" pnpm build`
- confirmed the floor test fails when the global setup is removed, then restored it