### PR TITLE
fix(oauth): surface in-band request rejections instead of an empty 200

### DIFF
--- a/src/oauth/responses-websocket.ts
+++ b/src/oauth/responses-websocket.ts
@@ -462,6 +462,38 @@ function responseRetryAfterSeconds(event: unknown): number | undefined {
   return undefined;
 }
 
+/**
+ * HTTP status carried by an in-band error frame. The Codex backend reports it
+ * as a top-level `status` (e.g. 400 alongside an `unsupported_parameter`
+ * error); `response.status` is the response lifecycle state, not a status code,
+ * so it is deliberately not consulted here.
+ */
+function responseErrorStatus(event: unknown): number | undefined {
+  if (!event || typeof event !== 'object') return undefined;
+  const record = event as JsonObject;
+  for (const candidate of [record.status, (record.error as JsonObject | undefined)?.status]) {
+    if (typeof candidate === 'number' && Number.isInteger(candidate)
+      && candidate >= 400 && candidate <= 599) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+function responseErrorMessage(event: unknown): string | undefined {
+  if (!event || typeof event !== 'object') return undefined;
+  const record = event as JsonObject;
+  const response = record.response && typeof record.response === 'object'
+    ? record.response as JsonObject
+    : undefined;
+  for (const candidate of [record.error, response?.error, record]) {
+    if (!candidate || typeof candidate !== 'object') continue;
+    const message = (candidate as JsonObject).message;
+    if (typeof message === 'string' && message.trim()) return message.trim();
+  }
+  return undefined;
+}
+
 function boundedDiagnosticIdentifier(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
   const normalized = value.trim();
@@ -1121,6 +1153,30 @@ function handleSocketMessage(entry: ConnectionEntry, data: RawData): void {
     resetContextForRetry(ctx);
     const replacement = ctx.createReplacement();
     dispatchContext(replacement, ctx);
+    return;
+  }
+
+  // A bare `error` frame carrying an HTTP status is a rejected request, not a
+  // response: forwarding it verbatim ends the stream with no content, so the
+  // client sees an empty 200 and reports a generic failure instead of the
+  // upstream reason. Map it to a real error frame while nothing has been
+  // emitted yet — once model data is downstream the stream is already
+  // committed, and the existing partial-output path must keep handling it.
+  const errorStatus = type === 'error' && !ctx.emittedModelData
+    ? responseErrorStatus(event)
+    : undefined;
+  if (errorStatus !== undefined) {
+    failContext(
+      entry,
+      ctx,
+      responseErrorMessage(event) ?? `OpenAI rejected the request (HTTP ${errorStatus})`,
+      {
+        source: 'error_frame',
+        errorCode,
+        mappedStatusCode: errorStatus,
+      },
+      errorStatus,
+    );
     return;
   }
 

--- a/tests/responses-websocket.test.ts
+++ b/tests/responses-websocket.test.ts
@@ -911,6 +911,79 @@ describe('createResponsesWebSocketFetch', () => {
     }));
   });
 
+  it('maps an in-band rejected request to its upstream status instead of an empty stream', async () => {
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
+      onDiagnostic: event => diagnostics.push(event),
+    });
+    const res = await withResponsesWebSocketDiagnosticContext(
+      { requestId: 'req-unsupported-parameter' },
+      () => wsFetch('https://x', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer tok' },
+        body: JSON.stringify(sessionPayload([])),
+      }),
+    );
+    const socket = lastSocket();
+    socket.emit('open');
+    socket.emit('message', Buffer.from(JSON.stringify({
+      type: 'error',
+      error: {
+        type: 'invalid_request_error',
+        code: 'unsupported_parameter',
+        message: "Unsupported parameter: 'reasoning.summary' is not supported with the 'gpt-5.3-codex-spark' model.",
+        param: 'reasoning.summary',
+      },
+      status: 400,
+    })));
+
+    const body = await readAll(res);
+    expect(await readErrorFrame(new Response(body))).toEqual({
+      type: 'error',
+      sequence_number: 1,
+      error: {
+        type: 'invalid_request_error',
+        code: '400',
+        message: "Unsupported parameter: 'reasoning.summary' is not supported with the 'gpt-5.3-codex-spark' model.",
+        param: null,
+      },
+    });
+    // The failure must reach the caller as a 400, not as a content-free 200.
+    expect(await classifyThroughSdk(body)).toMatchObject({
+      statusCode: 400,
+      isRetryable: false,
+    });
+    expect(diagnostics).toContainEqual(expect.objectContaining({
+      event: 'ws_response_error',
+      requestId: 'req-unsupported-parameter',
+      source: 'error_frame',
+      errorCode: 'unsupported_parameter',
+      mappedStatusCode: 400,
+      emittedModelData: false,
+    }));
+  });
+
+  it('leaves a status-carrying error frame alone once model data is downstream', async () => {
+    const wsFetch = createResponsesWebSocketFetch(WS_URL);
+    const res = await wsFetch('https://x', { method: 'POST', headers: {}, body: '{}' });
+    const socket = lastSocket();
+    socket.emit('open');
+    socket.emit('message', Buffer.from(JSON.stringify({
+      type: 'response.output_text.delta', delta: 'partial',
+    })));
+    socket.emit('message', Buffer.from(JSON.stringify({
+      type: 'error',
+      error: { type: 'server_error', code: 'internal_error', message: 'late failure' },
+      status: 500,
+    })));
+
+    // Already-committed stream: the frame is forwarded verbatim, not rewritten
+    // into a synthetic error that would contradict the emitted output.
+    const body = await readAll(res);
+    expect(body).toContain('partial');
+    expect(body).not.toContain('"code":"500"');
+  });
+
   it('logs sanitized upstream response failure details after partial output', async () => {
     const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
     const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {


### PR DESCRIPTION
Follow-up to #65, as offered there.

## The bug

When the Codex Responses WebSocket rejects a request outright, it sends a bare `error` frame carrying an HTTP status:

```json
{"type":"error","error":{"type":"invalid_request_error","code":"unsupported_parameter",
 "message":"Unsupported parameter: 'reasoning.summary' is not supported with the 'gpt-5.3-codex-spark' model.",
 "param":"reasoning.summary"},"status":400}
```

`handleSocketMessage` pushes that frame to `pendingEvents` and forwards it verbatim. The frame is terminal, so the stream ends with no content and the caller gets a well-formed **HTTP 200 with zero output tokens and no error**. A precise upstream reason arrives at Claude Code as `No assistant messages found`.

Diagnosing it is disproportionately expensive: `--ws-diagnostics` reports `errorType`/`errorCode` but deliberately hashes `errorMessage`, so recovering the text — the part that says *what* was wrong — required patching a local build. That's what turned #65 into a multi-hour investigation of an error the backend had stated plainly.

## The fix

Route these frames through the existing `failContext`, which already maps a status to an Anthropic error type and emits a real error frame — the same treatment `websocket_connection_limit_reached` already gets one branch above. No new machinery; the gap was that only that one error code reached it.

Two small extractors follow the existing `responseErrorCode` / `responseRetryAfterSeconds` shape:

- `responseErrorStatus` — reads the top-level `status` (and `error.status`), bounded to 4xx/5xx. It deliberately does **not** consult `response.status`, which is the lifecycle state (`"failed"`, `"incomplete"`), not a status code.
- `responseErrorMessage` — the upstream message, for the client-facing error.

**Placement matters.** The check sits after the `previous_response_not_found` retry so chain recovery keeps priority, and it is gated on `!ctx.emittedModelData`: once model output is downstream the stream is committed, and rewriting it into a synthetic error would contradict what the client already received. That path stays exactly as it was — the second test pins it.

Only `type === 'error'` frames are affected. `response.failed` / `response.incomplete` carry a lifecycle status rather than an HTTP one and keep their current handling.

## Verification

End to end against the real `openai-oauth` route. To reproduce a genuine upstream 400 I temporarily reverted the #65 fix, so the model rejected `reasoning.summary` for real:

| | result |
|---|---|
| before | `HTTP 200`, empty body |
| after | `HTTP 400`, `Unsupported parameter: 'reasoning.summary' is not supported with the 'gpt-5.3-codex-spark' model. (HTTP 400)` |

Tests: one pinning the mapped error frame (asserting the shape, the SDK-classified `statusCode: 400` / `isRetryable: false` via the existing `classifyThroughSdk` helper, and the diagnostic), one pinning that a status-carrying frame arriving *after* model data is still forwarded untouched. Both fail if the fix is reverted — verified by removing it (1 failure) and restoring.

`pnpm typecheck && pnpm test && pnpm build` all pass (1185 tests).

## Note

This surfaces the error but does not make the message any easier to find in diagnostics — `errorMessage` stays hashed there, which is the right default for a log that may carry conversation content. Now that the message reaches the client, that trade-off costs less. Happy to revisit separately if you'd rather have it logged behind an explicit opt-in.
