### PR TITLE
fix(providers): reconcile credential cleanup for interactive hub mutations

### DIFF
--- a/src/providers-command.ts
+++ b/src/providers-command.ts
@@ -479,7 +479,8 @@ async function runProviderDetail(id: string): Promise<'back' | 'removed'> {
   }
 
   if (action === 'auth') {
-    await runProvidersAuth(id);
+    await runWithCredentialCleanup(state =>
+      runProvidersAuthWithCleanupState(id, undefined, state));
     return 'back';
   }
 
@@ -491,7 +492,8 @@ async function runProviderDetail(id: string): Promise<'back' | 'removed'> {
     return 'back';
   }
 
-  const code = await runProvidersRemove(id, true);
+  const code = await runWithCredentialCleanup(state =>
+    runProvidersRemoveWithCleanupState(id, true, state));
   return code === 0 ? 'removed' : 'back';
 }
 
@@ -529,7 +531,7 @@ export async function runProvidersHub(): Promise<number> {
       return 0;
     }
     if (choice === 'add') {
-      await runProvidersAdd();
+      await runWithCredentialCleanup(state => runProvidersAddWithCleanupState(state));
       continue;
     }
     if (choice === 'refresh-all') {
@@ -537,7 +539,8 @@ export async function runProvidersHub(): Promise<number> {
       continue;
     }
     if (choice === 'auth-menu') {
-      await runProvidersAuth('openai');
+      await runWithCredentialCleanup(state =>
+        runProvidersAuthWithCleanupState('openai', undefined, state));
       continue;
     }
     if (typeof choice === 'string' && choice.startsWith('provider:')) {

--- a/tests/providers-command.test.ts
+++ b/tests/providers-command.test.ts
@@ -443,6 +443,56 @@ describe('provider command cleanup reconciliation', () => {
       'Credential cleanup is pending and will be retried by the next provider command.',
     );
   });
+
+  it('reconciles hub add cleanup when the mutation throws after journaling', async () => {
+    const authRef = helperRef('provider:replaced');
+    selectMock
+      .mockResolvedValueOnce('add')
+      .mockResolvedValueOnce('apikey');
+    passwordMock.mockResolvedValue('test-key');
+    addTemplateMock.mockImplementation(async () => {
+      await queueCredentialDelete(authRef);
+      throw new Error('Credential save failed.');
+    });
+    const deleteSpy = vi.spyOn(env, 'deleteProviderCredential').mockResolvedValue(false);
+
+    await expect(runProvidersCommand([])).rejects.toThrow('Credential save failed.');
+
+    expect(deleteSpy).toHaveBeenCalledOnce();
+    expect(deleteSpy).toHaveBeenCalledWith(authRef);
+    await expect(loadPendingCredentialDeletes()).resolves.toEqual([authRef]);
+    expect(warnMock).toHaveBeenCalledOnce();
+    expect(warnMock).toHaveBeenCalledWith(
+      'Credential cleanup is pending and will be retried by the next provider command.',
+    );
+  });
+
+  it('reconciles provider-detail OAuth cleanup when authentication fails after journaling', async () => {
+    const authRef = helperRef('provider:replaced-oauth');
+    const registry = emptyRegistry();
+    registry.providers.push(openaiEntry());
+    withRegistryWriteLockSync(() => saveRegistry(registry));
+    selectMock
+      .mockResolvedValueOnce('provider:openai')
+      .mockResolvedValueOnce('auth')
+      .mockResolvedValueOnce('done');
+    authenticateProviderMock.mockImplementation(async () => {
+      await queueCredentialDelete(authRef);
+      throw new Error('Credential save failed.');
+    });
+    const deleteSpy = vi.spyOn(env, 'deleteProviderCredential').mockResolvedValue(false);
+
+    await expect(runProvidersCommand([])).resolves.toBe(0);
+
+    expect(logErrorMock).toHaveBeenCalledWith('Credential save failed.');
+    expect(deleteSpy).toHaveBeenCalledOnce();
+    expect(deleteSpy).toHaveBeenCalledWith(authRef);
+    await expect(loadPendingCredentialDeletes()).resolves.toEqual([authRef]);
+    expect(warnMock).toHaveBeenCalledOnce();
+    expect(warnMock).toHaveBeenCalledWith(
+      'Credential cleanup is pending and will be retried by the next provider command.',
+    );
+  });
 });
 
 describe('providers add menu', () => {


### PR DESCRIPTION
## Summary

- Wrap interactive provider add, authentication, and removal actions in the same credential-cleanup scope used by non-interactive commands.
- Reconcile and report journaled credential deletes immediately when a hub mutation fails, instead of leaving them pending until the next providers command.
- Leave `refresh-all` unwrapped because model refresh does not mutate credentials or journal credential deletes.

## Verification

- `CLODEX_HOME="$(mktemp -d)" pnpm typecheck`
- `CLODEX_HOME="$(mktemp -d)" pnpm test`
- `CLODEX_HOME="$(mktemp -d)" pnpm build`