### PR TITLE
fix(oauth): continue chains when a reasoning item carries empty content

### DIFF
--- a/src/oauth/responses-websocket.ts
+++ b/src/oauth/responses-websocket.ts
@@ -352,6 +352,16 @@ function normalizeToolCallJson(value: unknown): unknown {
       // A malformed/non-JSON custom-tool input must still match byte-for-byte.
     }
   }
+
+  // A reasoning item comes back from the Responses API carrying an empty
+  // `content: []`, which we retain when snapshotting the expected assistant
+  // items. The SDK rebuilds the echoed item from the encrypted content and
+  // summary alone, so it never re-emits that key and the chain head could
+  // never match its own echo. An empty array carries no information; drop it
+  // from both sides. A populated `content` is real data and still compared.
+  if (record.type === 'reasoning' && Array.isArray(record.content) && record.content.length === 0) {
+    delete out.content;
+  }
   return out;
 }
 
@@ -378,7 +388,65 @@ function conversationItemHash(value: unknown): string {
   return createHash('sha256').update(canonicalJson(normalizeToolCallJson(value))).digest('hex').slice(0, 16);
 }
 
-function continuationMismatchDetails(entry: ConnectionEntry, payload: JsonObject): Record<string, unknown> {
+/**
+ * Names the fields that differ between the stored reasoning item and the one
+ * Claude echoed back, but ONLY when both carry the same `encrypted_content`.
+ *
+ * That blob is the reasoning item's identity: when it matches, the two objects
+ * describe the same reasoning and the continuation should have been accepted,
+ * so any remaining difference is a normalization gap on our side. When it
+ * differs the items are genuinely different reasoning (a divergent branch or a
+ * fresh turn) and the mismatch is correct, not a defect — reporting those would
+ * bury the signal in noise.
+ */
+function reasoningNormalizationGap(expected: unknown, actual: unknown): string[] | undefined {
+  if (conversationItemKind(expected) !== 'reasoning' || conversationItemKind(actual) !== 'reasoning') return undefined;
+  const left = expected as JsonObject;
+  const right = actual as JsonObject;
+  const blob = left.encrypted_content;
+  if (typeof blob !== 'string' || !blob || blob !== right.encrypted_content) return undefined;
+  const fields = [...new Set([...Object.keys(left), ...Object.keys(right)])].sort()
+    .filter(key => canonicalJson(normalizeToolCallJson(left[key])) !== canonicalJson(normalizeToolCallJson(right[key])));
+  return fields.length ? fields : undefined;
+}
+
+const warnedReasoningGaps = new Set<string>();
+const MAX_REASONING_GAP_WARNINGS = 3;
+
+/**
+ * Surfaces a normalization gap on stderr so it is visible in the terminal that
+ * started clodex without needing --trace. Deduplicated by the differing-field
+ * signature and hard-capped, because this shares a terminal with Claude Code's
+ * interactive UI and must never become a stream.
+ */
+function warnReasoningNormalizationGap(fields: string[], log?: (message: string) => void): void {
+  const signature = fields.join(',');
+  const message = 'clodex: warning: a reasoning item with identical encrypted_content failed the '
+    + `continuation match on field(s): ${signature}. Prompt caching is degraded for this turn — `
+    + 'this is a clodex normalization gap, please report it at '
+    + 'https://github.com/bman654/clodex/issues';
+  try { log?.(`reasoning normalization gap: ${signature}`); } catch { /* ignore */ }
+  if (warnedReasoningGaps.has(signature)) return;
+  if (warnedReasoningGaps.size >= MAX_REASONING_GAP_WARNINGS) return;
+  warnedReasoningGaps.add(signature);
+  try {
+    process.stderr.write(`${message}\n`);
+    if (warnedReasoningGaps.size === MAX_REASONING_GAP_WARNINGS) {
+      process.stderr.write('clodex: warning: further reasoning-normalization warnings suppressed.\n');
+    }
+  } catch { /* a warning must never break a request */ }
+}
+
+/** Test seam: the warning cap is process-wide and would leak between cases. */
+export function resetReasoningGapWarningsForTests(): void {
+  warnedReasoningGaps.clear();
+}
+
+function continuationMismatchDetails(
+  entry: ConnectionEntry,
+  payload: JsonObject,
+  log?: (message: string) => void,
+): Record<string, unknown> {
   const full = inputArray(payload);
   const prefix = [...(entry.requestInput ?? []), ...(entry.expectedAssistant ?? [])];
   const comparable = Math.min(full.length, prefix.length);
@@ -391,6 +459,8 @@ function continuationMismatchDetails(entry: ConnectionEntry, payload: JsonObject
   }
   const expected = mismatch < prefix.length ? prefix[mismatch] : undefined;
   const actual = mismatch < full.length ? full[mismatch] : undefined;
+  const reasoningGap = reasoningNormalizationGap(expected, actual);
+  if (reasoningGap) warnReasoningNormalizationGap(reasoningGap, log);
   return {
     fullItems: full.length,
     expectedPrefixItems: prefix.length,
@@ -399,11 +469,16 @@ function continuationMismatchDetails(entry: ConnectionEntry, payload: JsonObject
     actualKind: actual === undefined ? 'none' : conversationItemKind(actual),
     ...(expected !== undefined ? { expectedHash: conversationItemHash(expected) } : {}),
     ...(actual !== undefined ? { actualHash: conversationItemHash(actual) } : {}),
+    ...(reasoningGap ? { reasoningNormalizationGap: reasoningGap } : {}),
   };
 }
 
-function continuationMismatchSummary(entry: ConnectionEntry, payload: JsonObject): string {
-  const details = continuationMismatchDetails(entry, payload);
+function continuationMismatchSummary(
+  entry: ConnectionEntry,
+  payload: JsonObject,
+  log?: (message: string) => void,
+): string {
+  const details = continuationMismatchDetails(entry, payload, log);
   return `full_items=${details.fullItems} expected_prefix_items=${details.expectedPrefixItems} `
     + `first_mismatch=${details.firstMismatch} expected=${details.expectedKind} actual=${details.actualKind}`;
 }
@@ -1481,7 +1556,7 @@ export function createResponsesWebSocketFetch(
       // head. Existing heads remain eligible for later exact-prefix matches.
       debug(
         `history mismatch starting an additional chain; retained ${candidates.length} existing head(s) `
-        + `(${continuationMismatchSummary(diagnosticEntry, payload)})`,
+        + `(${continuationMismatchSummary(diagnosticEntry, payload, debug)})`,
       );
       decision = 'history_mismatch_new_head';
     } else if (partitionKey) {
@@ -1547,7 +1622,7 @@ export function createResponsesWebSocketFetch(
         ttlPausedMs: entry.ttlPausedMs,
         idleMs: Math.max(0, now - entry.lastUsedAt),
         promptChanges: changedPromptFields(entry.promptFieldHashes, promptFieldHashes),
-        mismatch: continuationMismatchDetails(entry, payload),
+        mismatch: continuationMismatchDetails(entry, payload, debug),
       })),
       evictions,
     }, diagnosticCorrelation);

--- a/tests/responses-websocket.test.ts
+++ b/tests/responses-websocket.test.ts
@@ -23,6 +23,7 @@ vi.mock('ws', () => ({ WebSocket: FakeWebSocket, default: FakeWebSocket }));
 
 import {
   createResponsesWebSocketFetch,
+  resetReasoningGapWarningsForTests,
   resetResponsesWebSocketConnectionsForTests,
   responsesWebSocketPartitionKey,
   responsesWebSocketPromptFingerprint,
@@ -131,6 +132,7 @@ function emitTextResponse(socket: FakeWebSocket, responseId: string, text: strin
 describe('createResponsesWebSocketFetch', () => {
   beforeEach(() => {
     resetResponsesWebSocketConnectionsForTests();
+    resetReasoningGapWarningsForTests();
     fakeSockets.length = 0;
   });
 
@@ -1674,6 +1676,189 @@ describe('createResponsesWebSocketFetch', () => {
     });
     emitTextResponse(socket, 'resp_after_tool', 'done');
     await readAll(second);
+  });
+
+  it('continues when the upstream reasoning item carried an empty content array', async () => {
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const input = [{ role: 'user', content: [{ type: 'input_text', text: 'inspect it' }] }];
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
+      accountId: 'acct-empty-reasoning-content',
+      onDiagnostic: event => diagnostics.push(event),
+    });
+    const first = await wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(input)),
+    });
+    const socket = lastSocket();
+    socket.emit('open');
+    socket.emit('message', Buffer.from(JSON.stringify({
+      type: 'response.created', response: { id: 'resp_empty_content' },
+    })));
+    // The Responses API ships `content: []` on reasoning items. The SDK rebuilds
+    // the echoed item from encrypted content and summary alone, so that key never
+    // comes back and must not be treated as a divergence.
+    socket.emit('message', Buffer.from(JSON.stringify({
+      type: 'response.output_item.done', output_index: 0,
+      item: {
+        type: 'reasoning', id: 'rs_1', encrypted_content: 'enc_1', content: [],
+        summary: [{ type: 'summary_text', text: 'weighing it' }], status: 'completed',
+      },
+    })));
+    socket.emit('message', Buffer.from(JSON.stringify({
+      type: 'response.output_item.done', output_index: 1,
+      item: {
+        type: 'function_call', id: 'fc_1', call_id: 'call_1', name: 'Read',
+        arguments: '{"path":"file.ts"}', status: 'completed',
+      },
+    })));
+    socket.emit('message', Buffer.from(JSON.stringify({
+      type: 'response.completed', response: { id: 'resp_empty_content' },
+    })));
+    await readAll(first);
+
+    const echoedReasoning = {
+      type: 'reasoning', encrypted_content: 'enc_1',
+      summary: [{ type: 'summary_text', text: 'weighing it' }],
+    };
+    const echoedCall = {
+      type: 'function_call', call_id: 'call_1', name: 'Read', arguments: '{"path":"file.ts"}',
+    };
+    const toolOutput = { type: 'function_call_output', call_id: 'call_1', output: 'contents' };
+    const second = await wsFetch('https://x', {
+      method: 'POST', headers: {},
+      body: JSON.stringify(sessionPayload([...input, echoedReasoning, echoedCall, toolOutput])),
+    });
+
+    expect(fakeSockets).toHaveLength(1);
+    const sent = JSON.parse(socket.send.mock.calls[1]![0] as string);
+    expect(sent.previous_response_id).toBe('resp_empty_content');
+    expect(sent.input).toEqual([toolOutput]);
+    expect(diagnostics.at(-1)).toMatchObject({
+      event: 'ws_head_decision',
+      decision: 'continuation',
+      continuationMatchMode: 'exact',
+    });
+    emitTextResponse(socket, 'resp_after_empty_content', 'done');
+    await readAll(second);
+  });
+
+  // Drives one mismatch between a stored reasoning item and the item Claude echoes
+  // back, returning what reached stderr and the head-decision diagnostic.
+  async function runReasoningMismatch(options: {
+    accountId: string;
+    storedReasoning: Record<string, unknown>;
+    echoedReasoning: Record<string, unknown>;
+    responseId: string;
+  }): Promise<{ stderr: string[]; diagnostics: ResponsesWebSocketDiagnosticEvent[] }> {
+    const stderr: string[] = [];
+    const spy = vi.spyOn(process.stderr, 'write')
+      .mockImplementation((chunk: unknown) => { stderr.push(String(chunk)); return true; });
+    try {
+      const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+      const input = [{ role: 'user', content: [{ type: 'input_text', text: 'inspect it' }] }];
+      const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
+        accountId: options.accountId,
+        onDiagnostic: event => diagnostics.push(event),
+      });
+      const first = await wsFetch('https://x', {
+        method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(input)),
+      });
+      const socket = lastSocket();
+      socket.emit('open');
+      socket.emit('message', Buffer.from(JSON.stringify({
+        type: 'response.created', response: { id: options.responseId },
+      })));
+      socket.emit('message', Buffer.from(JSON.stringify({
+        type: 'response.output_item.done', output_index: 0, item: options.storedReasoning,
+      })));
+      socket.emit('message', Buffer.from(JSON.stringify({
+        type: 'response.output_item.done', output_index: 1,
+        item: {
+          type: 'function_call', id: 'fc_1', call_id: 'call_1', name: 'Read',
+          arguments: '{"path":"file.ts"}', status: 'completed',
+        },
+      })));
+      socket.emit('message', Buffer.from(JSON.stringify({
+        type: 'response.completed', response: { id: options.responseId },
+      })));
+      await readAll(first);
+
+      const echoedCall = {
+        type: 'function_call', call_id: 'call_1', name: 'Read', arguments: '{"path":"file.ts"}',
+      };
+      const toolOutput = { type: 'function_call_output', call_id: 'call_1', output: 'contents' };
+      const second = await wsFetch('https://x', {
+        method: 'POST', headers: {},
+        body: JSON.stringify(sessionPayload([...input, options.echoedReasoning, echoedCall, toolOutput])),
+      });
+      emitTextResponse(lastSocket(), `${options.responseId}_next`, 'done');
+      await readAll(second);
+      return { stderr, diagnostics };
+    } finally {
+      spy.mockRestore();
+    }
+  }
+
+  const GAP_SUMMARY = [{ type: 'summary_text', text: 'weighing it' }];
+
+  it('warns on stderr when an identical reasoning item still fails the continuation match', async () => {
+    const { stderr, diagnostics } = await runReasoningMismatch({
+      accountId: 'acct-reasoning-gap',
+      responseId: 'resp_gap',
+      // A populated `content` is exactly the case the empty-array normalization
+      // deliberately does not cover, so it must be reported rather than absorbed.
+      storedReasoning: {
+        type: 'reasoning', id: 'rs_1', encrypted_content: 'enc_same',
+        content: [{ type: 'reasoning_text', text: 'private' }], summary: GAP_SUMMARY,
+      },
+      echoedReasoning: {
+        type: 'reasoning', encrypted_content: 'enc_same', summary: GAP_SUMMARY,
+      },
+    });
+
+    expect(stderr.join('')).toContain('identical encrypted_content');
+    expect(stderr.join('')).toContain('content');
+    const decision = diagnostics.filter(event => event.event === 'ws_head_decision').at(-1)!;
+    expect(decision.decision).toBe('history_mismatch_new_head');
+    expect((decision.heads as { mismatch: Record<string, unknown> }[])[0]!.mismatch)
+      .toMatchObject({ reasoningNormalizationGap: ['content'] });
+  });
+
+  it('stays silent when the reasoning items are genuinely different reasoning', async () => {
+    const { stderr, diagnostics } = await runReasoningMismatch({
+      accountId: 'acct-reasoning-divergent',
+      responseId: 'resp_divergent',
+      storedReasoning: {
+        type: 'reasoning', id: 'rs_1', encrypted_content: 'enc_stored', summary: GAP_SUMMARY,
+      },
+      // A different blob means a different turn — mismatching is correct here.
+      echoedReasoning: {
+        type: 'reasoning', encrypted_content: 'enc_other', summary: GAP_SUMMARY,
+      },
+    });
+
+    expect(stderr.join('')).toBe('');
+    const decision = diagnostics.filter(event => event.event === 'ws_head_decision').at(-1)!;
+    expect((decision.heads as { mismatch: Record<string, unknown> }[])[0]!.mismatch)
+      .not.toHaveProperty('reasoningNormalizationGap');
+  });
+
+  it('reports a repeated reasoning gap once rather than on every turn', async () => {
+    const storedReasoning = {
+      type: 'reasoning', id: 'rs_1', encrypted_content: 'enc_same',
+      content: [{ type: 'reasoning_text', text: 'private' }], summary: GAP_SUMMARY,
+    };
+    const echoedReasoning = {
+      type: 'reasoning', encrypted_content: 'enc_same', summary: GAP_SUMMARY,
+    };
+    const first = await runReasoningMismatch({
+      accountId: 'acct-reasoning-repeat-1', responseId: 'resp_r1', storedReasoning, echoedReasoning,
+    });
+    const second = await runReasoningMismatch({
+      accountId: 'acct-reasoning-repeat-2', responseId: 'resp_r2', storedReasoning, echoedReasoning,
+    });
+
+    expect(first.stderr.join('')).toContain('identical encrypted_content');
+    expect(second.stderr.join('')).toBe('');
   });
 
   it('continues when Claude omits reasoning but exactly echoes the following assistant text', async () => {


### PR DESCRIPTION
## Problem

Prompt caching on the ChatGPT/Codex OAuth path was performing far below what the WebSocket continuation machinery should deliver. Over a week of diagnostic logs — 13,743 requests, 1.13B input tokens — only **41.4%** of input tokens were served from cache.

The breakdown showed the mechanism itself works, but almost never engages:

| Head decision | Requests | Share | Cache hit |
|---|---:|---:|---:|
| `continuation` | 2,247 | 16.3% | **95.7%** |
| `history_mismatch_new_head` | 7,119 | 51.8% | 35.6% |
| `parallel_isolated` | 4,286 | 31.1% | 26.7% |
| `new_partition_head` | 91 | 0.7% | 4.4% |

**94% of those mismatches (6,676) were a reasoning item diverging from the stored one.** Head expiry was not a factor (91 requests found no candidate head), nor was transport error (91 events total), nor prompt size.

## Root cause

The Responses API ships `content: []` on reasoning items. `expectedAssistantItems` snapshots the raw item and `withoutEphemeralFields` strips only `id`/`status`/`phase`/`role` and nulls — an empty array is none of those, so the key survives into the chain head. The AI SDK rebuilds the echoed item from `encrypted_content` and `summary` alone and never re-emits `content`, so a head could never match its own echo.

Capturing both sides of a real mismatch confirmed it — the round-trip is otherwise perfect:

```
stored:  {"type":"reasoning","content":[],
          "encrypted_content":"<1228 bytes>",
          "summary":[{"type":"summary_text","text":"..."}]}

echoed:  {"type":"reasoning",
          "encrypted_content":"<1228 bytes>",   ← identical sha
          "summary":[{"type":"summary_text","text":"..."}]}
```

`encrypted_content` and `summary` are byte-identical. The empty array was the only difference. (Key ordering was never a factor — `canonicalize` sorts keys.)

## Fix

Normalize the empty array away on both sides in `normalizeToolCallJson`, next to the existing function-call argument normalization that exists for the same "the SDK re-serializes it differently" reason. A populated `content` is real data and is still compared.

## Detecting the remaining gap

The normalization is deliberately scoped to *empty* `content`, so a populated `content` would reintroduce this class of miss. Since the SDK never emits that key at all, that would be silent — so this also warns on stderr when two reasoning items share an `encrypted_content` but still fail to match.

That condition is the discriminator: the blob is the reasoning item's identity, so when it matches the continuation should have been accepted and any remaining difference is our normalization gap. When it differs the items are genuinely different reasoning and mismatching is correct — those stay quiet. The warning is deduplicated by differing-field signature and capped at 3, because it shares a terminal with Claude Code's interactive UI and must never become a stream. The differing fields are also recorded as `reasoningNormalizationGap` on the head-decision diagnostic.

## Verification

A/B on identical prompts, only the fix toggled:

| Turn | Fix off | Fix on |
|---|---|---|
| 1 (cold) | cached 0 | cached 0 |
| 2 | **history mismatch → 2nd socket, cached 0** (23,025 tok re-read) | continuing, **cached 22,272** |
| 3–4 | continuing, cached 22,272 | continuing, cached 22,272 |

- New regression test reproduces the real upstream item shape; it fails without the fix by opening 2 sockets — the exact production symptom — and passes with it.
- Three tests cover the warning: it fires and names the differing field, stays silent on genuinely divergent reasoning, and reports a repeated gap only once.
- Full suite green (1,235 tests), typecheck and build clean.
- Live `claude -p` runs against the real backend confirm a single retained socket with every follow-up turn continuing at ~96.7% cached, and no warning.

Expected effect on the analyzed week: overall caching from 41.4% toward ~72%, roughly halving uncached input tokens for identical work.
