### PR TITLE
fix(deps): bump undici to 7.29.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "open": "11.0.0",
     "picocolors": "1.1.1",
     "tweakcc": "4.3.0",
-    "undici": "7.28.0",
+    "undici": "7.29.0",
     "ws": "8.21.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: 4.3.0
         version: 4.3.0
       undici:
-        specifier: 7.28.0
-        version: 7.28.0
+        specifier: 7.29.0
+        version: 7.29.0
       ws:
         specifier: 8.21.0
         version: 8.21.0
@@ -1807,8 +1807,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.1.0:
@@ -3396,7 +3396,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unicorn-magic@0.1.0: {}
 


### PR DESCRIPTION
Bumps the pinned `undici` runtime dependency from 7.28.0 to 7.29.0, clearing five open Dependabot advisories — one rated high, four moderate.

| Advisory | Severity | Issue |
| --- | --- | --- |
| [GHSA-4cwx-7wf7-3272](https://github.com/advisories/GHSA-4cwx-7wf7-3272) | High | Shared-cache disclosure + parse-time crash via degenerate qualified `private` cache directives |
| [GHSA-jr45-8vmc-qm54](https://github.com/advisories/GHSA-jr45-8vmc-qm54) | Moderate | Cross-user disclosure via whitespace around `=` in qualified `Cache-Control` directives |
| [GHSA-8xcm-r25x-g524](https://github.com/advisories/GHSA-8xcm-r25x-g524) | Moderate | Downstream response desynchronization via the retry interceptor |
| [GHSA-v3r7-h72x-cjcm](https://github.com/advisories/GHSA-v3r7-h72x-cjcm) | Moderate | Cookie attribute injection through unsanitized `setCookie` `domain` / `unparsed` fields |
| [GHSA-m8rv-5g2x-5cg5](https://github.com/advisories/GHSA-m8rv-5g2x-5cg5) | Moderate | CRLF injection via a blob-like body's `type` property |

## None of these are reachable from clodex

This is dependency hygiene rather than a fix for exploitable behavior. The entire undici surface clodex touches is two symbols in `src/outbound-proxy.ts`:

```ts
const { EnvHttpProxyAgent, setGlobalDispatcher } = await import('undici');
setGlobalDispatcher(new EnvHttpProxyAgent());
```

Checked against each advisory's stated precondition:

- **Both cache advisories** require `interceptors.cache()`. clodex never constructs an interceptor chain.
- **The retry advisory** requires `interceptors.retry()`. Same — never enabled. (Worth stating explicitly since clodex *does* forward upstream responses downstream, which is the affected application shape; the vector still needs undici's retry interceptor in the path, and it isn't.)
- **The cookie advisory** requires calling `setCookie()`. clodex never calls it.
- **The blob advisory** requires a duck-typed blob body passed to `request`/`stream`/`pipeline`/`dispatch`. clodex issues requests only through global `fetch` with string bodies, and the advisory notes `fetch()` is unaffected because it validates through the `Headers` class.

A sweep of `src/` for `interceptors`, `.compose(`, the non-`fetch` dispatcher APIs, `setCookie`, `Blob`, and `FormData` turns up nothing, and `pnpm why undici` confirms clodex is the sole consumer — no transitive dependency pulls it in through a different surface.

## Why 7.29.0 and not 8.x

`undici@8.10.0` is the current `latest`, but it declares `engines.node: ">=22.19.0"` while this package supports `>=22`. Taking 8.x would silently drop Node 22.0–22.18. `undici@7.29.0` requires only `>=20.18.1` and contains every patch listed above, so it clears the alerts without narrowing the supported runtime range.

7.29.0 published 2026-07-24, comfortably past the 10-day `minimumReleaseAge` floor in `pnpm-workspace.yaml`, so it resolves without an `ERR_PNPM_NO_MATURE_MATCHING_VERSION` override.

## Verification

- `pnpm install` — resolves cleanly; lockfile and `node_modules/undici/package.json` both report 7.29.0
- `pnpm typecheck` — clean
- `pnpm test` — 82 files, 1240 tests, all passing
- `pnpm build` — succeeds
