### PR TITLE
fix: recover provider message and status from mid-stream error frames

### DIFF
--- a/src/oauth/responses-websocket.ts
+++ b/src/oauth/responses-websocket.ts
@@ -447,6 +447,21 @@ function responseErrorCode(event: unknown): string | undefined {
   return typeof responseError?.code === 'string' ? responseError.code : undefined;
 }
 
+/**
+ * Error CLASS of a frame, e.g. `usage_limit_reached`. Deliberately does not
+ * fall back to the frame's own `type`: on an error chunk that is the chunk
+ * discriminator (`'error'`), which names nothing.
+ */
+function responseErrorType(event: unknown): string | undefined {
+  if (!event || typeof event !== 'object') return undefined;
+  const record = event as JsonObject;
+  const error = record.error && typeof record.error === 'object' ? record.error as JsonObject : undefined;
+  if (typeof error?.type === 'string') return error.type;
+  const response = record.response && typeof record.response === 'object' ? record.response as JsonObject : undefined;
+  const responseError = response?.error && typeof response.error === 'object' ? response.error as JsonObject : undefined;
+  return typeof responseError?.type === 'string' ? responseError.type : undefined;
+}
+
 function responseRetryAfterSeconds(event: unknown): number | undefined {
   if (!event || typeof event !== 'object') return undefined;
   const record = event as JsonObject;
@@ -1138,7 +1153,24 @@ function handleSocketMessage(entry: ConnectionEntry, data: RawData): void {
     );
     return;
   }
-  if (FAILURE_EVENT_TYPES.has(type ?? '')) {
+  // A bare `error` frame carrying an HTTP status is a rejected request, not a
+  // response: forwarding it verbatim ends the stream with no content, so the
+  // client sees an empty 200 and reports a generic failure instead of the
+  // upstream reason. Map it to a real error frame while nothing has been
+  // emitted yet — once model data is downstream the stream is already
+  // committed, and the existing partial-output path must keep handling it.
+  //
+  // Resolved here, above the generic failure record, only so that record can be
+  // suppressed when the rejection branch below emits its own. The branch itself
+  // must stay after the `willRetry` return — ahead of it, it would swallow a
+  // `previous_response_not_found` frame (which carries a 400) and kill the retry.
+  const errorStatus = type === 'error' && !ctx.emittedModelData
+    ? responseErrorStatus(event)
+    : undefined;
+  // One rejection, one diagnostic record. Without this gate a rejected request
+  // emits both this record and `failContext`'s, under different `source` values
+  // with disjoint fields, reading as two failures of one request.
+  if (FAILURE_EVENT_TYPES.has(type ?? '') && (errorStatus === undefined || willRetry)) {
     emitResponseErrorDiagnostic(entry, ctx, {
       source: 'response_event',
       upstreamEventType: type,
@@ -1156,26 +1188,41 @@ function handleSocketMessage(entry: ConnectionEntry, data: RawData): void {
     return;
   }
 
-  // A bare `error` frame carrying an HTTP status is a rejected request, not a
-  // response: forwarding it verbatim ends the stream with no content, so the
-  // client sees an empty 200 and reports a generic failure instead of the
-  // upstream reason. Map it to a real error frame while nothing has been
-  // emitted yet — once model data is downstream the stream is already
-  // committed, and the existing partial-output path must keep handling it.
-  const errorStatus = type === 'error' && !ctx.emittedModelData
-    ? responseErrorStatus(event)
-    : undefined;
   if (errorStatus !== undefined) {
+    // The AI SDK strips unknown frame fields, so a backoff hint survives only
+    // baked into the message text — same reason the connection-limit branch
+    // above spells it out. Clamped, so a hostile hint cannot park a client past
+    // the 120s no-event stream abort.
+    // Only when upstream actually gave one. `clampRetryAfterSeconds` supplies a
+    // 5s DEFAULT for a missing hint, so clamping unconditionally would have
+    // every 429 assert a backoff upstream never stated — and that value becomes
+    // a real `retry-after` header downstream. Worse on a plan-level limit,
+    // where the reason says hours: a prose-only "retry after 1800s" would get
+    // "; retry after 5s" appended, and the client reads the first match.
+    const statedRetryAfter = errorStatus === 429 ? responseRetryAfterSeconds(event) : undefined;
+    const retryAfterSeconds = statedRetryAfter === undefined
+      ? undefined
+      : clampRetryAfterSeconds(statedRetryAfter);
+    const reason = responseErrorMessage(event) ?? `OpenAI rejected the request (HTTP ${errorStatus})`;
     failContext(
       entry,
       ctx,
-      responseErrorMessage(event) ?? `OpenAI rejected the request (HTTP ${errorStatus})`,
+      retryAfterSeconds === undefined ? reason : `${reason}; retry after ${retryAfterSeconds}s`,
       {
         source: 'error_frame',
-        errorCode,
+        // Names the failure. Without it this record — now the ONLY one for a
+        // rejection — can carry no indication of what failed, since a bare
+        // error frame often has no `code` at all.
+        errorType: boundedDiagnosticIdentifier(responseErrorType(event)),
+        // Upstream-controlled, so bounded like every other identifier in this
+        // file's diagnostics. The connection-limit branch can pass its code raw
+        // only because it has just been compared `===` to a known constant.
+        errorCode: boundedDiagnosticIdentifier(errorCode),
         mappedStatusCode: errorStatus,
+        ...(retryAfterSeconds !== undefined ? { retryAfterSeconds } : {}),
       },
       errorStatus,
+      retryAfterSeconds,
     );
     return;
   }

--- a/src/upstream-error.ts
+++ b/src/upstream-error.ts
@@ -38,20 +38,238 @@ export function clampRetryAfterSeconds(value?: number): number {
   return Math.min(Math.round(value), MAX_RETRY_AFTER_SECONDS);
 }
 
+/**
+ * Recover a backoff hint from message prose. The OAuth WebSocket transport's
+ * synthetic error frames can only carry the hint this way — the AI SDK's chunk
+ * schema is a closed zod object, so it strips `retry_after_seconds`.
+ */
+function retryAfterFromText(message: unknown): number | undefined {
+  if (typeof message !== 'string') return undefined;
+  const match = /retry after (\d+)s\b/i.exec(message);
+  return match ? Number(match[1]) : undefined;
+}
+
 function numericRetryAfterSeconds(inner: InstanceType<typeof APICallError>): number | undefined {
   const data = inner.data as { error?: { retry_after_seconds?: unknown; message?: unknown } } | undefined;
   const fromBody = data?.error?.retry_after_seconds;
   if (typeof fromBody === 'number' && Number.isFinite(fromBody) && fromBody >= 0) return fromBody;
   const fromHeader = inner.responseHeaders?.['retry-after'];
   if (typeof fromHeader === 'string' && /^\d+$/.test(fromHeader.trim())) return Number(fromHeader.trim());
-  // The OAuth WebSocket transport's synthetic error frames can only carry the
-  // hint in message text — the AI SDK's chunk schema strips unknown fields.
   for (const message of [data?.error?.message, inner.message]) {
-    if (typeof message !== 'string') continue;
-    const match = /retry after (\d+)s\b/i.exec(message);
-    if (match) return Number(match[1]);
+    const fromText = retryAfterFromText(message);
+    if (fromText !== undefined) return fromText;
   }
   return undefined;
+}
+
+// ── Provider stream error frames ────────────────────────────────────────────
+//
+// `@ai-sdk/openai` handles a stream failure in one of two ways depending on
+// WHEN it arrives:
+//
+//   before the first output chunk — `throwIfOpenAIStreamErrorBeforeOutput`
+//     converts the frame into a real APICallError with a mapped statusCode, so
+//     the APICallError branch below already handles it correctly.
+//   after output has started — the frame is enqueued verbatim as
+//     `{type:'error', error: <payload>}` and our adapter rethrows that payload,
+//     which is a plain object with no top-level `message` or `statusCode`.
+//
+// Only the second case reaches here, and before this recovery existed it
+// collapsed to the generic fallback string plus a fabricated HTTP 500 —
+// discarding the provider's own message on every mid-stream failure.
+//
+// The payload shapes the SDK actually produces:
+//
+//   {type:'error', sequence_number, error:{type, code, message, param}}   nested
+//   {type:'response.failed', sequence_number, response:{error:{code, message}}}
+//   {type:'error', sequence_number, code, message, param}                 flat
+//   {type, code, message, param}                       bare (chat completions)
+
+const MAX_CLIENT_MESSAGE_CHARS = 240;
+
+/** Chunk discriminators — never an error class, so they must not map to a status. */
+const CHUNK_DISCRIMINATOR_TYPES = new Set(['error', 'response.failed']);
+
+interface ProviderErrorFrame {
+  message: string;
+  statusCode: number;
+  /** Decided from the frame's own code/type, never from loose prose. */
+  contextLengthExceeded: boolean;
+  retryAfterSeconds?: number;
+  transportCode?: 'websocket_transport_error';
+  /** Full payload, for the diagnostic log only — never the user-facing message. */
+  serialized: string;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function nonEmptyString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' && value.trim() !== '' ? value : undefined;
+}
+
+/**
+ * `code` is `string | number | null` in the SDK's error schema, and the SDK's
+ * own `getStatusCode` reads both forms. Reading only strings dropped a numeric
+ * `code: 503` on the floor and classified it 500 — reintroducing, for that
+ * payload, the pre/post-output split this module exists to remove.
+ *
+ * Any finite number is kept, not just an integer in HTTP range: the SDK folds
+ * the raw value into its discriminator either way, and `frameStatusCode`
+ * already rejects anything that is not three digits before using it as a
+ * status. Filtering earlier would only diverge from the SDK.
+ */
+function errorCodeValue(record: Record<string, unknown>): string | undefined {
+  const value = record.code;
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  return typeof value === 'string' && value.trim() !== '' ? value : undefined;
+}
+
+/**
+ * Real HTTP status behind a frame.
+ *
+ * Deliberately mirrors `@ai-sdk/openai`'s own `getStatusCode`: substring
+ * discriminators rather than an exact-match table, and 500 when nothing
+ * matches. That keeps a mid-stream frame classified IDENTICALLY to the same
+ * frame arriving pre-output (which the SDK maps itself), and it degrades
+ * gracefully as OpenAI adds codes instead of silently falling out of date.
+ *
+ * Always returning a status also matters for correctness, not just tidiness:
+ * an undefined result would send the recovered message on to the prose
+ * sniffing in `upstreamHttpStatus`, where a digit in the provider's own text
+ * ("consumed 429000 of 500000 tokens") gets misread as a rate limit.
+ *
+ * clodex's own synthetic frames set `code` to the stringified status, so that
+ * exact channel is preferred over any discriminator.
+ */
+function frameStatusCode(code: string | undefined, discriminator: string): number {
+  if (code !== undefined && /^\d{3}$/.test(code)) {
+    const numeric = Number(code);
+    if (numeric >= 400 && numeric <= 599) return numeric;
+  }
+  // Mirrored ordering, quirks included: `invalid_api_key` matches /invalid/
+  // before any auth check and so reports 400 here exactly as it does in the
+  // SDK. Diverging would reintroduce the pre/post-output split this avoids,
+  // and an auth failure cannot reach a mid-stream frame anyway.
+  if (/insufficient_quota|rate_limit/.test(discriminator)) return 429;
+  if (discriminator.includes('authentication')) return 401;
+  if (discriminator.includes('permission')) return 403;
+  if (discriminator.includes('not_found')) return 404;
+  if (/invalid|bad_request|context_length/.test(discriminator)) return 400;
+  if (discriminator.includes('overload')) return 503;
+  if (discriminator.includes('timeout')) return 504;
+  return 500;
+}
+
+/**
+ * Context overflow decided from the frame's structured code/type, falling back
+ * only to unambiguous message wording.
+ *
+ * Deliberately stricter than `isContextLengthExceededError`'s prose scan, which
+ * matches a bare "context window". Acting on this discards the provider's real
+ * message in favour of a synthetic "prompt is too long" that Claude Code parses
+ * to drive auto-compaction — so a false positive costs the user conversation
+ * history AND hides the error that actually needs fixing.
+ */
+function frameIsContextLengthExceeded(discriminator: string, message: string): boolean {
+  if (/context_length|context_window/.test(discriminator)) return true;
+  return /context_length_exceeded|maximum context length|prompt is too long/i.test(message);
+}
+
+/** Retryable classes only. A transport failure is transient by definition. */
+function frameIsRetryable(frame: Pick<ProviderErrorFrame, 'statusCode' | 'transportCode'>): boolean {
+  if (frame.transportCode !== undefined) return true;
+  const { statusCode } = frame;
+  return statusCode === 408 || statusCode === 409 || statusCode === 429 || statusCode >= 500;
+}
+
+/** Parse an AI SDK stream error part into the provider payload it wraps. */
+export function providerErrorFrame(err: unknown): ProviderErrorFrame | undefined {
+  const outer = asRecord(err);
+  if (!outer) return undefined;
+
+  const nested = asRecord(outer.error) ?? asRecord(asRecord(outer.response)?.error);
+  // An unwrapped payload (the flat chunk, and the bare object the chat
+  // transport enqueues) needs a positive signal that it is an OpenAI error
+  // object rather than an ordinary failure.
+  //
+  // Provenance is that signal, not field shape. The payload the adapter
+  // rethrows is a plain parsed object; the failures that must stay out —
+  // socket errors, aborts, undici failures, validation errors — are all `Error`
+  // instances. Excluding those lets this mirror the SDK's own predicate
+  // exactly for plain objects.
+  //
+  // Approximating it with field checks instead failed in both directions:
+  // demanding a string `type` left `{message, code:'rate_limit_exceeded'}`
+  // (429 before first output) classified 500 after it, while accepting a bare
+  // `code`/`param` on anything would have swallowed `code: 'ECONNRESET'`.
+  // `typeof === 'string'`, not "non-empty": the SDK's schema permits `type: ''`
+  // and its predicate accepts any string. Requiring a non-empty one rejected
+  // that payload here while the SDK accepted it pre-output — and a rejected
+  // payload falls through to the prose sniffing in `upstreamHttpStatus`, which
+  // read the digits in "consumed 429000 of 500000 tokens" as a rate limit. So
+  // the near-miss did not merely lose metadata, it inverted retryability.
+  const unwrapped = !(err instanceof Error)
+    && (typeof outer.type === 'string'
+      || Object.hasOwn(outer, 'code')
+      || Object.hasOwn(outer, 'param'))
+    ? outer
+    : undefined;
+  const payload = nested ?? unwrapped;
+  if (!payload) return undefined;
+
+  // The SDK's schema requires only that `message` be a string, so a blank one
+  // is still a valid frame whose STATUS is worth recovering — rejecting it
+  // outright would report a 429 as a fabricated 500. Recognition keys off the
+  // string being present; blank text gets a stand-in. No status in the
+  // stand-in: `formatUpstreamError` appends `(HTTP nnn)` itself.
+  const rawMessage = payload.message;
+  if (typeof rawMessage !== 'string') return undefined;
+  const message = rawMessage.trim() !== '' ? rawMessage : 'Provider returned an error';
+
+  const code = errorCodeValue(payload);
+  // On an unwrapped chunk `type` is the discriminator ('error'), not an error
+  // class; on the bare chat payload it IS the error class. Only the latter may
+  // reach the status mapping.
+  const rawType = nonEmptyString(payload, 'type');
+  const type = rawType !== undefined && CHUNK_DISCRIMINATOR_TYPES.has(rawType) ? undefined : rawType;
+  const discriminator = [code, type].filter(value => value !== undefined).join(' ').toLowerCase();
+  const statusCode = frameStatusCode(code, discriminator);
+
+  const rawRetryAfter = statusCode === 429
+    ? (typeof payload.retry_after_seconds === 'number' && Number.isFinite(payload.retry_after_seconds)
+      && payload.retry_after_seconds >= 0
+        ? payload.retry_after_seconds
+        : retryAfterFromText(message))
+    : undefined;
+
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(payload) ?? message;
+  } catch {
+    // Circular or unserializable payload — the message is still worth keeping.
+    serialized = message;
+  }
+
+  return {
+    message,
+    statusCode,
+    contextLengthExceeded: frameIsContextLengthExceeded(discriminator, message),
+    ...(rawRetryAfter !== undefined ? { retryAfterSeconds: clampRetryAfterSeconds(rawRetryAfter) } : {}),
+    ...(code === 'websocket_transport_error' ? { transportCode: 'websocket_transport_error' as const } : {}),
+    serialized,
+  };
+}
+
+/** Unwrap a RetryError before looking for a frame; retries wrap the real payload. */
+function frameFromError(err: unknown): { frame: ProviderErrorFrame; attemptCount: number } | undefined {
+  const retry = RetryError.isInstance(err) ? err : undefined;
+  const frame = providerErrorFrame(retry?.lastError ?? err);
+  return frame ? { frame, attemptCount: retry?.errors.length ?? 1 } : undefined;
 }
 
 function boundedTransportCode(data: unknown): 'websocket_transport_error' | undefined {
@@ -67,7 +285,19 @@ function boundedTransportCode(data: unknown): 'websocket_transport_error' | unde
 export function sdkUpstreamErrorDetails(err: unknown): SdkUpstreamErrorDetails | undefined {
   const retry = RetryError.isInstance(err) ? err : undefined;
   const inner = retry?.lastError ?? err;
-  if (!APICallError.isInstance(inner)) return undefined;
+  if (!APICallError.isInstance(inner)) {
+    const recovered = frameFromError(err);
+    if (!recovered) return undefined;
+    const { frame, attemptCount } = recovered;
+    return {
+      statusCode: frame.statusCode,
+      errorContent: frame.serialized,
+      isRetryable: frameIsRetryable(frame),
+      attemptCount,
+      ...(frame.retryAfterSeconds !== undefined ? { retryAfterSeconds: frame.retryAfterSeconds } : {}),
+      ...(frame.transportCode !== undefined ? { transportCode: frame.transportCode } : {}),
+    };
+  }
 
   let errorContent = inner.responseBody;
   if (!errorContent && inner.data !== undefined) {
@@ -96,6 +326,11 @@ export function sdkUpstreamErrorDetails(err: unknown): SdkUpstreamErrorDetails |
 
 /** True when an upstream SDK/provider error says the model context was exceeded. */
 export function isContextLengthExceededError(err: unknown, formattedMessage = ''): boolean {
+  // A frame carries a structured code, so trust it rather than the prose scan
+  // below — which would also be scanning the frame's full serialized payload.
+  const frame = frameFromError(err)?.frame;
+  if (frame) return frame.contextLengthExceeded;
+
   const details = sdkUpstreamErrorDetails(err);
   const rec = err && typeof err === 'object' ? err as ApiCallLike : undefined;
   const candidates = [
@@ -121,6 +356,19 @@ export function formatUpstreamError(err: unknown): string {
   if (!err || typeof err !== 'object') return 'Upstream model request failed.';
 
   const rec = err as ApiCallLike;
+
+  // Stream error parts carry no top-level message, so they must be unwrapped
+  // before the branches below fall through to the generic fallback.
+  const frame = frameFromError(err)?.frame;
+  if (frame) {
+    // Bound the least-trusted message source rather than dropping it; the full
+    // payload is still recorded as errorContent for the diagnostic log.
+    // sanitizeMessage keeps only the first line, which a leading newline makes
+    // empty — an empty `message` field reads to Claude Code as no message at
+    // all and it prints the raw error envelope instead.
+    const short = truncateForClient(sanitizeMessage(frame.message)) || 'Upstream model request failed.';
+    return `${short} (HTTP ${frame.statusCode})`;
+  }
 
   if (rec.data?.error?.message) {
     const short = sanitizeMessage(rec.data.error.message);
@@ -166,6 +414,11 @@ export function upstreamHttpStatus(err: unknown, message: string): number {
     const code = (err as { statusCode?: number }).statusCode;
     if (typeof code === 'number' && code >= 400 && code <= 599) return code;
   }
+  // A recognized frame always resolves to a status, so the recovered provider
+  // message never reaches the prose sniffing below — where a digit in the
+  // provider's own text would be misread as an HTTP status.
+  const frameStatus = frameFromError(err)?.frame.statusCode;
+  if (frameStatus !== undefined) return frameStatus;
   if (message.includes('HTTP 429') || message.includes('429')) return 429;
   if (message.includes('HTTP 400')) return 400;
   return 500;
@@ -181,6 +434,13 @@ export function anthropicErrorType(status: number): string {
     case 429: return 'rate_limit_error';
     default: return 'api_error';
   }
+}
+
+function truncateForClient(message: string): string {
+  if (message.length <= MAX_CLIENT_MESSAGE_CHARS) return message;
+  // Slice by code point: a UTF-16 slice can cut a surrogate pair in half and
+  // emit a lone surrogate, which does not survive JSON serialization intact.
+  return `${[...message].slice(0, MAX_CLIENT_MESSAGE_CHARS - 1).join('')}…`;
 }
 
 function sanitizeMessage(message: string): string {

--- a/tests/responses-websocket.test.ts
+++ b/tests/responses-websocket.test.ts
@@ -961,6 +961,184 @@ describe('createResponsesWebSocketFetch', () => {
       mappedStatusCode: 400,
       emittedModelData: false,
     }));
+    // One rejection, one record. The generic `response_event` record is
+    // suppressed so a diagnostics consumer does not read one failed request as
+    // two distinct failures under disjoint field sets.
+    expect(diagnostics.filter(event => event.event === 'ws_response_error')).toHaveLength(1);
+  });
+
+  it('bounds an upstream-controlled error code in the rejection diagnostic', async () => {
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
+      onDiagnostic: event => diagnostics.push(event),
+    });
+    const res = await wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload([])),
+    });
+    const socket = lastSocket();
+    socket.emit('open');
+    socket.emit('message', Buffer.from(JSON.stringify({
+      type: 'error',
+      // Hostile: overlong and newline-bearing, so it would corrupt a log line
+      // if forwarded verbatim the way the raw value was.
+      error: { type: 'invalid_request_error', code: `${'c'.repeat(400)}\nsecond line`, message: 'nope' },
+      status: 400,
+    })));
+    await readAll(res);
+
+    const record = diagnostics.find(event => event.event === 'ws_response_error');
+    expect(record).toMatchObject({ source: 'error_frame', mappedStatusCode: 400 });
+    // Rejected outright rather than truncated — same discipline every other
+    // identifier in this file's diagnostics already follows.
+    expect(record?.errorCode).toBeUndefined();
+  });
+
+  it('carries an in-band 429 backoff hint through as message text', async () => {
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
+      onDiagnostic: event => diagnostics.push(event),
+    });
+    const res = await wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload([])),
+    });
+    const socket = lastSocket();
+    socket.emit('open');
+    socket.emit('message', Buffer.from(JSON.stringify({
+      type: 'error',
+      error: { type: 'rate_limit_error', message: 'usage limit reached', retry_after_seconds: 45 },
+      status: 429,
+    })));
+
+    const body = await readAll(res);
+    // The AI SDK strips unknown frame fields, so the hint only survives baked
+    // into the message — which is how the consumer recovers it.
+    expect(body).toContain('retry after 45s');
+    expect(await classifyThroughSdk(body)).toMatchObject({
+      statusCode: 429,
+      isRetryable: true,
+      retryAfterSeconds: 45,
+    });
+    expect(diagnostics).toContainEqual(expect.objectContaining({
+      event: 'ws_response_error',
+      source: 'error_frame',
+      // The record that survives dedup must still name the failure.
+      errorType: 'rate_limit_error',
+      retryAfterSeconds: 45,
+    }));
+  });
+
+  it('clamps an absurd in-band backoff hint', async () => {
+    const wsFetch = createResponsesWebSocketFetch(WS_URL);
+    const res = await wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload([])),
+    });
+    const socket = lastSocket();
+    socket.emit('open');
+    socket.emit('message', Buffer.from(JSON.stringify({
+      type: 'error',
+      error: { type: 'rate_limit_error', message: 'slow down', retry_after_seconds: 86400 },
+      status: 429,
+    })));
+
+    // Bounded so a hostile hint cannot park a client past the 120s stream abort.
+    expect(await readAll(res)).toContain('retry after 60s');
+  });
+
+  it('states no backoff hint on a 429 when upstream gave none', async () => {
+    const wsFetch = createResponsesWebSocketFetch(WS_URL);
+    const res = await wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload([])),
+    });
+    const socket = lastSocket();
+    socket.emit('open');
+    socket.emit('message', Buffer.from(JSON.stringify({
+      type: 'error',
+      // A plan-level limit: the reason is stated in prose, on an hours scale.
+      error: { type: 'usage_limit_reached', message: 'Usage limit reached. Resets in 4 hours.' },
+      status: 429,
+    })));
+
+    const body = await readAll(res);
+    expect(body).toContain('Resets in 4 hours.');
+    // Inventing a hint here would become a real `retry-after: 5` header and
+    // send the client back long before the limit resets.
+    expect(body).not.toContain('retry after');
+    expect(await classifyThroughSdk(body)).toMatchObject({ statusCode: 429 });
+  });
+
+  it('reads a status nested under error, not only the top-level one', async () => {
+    const wsFetch = createResponsesWebSocketFetch(WS_URL);
+    const res = await wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload([])),
+    });
+    const socket = lastSocket();
+    socket.emit('open');
+    socket.emit('message', Buffer.from(JSON.stringify({
+      type: 'error',
+      error: { type: 'invalid_request_error', message: 'nested status', status: 400 },
+    })));
+
+    expect(await classifyThroughSdk(await readAll(res))).toMatchObject({ statusCode: 400 });
+  });
+
+  // The fall-through cases. `status` must be an HTTP error code specifically —
+  // a success status is not a rejection, and `response.status` is a lifecycle
+  // string this must never mistake for one.
+  it.each([
+    ['a non-error status', { type: 'error', error: { type: 'server_error', message: 'keep me' }, status: 200 }],
+    ['a lifecycle response status', { type: 'error', error: { type: 'server_error', message: 'keep me' }, response: { status: 'failed' } }],
+    ['a fractional status', { type: 'error', error: { type: 'server_error', message: 'keep me' }, status: 400.5 }],
+    // `response.status` is a lifecycle state, never an HTTP code. Pinned with a
+    // NUMERIC value on purpose: a string one is rejected by the type guard
+    // anyway, so only this shape can catch a future edit that starts consulting
+    // that field and reports a lifecycle position as a status.
+    ['a numeric response status', { type: 'error', error: { type: 'server_error', message: 'keep me' }, response: { status: 400 } }],
+  ])('leaves a frame carrying %s to the existing path', async (_label, frame) => {
+    const wsFetch = createResponsesWebSocketFetch(WS_URL);
+    const res = await wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload([])),
+    });
+    const socket = lastSocket();
+    socket.emit('open');
+    socket.emit('message', Buffer.from(JSON.stringify(frame)));
+
+    const body = await readAll(res);
+    expect(body).toContain('keep me');
+    // Not rewritten into a synthetic frame: no status was recovered, so the
+    // original is forwarded exactly as before this branch existed.
+    expect(body).not.toContain('"code":"200"');
+    expect(await classifyThroughSdk(body)).toBeUndefined();
+  });
+
+  // Each message source the helper consults, pinned separately — otherwise a
+  // "simplification" that drops one of the fallbacks ships green.
+  it.each([
+    ['nested under response.error', { type: 'error', status: 400, response: { error: { message: 'from response error' } } }, 'from response error'],
+    ['on the frame itself', { type: 'error', status: 400, message: 'from the frame' }, 'from the frame'],
+  ])('recovers a rejection message %s', async (_label, frame, expected) => {
+    const wsFetch = createResponsesWebSocketFetch(WS_URL);
+    const res = await wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload([])),
+    });
+    const socket = lastSocket();
+    socket.emit('open');
+    socket.emit('message', Buffer.from(JSON.stringify(frame)));
+
+    expect(await readAll(res)).toContain(expected);
+  });
+
+  it('falls back to a generic reason when a rejection carries no message', async () => {
+    const wsFetch = createResponsesWebSocketFetch(WS_URL);
+    const res = await wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload([])),
+    });
+    const socket = lastSocket();
+    socket.emit('open');
+    socket.emit('message', Buffer.from(JSON.stringify({ type: 'error', status: 503 })));
+
+    const body = await readAll(res);
+    expect(body).toContain('OpenAI rejected the request (HTTP 503)');
+    expect(await classifyThroughSdk(body)).toMatchObject({ statusCode: 503 });
   });
 
   it('leaves a status-carrying error frame alone once model data is downstream', async () => {
@@ -981,6 +1159,12 @@ describe('createResponsesWebSocketFetch', () => {
     // into a synthetic error that would contradict the emitted output.
     const body = await readAll(res);
     expect(body).toContain('partial');
+    // Assert the ORIGINAL frame is still there, not merely that the synthetic
+    // one is absent: `not.toContain` alone passes just as happily when the
+    // frame is dropped entirely, which is the regression this test exists to
+    // catch. Both halves are required.
+    expect(body).toContain('late failure');
+    expect(body).toContain('"status":500');
     expect(body).not.toContain('"code":"500"');
   });
 
@@ -1672,6 +1856,51 @@ describe('createResponsesWebSocketFetch', () => {
     emitTextResponse(replacement, 'resp_recovered', 'recovered');
     const body = await readAll(second);
     expect(body).not.toContain('previous_response_not_found');
+  });
+
+  it('still logs a retried rejection, which no error_frame record covers', async () => {
+    // The retry frame carries a 400, so the rejection branch would claim it if
+    // the willRetry arm of the diagnostic gate were dropped — and because the
+    // retry returns before that branch, the failure would then be logged
+    // NOWHERE. This pins the arm that prevents it.
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const input = [{ role: 'user', content: [{ type: 'input_text', text: 'one' }] }];
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
+      accountId: 'acct-retry-diag',
+      onDiagnostic: event => diagnostics.push(event),
+    });
+    const first = await wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(input)),
+    });
+    const firstSocket = lastSocket();
+    firstSocket.emit('open');
+    emitTextResponse(firstSocket, 'resp_old', 'answer');
+    await readAll(first);
+
+    const second = await wsFetch('https://x', {
+      method: 'POST',
+      headers: {},
+      body: JSON.stringify(sessionPayload([
+        ...input,
+        { role: 'assistant', content: [{ type: 'output_text', text: 'answer' }] },
+        { role: 'user', content: [{ type: 'input_text', text: 'two' }] },
+      ])),
+    });
+    firstSocket.emit('message', Buffer.from(JSON.stringify({
+      type: 'error', status: 400,
+      error: { code: 'previous_response_not_found', message: 'gone' },
+    })));
+    const replacement = lastSocket();
+    replacement.emit('open');
+    emitTextResponse(replacement, 'resp_recovered', 'recovered');
+    await readAll(second);
+
+    expect(diagnostics).toContainEqual(expect.objectContaining({
+      event: 'ws_response_error',
+      source: 'response_event',
+      errorCode: 'previous_response_not_found',
+      willRetry: true,
+    }));
   });
 
   it('resets a rewind/branch to full context and establishes the branch as the new head', async () => {

--- a/tests/upstream-error.test.ts
+++ b/tests/upstream-error.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { APICallError } from 'ai';
-import { anthropicErrorType, clampRetryAfterSeconds, sdkUpstreamErrorDetails } from '../src/upstream-error.js';
+import { APICallError, RetryError } from 'ai';
+import {
+  anthropicErrorType,
+  clampRetryAfterSeconds,
+  formatUpstreamError,
+  isContextLengthExceededError,
+  sdkUpstreamErrorDetails,
+  upstreamHttpStatus,
+} from '../src/upstream-error.js';
 
 function apiCallError(overrides: {
   statusCode: number;
@@ -114,6 +121,357 @@ describe('sdkUpstreamErrorDetails transport-code extraction', () => {
 
     expect(details).toBeDefined();
     expect(details).not.toHaveProperty('transportCode');
+  });
+});
+
+// `@ai-sdk/openai` converts a stream failure arriving BEFORE the first output
+// chunk into a real APICallError. Once output has started it instead enqueues
+// the frame verbatim, and our adapter rethrows that raw payload — these are the
+// shapes it produces, and the only ones that reach the recovery under test.
+const nestedErrorChunk = {
+  type: 'error',
+  sequence_number: 42,
+  error: {
+    type: 'server_error',
+    code: 'server_error',
+    message: 'The model produced an internal error',
+    param: null,
+  },
+};
+const responseFailedChunk = {
+  type: 'response.failed',
+  sequence_number: 7,
+  response: {
+    error: { code: 'server_error', message: 'The server had an error while processing' },
+    incomplete_details: null,
+  },
+};
+const flatErrorChunk = {
+  type: 'error',
+  sequence_number: 3,
+  code: 'rate_limit_exceeded',
+  message: 'Rate limit reached for gpt-5.6',
+  param: null,
+};
+
+describe('provider stream error frames', () => {
+  it('recovers the provider message from a mid-stream nested error chunk', () => {
+    // The production failure: 26s into a healthy stream an error part arrived
+    // and collapsed to "Upstream model request failed." with a synthesized
+    // HTTP 500 and no details, discarding everything the provider said.
+    const message = formatUpstreamError(nestedErrorChunk);
+    expect(message).toBe('The model produced an internal error (HTTP 500)');
+    expect(upstreamHttpStatus(nestedErrorChunk, message)).toBe(500);
+    expect(sdkUpstreamErrorDetails(nestedErrorChunk)).toMatchObject({
+      statusCode: 500,
+      isRetryable: true,
+      attemptCount: 1,
+    });
+  });
+
+  it('recovers the error nested under response.failed', () => {
+    const message = formatUpstreamError(responseFailedChunk);
+    expect(message).toBe('The server had an error while processing (HTTP 500)');
+    expect(sdkUpstreamErrorDetails(responseFailedChunk)).toMatchObject({ statusCode: 500 });
+  });
+
+  it('maps a flat error chunk code to its real status', () => {
+    const message = formatUpstreamError(flatErrorChunk);
+    expect(message).toBe('Rate limit reached for gpt-5.6 (HTTP 429)');
+    expect(upstreamHttpStatus(flatErrorChunk, message)).toBe(429);
+    expect(anthropicErrorType(429)).toBe('rate_limit_error');
+  });
+
+  it('parses the bare payload the chat-completions transport enqueues', () => {
+    // That transport enqueues `error: chunk.error` — the OpenAI error object
+    // with no chunk wrapper around it.
+    const bare = {
+      type: 'invalid_request_error',
+      code: 'context_length_exceeded',
+      message: 'Your input exceeds the context window of this model',
+      param: 'messages',
+    };
+    const message = formatUpstreamError(bare);
+    expect(message).toBe('Your input exceeds the context window of this model (HTTP 400)');
+    expect(sdkUpstreamErrorDetails(bare)).toMatchObject({ statusCode: 400, isRetryable: false });
+    expect(isContextLengthExceededError(bare, message)).toBe(true);
+  });
+
+  it('classifies a mid-stream frame the same way the SDK classifies it pre-output', () => {
+    // The same failure must not report a different status depending on whether
+    // it landed before or after the first output chunk, so this mirrors
+    // @ai-sdk/openai's own getStatusCode discriminators.
+    const statusFor = (code: string | undefined, type: string | undefined) => {
+      const frame = { type: 'error', sequence_number: 0, error: { code, type, message: 'failed' } };
+      return upstreamHttpStatus(frame, formatUpstreamError(frame));
+    };
+    expect(statusFor('rate_limit_exceeded', undefined)).toBe(429);
+    expect(statusFor('insufficient_quota', undefined)).toBe(429);
+    expect(statusFor(undefined, 'authentication_error')).toBe(401);
+    expect(statusFor(undefined, 'permission_error')).toBe(403);
+    expect(statusFor(undefined, 'not_found_error')).toBe(404);
+    expect(statusFor('context_length_exceeded', undefined)).toBe(400);
+    expect(statusFor('invalid_prompt', undefined)).toBe(400);
+    expect(statusFor('overloaded_error', undefined)).toBe(503);
+    expect(statusFor('timeout', undefined)).toBe(504);
+    expect(statusFor('server_error', undefined)).toBe(500);
+    // clodex's own synthetic frames carry the stringified status as the code.
+    expect(statusFor('429', 'rate_limit_error')).toBe(429);
+  });
+
+  it('never infers a status from digits in the provider message', () => {
+    // A recognized frame must resolve its own status; letting the recovered
+    // message reach upstreamHttpStatus's prose sniffing turned a token count
+    // into a phantom rate limit, telling the client to retry a hard failure.
+    const frame = {
+      type: 'error',
+      sequence_number: 1,
+      error: {
+        type: 'billing_error',
+        code: 'quota_billing_hard_limit_reached',
+        message: 'You have consumed 429000 of your 500000 monthly tokens.',
+        param: null,
+      },
+    };
+    const message = formatUpstreamError(frame);
+    expect(upstreamHttpStatus(frame, message)).toBe(500);
+    const details = sdkUpstreamErrorDetails(frame);
+    expect(details?.statusCode).toBe(500);
+    // isRetryable must agree with the status it is reported alongside; the
+    // phantom 429 was logged next to isRetryable:false.
+    expect(details?.isRetryable).toBe(true);
+  });
+
+  it('decides context overflow from the frame code, not from loose prose', () => {
+    // Acting on this substitutes a synthetic "prompt is too long" that Claude
+    // Code parses to drive auto-compaction, so a false positive both discards
+    // the real error and drops conversation history.
+    const unrelated = {
+      type: 'error',
+      sequence_number: 1,
+      error: {
+        type: 'invalid_request_error',
+        code: 'unsupported_parameter',
+        message: "Unsupported parameter 'reasoning' for this model; see the context window docs",
+      },
+    };
+    expect(upstreamHttpStatus(unrelated, formatUpstreamError(unrelated))).toBe(400);
+    expect(isContextLengthExceededError(unrelated, formatUpstreamError(unrelated))).toBe(false);
+
+    const byCode = {
+      type: 'error',
+      sequence_number: 1,
+      error: { type: 'invalid_request_error', code: 'context_length_exceeded', message: 'Input too large' },
+    };
+    expect(isContextLengthExceededError(byCode, formatUpstreamError(byCode))).toBe(true);
+
+    const byWording = {
+      type: 'error',
+      sequence_number: 1,
+      error: {
+        type: 'invalid_request_error',
+        code: 'bad_request',
+        message: "This model's maximum context length is 272000 tokens",
+      },
+    };
+    expect(isContextLengthExceededError(byWording, formatUpstreamError(byWording))).toBe(true);
+  });
+
+  it('still says something when the provider message starts with a blank line', () => {
+    // sanitizeMessage keeps only the first line; an empty message field reads
+    // to Claude Code as no message and it prints the raw error envelope.
+    const frame = {
+      type: 'error',
+      sequence_number: 1,
+      error: { type: 'server_error', code: 'server_error', message: '\nThe model produced an internal error' },
+    };
+    expect(formatUpstreamError(frame)).toBe('Upstream model request failed. (HTTP 500)');
+  });
+
+  it('recovers a rate-limit backoff hint that survives only in message text', () => {
+    // The AI SDK's chunk schema is a closed zod object, so it strips
+    // `retry_after_seconds`; the hint reaches us only as prose.
+    const frame = (message: string) => ({
+      type: 'error',
+      sequence_number: 0,
+      error: { type: 'rate_limit_error', code: '429', message },
+    });
+    expect(sdkUpstreamErrorDetails(frame('throttled; retry after 7s')))
+      .toMatchObject({ statusCode: 429, isRetryable: true, retryAfterSeconds: 7 });
+    // Clamped so a hostile or absurd hint cannot park a client past the
+    // 120s no-event stream abort.
+    expect(sdkUpstreamErrorDetails(frame('throttled; retry after 3600s'))?.retryAfterSeconds).toBe(60);
+  });
+
+  it('preserves the WebSocket transport code and treats it as transient', () => {
+    const frame = {
+      type: 'error',
+      sequence_number: 0,
+      error: {
+        type: 'transport_error',
+        code: 'websocket_transport_error',
+        message: 'WebSocket closed before the response completed',
+        param: null,
+      },
+    };
+    expect(sdkUpstreamErrorDetails(frame)).toMatchObject({
+      transportCode: 'websocket_transport_error',
+      isRetryable: true,
+      statusCode: 500,
+    });
+    expect(formatUpstreamError(frame)).toBe('WebSocket closed before the response completed (HTTP 500)');
+  });
+
+  it('records the whole payload as errorContent for the diagnostic log', () => {
+    const content = sdkUpstreamErrorDetails(nestedErrorChunk)?.errorContent ?? '';
+    // Exact equality, not a subset: the promise of this field is the WHOLE
+    // payload, so dropping a key (`param` here) has to fail the test.
+    expect(JSON.parse(content)).toEqual(nestedErrorChunk.error);
+  });
+
+  it('bounds an overlong provider message rather than dropping it', () => {
+    const frame = {
+      type: 'error',
+      sequence_number: 0,
+      error: { type: 'server_error', code: 'server_error', message: 'x'.repeat(5000) },
+    };
+    const message = formatUpstreamError(frame);
+    expect(message.length).toBeLessThan(300);
+    expect(message).toContain('xxx');
+    expect(message).not.toBe('Upstream model request failed.');
+  });
+
+  it('does not split a surrogate pair when bounding the message', () => {
+    // A lone surrogate does not survive JSON serialization to the client.
+    const frame = {
+      type: 'error',
+      sequence_number: 0,
+      error: { type: 'server_error', code: 'server_error', message: `${'a'.repeat(238)}😀z` },
+    };
+    const message = formatUpstreamError(frame);
+    expect(message.isWellFormed()).toBe(true);
+    expect(JSON.parse(JSON.stringify({ message })).message).toBe(message);
+  });
+
+  it('counts retry attempts when the SDK wraps a frame in a RetryError', () => {
+    const retry = new RetryError({
+      message: 'Failed after 2 attempts',
+      reason: 'maxRetriesExceeded',
+      errors: [nestedErrorChunk, nestedErrorChunk],
+    });
+    expect(sdkUpstreamErrorDetails(retry)).toMatchObject({ statusCode: 500, attemptCount: 2 });
+    expect(formatUpstreamError(retry)).toBe('The model produced an internal error (HTTP 500)');
+  });
+});
+
+describe('provider frame recovery leaves other error sources alone', () => {
+  it('does not treat a local abort or timeout as a provider frame', () => {
+    const abort = new Error('SDK stream aborted');
+    abort.name = 'AbortError';
+    expect(sdkUpstreamErrorDetails(abort)).toBeUndefined();
+    expect(formatUpstreamError(abort)).toBe('SDK stream aborted');
+
+    const idle = new Error('no data received from provider for 120s');
+    expect(sdkUpstreamErrorDetails(idle)).toBeUndefined();
+    expect(formatUpstreamError(idle)).toBe('no data received from provider for 120s');
+  });
+
+  it('does not treat an arbitrary object carrying a message as a provider frame', () => {
+    expect(sdkUpstreamErrorDetails({ message: 'something went wrong' })).toBeUndefined();
+  });
+
+  // The SDK's error schema types `code` as `string | number` and `type` as
+  // nullish, and its own `getStatusCode` reads a numeric code first. Reading
+  // only string codes, or demanding a string `type`, classified these payloads
+  // 500 after first output while the SDK classified them exactly before it —
+  // the pre/post-output split this module exists to remove.
+  it('classifies a numeric code the way the SDK does', () => {
+    const frame = { type: 'server_error', code: 503, message: 'service unavailable', param: null };
+    expect(sdkUpstreamErrorDetails(frame)).toMatchObject({ statusCode: 503, isRetryable: true });
+    expect(formatUpstreamError(frame)).toBe('service unavailable (HTTP 503)');
+  });
+
+  it('recovers a rejection whose type is null, as the SDK schema permits', () => {
+    const frame = { message: 'Too many requests', type: null, param: null, code: 429 };
+    expect(sdkUpstreamErrorDetails(frame)).toMatchObject({ statusCode: 429, isRetryable: true });
+  });
+
+  it('recovers a status-like code with neither type nor param', () => {
+    expect(sdkUpstreamErrorDetails({ message: 'gateway timeout', code: '504' }))
+      .toMatchObject({ statusCode: 504, isRetryable: true });
+  });
+
+  // The SDK accepts an unwrapped payload on ANY ONE of a string `type`, a
+  // `code` key, or a `param` key. Each is pinned separately, because requiring
+  // combinations of them is what previously left a rate limit as a 500 once
+  // output had started.
+  it.each([
+    ['a non-status code alone', { message: 'limited', code: 'rate_limit_exceeded' }, 429],
+    ['a type alone', { message: 'limited', type: 'rate_limit_error' }, 429],
+    ['a param alone', { message: 'bad field', param: 'reasoning.summary' }, 500],
+    ['a null code', { message: 'failed', code: null }, 500],
+    // Numeric statuses beyond the retryable ones: covering only 429/503 let an
+    // implementation that recognized just those two pass while every other
+    // numeric code silently became 500 after output.
+    ['a terminal numeric code', { message: 'auth failed', code: 401 }, 401],
+    ['a numeric code at the range floor', { message: 'bad request', code: 400 }, 400],
+    ['a numeric code at the range ceiling', { message: 'unknown', code: 599 }, 599],
+  ])('recovers an unwrapped frame identified by %s', (_label, frame, statusCode) => {
+    expect(sdkUpstreamErrorDetails(frame)).toMatchObject({ statusCode });
+  });
+
+  it('recognizes an empty type the way the SDK does, instead of sniffing prose', () => {
+    // `type: ''` is schema-valid and the SDK accepts any string, mapping this
+    // to 500. Rejecting it here sent the message on to the digit scan in
+    // `upstreamHttpStatus`, which read the token counts as a rate limit — so
+    // the same payload was terminal before first output and retryable after.
+    const frame = { message: 'consumed 429000 of 500000 tokens', type: '' };
+    expect(sdkUpstreamErrorDetails(frame)).toMatchObject({ statusCode: 500, isRetryable: true });
+    expect(upstreamHttpStatus(frame, formatUpstreamError(frame))).toBe(500);
+  });
+
+  it('recovers the status of a frame whose message is blank', () => {
+    // Schema-valid: `message` need only be a string. The status still matters —
+    // this one carries retryability and a backoff hint.
+    const details = sdkUpstreamErrorDetails({ message: '', code: 429 });
+    expect(details).toMatchObject({ statusCode: 429, isRetryable: true });
+    expect(formatUpstreamError({ message: '', code: 429 }))
+      .toBe('Provider returned an error (HTTP 429)');
+  });
+
+  // Provenance is the discriminator: these carry the very fields the predicate
+  // accepts on a plain object, but they are thrown Errors, not provider frames.
+  it.each([
+    ['param', Object.assign(new Error('bad local argument'), { param: 'url' })],
+    ['a numeric code', Object.assign(new Error('local numeric code'), { code: 429 })],
+    ['type and code', Object.assign(new Error('socket event'), { type: 'error', code: 'EPIPE' })],
+  ])('does not treat an ordinary Error carrying %s as a provider frame', (_label, error) => {
+    expect(sdkUpstreamErrorDetails(error)).toBeUndefined();
+  });
+
+  it('does not treat a socket error as a provider frame despite its code', () => {
+    // Node system errors carry a `code` ('ECONNRESET'), so a bare `code` can
+    // never be sufficient on its own to call something a provider frame — it
+    // is neither status-like nor accompanied by `type`/`param`.
+    const socketError = Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
+    expect(sdkUpstreamErrorDetails(socketError)).toBeUndefined();
+    expect(formatUpstreamError(socketError)).toBe('socket hang up');
+  });
+
+  it('keeps APICallError classification authoritative', () => {
+    const apiError = apiCallError({
+      statusCode: 403,
+      responseBody: JSON.stringify({ error: { message: 'Your account may not use this model.' } }),
+    });
+    expect(sdkUpstreamErrorDetails(apiError)).toMatchObject({ statusCode: 403, isRetryable: false });
+    expect(formatUpstreamError(apiError)).toBe('Your account may not use this model. (HTTP 403)');
+
+    const wrapped = new RetryError({
+      message: 'Failed after 2 attempts',
+      reason: 'maxRetriesExceeded',
+      errors: [apiError, apiError],
+    });
+    expect(sdkUpstreamErrorDetails(wrapped)).toMatchObject({ statusCode: 403, attemptCount: 2 });
   });
 });
 


### PR DESCRIPTION
## The bug

Every mid-stream provider failure reached the client as the generic string
`"Upstream model request failed."` with a fabricated HTTP 500. The provider's actual message —
the part that says *why* — was discarded, and the diagnostic log recorded the synthesized status
with no error content. The case that prompted this was a 29-second-old healthy stream that died on
a provider error frame nobody could read afterwards.

## Root cause

`@ai-sdk/openai` handles a stream failure two different ways depending on **when** it arrives:

- **Before** the first output chunk, `throwIfOpenAIStreamErrorBeforeOutput` converts the frame into
  a real `APICallError` with a mapped status. clodex's existing `APICallError` branch already
  handled this correctly.
- **After** output has started, the SDK enqueues the frame *verbatim* and the adapter rethrows that
  payload — a plain object with no top-level `message` or `statusCode`.

Only the second case reaches the error formatter, and nothing recognized it. `sdkUpstreamErrorDetails`
returned `undefined`, `formatUpstreamError` fell through to its generic fallback, and
`upstreamHttpStatus` returned its default 500.

## The fix

Parse the payload shapes the SDK actually emits — nested `error` chunk, `response.failed`, flat
`error` chunk, and the bare object the chat transport enqueues — and recover the message, status,
and rate-limit backoff hint. The hint survives only as message text, because the SDK's closed chunk
schema strips `retry_after_seconds`.

Three decisions worth a reviewer's attention:

**Status classification mirrors the SDK's own `getStatusCode` substring discriminators** rather than
using an exact-match table, so a frame is classified identically whether it lands before or after the
first output chunk, and new provider codes degrade gracefully instead of silently falling out of date.
The mirroring is faithful including its quirks — `invalid_api_key` matches `/invalid/` before any auth
check and so reports 400 here exactly as it does in the SDK. Diverging would reintroduce the
pre/post-output split this is meant to remove.

**Always resolving to a status** is a correctness requirement, not tidiness. An undefined result would
pass the recovered message on to the prose sniffing in `upstreamHttpStatus`, where a digit in the
provider's own text (`"consumed 429000 of 500000 tokens"`) was read as a rate limit and told the client
to retry a terminal failure.

**Context-overflow detection keys off the structured code**, deliberately stricter than the existing
prose scan. Acting on it replaces the provider's message with a synthetic "prompt is too long" that
Claude Code parses to drive auto-compaction — so a false positive both hides the real error and drops
conversation history.

## Recognizing a frame: provenance, not field shape

The interesting problem is telling a provider payload apart from any other thrown value, since only
the former should be given a status.

Field-shape rules fail in both directions. The SDK's schema types `code` as `string | number` and
`type` as nullish, and its predicate accepts a string `type` **or** a `code` key **or** a `param`
key — so `{message, code: 'rate_limit_exceeded'}` is a 429 before first output. Demand a string
`type` and that same payload becomes a 500 after first output, which is exactly the split this PR
exists to remove. But any rule loose enough to admit it on shape alone would also admit a Node socket
error's `code: 'ECONNRESET'`.

Provenance separates them cleanly: what the adapter rethrows is a plain parsed object, while socket
errors, aborts, undici failures, and validation errors are all `Error` instances. Excluding those
lets the predicate mirror the SDK's exactly. Tests pin both directions, including `Error`s
deliberately carrying `param`, a numeric `code`, and `type` + `code`.

"Mirror exactly" is meant literally, down to `typeof type === 'string'` rather than "non-empty
string" — the schema permits `type: ''`. That one-field near-miss was not a metadata difference: a
rejected payload falls through to the prose sniffing in `upstreamHttpStatus`, which read the digits
in `"consumed 429000 of 500000 tokens"` as a rate limit, making the same failure terminal before
first output and retryable after it.

Two smaller alignments: any finite numeric `code` is kept (the SDK folds the raw value into its
discriminator regardless; only a three-digit value is used directly as a status), and a blank
`message` is still a valid frame — the schema requires only a string — so its status is recovered and
the client text gets a stand-in. The `APICallError` path is unchanged and stays authoritative.

## Verification

`pnpm typecheck && pnpm test && pnpm build` pass — 1231 tests, 48 new.

Live smoke tested in **proxy mode** — the default bridge mode — against a real running server, plus
endpoint mode:

| # | Request through the MITM | Result |
|---|---|---|
| 1 | OpenAI model by saved alias | 200, correct content; response `model` echoes `luna` verbatim |
| 2 | `claude-sonnet-4-20250514`, invalid key | Anthropic's own 401 body with a genuine `request_id` |
| 3 | Unrelated host (`api.github.com`) | 200, tunneled, not intercepted |
| 4 | Malformed tool schema (the empty-200 repro) | **400 with the upstream reason**, in Anthropic error shape |
| 5 | Happy path after the failure | 200, unaffected |

Row 2 is the one that matters for this change: an Anthropic passthrough error comes back byte-for-byte
from the real API, untouched by the new frame recognition, and is logged as `route: passthrough`
status 401. Row 4 is the same failure that previously produced an empty 200 with zero tokens.

Also verified through real Claude Code over the default proxy path, which is what users actually run:

```
clodex claude -- --model luna  -p 'Reply with exactly: LUNA-OK'   -> LUNA-OK
clodex claude -- --model haiku -p 'Reply with exactly: HAIKU-OK'  -> HAIKU-OK
```

`haiku` is a genuine successful Anthropic passthrough completion, not just a well-formed error.

I could not provoke a genuine *mid-stream* failure from a healthy provider on demand, which is the
nature of that half of the bug — the upstream clamped an oversized `max_tokens` and accepted a
340k-token prompt rather than erroring. Those frame shapes are covered by unit tests written against
what the pinned SDK actually emits, and by mutation testing rather than by a live repro.

## Relationship to #67

These are two halves of one seam and do not overlap.

#67 (merged) fires only while `!ctx.emittedModelData` — before any output. Its synthetic frame
reaches the SDK *pre-output*, where `throwIfOpenAIStreamErrorBeforeOutput` turns it into a real
`APICallError` the existing branch already handles. The first commit here handles frames arriving
*after* first output, which #67 deliberately leaves alone.

They are mutually exclusive by construction: on the pre-output path `sdkUpstreamErrorDetails` takes
its `APICallError` branch and never consults `providerErrorFrame`, which returns `undefined` for an
`APICallError` anyway. One narrow window makes both matter — clodex's `isModelDataEvent` is narrower
than the SDK's `isResponseOutputChunk`, so a few event types are SDK-committed but not
clodex-committed. A frame landing there is exactly what the first commit recovers.

## Second commit: follow-ups on the #67 path

Review notes from #67, carried here rather than sending that PR back for another round.

**`errorCode` reached the `error_frame` diagnostic raw** — the only identifier in that file bypassing
`boundedDiagnosticIdentifier`. The connection-limit branch looks like precedent but isn't: there the
value has just been compared `===` to a known constant. A degenerate upstream `code` could inject
newlines into a log line.

**A rejection emitted two `ws_response_error` records** — the generic `response_event` one plus
`failContext`'s — under different `source` values with disjoint fields, reading as two failures of
one request. `errorStatus` now resolves above that record so it can be suppressed when the rejection
branch emits its own. The branch itself stays put: ahead of the `willRetry` return it would swallow a
`previous_response_not_found` frame (which carries a 400) and kill the retry.

**An in-band 429 dropped its `retry_after_seconds`.** The SDK strips unknown frame fields, so the
hint survives only baked into the message text — which is why the connection-limit branch spells it
out. Same treatment, clamped.

**Test hardening.** The committed-stream test asserted only that the *synthetic* frame was absent, so
deleting the forwarded frame outright passed — the exact regression it exists to catch. It now
asserts the original frame is present. Added coverage for each message source, the nested
`error.status`, the fallback reason, and the fall-through cases that must not convert: a success
status, a fractional status, and a `response.status` — pinned with a *numeric* value, since a string
one is rejected by the type guard anyway and so cannot catch a future edit that starts consulting
that field.

Verified by mutation: nine mutations of this path, all killed. Five of them survived the suite before
these tests existed.
