### PR TITLE
fix(proxy): reuse private adapter connections

### DIFF
--- a/src/http-proxy/server.ts
+++ b/src/http-proxy/server.ts
@@ -455,6 +455,7 @@ function forwardToAdapter(
   rawBody: Buffer,
   adapter: ProxyHandle,
   adapterRequest: typeof http.request = http.request,
+  adapterAgent?: http.Agent,
   lifecycle?: {
     logPath: string;
     requestId: string;
@@ -584,6 +585,7 @@ function forwardToAdapter(
       port: adapter.port,
       method: 'POST',
       path: req.url,
+      agent: adapterAgent,
       headers: {
         'Content-Type': 'application/json',
         'Content-Length': String(rawBody.length),
@@ -730,6 +732,7 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
       options.modelAliases,
     );
   }
+  const adapterAgent = adapter ? new http.Agent({ keepAlive: true }) : undefined;
   let shuttingDown = false;
 
   const mitmServer = https.createServer({
@@ -848,6 +851,7 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
           adapterBody,
           adapter,
           options.adapterRequest,
+          adapterAgent,
           messagesEndpoint === 'messages' && options.inferenceLogPath
             ? {
                 logPath: options.inferenceLogPath,
@@ -971,6 +975,7 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
       options.host ?? '127.0.0.1',
     );
   } catch (err) {
+    adapterAgent?.destroy();
     adapter?.close();
     throw err;
   }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -71,6 +71,7 @@ type ProxyLog = (message: string | (() => string)) => void;
 // still surfaced by the SDK idle watchdog rather than masked by pings forever.
 const STREAM_KEEPALIVE_INTERVAL_MS = 20_000;
 const STREAM_KEEPALIVE_PING = 'event: ping\ndata: {"type":"ping"}\n\n';
+const INTERNAL_ADAPTER_KEEPALIVE_TIMEOUT_MS = 60_000;
 
 function createTranslationLifecycle(
   logPath: string | undefined,
@@ -749,6 +750,7 @@ export async function startProxyCatalog(
     // Everything else → 404
     anthropicError(res, 404, `Unknown endpoint: ${req.method} ${req.url}`);
   });
+  server.keepAliveTimeout = INTERNAL_ADAPTER_KEEPALIVE_TIMEOUT_MS;
 
   let address: AddressInfo;
   try {

--- a/tests/http-proxy-server.test.ts
+++ b/tests/http-proxy-server.test.ts
@@ -1200,6 +1200,90 @@ describe('selective HTTP proxy', () => {
     }
   }, 20_000);
 
+  it('keeps translated adapter connections out of the process-global pool', async () => {
+    const certificates = ensureHttpProxyCertificates();
+    let connectionCount = 0;
+    const adapterServer = http.createServer((req, res) => {
+      req.resume();
+      req.once('end', () => {
+        res.writeHead(200, {
+          'Content-Type': 'application/json',
+          'Content-Length': '2',
+        });
+        res.end('{}');
+      });
+    });
+    adapterServer.keepAliveTimeout = 60_000;
+    adapterServer.on('connection', () => {
+      connectionCount += 1;
+    });
+    const adapterPort = await listen(adapterServer);
+    const route = {
+      aliasId: 'clodex:test:translated-model',
+      realModelId: 'translated-model',
+      displayName: 'Translated Model',
+      upstreamUrl: '',
+      apiKey: 'provider-key',
+      modelFormat: 'openai' as const,
+      npm: '@ai-sdk/openai-compatible',
+      providerId: 'test-provider',
+    };
+    const proxy = await startHttpProxy({
+      routes: [route],
+      adapterHandle: {
+        port: adapterPort,
+        token: 'adapter-local-token',
+        close: () => {
+          adapterServer.closeAllConnections();
+          adapterServer.close();
+        },
+      },
+      adapterRequest: ((options: http.RequestOptions, onResponse: (response: http.IncomingMessage) => void) =>
+        http.request(
+          { ...options, agent: options.agent ?? false },
+          onResponse,
+        )) as typeof http.request,
+    });
+
+    try {
+      const body = JSON.stringify({
+        model: route.aliasId,
+        messages: [{ role: 'user', content: 'test adapter connection reuse' }],
+        stream: false,
+      });
+      const requestTranslatedModel = async () => {
+        const secure = await connectMitm(proxy.port, certificates.caCert);
+        const payload = Buffer.from(body);
+        secure.write([
+          'POST /v1/messages HTTP/1.1',
+          'Host: api.anthropic.com',
+          'Content-Type: application/json',
+          `Content-Length: ${payload.length}`,
+          'Connection: close',
+          '',
+          '',
+        ].join('\r\n'));
+        secure.write(payload);
+
+        let response = '';
+        for await (const chunk of secure) {
+          response += chunk.toString();
+          if (response.includes('\r\n\r\n{}')) break;
+        }
+        secure.destroy();
+        return response;
+      };
+      const firstResponse = await requestTranslatedModel();
+      const secondResponse = await requestTranslatedModel();
+
+      expect(firstResponse).toContain('200');
+      expect(secondResponse).toContain('200');
+      expect(connectionCount).toBe(1);
+    } finally {
+      await proxy.close();
+    }
+  }, 20_000);
+
   it('logs a distinct source when the adapter request closes before headers', async () => {
     const certificates = ensureHttpProxyCertificates();
     const inferenceLogPath = join(testHome, 'adapter-request-close-inference.jsonl');


### PR DESCRIPTION
## Summary

- isolate the loopback translation adapter from Node's process-global HTTP pool
- retain healthy internal connections across ordinary request gaps
- cover private-pool reuse with a local transport regression test

## Problem

Translated requests currently use the process-global HTTP agent for the private loopback hop. Its short socket lifetime causes frequent reconnects between tool turns and couples adapter traffic to unrelated HTTP users in the process. A reset during that connection phase fails the request before the adapter can return response headers.

The proxy now owns a keep-alive agent for that hop. The adapter advertises a 60-second idle window, allowing the private pool to retain healthy sockets while leaving active request timeouts unchanged. Startup failures still destroy the pool immediately, while normal shutdown preserves the existing local-shutdown lifecycle ordering.

## Validation

- `pnpm vitest run tests/http-proxy-server.test.ts`
- `pnpm typecheck`
- `pnpm test` (80 files, 1,026 tests)
- `pnpm build`
- `gitleaks git --staged`
