### PR TITLE
feat: opt in to Claude Code native computer use

### DIFF
--- a/src/patch-transforms.ts
+++ b/src/patch-transforms.ts
@@ -65,7 +65,7 @@ export function formatPatchSiteLine(result: PatchSiteResult): string {
 }
 
 /**
- * Apply the clodex patch sites (PATCH 1–7) to the Claude Code source.
+ * Apply the clodex patch sites (PATCH 1–9) to the Claude Code source.
  * Pure: source string in → patched string + per-site results out. Throws
  * `PatchApplyError` when the config is invalid or a required site fails —
  * nothing should be written to the binary in that case.
@@ -347,6 +347,54 @@ export function applyClodexPatches(source: string, config: PatchScriptModelConfi
         { required: true }
       );
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // PATCH 8 — opt in to Claude Code's bundled native Computer Use MCP.
+  //
+  // Claude Code ships a macOS-native computer-use MCP server and guards both
+  // its dynamic registration and its tools/list response through one predicate.
+  // Keep Claude's HIPAA guard authoritative, but permit an explicit Clodex env
+  // opt-in to bypass the Anthropic subscription-tier / rollout checks. The
+  // surrounding upstream call site still limits automatic registration to
+  // interactive macOS sessions.
+  //
+  // Off by default: users must set CLODEX_NATIVE_COMPUTER_USE=1.
+  // ---------------------------------------------------------------------------
+  {
+    const MARKER = '/*clodex:native-computer-use*/';
+    applyOnce(
+      'PATCH 8: native Computer Use opt-in',
+      /function ([\w$]+)\(\)\{if\(([\w$]+)\("hipaa"\)\)return!1;return ([\w$]+)\(\)&&([\w$]+)\(\)\.enabled\}/,
+      (_m, predicate, hipaaGate, tierGate, rolloutGate) =>
+        'function ' + predicate + '(){if(' + hipaaGate + '("hipaa"))return!1;'
+        + MARKER + 'if(process.env.CLODEX_NATIVE_COMPUTER_USE==="1")return!0;'
+        + 'return ' + tierGate + '()&&' + rolloutGate + '().enabled}',
+      { marker: MARKER, required: false }
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // PATCH 9 — make the explicit native Computer Use opt-in global.
+  //
+  // Upstream requires enabling the built-in `computer-use` server separately
+  // in every project. When the same Clodex env opt-in is set, treat that server
+  // as enabled without changing the normal project-scoped behavior for any
+  // other MCP. Removing the env restores Claude Code's upstream toggle logic.
+  // ---------------------------------------------------------------------------
+  {
+    const MARKER = '/*clodex:native-computer-use-default*/';
+    applyOnce(
+      'PATCH 9: native Computer Use default enable',
+      /function ([\w$]+)\(e\)\{let t=([\w$]+)\(\);if\(([\w$]+)\(e\)\)return!([\w$]+)\(t\.enabledMcpServers\)\.includes\(e\);return ([\w$]+)\(t\.disabledMcpServers\)\.includes\(e\)\}/,
+      (_m, predicate, readProject, isBuiltin, normalizeEnabled, normalizeDisabled) =>
+        'function ' + predicate + '(e){'
+        + MARKER + 'if(' + isBuiltin + '(e)&&process.env.CLODEX_NATIVE_COMPUTER_USE==="1")return!1;'
+        + 'let t=' + readProject + '();if(' + isBuiltin + '(e))return!'
+        + normalizeEnabled + '(t.enabledMcpServers).includes(e);return '
+        + normalizeDisabled + '(t.disabledMcpServers).includes(e)}',
+      { marker: MARKER, required: false }
+    );
   }
 
   return { content: js, results: report };

--- a/src/patcher.ts
+++ b/src/patcher.ts
@@ -103,6 +103,11 @@ export interface PatchModelMeta {
   displayName?: string;
 }
 
+// Bump whenever the binary transform set changes so existing installations are
+// restored from their pristine backup and repatched instead of being mistaken
+// for current solely because their model map is unchanged.
+const PATCH_SCHEMA_VERSION = 2;
+
 /**
  * Build the patch model config from favorites + aliases.
  * Keys are the bare `clodex:<provider>:<model>` ids (no [1m] suffix — the
@@ -141,7 +146,9 @@ export function computePatchConfigHash(config: PatchScriptModelConfig): string {
     const entry = config[key]!;
     return [key, entry.alias ?? null, entry.context ?? null, entry.display ?? null];
   });
-  return createHash('sha256').update(JSON.stringify(canonical)).digest('hex');
+  return createHash('sha256')
+    .update(JSON.stringify([PATCH_SCHEMA_VERSION, canonical]))
+    .digest('hex');
 }
 
 /** Read favorites + aliases + registry model metadata from disk (no network, no credentials). */

--- a/tests/patcher.test.ts
+++ b/tests/patcher.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createHash } from 'node:crypto';
 import { mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -88,6 +89,13 @@ describe('computePatchConfigHash', () => {
     expect(computePatchConfigHash({ 'clodex:p:m1': { alias: 'x', context: 1000, display: 'M One (P)' } })).not.toBe(
       computePatchConfigHash({ 'clodex:p:m1': { alias: 'x', context: 1000, display: 'M One (Q)' } }),
     );
+  });
+
+  it('includes the binary patch schema in the persisted digest', () => {
+    const config = { 'clodex:p:m1': { alias: 'x', context: 1000 } };
+    const legacyCanonical = [['clodex:p:m1', 'x', 1000, null]];
+    const legacyHash = createHash('sha256').update(JSON.stringify(legacyCanonical)).digest('hex');
+    expect(computePatchConfigHash(config)).not.toBe(legacyHash);
   });
 });
 

--- a/tests/patcher.test.ts
+++ b/tests/patcher.test.ts
@@ -248,6 +248,8 @@ const CLAUDE_FIXTURE = [
   'function rz(x){switch(x){case"best":{return "opus"}default:return null}}',
   'function opts(e,t,r){let n=cur(),o=(n==="opus")?[n,r]:[r];for(let i of o)Dlh(e,i,t);return e}',
   'function RS(e,t){let r=FAc();if(r!==void 0)return r;if(EHi(e,t))return Dve;return $Ac(e,t)}',
+  'function Lbo(){if(lK("hipaa"))return!1;return QE_()&&iEs().enabled}',
+  'function Fw(e){let t=Rd();if(oSs(e))return!Syo(t.enabledMcpServers).includes(e);return Syo(t.disabledMcpServers).includes(e)}',
 ].join('\n');
 
 function runPatchScript(config: Parameters<typeof applyClodexPatches>[1], source = CLAUDE_FIXTURE): string {
@@ -333,6 +335,8 @@ describe('patch script identity naming', () => {
       ['PATCH 5: model picker options', 'OK'],
       ['PATCH 4: Agent tool model description', 'OK'],
       ['PATCH 7: per-model context window', 'OK'],
+      ['PATCH 8: native Computer Use opt-in', 'OK'],
+      ['PATCH 9: native Computer Use default enable', 'OK'],
     ]);
     const rerun = applyClodexPatches(fresh.content, config);
     expect(rerun.results.map(r => [r.name, r.status])).toEqual([
@@ -344,7 +348,28 @@ describe('patch script identity naming', () => {
       // PATCH 7 re-runs through the in-place refresh path; an unchanged config
       // rewrites the identical table, which reports as already patched.
       ['PATCH 7: per-model context window (refresh)', 'SKIP'],
+      ['PATCH 8: native Computer Use opt-in', 'SKIP'],
+      ['PATCH 9: native Computer Use default enable', 'SKIP'],
     ]);
+  });
+
+  it('enables native Computer Use only by explicit env opt-in and preserves the HIPAA guard', () => {
+    const out = runPatchScript(config);
+    expect(out).toContain(
+      'function Lbo(){if(lK("hipaa"))return!1;/*clodex:native-computer-use*/'
+      + 'if(process.env.CLODEX_NATIVE_COMPUTER_USE==="1")return!0;'
+      + 'return QE_()&&iEs().enabled}'
+    );
+  });
+
+  it('defaults only the built-in Computer Use MCP to enabled under the same opt-in', () => {
+    const out = runPatchScript(config);
+    expect(out).toContain(
+      'function Fw(e){/*clodex:native-computer-use-default*/'
+      + 'if(oSs(e)&&process.env.CLODEX_NATIVE_COMPUTER_USE==="1")return!1;'
+      + 'let t=Rd();if(oSs(e))return!Syo(t.enabledMcpServers).includes(e);'
+      + 'return Syo(t.disabledMcpServers).includes(e)}'
+    );
   });
 
   it('refreshes the baked context table in place when only the window changes', () => {


### PR DESCRIPTION
## Summary

- add an explicit `CLODEX_NATIVE_COMPUTER_USE=1` opt-in for Claude Code’s bundled `computer-use` MCP
- enable that built-in MCP globally under the same opt-in instead of requiring a per-project toggle
- version the binary patch digest so existing installations restore and repatch after transform changes

## Safety

The patch preserves Claude Code’s HIPAA, macOS, and interactive-session guards. It does not bypass the native per-app approval dialog, computer-use lock, screen filtering, or macOS Privacy & Security controls. Removing the environment variable restores upstream behavior.

## Validation

- Claude Code 2.1.220: `/mcp` reported `computer-use · connected · 24 tools`
- live Sol and Luna smoke tests completed native app approval and screen interaction
- 1,029 tests passed
- `pnpm typecheck` passed
- `pnpm build` passed