### PR TITLE
fix(adapter): prevent cached input usage inflation

### DIFF
--- a/src/sdk-adapter.ts
+++ b/src/sdk-adapter.ts
@@ -605,7 +605,7 @@ type LogFn = (msg: () => string) => void;
 export interface AnthropicStreamObserver {
   /** Called for every AI SDK fullStream part before Relay translates it. */
   onPart?: (partType: string) => void;
-  /** Local estimate used until the provider reports actual usage at stream completion. */
+  /** Local fallback used when the provider omits usage at stream completion. */
   initialInputTokens?: number;
   abortSignal?: AbortSignal;
   /** Abort if the provider produces no stream event for this long. */
@@ -664,7 +664,7 @@ export async function writeAnthropicStream(
   let openToolId: string | null = null;
   let finishReason = 'end_turn';
   let usage: AnthropicUsage = {
-    input_tokens: 0,
+    input_tokens: observer?.initialInputTokens ?? 0,
     output_tokens: 0,
     cache_creation_input_tokens: 0,
     cache_read_input_tokens: 0,
@@ -679,7 +679,7 @@ export async function writeAnthropicStream(
         id: messageId, type: 'message', role: 'assistant', content: [],
         model: modelId, stop_reason: null, stop_sequence: null,
         usage: {
-          input_tokens: observer?.initialInputTokens ?? 0,
+          input_tokens: 0,
           output_tokens: 0,
           cache_creation_input_tokens: 0,
           cache_read_input_tokens: 0,
@@ -812,7 +812,13 @@ export async function writeAnthropicStream(
 
       case 'finish':
         if (part.totalUsage) {
-          usage = toAnthropicUsage(part.totalUsage);
+          const finalUsage = toAnthropicUsage(part.totalUsage);
+          const hasFinalInputUsage = finalUsage.input_tokens
+            + finalUsage.cache_creation_input_tokens
+            + finalUsage.cache_read_input_tokens > 0;
+          usage = hasFinalInputUsage
+            ? finalUsage
+            : { ...usage, output_tokens: finalUsage.output_tokens };
         }
         if (part.finishReason === 'tool-calls') finishReason = 'tool_use';
         else if (part.finishReason === 'length') finishReason = 'max_tokens';

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -971,6 +971,16 @@ describe('SDK translated error logging', () => {
         .find(block => block.startsWith('event: message_start'))!;
       const messageStart = JSON.parse(messageStartBlock.split('\n')[1]!.replace('data: ', ''));
       expect(messageStart.message.usage).toEqual({
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      });
+      const messageDeltaBlock = res.body
+        .split('\n\n')
+        .find(block => block.startsWith('event: message_delta'))!;
+      const messageDelta = JSON.parse(messageDeltaBlock.split('\n')[1]!.replace('data: ', ''));
+      expect(messageDelta.usage).toEqual({
         input_tokens: expectedInputTokens,
         output_tokens: 0,
         cache_creation_input_tokens: 0,

--- a/tests/sdk-adapter.test.ts
+++ b/tests/sdk-adapter.test.ts
@@ -722,7 +722,7 @@ describe('writeAnthropicStream', () => {
     ]);
     const start = events.find(e => e.event === 'message_start')!;
     expect(start.data.message.usage).toEqual({
-      input_tokens: 37,
+      input_tokens: 0,
       output_tokens: 0,
       cache_creation_input_tokens: 0,
       cache_read_input_tokens: 0,
@@ -732,6 +732,57 @@ describe('writeAnthropicStream', () => {
     expect(delta.data.usage).toEqual({
       input_tokens: 5,
       output_tokens: 2,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+    });
+  });
+
+  it('does not double-count the local estimate when final input is fully cached', async () => {
+    const { events } = await collect([
+      { type: 'start' },
+      {
+        type: 'finish',
+        finishReason: 'stop',
+        totalUsage: {
+          inputTokens: 173_000,
+          outputTokens: 100,
+          inputTokenDetails: { cacheReadTokens: 173_000 },
+        },
+      },
+    ], 'm', { initialInputTokens: 61_500 });
+
+    const start = events.find(e => e.event === 'message_start')!.data.message.usage;
+    const delta = events.find(e => e.event === 'message_delta')!.data.usage;
+    const claudeMergedUsage = {
+      input_tokens: delta.input_tokens > 0 ? delta.input_tokens : start.input_tokens,
+      cache_creation_input_tokens: delta.cache_creation_input_tokens > 0
+        ? delta.cache_creation_input_tokens
+        : start.cache_creation_input_tokens,
+      cache_read_input_tokens: delta.cache_read_input_tokens > 0
+        ? delta.cache_read_input_tokens
+        : start.cache_read_input_tokens,
+    };
+
+    expect(
+      claudeMergedUsage.input_tokens
+      + claudeMergedUsage.cache_creation_input_tokens
+      + claudeMergedUsage.cache_read_input_tokens,
+    ).toBe(173_000);
+  });
+
+  it('uses the local input estimate when final usage omits input tokens', async () => {
+    const { events } = await collect([
+      { type: 'start' },
+      {
+        type: 'finish',
+        finishReason: 'stop',
+        totalUsage: { inputTokens: 0, outputTokens: 7 },
+      },
+    ], 'm', { initialInputTokens: 37 });
+
+    expect(events.find(e => e.event === 'message_delta')!.data.usage).toEqual({
+      input_tokens: 37,
+      output_tokens: 7,
       cache_creation_input_tokens: 0,
       cache_read_input_tokens: 0,
     });


### PR DESCRIPTION
## Summary
- keep local input estimates out of initial streamed usage
- prefer provider-reported input usage and retain estimates only as completion fallbacks
- cover fully cached input and missing-usage streams

## Root cause
The adapter emitted estimated input usage at stream start and cache-split provider usage at completion. Consumers that preserve zero-valued fields could retain the estimate alongside cache-read tokens, inflating context totals and triggering compaction too early.

## Test plan
- [x] `pnpm exec vitest run tests/sdk-adapter.test.ts tests/proxy.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `gitleaks dir . --no-banner --redact`
