### PR TITLE
feat!: remove legacy ~/.relay-ai migration support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,14 +72,14 @@ clodex-claude [args...]     # second bin: launch claude bridged to a running clo
 
 **Critical URL constraint:** Anthropic-passthrough base URLs must NOT include `/v1` — the Anthropic SDK appends `/v1/messages` itself.
 
-**Provider registry** (`src/registry/`): only two providers exist — templates in `src/provider-templates.ts` (`openai` API-key template with `https://api.openai.com/v1`, and `openai-oauth`). `provider-auth.ts` implements the OpenAI device-code OAuth flow; `refresh-models.ts` fetches the model list (3-tier fetch for OAuth). `io.ts::loadRegistry` and `config.ts::readConfig` both trigger the one-time legacy migration. Materialization (`materialize.ts`) turns registry providers into `LocalProvider`s with per-model `npm`/`baseUrl`/`upstreamModelId`.
+**Provider registry** (`src/registry/`): only two providers exist — templates in `src/provider-templates.ts` (`openai` API-key template with `https://api.openai.com/v1`, and `openai-oauth`). `provider-auth.ts` implements the OpenAI device-code OAuth flow; `refresh-models.ts` fetches the model list (3-tier fetch for OAuth). Materialization (`materialize.ts`) turns registry providers into `LocalProvider`s with per-model `npm`/`baseUrl`/`upstreamModelId`.
 
 Registry writes use atomic hard-link lock publication, so the filesystem containing `CLODEX_HOME` must support hard links. A parseable lock owned by a live PID is never reclaimed based on age; contenders wait for a bounded interval and fail with the owner PID. Malformed locks and locks owned by dead PIDs remain reclaimable. This live-owner rule is what makes the final ownership check before `providers.json` publication meaningful because a concurrent process cannot invalidate a live writer between its check and rename.
 
-**Config & migration** (`src/paths.ts`, `src/config.ts`, `src/env.ts`):
+**Config** (`src/paths.ts`, `src/config.ts`, `src/env.ts`):
 
-- Config home `~/.clodex`, override `CLODEX_HOME`. `ensureLegacyAppHomeMigrated()` silently copies a legacy `~/.relay-ai` (skipping `logs/`) on first read — **never mutates the legacy directory**.
-- Keychain service `clodex` with per-account fallback read from legacy service `relay-ai` (copied into `clodex` on first hit). Chunked-entry support retained for Windows credential size limits.
+- Config home `~/.clodex`, override `CLODEX_HOME`.
+- Keychain service `clodex` supports chunked entries for Windows credential size limits.
 - Preferences: `lastModel`, `lastProvider`, `recentModelsByProvider`, `favoriteModels`, `modelAliases`, `claudeBridgeMode`, `serverBridgeMode`, `appPathOverrides`, `recentLaunchFolders`, `server*` settings. All writes skipped when `dryRun`.
 - `CLODEX_CLAUDE_PATH` overrides Claude Code binary discovery (`src/launch.ts`).
 
@@ -103,7 +103,7 @@ Registry writes use atomic hard-link lock publication, so the filesystem contain
 
 **Outbound proxy** (`src/outbound-proxy.ts`): when `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` are set in clodex's environment, `installOutboundProxyDispatcher()` (called at the top of `main()`) installs undici's `EnvHttpProxyAgent` as the global fetch dispatcher, so every fetch-based call (OAuth device flow/refresh, model-list + models.dev refresh, AI-SDK upstream calls) honors them; without proxy env vars it is a no-op and nothing changes. The `ws`-based OAuth Responses WebSocket doesn't use the undici dispatcher — `outboundWsProxyAgent()` gives it an `https-proxy-agent` CONNECT-tunnel agent instead (passed through `createConnection`). Self-loop guard: clodex never sets proxy vars in its own `process.env`; proxy bridge mode points only the CHILD at the MITM listener via env copies (`buildChildEnv`/`buildHttpProxyChildEnv` never mutate `process.env` — covered by a test), so the dispatcher can never route clodex's upstream calls through clodex's own listener.
 
-**Tests** (`tests/`): pure functions only — adapter, provider factory, proxy, http-proxy routes, registry, config/migration, bridge-mode persistence, patcher (config building, hash stability, manifest staleness, lock behavior, per-site patch transforms), help text. Interactive launch flow and real-provider behavior are verified manually.
+**Tests** (`tests/`): pure functions only — adapter, provider factory, proxy, http-proxy routes, registry, config, bridge-mode persistence, patcher (config building, hash stability, manifest staleness, lock behavior, per-site patch transforms), help text. Interactive launch flow and real-provider behavior are verified manually.
 
 ## Key constraints
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import type { UserPreferences } from './types.js';
 import { dirname } from 'node:path';
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { ensureLegacyAppHomeMigrated, getConfigPath } from './paths.js';
+import { getConfigPath } from './paths.js';
 
 function readJsonFile(path: string): UserPreferences | null {
   try {
@@ -13,7 +13,6 @@ function readJsonFile(path: string): UserPreferences | null {
 }
 
 function readConfig(): UserPreferences {
-  ensureLegacyAppHomeMigrated();
   return readJsonFile(getConfigPath()) ?? {};
 }
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -128,8 +128,6 @@ export function classifyKeyringError(err: unknown): string {
 }
 
 const KEYRING_SERVICE = 'clodex';
-/** One-time silent migration source: credentials stored by relay-ai. */
-const LEGACY_KEYRING_SERVICE = 'relay-ai';
 // Windows Credential Manager caps a single credential blob at 2560 bytes (CredWriteW).
 // keyring-rs encodes the password as UTF-16 (2 bytes/char) before that check, so the
 // usable limit is 2560 / 2 = 1280 chars — long OAuth tokens (e.g. OpenAI's JWTs) exceed
@@ -254,20 +252,7 @@ function readKeyringAccountFromService(
 async function readKeyringAccount(account: string, diag?: (msg: string) => void): Promise<string | null> {
   try {
     const { Entry } = await import('@napi-rs/keyring');
-    const value = readKeyringAccountFromService(Entry, KEYRING_SERVICE, account);
-    if (value !== null) return value;
-    // One-time silent migration: fall back to the relay-ai keychain service and
-    // copy the credential into the clodex service on first read.
-    let legacy: string | null = null;
-    try {
-      legacy = readKeyringAccountFromService(Entry, LEGACY_KEYRING_SERVICE, account);
-    } catch {
-      legacy = null;
-    }
-    if (legacy !== null) {
-      await writeKeyringAccount(account, legacy, diag);
-    }
-    return legacy;
+    return readKeyringAccountFromService(Entry, KEYRING_SERVICE, account);
   } catch (err) {
     diag?.(classifyKeyringError(err));
     return null;

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,10 +1,7 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { cpSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
 
 export const APP_DIR_NAME = 'clodex';
-/** One-time silent migration source: the relay-ai config home. */
-export const LEGACY_APP_DIR_NAME = 'relay-ai';
 
 interface HomeEnv {
   HOME?: string;
@@ -25,42 +22,6 @@ export function getAppHome(env: HomeEnv = process.env): string {
   const override = resolveAppHomeOverride(env);
   if (override) return override;
   return join(userHome(env), `.${APP_DIR_NAME}`);
-}
-
-export function getLegacyAppHome(env: HomeEnv = process.env): string {
-  return join(userHome(env), `.${LEGACY_APP_DIR_NAME}`);
-}
-
-let legacyMigrationDone = false;
-
-/**
- * One-time silent migration: when the clodex home does not exist yet but a
- * legacy ~/.relay-ai does, copy its config + auth state over so existing
- * providers and OAuth credentials keep working. The legacy directory itself is
- * never modified or deleted.
- */
-export function ensureLegacyAppHomeMigrated(env: HomeEnv = process.env): void {
-  if (legacyMigrationDone) return;
-  legacyMigrationDone = true;
-  try {
-    const appHome = getAppHome(env);
-    if (existsSync(appHome)) return;
-    const legacyHome = getLegacyAppHome(env);
-    if (!existsSync(legacyHome)) return;
-
-    mkdirSync(appHome, { recursive: true, mode: 0o700 });
-    for (const entry of readdirSync(legacyHome)) {
-      if (entry === 'logs') continue; // session logs are not config/auth state
-      cpSync(join(legacyHome, entry), join(appHome, entry), { recursive: true });
-    }
-  } catch {
-    // Migration is best-effort; a fresh home still works.
-  }
-}
-
-/** Test hook: allow the migration to run again against a new CLODEX_HOME. */
-export function resetLegacyMigrationForTests(): void {
-  legacyMigrationDone = false;
 }
 
 export function getConfigPath(env: HomeEnv = process.env): string {

--- a/src/registry/credential-cleanup-journal.ts
+++ b/src/registry/credential-cleanup-journal.ts
@@ -14,10 +14,7 @@ import {
 } from 'node:fs';
 import { dirname } from 'node:path';
 import { parseAuthRef } from '../env.js';
-import {
-  ensureLegacyAppHomeMigrated,
-  getCredentialCleanupPath,
-} from '../paths.js';
+import { getCredentialCleanupPath } from '../paths.js';
 import { ensureSecureAppHome } from './io.js';
 import {
   assertRegistryWriteOwnership,
@@ -204,7 +201,6 @@ function journalLockPath(path: string): string {
 export async function loadPendingCredentialDeletes(
   path = getCredentialCleanupPath(),
 ): Promise<string[]> {
-  ensureLegacyAppHomeMigrated();
   return withRegistryWriteLock(
     () => [...readJournalUnlocked(path).pendingCredentialDeletes],
     { lockPath: journalLockPath(path) },
@@ -215,7 +211,6 @@ async function updatePendingCredentialDeletes(
   update: (pending: string[]) => string[],
   path = getCredentialCleanupPath(),
 ): Promise<{ before: string[]; after: string[] }> {
-  ensureLegacyAppHomeMigrated();
   return withRegistryWriteLock(() => {
     const journal = readJournalUnlocked(path);
     const before = [...journal.pendingCredentialDeletes];

--- a/src/registry/io.ts
+++ b/src/registry/io.ts
@@ -15,7 +15,7 @@ import {
   writeSync,
 } from 'node:fs';
 import { dirname } from 'node:path';
-import { ensureLegacyAppHomeMigrated, getAppHome, getProvidersPath } from '../paths.js';
+import { getAppHome, getProvidersPath } from '../paths.js';
 import type { ProviderRegistry, RegistryProvider } from './types.js';
 import { REGISTRY_SCHEMA_VERSION } from './types.js';
 import {
@@ -199,7 +199,6 @@ function readRegistryStrict(path: string): ProviderRegistry {
 }
 
 export function loadRegistry(path = getProvidersPath()): ProviderRegistry {
-  ensureLegacyAppHomeMigrated();
   if (!existsSync(path)) {
     return { schemaVersion: REGISTRY_SCHEMA_VERSION, providers: [] };
   }
@@ -230,7 +229,6 @@ export function loadRegistry(path = getProvidersPath()): ProviderRegistry {
  * unreadable registry with an empty one.
  */
 export function loadRegistryStrict(path = getProvidersPath()): ProviderRegistry {
-  ensureLegacyAppHomeMigrated();
   if (!existsSync(path)) {
     return { schemaVersion: REGISTRY_SCHEMA_VERSION, providers: [] };
   }

--- a/src/registry/materialize.ts
+++ b/src/registry/materialize.ts
@@ -83,13 +83,9 @@ export function cachedModelToLocal(
 }
 
 export function isAnonymousProvider(
-  provider: Pick<RegistryProvider, 'authRef' | 'authType'>
-    & Partial<Pick<RegistryProvider, 'id'>>,
+  provider: Pick<RegistryProvider, 'authRef' | 'authType'>,
 ): boolean {
-  if (provider.authType !== 'none') return false;
-  if (provider.authRef === 'none:anonymous') return true;
-  return provider.id !== undefined
-    && provider.authRef === `keyring:provider:${provider.id}`;
+  return provider.authType === 'none' && provider.authRef === 'none:anonymous';
 }
 
 function isLegacyAnonymousCustomEndpoint(

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -15,12 +15,7 @@ import {
   setSavedServerPassword,
   setServerListenMode,
 } from '../src/config.js';
-import {
-  getAppHome,
-  getConfigPath,
-  getLegacyAppHome,
-  resetLegacyMigrationForTests,
-} from '../src/paths.js';
+import { getAppHome, getConfigPath } from '../src/paths.js';
 
 let tempHome: string;
 let previousHome: string | undefined;
@@ -30,7 +25,6 @@ beforeEach(() => {
   previousHome = process.env['HOME'];
   process.env['HOME'] = tempHome;
   process.env['CLODEX_HOME'] = join(tempHome, 'app-home');
-  resetLegacyMigrationForTests();
 });
 
 afterEach(() => {
@@ -38,7 +32,6 @@ afterEach(() => {
   if (previousHome === undefined) delete process.env['HOME'];
   else process.env['HOME'] = previousHome;
   delete process.env['CLODEX_HOME'];
-  resetLegacyMigrationForTests();
 });
 
 describe('app paths', () => {
@@ -170,43 +163,5 @@ describe('bridge-mode memory', () => {
     expect(resolveBridgeMode('claude', 'proxy', { persist: true })).toBe('proxy');
     expect(resolveBridgeMode('claude', undefined)).toBe('proxy');
     expect(resolveBridgeMode('server', undefined)).toBe('endpoint');
-  });
-});
-
-describe('legacy ~/.relay-ai migration', () => {
-  it('copies config and auth state on first read when the clodex home is missing', () => {
-    delete process.env['CLODEX_HOME'];
-    const legacyHome = getLegacyAppHome({ HOME: tempHome });
-    mkdirSync(join(legacyHome, 'http-proxy'), { recursive: true });
-    writeFileSync(join(legacyHome, 'config.json'), JSON.stringify({ lastModel: 'gpt-5.6-sol' }), 'utf8');
-    writeFileSync(join(legacyHome, 'providers.json'), JSON.stringify({ schemaVersion: 1, providers: [] }), 'utf8');
-    writeFileSync(join(legacyHome, 'http-proxy', 'ca.pem'), 'PEM', 'utf8');
-    mkdirSync(join(legacyHome, 'logs'), { recursive: true });
-    writeFileSync(join(legacyHome, 'logs', 'session.log'), 'log', 'utf8');
-    resetLegacyMigrationForTests();
-
-    expect(loadPreferences().lastModel).toBe('gpt-5.6-sol');
-    const appHome = getAppHome({ HOME: tempHome });
-    expect(existsSync(join(appHome, 'config.json'))).toBe(true);
-    expect(existsSync(join(appHome, 'providers.json'))).toBe(true);
-    expect(existsSync(join(appHome, 'http-proxy', 'ca.pem'))).toBe(true);
-    // logs are session state, not config — never copied
-    expect(existsSync(join(appHome, 'logs'))).toBe(false);
-    // the legacy home is never modified
-    expect(readFileSync(join(legacyHome, 'config.json'), 'utf8')).toContain('gpt-5.6-sol');
-  });
-
-  it('does not migrate when the clodex home already exists', () => {
-    delete process.env['CLODEX_HOME'];
-    const appHome = getAppHome({ HOME: tempHome });
-    mkdirSync(appHome, { recursive: true });
-    writeFileSync(join(appHome, 'config.json'), JSON.stringify({ lastModel: 'existing' }), 'utf8');
-
-    const legacyHome = getLegacyAppHome({ HOME: tempHome });
-    mkdirSync(legacyHome, { recursive: true });
-    writeFileSync(join(legacyHome, 'config.json'), JSON.stringify({ lastModel: 'legacy' }), 'utf8');
-    resetLegacyMigrationForTests();
-
-    expect(loadPreferences().lastModel).toBe('existing');
   });
 });

--- a/tests/credential-cleanup-journal-durability.test.ts
+++ b/tests/credential-cleanup-journal-durability.test.ts
@@ -66,7 +66,7 @@ import {
   rmSync,
 } from 'node:fs';
 import { queueCredentialDelete } from '../src/registry/credential-cleanup-journal.js';
-import { getCredentialCleanupPath, resetLegacyMigrationForTests } from '../src/paths.js';
+import { getCredentialCleanupPath } from '../src/paths.js';
 
 describe('credential cleanup journal durability', () => {
   const previousHome = process.env.CLODEX_HOME;
@@ -75,7 +75,6 @@ describe('credential cleanup journal durability', () => {
   beforeEach(() => {
     home = mkdtempSync(join(tmpdir(), 'clodex-journal-durability-'));
     process.env.CLODEX_HOME = home;
-    resetLegacyMigrationForTests();
     fsState.journalPath = getCredentialCleanupPath();
     fsState.openPaths.clear();
     fsState.tempOpenFlags = [];
@@ -87,7 +86,6 @@ describe('credential cleanup journal durability', () => {
   afterEach(() => {
     if (previousHome === undefined) delete process.env.CLODEX_HOME;
     else process.env.CLODEX_HOME = previousHome;
-    resetLegacyMigrationForTests();
     rmSync(home, { recursive: true, force: true });
   });
 

--- a/tests/credential-cleanup-journal.test.ts
+++ b/tests/credential-cleanup-journal.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   chmodSync,
-  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -18,53 +17,24 @@ import {
 } from '../src/registry/credential-cleanup-journal.js';
 import { emptyRegistry, saveRegistry } from '../src/registry/io.js';
 import { withRegistryWriteLockSync } from '../src/registry/lock.js';
-import {
-  getCredentialCleanupPath,
-  getProvidersPath,
-  resetLegacyMigrationForTests,
-} from '../src/paths.js';
+import { getCredentialCleanupPath, getProvidersPath } from '../src/paths.js';
 
 const TEST_HELPER_ID = 'a'.repeat(64);
 const helperRef = (account: string): string => `helper:v1:${TEST_HELPER_ID}:${account}`;
 
 describe('credential cleanup journal', () => {
   const previousHome = process.env.CLODEX_HOME;
-  const previousUserHome = process.env.HOME;
   let home = '';
 
   beforeEach(() => {
     home = mkdtempSync(join(tmpdir(), 'clodex-cleanup-journal-'));
     process.env.CLODEX_HOME = home;
-    resetLegacyMigrationForTests();
   });
 
   afterEach(() => {
     if (previousHome === undefined) delete process.env.CLODEX_HOME;
     else process.env.CLODEX_HOME = previousHome;
-    if (previousUserHome === undefined) delete process.env.HOME;
-    else process.env.HOME = previousUserHome;
-    resetLegacyMigrationForTests();
     rmSync(home, { recursive: true, force: true });
-  });
-
-  it('migrates the legacy app home before publishing its first journal lock', async () => {
-    const appHome = join(home, '.clodex');
-    const legacyHome = join(home, '.relay-ai');
-    const legacyRegistry = `${JSON.stringify({
-      schemaVersion: 1,
-      providers: [{ id: 'legacy-provider' }],
-    })}\n`;
-    process.env.HOME = home;
-    process.env.CLODEX_HOME = appHome;
-    mkdirSync(legacyHome, { recursive: true });
-    writeFileSync(join(legacyHome, 'providers.json'), legacyRegistry);
-    resetLegacyMigrationForTests();
-
-    expect(await loadPendingCredentialDeletes()).toEqual([]);
-
-    expect(readFileSync(join(appHome, 'providers.json'), 'utf8')).toBe(
-      legacyRegistry,
-    );
   });
 
   it('serializes concurrent updates without dropping references', async () => {

--- a/tests/credential-lifecycle-persistence.test.ts
+++ b/tests/credential-lifecycle-persistence.test.ts
@@ -18,10 +18,7 @@ import {
 } from '../src/registry/credential-lifecycle.js';
 import { emptyRegistry, saveRegistry } from '../src/registry/io.js';
 import { withRegistryWriteLockSync } from '../src/registry/lock.js';
-import {
-  getProvidersPath,
-  resetLegacyMigrationForTests,
-} from '../src/paths.js';
+import { getProvidersPath } from '../src/paths.js';
 
 const helperPath = fileURLToPath(
   new URL('./fixtures/credential-helper.mjs', import.meta.url),
@@ -38,7 +35,6 @@ describe('persisted credential cleanup recovery', () => {
     process.env.CLODEX_HOME = home;
     process.env.CLODEX_CREDENTIAL_HELPER = helperPath;
     process.env.CLODEX_TEST_CREDENTIAL_HELPER_STORE = join(home, 'helper-store.json');
-    resetLegacyMigrationForTests();
   });
 
   afterEach(() => {
@@ -48,7 +44,6 @@ describe('persisted credential cleanup recovery', () => {
     else process.env.CLODEX_CREDENTIAL_HELPER = previousHelper;
     if (previousStore === undefined) delete process.env.CLODEX_TEST_CREDENTIAL_HELPER_STORE;
     else process.env.CLODEX_TEST_CREDENTIAL_HELPER_STORE = previousStore;
-    resetLegacyMigrationForTests();
     rmSync(home, { recursive: true, force: true });
   });
 

--- a/tests/provider-catalog-display.test.ts
+++ b/tests/provider-catalog-display.test.ts
@@ -161,11 +161,6 @@ describe('provider-catalog-display', () => {
         authRef: 'none:anonymous',
         authType: 'none',
       } as any)).toBe('anonymous');
-      expect(formatRegistryAuthLabel({
-        id: 'legacy-local',
-        authRef: 'keyring:provider:legacy-local',
-        authType: 'none',
-      } as any)).toBe('anonymous');
     });
   });
 

--- a/tests/refresh-credentials.test.ts
+++ b/tests/refresh-credentials.test.ts
@@ -77,21 +77,16 @@ describe('resolveRefreshCredential', () => {
     const previous = process.env['OPENAI_API_KEY'];
     process.env['OPENAI_API_KEY'] = 'sk-from-env';
     try {
-      for (const authRef of [
-        'none:anonymous',
-        'keyring:provider:openai',
-      ]) {
-        let called = false;
-        const key = await resolveRefreshCredential(
-          makeProvider({ authRef, authType: 'none' }),
-          async () => {
-            called = true;
-            return 'stale-key';
-          },
-        );
-        expect(key).toBeNull();
-        expect(called).toBe(false);
-      }
+      let called = false;
+      const key = await resolveRefreshCredential(
+        makeProvider({ authRef: 'none:anonymous', authType: 'none' }),
+        async () => {
+          called = true;
+          return 'stale-key';
+        },
+      );
+      expect(key).toBeNull();
+      expect(called).toBe(false);
     } finally {
       if (previous === undefined) delete process.env['OPENAI_API_KEY'];
       else process.env['OPENAI_API_KEY'] = previous;

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -485,41 +485,6 @@ describe('materializeRegistry', () => {
     expect(locals[0]?.authType).toBeUndefined();
   });
 
-  it('normalizes the unambiguous legacy no-auth representation', () => {
-    const registry = emptyRegistry();
-    registry.providers.push({
-      id: 'legacy-anonymous',
-      templateId: 'custom-openai',
-      name: 'Legacy Anonymous',
-      enabled: true,
-      authRef: 'keyring:provider:legacy-anonymous',
-      authType: 'none',
-      api: {
-        npm: '@ai-sdk/openai-compatible',
-        url: 'https://legacy-anonymous.example/v1',
-      },
-      addedAt: '2026-06-09T00:00:00.000Z',
-      modelsCache: {
-        fetchedAt: '2026-06-09T00:00:00.000Z',
-        models: [{
-          id: 'local-model',
-          name: 'Local Model',
-          upstreamModelId: 'local-model',
-          modelFormat: 'openai',
-          npm: '@ai-sdk/openai-compatible',
-        }],
-      },
-    });
-
-    const locals = materializeRegistry(registry, () => {
-      throw new Error('legacy no-auth access must not resolve a credential');
-    });
-
-    expect(locals).toHaveLength(1);
-    expect(locals[0]?.apiKey).toBe('');
-    expect(locals[0]?.authRef).toBe('none:anonymous');
-  });
-
   it('marks NVIDIA imported models as free provider access', () => {
     const registry = emptyRegistry();
     registry.providers.push({


### PR DESCRIPTION
## Summary

- remove the runtime copy from `~/.relay-ai` to `~/.clodex`
- remove fallback reads and copy-forward behavior for `relay-ai` keychain entries
- remove the obsolete compatibility paths and their migration-specific tests

The legacy migration was unsupported and its out-of-lock directory copy could race across
processes and lose data. Current `~/.clodex` users are unaffected. The `local`-placeholder
custom-endpoint compatibility behavior remains unchanged.

## Breaking change

Un-migrated `~/.relay-ai` configuration and keychain state is no longer read. Users who still
depend on that state must reconfigure clodex.

## Verification

Each check ran with a fresh throwaway `CLODEX_HOME`:

- `pnpm typecheck`
- `pnpm test` (77 files, 869 tests)
- `pnpm build`