### PR TITLE
test: remove vitest temp sandboxes after each run

### DIFF
--- a/tests/test-sandbox-floor.test.ts
+++ b/tests/test-sandbox-floor.test.ts
@@ -1,7 +1,19 @@
 import { tmpdir, userInfo } from 'node:os';
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { getAppHome } from '../src/paths.js';
+import { getAppHome, getCredentialCleanupPath } from '../src/paths.js';
+import { getCredentialMutationLockPath } from '../src/registry/lock.js';
+
+function expectInsideVitestSandbox(candidate: string): void {
+  const relativeToTemp = relative(resolve(tmpdir()), resolve(candidate));
+
+  expect(relativeToTemp).not.toBe('');
+  expect(relativeToTemp).not.toMatch(/^\.\.(?:[/\\]|$)/);
+  expect(isAbsolute(relativeToTemp)).toBe(false);
+  expect(relativeToTemp.split(/[/\\]/)).toContainEqual(
+    expect.stringMatching(/^clodex-vitest-sandbox-/),
+  );
+}
 
 describe('test sandbox floor', () => {
   it('keeps the default app home inside a Vitest temp sandbox', () => {
@@ -16,5 +28,22 @@ describe('test sandbox floor', () => {
     expect(basename(dirname(clodexHome))).toMatch(/^clodex-vitest-sandbox-/);
     expect(getAppHome()).toBe(clodexHome);
     expect(getAppHome()).not.toBe(join(userInfo().homedir, '.clodex'));
+  });
+
+  // Credential locking and credential cleanup state are derived from CLODEX_HOME today, so these
+  // assertions pass trivially. They exist to fail loudly if that derivation is ever relocated to
+  // the real user home - `os.userInfo().homedir` in particular reads the OS account record and
+  // ignores $HOME, so it would escape this sandbox and let the suite mutate a developer's own
+  // credential state.
+  it('keeps credential lock and cleanup state inside the same sandbox', () => {
+    const realHome = userInfo().homedir;
+
+    const lockPath = getCredentialMutationLockPath('openai-oauth:default');
+    expectInsideVitestSandbox(lockPath);
+    expect(relative(resolve(realHome), resolve(lockPath))).toMatch(/^\.\.(?:[/\\]|$)/);
+
+    const cleanupPath = getCredentialCleanupPath();
+    expectInsideVitestSandbox(cleanupPath);
+    expect(relative(resolve(realHome), resolve(cleanupPath))).toMatch(/^\.\.(?:[/\\]|$)/);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    globalSetup: ['./vitest.global-setup.ts'],
     setupFiles: ['./vitest.setup.ts'],
   },
 });

--- a/vitest.global-setup.ts
+++ b/vitest.global-setup.ts
@@ -1,0 +1,22 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export const RUN_ROOT_ENV_VAR = 'CLODEX_VITEST_RUN_ROOT';
+
+/**
+ * Creates one temp root per `vitest` run and removes it (with everything under it) when the run
+ * ends. `vitest.setup.ts` nests each test file's sandbox inside this root, so a per-file sandbox
+ * that never got to clean itself up - an import-time collection error kills the worker before any
+ * `afterAll` runs - is still swept away here. The env var is read by workers, which are forked
+ * after this hook and therefore inherit it.
+ */
+export default function setup(): () => void {
+  const runRoot = mkdtempSync(join(tmpdir(), 'clodex-vitest-run-'));
+  process.env[RUN_ROOT_ENV_VAR] = runRoot;
+
+  return () => {
+    delete process.env[RUN_ROOT_ENV_VAR];
+    rmSync(runRoot, { recursive: true, force: true });
+  };
+}

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,9 +1,14 @@
-import { mkdtempSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { beforeEach } from 'vitest';
+import { afterAll, beforeEach } from 'vitest';
+import { RUN_ROOT_ENV_VAR } from './vitest.global-setup.js';
 
-const sandboxRoot = mkdtempSync(join(tmpdir(), 'clodex-vitest-sandbox-'));
+// Vitest evaluates this setup file once per test file, so `sandboxRoot` is private to the test
+// file currently running - no other worker or test file ever reads or writes it. That is what
+// makes it safe to delete the whole tree from this file's own `afterAll`.
+const sandboxParent = process.env[RUN_ROOT_ENV_VAR] ?? tmpdir();
+const sandboxRoot = mkdtempSync(join(sandboxParent, 'clodex-vitest-sandbox-'));
 const sandboxHome = join(sandboxRoot, 'clodex-home');
 
 function establishSandboxFloor(): void {
@@ -11,6 +16,14 @@ function establishSandboxFloor(): void {
   // HOME is sandboxed too: the full suite supports this stronger floor for direct homedir() reads.
   process.env.HOME = sandboxRoot;
 }
+
+// Runs after every test in this file, including when tests fail or throw. Recursive because
+// suites write real files under the sandbox home; `force` so a missing or already-removed tree
+// never turns a green run red. Anything this misses is swept by the run-root teardown in
+// vitest.global-setup.ts.
+afterAll(() => {
+  rmSync(sandboxRoot, { recursive: true, force: true });
+});
 
 establishSandboxFloor();
 beforeEach(establishSandboxFloor);


### PR DESCRIPTION
## Problem

`vitest.setup.ts` creates the test sandbox with `mkdtempSync(join(tmpdir(), 'clodex-vitest-sandbox-'))` and never removes it. Vitest evaluates a setup file once per test file, so each run leaks one temp directory per test file — verified as exactly **79 new directories per `pnpm test`**. On my machine **2467** `clodex-vitest-sandbox-*` directories had piled up in `$TMPDIR` (about 1.5 MB, 288 of them holding real `clodex-home` state written by the suites: `providers.json`, `credential-cleanup.json`, `logs/`).

## What changed

- **`vitest.setup.ts`** — an `afterAll` removes that file's sandbox root with `rmSync(..., { recursive: true, force: true })`. Each root is private to the single test file that created it (confirmed empirically: one worker process and one root per test file), so deleting it from the file's own `afterAll` cannot touch a directory another worker or test file is still using. `afterAll` also runs when tests fail or throw.
- **`vitest.global-setup.ts`** (new) — creates one run-scoped parent directory and removes it, recursively, when the run ends. `vitest.setup.ts` nests each per-file sandbox inside it. This covers the one case `afterAll` cannot: an import-time collection error kills the worker before any hook runs. (I first tried a `process.on('exit')` net in the setup file and measured that it does *not* fire in that case — hence the run-scoped parent.)
- **`vitest.config.ts`** — registers the `globalSetup` file.
- **`tests/test-sandbox-floor.test.ts`** — new assertion that `getCredentialMutationLockPath()` and `getCredentialCleanupPath()` resolve inside the sandbox and outside the real user home.

The sandbox floor itself is unchanged: `CLODEX_HOME` and `HOME` are still set both at module scope and in `beforeEach`, so direct `homedir()` reads stay contained.

### About the new guard assertion

Both credential paths derive from `CLODEX_HOME` today, so the assertion passes trivially — that is the point. It is a tripwire: if credential locking or credential cleanup state is ever moved to `os.userInfo().homedir` (which reads the OS account record and ignores `$HOME`), it would silently escape the sandbox and let the suite mutate a developer's own credential state. The test then fails instead. A comment in the test says so.

No `src/` changes — shipped behavior is untouched.

## Verification

| | before | after |
|---|---|---|
| `clodex-vitest-sandbox-*` dirs after one `pnpm test` | +79 | **+0** |
| run-scoped parent dirs left behind | n/a | **0** |

- `CLODEX_HOME=$(mktemp -d) pnpm test` → **79 files, 898 tests passed** (897 on `main` + 1 new).
- `pnpm typecheck` and `pnpm build` pass.
- Failure paths checked explicitly with two throwaway test files — one that writes into the sandbox home and then fails an assertion, one that throws at import time. Delta after that run: **0** directories.
- Starting from a wiped `$TMPDIR` (the 2467 stale directories were verified as this suite's output by name and content, then removed) a full run leaves **0** behind.