### PR TITLE
fix(logging): attribute proxy transport failures

### DIFF
--- a/src/http-proxy/server.ts
+++ b/src/http-proxy/server.ts
@@ -23,6 +23,7 @@ import {
   writeInferenceResponseLifecycleLog,
   writeInferenceResponseErrorLog,
   writeWebSocketDiagnosticRequestLog,
+  type InferenceFailureSource,
   type InferenceResponsePhase,
 } from '../trace-log.js';
 
@@ -161,6 +162,8 @@ export interface HttpProxyOptions {
   anthropicRejectUnauthorized?: boolean;
   /** Test hook for observing relay-route isolation without calling an AI provider. */
   adapterHandle?: ProxyHandle;
+  /** Test hook for exercising adapter request transport failures. */
+  adapterRequest?: typeof http.request;
   /** Test hook; production emits a progress record every 30 seconds. */
   responseProgressIntervalMs?: number;
 }
@@ -451,6 +454,7 @@ function forwardToAdapter(
   res: http.ServerResponse,
   rawBody: Buffer,
   adapter: ProxyHandle,
+  adapterRequest: typeof http.request = http.request,
   lifecycle?: {
     logPath: string;
     requestId: string;
@@ -546,7 +550,10 @@ function forwardToAdapter(
       resolve();
     });
 
-    const failAdapterRequest = (err: Error) => {
+    const failAdapterRequest = (
+      err: Error,
+      failureSource: InferenceFailureSource,
+    ) => {
       if (clientDisconnected) {
         resolve();
         return;
@@ -563,6 +570,8 @@ function forwardToAdapter(
         bytes,
         chunks,
         errorType: err.name,
+        errorCode: (err as NodeJS.ErrnoException).code,
+        failureSource,
         terminationSource: 'upstream_failure',
       });
       if (!res.headersSent) res.writeHead(502, { 'Content-Type': 'text/plain' });
@@ -570,7 +579,7 @@ function forwardToAdapter(
       resolve();
     };
 
-    upstream = http.request({
+    upstream = adapterRequest({
       hostname: '127.0.0.1',
       port: adapter.port,
       method: 'POST',
@@ -606,7 +615,10 @@ function forwardToAdapter(
       copyResponse(upstreamRes, res, undefined, lifecycle
         ? usage => writeLifecycle('response_usage', usage)
         : undefined);
-      const failAdapterResponse = (err: Error) => {
+      const failAdapterResponse = (
+        err: Error,
+        failureSource: InferenceFailureSource,
+      ) => {
         if (clientDisconnected) {
           resolve();
           return;
@@ -624,6 +636,8 @@ function forwardToAdapter(
           bytes,
           chunks,
           errorType: err.name,
+          errorCode: (err as NodeJS.ErrnoException).code,
+          failureSource,
           terminationSource: 'upstream_failure',
         });
         if (!res.writableEnded) res.destroy(err);
@@ -634,16 +648,27 @@ function forwardToAdapter(
         lastActivityAt = Date.now();
         resolve();
       });
-      upstreamRes.once('error', failAdapterResponse);
-      upstreamRes.once('aborted', () => failAdapterResponse(new Error('Relay adapter response aborted')));
+      upstreamRes.once('error', err => failAdapterResponse(err, 'adapter_response_error'));
+      upstreamRes.once('aborted', () => failAdapterResponse(
+        new Error('Relay adapter response aborted'),
+        'adapter_response_aborted',
+      ));
       upstreamRes.once('close', () => {
-        if (!upstreamRes.complete) failAdapterResponse(new Error('Relay adapter response closed before completion'));
+        if (!upstreamRes.complete) {
+          failAdapterResponse(
+            new Error('Relay adapter response closed before completion'),
+            'adapter_response_close',
+          );
+        }
       });
     });
-    upstream.once('error', failAdapterRequest);
+    upstream.once('error', err => failAdapterRequest(err, 'adapter_request_error'));
     upstream.once('close', () => {
       if (!headersReceived && !failed) {
-        failAdapterRequest(new Error('Relay adapter connection closed before a response'));
+        failAdapterRequest(
+          new Error('Relay adapter connection closed before a response'),
+          'adapter_request_close',
+        );
       }
     });
     upstream.end(rawBody);
@@ -822,6 +847,7 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
           res,
           adapterBody,
           adapter,
+          options.adapterRequest,
           messagesEndpoint === 'messages' && options.inferenceLogPath
             ? {
                 logPath: options.inferenceLogPath,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -160,11 +160,16 @@ function createTranslationLifecycle(
       clearInterval(timer);
       write('translation_cancelled', snapshot(Date.now()));
     },
-    fail(errorType: string, errorSignature?: string) {
+    fail(errorType: string, errorSignature?: string, errorCode?: string) {
       if (stopped) return;
       stopped = true;
       clearInterval(timer);
-      write('translation_failed', { ...snapshot(Date.now()), errorType, errorSignature });
+      write('translation_failed', {
+        ...snapshot(Date.now()),
+        errorType,
+        errorSignature,
+        errorCode,
+      });
     },
   };
 }
@@ -677,6 +682,7 @@ export async function startProxyCatalog(
           translationLifecycle?.fail(
             err instanceof Error ? err.name : 'UpstreamError',
             sdkTranslationErrorSignature(err),
+            details?.transportCode,
           );
           const contextLengthExceeded = upstreamStatus === 400
             && isContextLengthExceededError(err, message);

--- a/src/trace-log.ts
+++ b/src/trace-log.ts
@@ -234,6 +234,13 @@ export type InferenceResponsePhase =
   | 'streaming'
   | 'delivering';
 
+export type InferenceFailureSource =
+  | 'adapter_request_error'
+  | 'adapter_request_close'
+  | 'adapter_response_error'
+  | 'adapter_response_aborted'
+  | 'adapter_response_close';
+
 export type InferenceTerminationSource =
   | 'downstream_client'
   | 'local_shutdown'
@@ -265,7 +272,9 @@ export interface InferenceResponseLifecycleLogEntry {
   cacheReadInputTokens?: number;
   lastPartType?: string;
   errorType?: string;
+  errorCode?: string;
   errorSignature?: string;
+  failureSource?: InferenceFailureSource;
   terminationSource?: InferenceTerminationSource;
 }
 
@@ -465,7 +474,9 @@ export function writeInferenceResponseLifecycleLog(
     ...(cacheReadInputTokens !== undefined ? { cacheReadInputTokens } : {}),
     ...(entry.lastPartType ? { lastPartType: compactLogValue(entry.lastPartType, 100) } : {}),
     ...(entry.errorType ? { errorType: compactLogValue(entry.errorType, 200) } : {}),
+    ...(entry.errorCode ? { errorCode: compactLogValue(entry.errorCode, 100) } : {}),
     ...(entry.errorSignature ? { errorSignature: compactLogValue(entry.errorSignature, 100) } : {}),
+    ...(entry.failureSource ? { failureSource: entry.failureSource } : {}),
     ...(entry.terminationSource ? { terminationSource: entry.terminationSource } : {}),
   }));
 }

--- a/src/upstream-error.ts
+++ b/src/upstream-error.ts
@@ -18,6 +18,7 @@ export interface SdkUpstreamErrorDetails {
   attemptCount: number;
   /** Client backoff hint (seconds); only present on rate-limit (429) failures. */
   retryAfterSeconds?: number;
+  transportCode?: 'websocket_transport_error';
 }
 
 /** Default downstream backoff hint when the upstream throttle gives none. */
@@ -53,6 +54,15 @@ function numericRetryAfterSeconds(inner: InstanceType<typeof APICallError>): num
   return undefined;
 }
 
+function boundedTransportCode(data: unknown): 'websocket_transport_error' | undefined {
+  if (!data || typeof data !== 'object') return undefined;
+  const error = (data as { error?: unknown }).error;
+  if (!error || typeof error !== 'object') return undefined;
+  return (error as { code?: unknown }).code === 'websocket_transport_error'
+    ? 'websocket_transport_error'
+    : undefined;
+}
+
 /** Extract the real HTTP failure from an AI SDK retry wrapper without relying on instanceof. */
 export function sdkUpstreamErrorDetails(err: unknown): SdkUpstreamErrorDetails | undefined {
   const retry = RetryError.isInstance(err) ? err : undefined;
@@ -79,6 +89,7 @@ export function sdkUpstreamErrorDetails(err: unknown): SdkUpstreamErrorDetails |
     isRetryable: inner.isRetryable,
     attemptCount: retry?.errors.length ?? 1,
     ...(retryAfterSeconds !== undefined ? { retryAfterSeconds } : {}),
+    transportCode: boundedTransportCode(inner.data),
   };
 }
 

--- a/tests/http-proxy-server.test.ts
+++ b/tests/http-proxy-server.test.ts
@@ -6,7 +6,7 @@ import * as https from 'node:https';
 import * as http from 'node:http';
 import * as net from 'node:net';
 import * as tls from 'node:tls';
-import { once } from 'node:events';
+import { EventEmitter, once } from 'node:events';
 import { gzipSync } from 'node:zlib';
 import { ensureHttpProxyCaBundle, ensureHttpProxyCertificates } from '../src/http-proxy/ca.js';
 import { shouldInterceptConnect, startHttpProxy } from '../src/http-proxy/server.js';
@@ -1054,6 +1054,126 @@ describe('selective HTTP proxy', () => {
     }
   }, 20_000);
 
+  it('logs adapter request errno and source when the adapter is unavailable before headers', async () => {
+    const certificates = ensureHttpProxyCertificates();
+    const inferenceLogPath = join(testHome, 'adapter-request-error-inference.jsonl');
+    const unavailableAdapter = http.createServer();
+    const unavailableAdapterPort = await listen(unavailableAdapter);
+    await new Promise<void>(resolve => unavailableAdapter.close(() => resolve()));
+    const route = {
+      aliasId: 'clodex:test:translated-model',
+      realModelId: 'translated-model',
+      displayName: 'Translated Model',
+      upstreamUrl: '',
+      apiKey: 'provider-key',
+      modelFormat: 'openai' as const,
+      npm: '@ai-sdk/openai-compatible',
+      providerId: 'test-provider',
+    };
+    const proxy = await startHttpProxy({
+      routes: [route],
+      adapterHandle: {
+        port: unavailableAdapterPort,
+        token: 'adapter-local-token',
+        close: () => {},
+      },
+      inferenceLogPath,
+    });
+
+    try {
+      const response = await requestMitm(
+        proxy.port,
+        certificates.caCert,
+        '/v1/messages',
+        JSON.stringify({
+          model: route.aliasId,
+          messages: [{ role: 'user', content: 'test unavailable adapter' }],
+          stream: true,
+        }),
+      );
+
+      expect(response).toContain('502');
+      const entries = readFileSync(inferenceLogPath, 'utf8').trim().split('\n').map(line => JSON.parse(line));
+      const requestEntry = entries.find(entry => !entry.event);
+      expect(entries).toContainEqual(expect.objectContaining({
+        event: 'response_failed',
+        requestId: requestEntry.requestId,
+        route: 'translated',
+        statusCode: 502,
+        phase: 'waiting_for_headers',
+        errorType: 'Error',
+        errorCode: expect.stringMatching(/^ECONN(?:REFUSED|RESET)$/),
+        failureSource: 'adapter_request_error',
+        terminationSource: 'upstream_failure',
+      }));
+    } finally {
+      await proxy.close();
+    }
+  }, 20_000);
+
+  it('logs a distinct source when the adapter request closes before headers', async () => {
+    const certificates = ensureHttpProxyCertificates();
+    const inferenceLogPath = join(testHome, 'adapter-request-close-inference.jsonl');
+    const route = {
+      aliasId: 'clodex:test:translated-model',
+      realModelId: 'translated-model',
+      displayName: 'Translated Model',
+      upstreamUrl: '',
+      apiKey: 'provider-key',
+      modelFormat: 'openai' as const,
+      npm: '@ai-sdk/openai-compatible',
+      providerId: 'test-provider',
+    };
+    const adapterRequest = () => {
+      const request = new EventEmitter() as EventEmitter & {
+        end(body: Buffer): void;
+        destroy(error?: Error): void;
+      };
+      request.end = () => queueMicrotask(() => request.emit('close'));
+      request.destroy = () => {};
+      return request;
+    };
+    const proxy = await startHttpProxy({
+      routes: [route],
+      adapterHandle: {
+        port: 1,
+        token: 'adapter-local-token',
+        close: () => {},
+      },
+      inferenceLogPath,
+      adapterRequest,
+    } as Parameters<typeof startHttpProxy>[0]);
+
+    try {
+      const response = await requestMitm(
+        proxy.port,
+        certificates.caCert,
+        '/v1/messages',
+        JSON.stringify({
+          model: route.aliasId,
+          messages: [{ role: 'user', content: 'test closed adapter request' }],
+          stream: true,
+        }),
+      );
+
+      expect(response).toContain('502');
+      const entries = readFileSync(inferenceLogPath, 'utf8').trim().split('\n').map(line => JSON.parse(line));
+      const requestEntry = entries.find(entry => !entry.event);
+      expect(entries).toContainEqual(expect.objectContaining({
+        event: 'response_failed',
+        requestId: requestEntry.requestId,
+        route: 'translated',
+        statusCode: 502,
+        phase: 'waiting_for_headers',
+        errorType: 'Error',
+        failureSource: 'adapter_request_close',
+        terminationSource: 'upstream_failure',
+      }));
+    } finally {
+      await proxy.close();
+    }
+  }, 20_000);
+
   it('terminates and logs a translated response when the adapter closes before end', async () => {
     const certificates = ensureHttpProxyCertificates();
     const inferenceLogPath = join(testHome, 'adapter-abort-inference.jsonl');
@@ -1123,6 +1243,7 @@ describe('selective HTTP proxy', () => {
         requestId: requestEntry.requestId,
         statusCode: 200,
         phase: 'streaming',
+        failureSource: 'adapter_response_aborted',
         terminationSource: 'upstream_failure',
       }));
       expect(entries.some(entry => entry.event === 'response_completed')).toBe(false);

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -786,6 +786,65 @@ describe('SDK translated error logging', () => {
     }
   }, 20_000);
 
+  it('records the bounded WebSocket transport code in the translation lifecycle', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'clodex-sdk-transport-error-'));
+    const inferenceLogPath = join(dir, 'inference.jsonl');
+    const upstream = http.createServer((req, res) => {
+      req.resume();
+      res.writeHead(400, {
+        'Content-Type': 'application/json',
+        'Connection': 'close',
+      });
+      res.end(JSON.stringify({
+        error: {
+          type: 'transport_error',
+          code: 'websocket_transport_error',
+          message: 'transport unavailable',
+        },
+      }));
+    });
+    await new Promise<void>((resolve, reject) => {
+      upstream.once('error', reject);
+      upstream.listen(0, '127.0.0.1', () => resolve());
+    });
+    const address = upstream.address();
+    if (!address || typeof address === 'string') throw new Error('test upstream did not bind');
+
+    const route: ProxyRoute = {
+      aliasId: 'clodex:test:translated-model',
+      realModelId: 'gpt-5.6-test',
+      displayName: 'Translated Model',
+      upstreamUrl: '',
+      apiKey: 'provider-key',
+      modelFormat: 'openai',
+      npm: '@ai-sdk/openai-compatible',
+      baseURL: `http://127.0.0.1:${address.port}/v1`,
+      providerId: 'test-provider',
+    };
+    const handle = await startProxyCatalog([route], route.aliasId, false, inferenceLogPath);
+
+    try {
+      const res = await postToProxy(handle.port, handle.token, {
+        model: route.aliasId,
+        max_tokens: 100,
+        messages: [{ role: 'user', content: 'test transport failure' }],
+        stream: true,
+      }, 'req-transport-error');
+
+      expect(res.status).toBe(400);
+      const entries = readFileSync(inferenceLogPath, 'utf8').trim().split('\n').map(line => JSON.parse(line));
+      expect(entries).toContainEqual(expect.objectContaining({
+        event: 'translation_failed',
+        requestId: 'req-transport-error',
+        errorCode: 'websocket_transport_error',
+      }));
+    } finally {
+      handle.close();
+      await new Promise<void>(resolve => upstream.close(() => resolve()));
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 20_000);
+
   it('translates an OpenAI context overflow into an Anthropic prompt-too-long error', async () => {
     const upstream = http.createServer((req, res) => {
       req.resume();

--- a/tests/trace-log.test.ts
+++ b/tests/trace-log.test.ts
@@ -42,7 +42,8 @@ describe('trace log redaction', () => {
   });
 
   it('redacts sk- prefixed keys', () => {
-    expect(redactTraceLine('key=sk-abc1234567890')).toBe('key=sk-[REDACTED]');
+    const keyShapedPlaceholder = ['sk', 'example-value'].join('-');
+    expect(redactTraceLine(`key=${keyShapedPlaceholder}`)).toBe('key=sk-[REDACTED]');
   });
 
   it('redacts full log content', () => {

--- a/tests/trace-log.test.ts
+++ b/tests/trace-log.test.ts
@@ -339,7 +339,9 @@ describe('inference request log', () => {
         provider: 'openai',
         route: 'translated',
         errorType: 'Error',
+        errorCode: 'ECONNRESET',
         errorSignature: 'reasoning_part_not_found',
+        failureSource: 'adapter_response_error',
         terminationSource: 'upstream_failure',
       });
       writeInferenceResponseLifecycleLog(path, {
@@ -381,7 +383,9 @@ describe('inference request log', () => {
       expect(failure).toMatchObject({
         event: 'response_failed',
         errorType: 'Error',
+        errorCode: 'ECONNRESET',
         errorSignature: 'reasoning_part_not_found',
+        failureSource: 'adapter_response_error',
         terminationSource: 'upstream_failure',
       });
       expect(failure).not.toHaveProperty('claudeSessionId');


### PR DESCRIPTION
## Summary

- distinguish client disconnects, adapter request failures, and adapter response aborts in lifecycle diagnostics
- preserve bounded transport error codes without copying unbounded platform error text
- carry failure source and transport code through request traces and translated stream logs
- keep aborted upstream responses attributed to the hop where the failure occurred

## Test plan

- [x] focused diagnostics suite: 3 files and 58 tests
- [x] complete suite: 79 files and 892 tests
- [x] type checking
- [x] production build
- [x] diff hygiene
- [x] changed-file secret scans
