### PR TITLE
fix(config): serialize and atomically write preferences

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,13 @@
 import type { UserPreferences } from './types.js';
-import { dirname } from 'node:path';
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import { readFileSync, renameSync, unlinkSync } from 'node:fs';
 import { getConfigPath } from './paths.js';
+import { syncParentDirectory, writeSecureFile } from './registry/io.js';
+import {
+  assertRegistryWriteOwnership,
+  withRegistryWriteLock,
+  withRegistryWriteLockSync,
+} from './registry/lock.js';
 
 function readJsonFile(path: string): UserPreferences | null {
   try {
@@ -18,8 +24,50 @@ function readConfig(): UserPreferences {
 
 function writeConfig(config: UserPreferences): void {
   const configPath = getConfigPath();
-  mkdirSync(dirname(configPath), { recursive: true, mode: 0o700 });
-  writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+  assertRegistryWriteOwnership(configPath);
+  const payload = `${JSON.stringify(config, null, 2)}\n`;
+  const tmp = `${configPath}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    writeSecureFile(tmp, payload);
+    assertRegistryWriteOwnership(configPath);
+    renameSync(tmp, configPath);
+    syncParentDirectory(configPath);
+  } finally {
+    try {
+      unlinkSync(tmp);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+  }
+}
+
+function updateConfig<T>(mutate: (config: UserPreferences) => T): T {
+  const configPath = getConfigPath();
+  return withRegistryWriteLockSync(() => {
+    const config = readJsonFile(configPath) ?? {};
+    const result = mutate(config);
+    writeConfig(config);
+    return result;
+  }, { lockPath: `${configPath}.lock` });
+}
+
+interface AsyncConfigUpdate<T> {
+  result: T;
+  write: boolean;
+}
+
+async function updateConfigAsync<T>(
+  mutate: (
+    config: UserPreferences,
+  ) => Promise<AsyncConfigUpdate<T>> | AsyncConfigUpdate<T>,
+): Promise<T> {
+  const configPath = getConfigPath();
+  return withRegistryWriteLock(async () => {
+    const config = readJsonFile(configPath) ?? {};
+    const update = await mutate(config);
+    if (update.write) writeConfig(config);
+    return update.result;
+  }, { lockPath: `${configPath}.lock` });
 }
 
 export function loadPreferences(): UserPreferences {
@@ -39,17 +87,17 @@ export function loadPreferences(): UserPreferences {
 }
 
 export function savePreferences(prefs: Partial<Pick<UserPreferences, 'lastModel' | 'lastProvider' | 'recentModelsByProvider' | 'favoriteModels' | 'modelAliases' | 'claudeBridgeMode' | 'serverBridgeMode' | 'appPathOverrides' | 'recentLaunchFolders'>>): void {
-  const config = readConfig();
-  if (prefs.lastModel !== undefined) config.lastModel = prefs.lastModel;
-  if (prefs.lastProvider !== undefined) config.lastProvider = prefs.lastProvider;
-  if (prefs.recentModelsByProvider !== undefined) config.recentModelsByProvider = prefs.recentModelsByProvider;
-  if (prefs.favoriteModels !== undefined) config.favoriteModels = prefs.favoriteModels;
-  if (prefs.modelAliases !== undefined) config.modelAliases = prefs.modelAliases;
-  if (prefs.claudeBridgeMode !== undefined) config.claudeBridgeMode = prefs.claudeBridgeMode;
-  if (prefs.serverBridgeMode !== undefined) config.serverBridgeMode = prefs.serverBridgeMode;
-  if (prefs.appPathOverrides !== undefined) config.appPathOverrides = prefs.appPathOverrides;
-  if (prefs.recentLaunchFolders !== undefined) config.recentLaunchFolders = prefs.recentLaunchFolders;
-  writeConfig(config);
+  updateConfig(config => {
+    if (prefs.lastModel !== undefined) config.lastModel = prefs.lastModel;
+    if (prefs.lastProvider !== undefined) config.lastProvider = prefs.lastProvider;
+    if (prefs.recentModelsByProvider !== undefined) config.recentModelsByProvider = prefs.recentModelsByProvider;
+    if (prefs.favoriteModels !== undefined) config.favoriteModels = prefs.favoriteModels;
+    if (prefs.modelAliases !== undefined) config.modelAliases = prefs.modelAliases;
+    if (prefs.claudeBridgeMode !== undefined) config.claudeBridgeMode = prefs.claudeBridgeMode;
+    if (prefs.serverBridgeMode !== undefined) config.serverBridgeMode = prefs.serverBridgeMode;
+    if (prefs.appPathOverrides !== undefined) config.appPathOverrides = prefs.appPathOverrides;
+    if (prefs.recentLaunchFolders !== undefined) config.recentLaunchFolders = prefs.recentLaunchFolders;
+  });
 }
 
 export function getAppPathOverride(appId: string): string | undefined {
@@ -58,15 +106,15 @@ export function getAppPathOverride(appId: string): string | undefined {
 }
 
 export function setAppPathOverride(appId: string, path: string | null): Record<string, string> {
-  const config = readConfig();
-  const next = { ...(config.appPathOverrides ?? {}) };
-  const trimmed = path?.trim() ?? '';
-  if (trimmed) next[appId] = trimmed;
-  else delete next[appId];
-  config.appPathOverrides = next;
-  if (Object.keys(next).length === 0) delete config.appPathOverrides;
-  writeConfig(config);
-  return next;
+  return updateConfig(config => {
+    const next = { ...(config.appPathOverrides ?? {}) };
+    const trimmed = path?.trim() ?? '';
+    if (trimmed) next[appId] = trimmed;
+    else delete next[appId];
+    config.appPathOverrides = next;
+    if (Object.keys(next).length === 0) delete config.appPathOverrides;
+    return next;
+  });
 }
 
 /**
@@ -93,12 +141,12 @@ const MAX_RECENT_LAUNCH_FOLDERS = 6;
 export function recordLaunchFolder(folder: string): string[] {
   const trimmed = folder.trim();
   if (!trimmed) return loadPreferences().recentLaunchFolders ?? [];
-  const config = readConfig();
-  const prev = config.recentLaunchFolders ?? [];
-  const next = [trimmed, ...prev.filter(path => path !== trimmed)].slice(0, MAX_RECENT_LAUNCH_FOLDERS);
-  config.recentLaunchFolders = next;
-  writeConfig(config);
-  return next;
+  return updateConfig(config => {
+    const prev = config.recentLaunchFolders ?? [];
+    const next = [trimmed, ...prev.filter(path => path !== trimmed)].slice(0, MAX_RECENT_LAUNCH_FOLDERS);
+    config.recentLaunchFolders = next;
+    return next;
+  });
 }
 
 export function recordLaunchSelection(
@@ -129,32 +177,30 @@ async function getServerPasswordKeyring(): Promise<any | null> {
 }
 
 export async function getSavedServerPassword(): Promise<string | null> {
-  const config = readConfig();
-  if (config.server?.savedPassword) {
-    const pwd = config.server.savedPassword;
-    const keyring = await getServerPasswordKeyring();
-    if (keyring) {
-      try {
-        await keyring.setPassword(pwd);
-        delete config.server.savedPassword;
-        if (Object.keys(config.server).length === 0) delete config.server;
-        writeConfig(config);
-      } catch {
-        // Fallback: keep in config.json if keyring fails
-      }
-    }
-    return pwd;
-  }
-
   const keyring = await getServerPasswordKeyring();
-  if (keyring) {
+  if (!keyring) return readConfig().server?.savedPassword ?? null;
+
+  const savedPassword = await updateConfigAsync(async config => {
+    const server = config.server;
+    const password = server?.savedPassword;
+    if (!password) return { result: null, write: false };
     try {
-      return await keyring.getPassword();
+      await keyring.setPassword(password);
+      delete server.savedPassword;
+      if (Object.keys(server).length === 0) delete config.server;
+      return { result: password, write: true };
     } catch {
-      return null;
+      // Fallback: keep in config.json if keyring fails
+      return { result: password, write: false };
     }
+  });
+  if (savedPassword) return savedPassword;
+
+  try {
+    return await keyring.getPassword();
+  } catch {
+    return null;
   }
-  return null;
 }
 
 export async function setSavedServerPassword(password: string): Promise<void> {
@@ -167,12 +213,13 @@ export async function setSavedServerPassword(password: string): Promise<void> {
       // Fallback
     }
   }
-  const config = readConfig();
-  config.server = {
-    ...(config.server ?? {}),
-    savedPassword: password,
-  };
-  writeConfig(config);
+  await updateConfigAsync(config => {
+    config.server = {
+      ...(config.server ?? {}),
+      savedPassword: password,
+    };
+    return { result: undefined, write: true };
+  });
 }
 
 export async function clearSavedServerPassword(): Promise<void> {
@@ -184,11 +231,12 @@ export async function clearSavedServerPassword(): Promise<void> {
       // Ignore
     }
   }
-  const config = readConfig();
-  if (!config.server) return;
-  delete config.server.savedPassword;
-  if (Object.keys(config.server).length === 0) delete config.server;
-  writeConfig(config);
+  await updateConfigAsync(config => {
+    if (!config.server) return { result: undefined, write: false };
+    delete config.server.savedPassword;
+    if (Object.keys(config.server).length === 0) delete config.server;
+    return { result: undefined, write: true };
+  });
 }
 
 export function getServerExposedProviders(): string[] | null {
@@ -197,12 +245,12 @@ export function getServerExposedProviders(): string[] | null {
 }
 
 export function setServerExposedProviders(providerIds: string[]): void {
-  const config = readConfig();
-  config.server = {
-    ...(config.server ?? {}),
-    exposedProviders: providerIds,
-  };
-  writeConfig(config);
+  updateConfig(config => {
+    config.server = {
+      ...(config.server ?? {}),
+      exposedProviders: providerIds,
+    };
+  });
 }
 
 export function getServerMaskGatewayIds(): boolean {
@@ -210,12 +258,12 @@ export function getServerMaskGatewayIds(): boolean {
 }
 
 export function setServerMaskGatewayIds(mask: boolean): void {
-  const config = readConfig();
-  config.server = {
-    ...(config.server ?? {}),
-    maskGatewayIds: mask,
-  };
-  writeConfig(config);
+  updateConfig(config => {
+    config.server = {
+      ...(config.server ?? {}),
+      maskGatewayIds: mask,
+    };
+  });
 }
 
 export function getServerFavoritesOnly(): boolean {
@@ -223,12 +271,12 @@ export function getServerFavoritesOnly(): boolean {
 }
 
 export function setServerFavoritesOnly(favoritesOnly: boolean): void {
-  const config = readConfig();
-  config.server = {
-    ...(config.server ?? {}),
-    favoritesOnly,
-  };
-  writeConfig(config);
+  updateConfig(config => {
+    config.server = {
+      ...(config.server ?? {}),
+      favoritesOnly,
+    };
+  });
 }
 
 export function getServerListenMode(): 'local' | 'network' {
@@ -236,10 +284,10 @@ export function getServerListenMode(): 'local' | 'network' {
 }
 
 export function setServerListenMode(listenMode: 'local' | 'network'): void {
-  const config = readConfig();
-  config.server = {
-    ...(config.server ?? {}),
-    listenMode,
-  };
-  writeConfig(config);
+  updateConfig(config => {
+    config.server = {
+      ...(config.server ?? {}),
+      listenMode,
+    };
+  });
 }

--- a/src/registry/io.ts
+++ b/src/registry/io.ts
@@ -38,7 +38,7 @@ export function ensureSecureAppHome(): void {
   }
 }
 
-function writeSecureFile(path: string, content: string): void {
+export function writeSecureFile(path: string, content: string): void {
   ensureSecureAppHome();
   mkdirSync(dirname(path), { recursive: true, mode: DIR_MODE });
   const fd = openSync(path, 'wx', FILE_MODE);
@@ -63,7 +63,7 @@ function writeSecureFile(path: string, content: string): void {
   }
 }
 
-function syncParentDirectory(path: string): void {
+export function syncParentDirectory(path: string): void {
   let fd: number | undefined;
   try {
     fd = openSync(dirname(path), 'r');

--- a/tests/config-concurrency.test.ts
+++ b/tests/config-concurrency.test.ts
@@ -1,0 +1,197 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'tsup';
+import { afterEach, describe, expect, it } from 'vitest';
+
+interface WorkerProcess {
+  child: ChildProcess;
+  ready: Promise<void>;
+  exit: Promise<{ code: number | null; stderr: string }>;
+}
+
+const roots: string[] = [];
+const workers = new Set<WorkerProcess>();
+
+function temporaryRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'config-concurrency-'));
+  roots.push(root);
+  return root;
+}
+
+async function buildWorker(root: string): Promise<string> {
+  const outDir = join(root, 'worker-build');
+  await build({
+    entry: [
+      fileURLToPath(
+        new URL('./fixtures/config-write-worker.ts', import.meta.url),
+      ),
+    ],
+    outDir,
+    outExtension: () => ({ js: '.mjs' }),
+    format: ['esm'],
+    platform: 'node',
+    target: 'node22',
+    splitting: false,
+    sourcemap: false,
+    external: ['@napi-rs/keyring'],
+    clean: false,
+    silent: true,
+    config: false,
+  });
+  return join(outDir, 'config-write-worker.mjs');
+}
+
+function workerEnvironment(
+  configHome: string,
+  workerId: string,
+  writeCount: number,
+): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = {
+    CLODEX_HOME: configHome,
+    CONFIG_WRITE_WORKER_ID: workerId,
+    CONFIG_WRITE_COUNT: String(writeCount),
+  };
+  for (const key of [
+    'HOME',
+    'PATH',
+    'TMPDIR',
+    'TEMP',
+    'TMP',
+    'SystemRoot',
+    'ComSpec',
+    'PATHEXT',
+  ]) {
+    if (process.env[key] !== undefined) environment[key] = process.env[key];
+  }
+  return environment;
+}
+
+function spawnWorker(
+  workerPath: string,
+  configHome: string,
+  workerId: string,
+  writeCount: number,
+): WorkerProcess {
+  const child = spawn(process.execPath, [workerPath], {
+    cwd: process.cwd(),
+    env: workerEnvironment(configHome, workerId, writeCount),
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  let stdout = '';
+  let stderr = '';
+  child.stdout?.setEncoding('utf8');
+  child.stderr?.setEncoding('utf8');
+  child.stdout?.on('data', (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr?.on('data', (chunk: string) => {
+    stderr += chunk;
+  });
+  const ready = new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error(`Timed out waiting for worker ${workerId}`)),
+      5_000,
+    );
+    const checkReady = (): void => {
+      if (!stdout.includes('READY\n')) return;
+      clearTimeout(timeout);
+      resolve();
+    };
+    child.stdout?.on('data', checkReady);
+    child.once('error', reject);
+    checkReady();
+  });
+  const exit = new Promise<{ code: number | null; stderr: string }>((resolve, reject) => {
+    child.once('error', reject);
+    child.once('close', (code) => resolve({ code, stderr }));
+  });
+  const worker = { child, ready, exit };
+  workers.add(worker);
+  void exit.then(
+    () => workers.delete(worker),
+    () => workers.delete(worker),
+  );
+  return worker;
+}
+
+async function observeJsonUntil(
+  path: string,
+  done: Promise<unknown>,
+): Promise<string[]> {
+  let finished = false;
+  void done.finally(() => {
+    finished = true;
+  });
+  const malformed: string[] = [];
+  while (!finished) {
+    if (existsSync(path)) {
+      try {
+        JSON.parse(readFileSync(path, 'utf8'));
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+          malformed.push(String(error));
+        }
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+  return malformed;
+}
+
+afterEach(async () => {
+  for (const worker of workers) {
+    if (worker.child.exitCode === null && worker.child.signalCode === null) {
+      worker.child.kill('SIGTERM');
+    }
+  }
+  await Promise.allSettled([...workers].map(worker => worker.exit));
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('preference write concurrency', () => {
+  it('preserves every concurrent update and never exposes malformed JSON', async () => {
+    const root = temporaryRoot();
+    const configHome = join(root, 'clodex-home');
+    const configPath = join(configHome, 'config.json');
+    const workerPath = await buildWorker(root);
+    const workerCount = 8;
+    const writesPerWorker = 4;
+    const spawned = Array.from({ length: workerCount }, (_, index) =>
+      spawnWorker(workerPath, configHome, `worker-${index}`, writesPerWorker),
+    );
+
+    await Promise.all(spawned.map(worker => worker.ready));
+    const exits = Promise.all(spawned.map(worker => worker.exit));
+    const malformed = observeJsonUntil(configPath, exits);
+    for (const worker of spawned) worker.child.stdin?.end('START\n');
+
+    const results = await exits;
+    expect(results).toEqual(
+      Array.from({ length: workerCount }, () => ({ code: 0, stderr: '' })),
+    );
+    expect(await malformed).toEqual([]);
+
+    const config = JSON.parse(readFileSync(configPath, 'utf8')) as {
+      appPathOverrides?: Record<string, string>;
+    };
+    const expected = Object.fromEntries(
+      Array.from({ length: workerCount }, (_, workerIndex) =>
+        Array.from({ length: writesPerWorker }, (_, writeIndex) => {
+          const key = `worker-${workerIndex}-${writeIndex}`;
+          return [key, `/tmp/${key}`];
+        }),
+      ).flat(),
+    );
+    expect(config.appPathOverrides).toEqual(expected);
+  }, 30_000);
+});

--- a/tests/fixtures/config-write-worker.ts
+++ b/tests/fixtures/config-write-worker.ts
@@ -1,0 +1,16 @@
+import { setAppPathOverride } from '../../src/config.js';
+
+const workerId = process.env['CONFIG_WRITE_WORKER_ID'];
+const writes = Number(process.env['CONFIG_WRITE_COUNT']);
+if (!workerId || !Number.isInteger(writes) || writes <= 0) {
+  throw new Error('Config write worker requires an id and positive write count.');
+}
+
+process.stdin.resume();
+process.stdin.once('data', () => {
+  for (let index = 0; index < writes; index += 1) {
+    const key = `${workerId}-${index}`;
+    setAppPathOverride(key, `/tmp/${key}`);
+  }
+});
+process.stdout.write('READY\n');


### PR DESCRIPTION
## Summary

- serialize each preference read-modify-write with a config-scoped lock
- persist `config.json` with a durable temp-file, rename, and directory sync sequence
- verify cross-process writers preserve every update and never expose malformed JSON

Concurrent clodex processes could previously read the same preferences and overwrite each other.
The direct write could also leave truncated JSON if interrupted. Reusing the registry lock and secure
writer prevents lost updates without making preference writes contend with provider registry writes.

This PR is based on `cleanup/remove-legacy-relay-ai` and should merge after that base branch.

## Verification

- `CLODEX_HOME="$(mktemp -d)" pnpm typecheck`
- `CLODEX_HOME="$(mktemp -d)" pnpm test`
- `CLODEX_HOME="$(mktemp -d)" pnpm build`