### PR TITLE
fix(proxy): contain upstream socket resets

### DIFF
--- a/src/http-proxy/server.ts
+++ b/src/http-proxy/server.ts
@@ -160,6 +160,8 @@ export interface HttpProxyOptions {
   anthropicOrigin?: string;
   /** Test hook for a local self-signed Anthropic origin. */
   anthropicRejectUnauthorized?: boolean;
+  /** Test hook for exercising Anthropic request socket failures. */
+  anthropicRequest?: typeof https.request;
   /** Test hook for observing relay-route isolation without calling an AI provider. */
   adapterHandle?: ProxyHandle;
   /** Test hook for exercising adapter request transport failures. */
@@ -269,6 +271,7 @@ function forwardRawAnthropicRequest(
   rawBody: Buffer,
   origin: URL,
   rejectUnauthorized: boolean,
+  requestImpl: typeof https.request = https.request,
   onErrorResponse?: (statusCode: number, body: string) => void,
   onResponseUsage?: (usage: ResponseUsage) => void,
   lifecycle?: {
@@ -337,7 +340,39 @@ function forwardRawAnthropicRequest(
       resolve();
     };
     const errorType = (err: Error): string => (err as NodeJS.ErrnoException).code ?? err.name;
-    const upstream = https.request({
+    const failUpstream = (err: Error) => {
+      if (clientDisconnected || failed) {
+        done();
+        return;
+      }
+      failed = true;
+      stopProgress();
+      const now = Date.now();
+      writeLifecycle('response_failed', {
+        statusCode: 502,
+        phase: responsePhase(),
+        durationMs: now - startedAt,
+        idleMs: now - lastActivityAt,
+        bytes,
+        chunks,
+        errorType: errorType(err),
+        terminationSource: 'upstream_failure',
+      });
+      onErrorResponse?.(502, `Anthropic upstream unreachable: ${err.message}`);
+      if (!res.headersSent) res.writeHead(502, { 'Content-Type': 'text/plain' });
+      res.end(`Anthropic upstream unreachable: ${err.message}`);
+      done();
+    };
+    let requestSocket: Socket | undefined;
+    let onRequestSocketError: ((err: Error) => void) | undefined;
+    const detachRequestSocketError = () => {
+      if (requestSocket && onRequestSocketError) {
+        requestSocket.removeListener('error', onRequestSocketError);
+      }
+      requestSocket = undefined;
+      onRequestSocketError = undefined;
+    };
+    const upstream = requestImpl({
       protocol: 'https:',
       hostname: origin.hostname,
       port: origin.port || 443,
@@ -347,6 +382,11 @@ function forwardRawAnthropicRequest(
       servername: net.isIP(origin.hostname) ? undefined : origin.hostname,
       rejectUnauthorized,
     }, upstreamRes => {
+      detachRequestSocketError();
+      if (failed) {
+        upstreamRes.destroy();
+        return;
+      }
       headersReceived = true;
       statusCode = upstreamRes.statusCode ?? 502;
       lastActivityAt = Date.now();
@@ -392,6 +432,14 @@ function forwardRawAnthropicRequest(
         done();
       });
     });
+    upstream.once('socket', socket => {
+      requestSocket = socket;
+      onRequestSocketError = err => {
+        failUpstream(err);
+        upstream.destroy(err);
+      };
+      socket.once('error', onRequestSocketError);
+    });
     res.once('finish', () => {
       stopProgress();
       if (failed || clientDisconnected) return;
@@ -423,27 +471,8 @@ function forwardRawAnthropicRequest(
       done();
     });
     upstream.once('error', err => {
-      if (clientDisconnected) {
-        done();
-        return;
-      }
-      failed = true;
-      stopProgress();
-      const now = Date.now();
-      writeLifecycle('response_failed', {
-        statusCode: 502,
-        phase: responsePhase(),
-        durationMs: now - startedAt,
-        idleMs: now - lastActivityAt,
-        bytes,
-        chunks,
-        errorType: errorType(err),
-        terminationSource: 'upstream_failure',
-      });
-      onErrorResponse?.(502, `Anthropic upstream unreachable: ${err.message}`);
-      if (!res.headersSent) res.writeHead(502, { 'Content-Type': 'text/plain' });
-      res.end(`Anthropic upstream unreachable: ${err.message}`);
-      done();
+      detachRequestSocketError();
+      failUpstream(err);
     });
     upstream.end(rawBody);
   });
@@ -877,6 +906,7 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
         rawBody,
         anthropicOrigin,
         options.anthropicRejectUnauthorized ?? true,
+        options.anthropicRequest,
         messagesEndpoint === 'messages' && options.inferenceLogPath
           ? (statusCode, errorContent) => writeInferenceResponseErrorLog(options.inferenceLogPath!, {
               requestId,
@@ -919,6 +949,7 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
       rawBody,
       anthropicOrigin,
       options.anthropicRejectUnauthorized ?? true,
+      options.anthropicRequest,
     );
   });
 

--- a/tests/http-proxy-server.test.ts
+++ b/tests/http-proxy-server.test.ts
@@ -109,6 +109,24 @@ function adapterRequestWithResponseEvents(
   }) as unknown as typeof http.request;
 }
 
+function anthropicRequestWithSocketError(error: Error): typeof https.request {
+  return ((_options: https.RequestOptions, _onResponse: (response: http.IncomingMessage) => void) => {
+    const request = new EventEmitter() as EventEmitter & {
+      end(body?: Buffer): void;
+      destroy(error?: Error): void;
+    };
+    request.end = () => {
+      queueMicrotask(() => {
+        const socket = new EventEmitter();
+        request.emit('socket', socket);
+        socket.emit('error', error);
+      });
+    };
+    request.destroy = () => {};
+    return request;
+  }) as unknown as typeof https.request;
+}
+
 async function adapterResponseFailureEntries(
   logName: string,
   emitEvents: (response: http.IncomingMessage) => void,
@@ -224,6 +242,39 @@ describe('selective HTTP proxy', () => {
       for (const client of clients) client.destroy();
       await proxy.close();
       await new Promise<void>(resolve => upstream.close(() => resolve()));
+    }
+  });
+
+  it('returns 502 when the upstream request socket resets before a response', async () => {
+    const certificates = ensureHttpProxyCertificates();
+    const origin = https.createServer({
+      key: certificates.serverKey,
+      cert: certificates.serverCert,
+    }, (_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json', 'Connection': 'close' });
+      res.end('{}');
+    });
+    const originPort = await listen(origin);
+    const socketError = Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
+    const proxy = await startHttpProxy({
+      routes: [],
+      anthropicOrigin: `https://127.0.0.1:${originPort}`,
+      anthropicRejectUnauthorized: false,
+      anthropicRequest: anthropicRequestWithSocketError(socketError),
+    });
+
+    try {
+      const response = await requestMitm(
+        proxy.port,
+        certificates.caCert,
+        '/api/oauth/usage',
+        '{}',
+      );
+      expect(response).toContain('502 Bad Gateway');
+      expect(response).toContain('Anthropic upstream unreachable: socket hang up');
+    } finally {
+      await proxy.close();
+      await new Promise<void>(resolve => origin.close(() => resolve()));
     }
   });
 


### PR DESCRIPTION
## Summary

- handle request-socket failures that arrive before response headers
- reuse the existing bounded `502` response and lifecycle diagnostics
- detach the temporary socket listener as soon as response handling takes over

## Scope

This branch was rebuilt directly on current `main`. The route-scoped configuration system, child-environment policy, transport replacement, and persisted proxy URL were removed. Raw passthrough support for the existing `HTTP(S)_PROXY`/`NO_PROXY` mechanism is isolated in #92.

## Test plan

- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm test` (83 files, 1,297 tests)
- [x] `corepack pnpm build`
- [x] focused pre-response socket reset test proving one bounded `502`
- [x] `git diff --check`
- [x] `gitleaks git --staged`
