### PR TITLE
fix(oauth): treat websocket_connection_limit_reached as a retryable limit

### DIFF
--- a/src/oauth/responses-websocket.ts
+++ b/src/oauth/responses-websocket.ts
@@ -447,6 +447,21 @@ function responseErrorCode(event: unknown): string | undefined {
   return typeof responseError?.code === 'string' ? responseError.code : undefined;
 }
 
+function responseRetryAfterSeconds(event: unknown): number | undefined {
+  if (!event || typeof event !== 'object') return undefined;
+  const record = event as JsonObject;
+  const response = record.response && typeof record.response === 'object' ? record.response as JsonObject : undefined;
+  const candidates = [record, record.error, response?.error];
+  for (const candidate of candidates) {
+    if (!candidate || typeof candidate !== 'object') continue;
+    const error = candidate as JsonObject;
+    const value = error.retry_after_seconds ?? error.retry_after;
+    if (typeof value === 'number') return value;
+    if (typeof value === 'string' && /^\d+(?:\.\d+)?$/.test(value.trim())) return Number(value);
+  }
+  return undefined;
+}
+
 function boundedDiagnosticIdentifier(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
   const normalized = value.trim();
@@ -1071,8 +1086,26 @@ function handleSocketMessage(entry: ConnectionEntry, data: RawData): void {
   }
   if (isModelDataEvent(type)) ctx.emittedModelData = true;
 
-  const previousMissing = responseErrorCode(event) === 'previous_response_not_found';
+  const errorCode = responseErrorCode(event);
+  const previousMissing = errorCode === 'previous_response_not_found';
   const willRetry = previousMissing && ctx.continued && !ctx.retried && !ctx.emittedModelData;
+  if (errorCode === 'websocket_connection_limit_reached' && !ctx.emittedModelData) {
+    const retryAfterSeconds = clampRetryAfterSeconds(responseRetryAfterSeconds(event));
+    failContext(
+      entry,
+      ctx,
+      `OpenAI reported the Responses WebSocket connection limit was reached; retry after ${retryAfterSeconds}s`,
+      {
+        source: 'error_frame',
+        errorCode,
+        mappedStatusCode: 429,
+        retryAfterSeconds,
+      },
+      429,
+      retryAfterSeconds,
+    );
+    return;
+  }
   if (FAILURE_EVENT_TYPES.has(type ?? '')) {
     emitResponseErrorDiagnostic(entry, ctx, {
       source: 'response_event',

--- a/tests/responses-websocket.test.ts
+++ b/tests/responses-websocket.test.ts
@@ -858,6 +858,59 @@ describe('createResponsesWebSocketFetch', () => {
     expect(fakeSockets).toHaveLength(2);
   }, 20_000);
 
+  it('maps an in-band WebSocket connection limit error to a retryable 429', async () => {
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
+      onDiagnostic: event => diagnostics.push(event),
+    });
+    const res = await withResponsesWebSocketDiagnosticContext(
+      { requestId: 'req-connection-limit' },
+      () => wsFetch('https://x', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer tok' },
+        body: JSON.stringify(sessionPayload([])),
+      }),
+    );
+    const socket = lastSocket();
+    socket.emit('open');
+    socket.emit('message', Buffer.from(JSON.stringify({
+      type: 'error',
+      error: {
+        code: 'websocket_connection_limit_reached',
+        message: 'connection limit reached',
+        retry_after_seconds: 12,
+      },
+    })));
+
+    const body = await readAll(res);
+    expect(JSON.parse(body.replace(/^data: /, '').trim())).toEqual({
+      type: 'error',
+      sequence_number: 1,
+      error: {
+        type: 'rate_limit_error',
+        code: '429',
+        message: 'OpenAI reported the Responses WebSocket connection limit was reached; retry after 12s',
+        param: null,
+        retry_after_seconds: 12,
+      },
+    });
+    expect(body).not.toContain('transport_error');
+    expect(await classifyThroughSdk(body)).toMatchObject({
+      statusCode: 429,
+      isRetryable: true,
+      retryAfterSeconds: 12,
+    });
+    expect(diagnostics).toContainEqual(expect.objectContaining({
+      event: 'ws_response_error',
+      requestId: 'req-connection-limit',
+      source: 'error_frame',
+      errorCode: 'websocket_connection_limit_reached',
+      mappedStatusCode: 429,
+      retryAfterSeconds: 12,
+      emittedModelData: false,
+    }));
+  });
+
   it('logs sanitized upstream response failure details after partial output', async () => {
     const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
     const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {


### PR DESCRIPTION
## Summary

The OAuth Responses WebSocket transport already maps edge HTTP 403 throttles to retryable 429 responses, but an in-band `websocket_connection_limit_reached` frame was treated as a terminal transport error. This change detects that per-account connection-cap signal before model data is emitted and maps it to the same retryable 429 path so Claude Code can back off and retry.

Retry hints from `retry_after` and `retry_after_seconds` are preserved and clamped consistently with the existing upgrade-throttle handling. This is defensive support for a signal that has not yet been observed in production.

## Verification

- `CLODEX_HOME="$(mktemp -d)" pnpm typecheck`
- `CLODEX_HOME="$(mktemp -d)" pnpm test`
- `CLODEX_HOME="$(mktemp -d)" pnpm build`