### PR TITLE
Redact resolved credentials from trace logs by value

### DIFF
--- a/src/registry/custom-endpoint.ts
+++ b/src/registry/custom-endpoint.ts
@@ -19,7 +19,11 @@ import {
 import type { CachedModel, RegistryProvider } from './types.js';
 import { customProviderId, isValidProviderId, slugifyProviderId } from './validate.js';
 import { validateCustomEndpointUrl } from './url-security.js';
-import { makeTraceLogger, getProviderDebugLogPath } from '../trace-log.js';
+import {
+  getProviderDebugLogPath,
+  makeTraceLogger,
+  registerTraceSecret,
+} from '../trace-log.js';
 
 export type CustomEndpointKind = 'openai' | 'anthropic';
 
@@ -75,6 +79,7 @@ export async function fetchAnthropicModels(
 
     let logTrace: ((msg: string) => void) | undefined;
     if (process.env.CLODEX_TRACE === '1') {
+      if (apiKey.trim()) registerTraceSecret(apiKey);
       logTrace = makeTraceLogger(getProviderDebugLogPath());
     }
 

--- a/src/registry/fetch-template-models.ts
+++ b/src/registry/fetch-template-models.ts
@@ -5,7 +5,11 @@ import { resolveContextWindow } from '../context-window.js';
 import type { ProviderTemplate } from '../provider-templates.js';
 import { normalizeGoogleDisplayName, normalizeGoogleModelId } from './google-model-id.js';
 import type { CachedModel } from './types.js';
-import { makeTraceLogger, getProviderDebugLogPath } from '../trace-log.js';
+import {
+  getProviderDebugLogPath,
+  makeTraceLogger,
+  registerTraceSecret,
+} from '../trace-log.js';
 import { classifyFreeStatus, isFreeStatus } from '../free-models.js';
 
 const TEST_TIMEOUT_MS = 10_000;
@@ -212,6 +216,7 @@ export async function fetchTemplateModels(
 
     let logTrace: ((msg: string) => void) | undefined;
     if (process.env.CLODEX_TRACE === '1') {
+      if (trimmedApiKey) registerTraceSecret(trimmedApiKey);
       logTrace = makeTraceLogger(getProviderDebugLogPath());
     }
 

--- a/src/trace-log.ts
+++ b/src/trace-log.ts
@@ -543,6 +543,19 @@ export function resetTraceLog(path: string): void {
   }
 }
 
+const MIN_TRACE_SECRET_LENGTH = 8;
+const knownTraceSecrets = new Set<string>();
+
+export function registerTraceSecret(value: string): void {
+  if (value.trim().length < MIN_TRACE_SECRET_LENGTH) return;
+  knownTraceSecrets.add(value);
+}
+
+/** Test hook: prevent registered credentials from leaking between test cases. */
+export function clearTraceSecrets(): void {
+  knownTraceSecrets.clear();
+}
+
 const REDACTION_PATTERNS: Array<(line: string) => string> = [
   // Bearer / Authorization headers
   line => line.replace(/Bearer\s+[A-Za-z0-9._\-+/=]+/gi, 'Bearer [REDACTED]'),
@@ -557,6 +570,9 @@ const REDACTION_PATTERNS: Array<(line: string) => string> = [
 
 export function redactTraceLine(line: string): string {
   let out = line;
+  for (const secret of knownTraceSecrets) {
+    out = out.split(secret).join('[REDACTED]');
+  }
   for (const apply of REDACTION_PATTERNS) {
     out = apply(out);
   }

--- a/tests/fetch-template-models.test.ts
+++ b/tests/fetch-template-models.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { fetchTemplateModels } from '../src/registry/fetch-template-models.js';
 import type { ProviderTemplate } from '../src/provider-templates.js';
+import { clearTraceSecrets, getProviderDebugLogPath } from '../src/trace-log.js';
 
 function template(partial: Partial<ProviderTemplate> & Pick<ProviderTemplate, 'id' | 'name' | 'npm'>): ProviderTemplate {
   return {
@@ -31,6 +35,7 @@ describe('fetchTemplateModels', () => {
   });
 
   afterEach(() => {
+    clearTraceSecrets();
     vi.unstubAllGlobals();
   });
 
@@ -77,6 +82,34 @@ describe('fetchTemplateModels', () => {
         }),
       }),
     );
+  });
+
+  it('redacts an opaque API key echoed in a traced response body', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'clodex-trace-redaction-'));
+    const previousHome = process.env.CLODEX_HOME;
+    const previousTrace = process.env.CLODEX_TRACE;
+    const secret = 'opaque.credential+$value[42]';
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => JSON.stringify({ echo: secret }),
+    } as Response);
+
+    process.env.CLODEX_HOME = home;
+    process.env.CLODEX_TRACE = '1';
+    try {
+      await fetchTemplateModels(openaiCompatTemplate, secret);
+
+      const trace = readFileSync(getProviderDebugLogPath(), 'utf8');
+      expect(trace).toContain('{"echo":"[REDACTED]"}');
+      expect(trace).not.toContain(secret);
+    } finally {
+      if (previousHome === undefined) delete process.env.CLODEX_HOME;
+      else process.env.CLODEX_HOME = previousHome;
+      if (previousTrace === undefined) delete process.env.CLODEX_TRACE;
+      else process.env.CLODEX_TRACE = previousTrace;
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 
   it('merges extra headers for custom endpoints needing plan/auth-tracking headers', async () => {

--- a/tests/trace-log.test.ts
+++ b/tests/trace-log.test.ts
@@ -1,12 +1,14 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect } from 'vitest';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
+  clearTraceSecrets,
   getInferenceSessionLogPath,
   getLatestMessagePreview,
   redactTraceLine,
   redactTraceLog,
+  registerTraceSecret,
   writeInferenceRequestLog,
   writeInferenceResponseLifecycleLog,
   writeInferenceResponseErrorLog,
@@ -15,6 +17,24 @@ import {
 } from '../src/trace-log.js';
 
 describe('trace log redaction', () => {
+  afterEach(() => {
+    clearTraceSecrets();
+  });
+
+  it('redacts registered opaque credentials as literal values', () => {
+    const secret = 'opaque.$credential+[42]';
+    registerTraceSecret(secret);
+
+    expect(redactTraceLine(`{"echo":"${secret}","again":"${secret}"}`))
+      .toBe('{"echo":"[REDACTED]","again":"[REDACTED]"}');
+  });
+
+  it('does not register too-short values', () => {
+    registerTraceSecret('short');
+
+    expect(redactTraceLine('{"echo":"short"}')).toBe('{"echo":"short"}');
+  });
+
   it('redacts bearer tokens', () => {
     expect(redactTraceLine('Authorization: Bearer sk-ant-api03-secret123')).toContain('[REDACTED]');
     expect(redactTraceLine('Authorization: Bearer sk-ant-api03-secret123')).not.toContain('secret123');


### PR DESCRIPTION
## Summary

- register resolved upstream credentials with trace logging before response bodies can be logged
- scrub registered credentials as literal substrings in every trace output path
- ignore short values to avoid over-redacting ordinary log content
- cover both template and custom endpoint credential resolution

Trace logging previously scrubbed only credential-shaped syntax. If an upstream reflected a token in an arbitrary field, the raw value could persist in `provider-debug.log`. Registering the resolved value closes that gap regardless of its format.

## Verification

- `CLODEX_HOME="$(mktemp -d)" pnpm typecheck`
- `CLODEX_HOME="$(mktemp -d)" pnpm test` (77 files, 876 tests)
- `CLODEX_HOME="$(mktemp -d)" pnpm build`
- focused coverage verifies opaque-token redaction, short-value guards, and reflected response bodies