### PR TITLE
test(proxy): assert parentPid/host/reason on lifecycle events

### DIFF
--- a/tests/http-proxy-index.test.ts
+++ b/tests/http-proxy-index.test.ts
@@ -57,15 +57,21 @@ describe('HTTP proxy startup model list', () => {
       ]);
       expect(entries[0]).toMatchObject({
         pid: process.pid,
+        parentPid: process.ppid,
         host: '127.0.0.1',
         port: expect.any(Number),
       });
       expect(entries[1]).toMatchObject({
         pid: process.pid,
+        parentPid: entries[0].parentPid,
+        host: entries[0].host,
         port: entries[0].port,
+        reason: 'shutdown signal received',
       });
       expect(entries[2]).toMatchObject({
         pid: process.pid,
+        parentPid: entries[0].parentPid,
+        host: entries[0].host,
         port: entries[0].port,
       });
     } finally {


### PR DESCRIPTION
## Summary

Strengthen the standalone proxy lifecycle test to assert every structured field emitted for startup and shutdown events. This pins the parent PID and host across all lifecycle records, plus the shutdown reason, so those fields cannot be dropped or miswired without failing the test.

This is a test-only change.

## Verification

- `CLODEX_HOME="$(mktemp -d)" pnpm typecheck`
- `CLODEX_HOME="$(mktemp -d)" pnpm test`
- `CLODEX_HOME="$(mktemp -d)" pnpm build`