### PR TITLE
fix(patcher): accept the 2.1.224 minified Agent-tool model enum shape

### DIFF
--- a/src/built-in-patch-proofs.ts
+++ b/src/built-in-patch-proofs.ts
@@ -107,7 +107,7 @@ export function captureBuiltInPatchProofs(
 
   addPattern(
     'PATCH 1: Agent tool model enum',
-    /\.enum\(\["sonnet","opus","haiku"(?:,"[^"]+")*\]\)\.optional\(\)\.describe\(/,
+    /(?:\.enum|model:[A-Za-z_$][\w$]*)\(\["sonnet","opus","haiku"(?:,"[^"]+")*\]\)\.optional\(\)\.describe\(/,
   );
   addPattern(
     'PATCH 3: known-alias validator list',

--- a/src/patch-transforms.ts
+++ b/src/patch-transforms.ts
@@ -33,7 +33,7 @@ import { isReservedModelAlias } from './model-aliases.js';
  * and never receive the new transforms, silently. `tests/patcher.test.ts` pins a
  * hash of this file to force that decision to be made rather than forgotten.
  */
-export const PATCH_TRANSFORMS_VERSION = 2;
+export const PATCH_TRANSFORMS_VERSION = 3;
 
 export interface PatchScriptModelEntry {
   alias?: string;
@@ -272,18 +272,20 @@ export function applyClodexPatches(source: string, config: PatchScriptModelConfi
 
   // ---------------------------------------------------------------------------
   // PATCH 1 — Agent/subagent tool 'model' zod enum.
-  // Anchor: .enum([ "sonnet",...,"fable" ]).optional().describe( — the array
-  // begins with the built-in aliases and is immediately followed by
-  // .optional().describe(. We append our identities (alias when defined, else
-  // the canonical id) inside the enum so the tool accepts them — this is the same
-  // enum subagent/skill 'model:' frontmatter is validated against, which is why
+  // Anchor: the aliases array ["sonnet",...,"fable"] wrapped in an enum
+  // constructor and immediately followed by .optional().describe(. Builds
+  // through 2.1.223 spell the constructor `.enum(`; 2.1.224+ minifies it to a
+  // bare helper call on the model property (`model:xr([...])`), so both are
+  // accepted. We append our identities (alias when defined, else the canonical
+  // id) inside the enum so the tool accepts them — this is the same enum
+  // subagent/skill 'model:' frontmatter is validated against, which is why
   // the short alias has to be the value that lands here.
   // (This same .describe( is patched by PATCH 4 below.)
   // ---------------------------------------------------------------------------
   applyOnce(
     'PATCH 1: Agent tool model enum',
-    /\.enum\((\["sonnet","opus","haiku"(?:,"[^"]+")*\])\)\.optional\(\)\.describe\(/,
-    (_m, arr) => '.enum(' + extendAliasArray(arr!) + ').optional().describe(',
+    /((?:\.enum|model:[A-Za-z_$][\w$]*)\()(\["sonnet","opus","haiku"(?:,"[^"]+")*\])\)(\.optional\(\)\.describe\()/,
+    (_m, open, arr, tail) => open! + extendAliasArray(arr!) + ')' + tail!,
     { required: true, noopIsSkip: true }
   );
 

--- a/tests/patcher.test.ts
+++ b/tests/patcher.test.ts
@@ -450,8 +450,8 @@ describe('PATCH_TRANSFORMS_VERSION', () => {
     ).replace(/\r\n/g, '\n');
     const digest = createHash('sha256').update(source).digest('hex');
     expect({ version: PATCH_TRANSFORMS_VERSION, digest }).toEqual({
-      version: 2,
-      digest: '944e9b8ee070d1921ad72e1053cd06c0a6cddbfe1a9c604f7333a9b35d88cb47',
+      version: 3,
+      digest: '8698e34835e19503f3591284d241f02ea2fb325844d6f5531f514f91ca76554b',
     });
   });
 });
@@ -1228,6 +1228,16 @@ describe('patch script identity naming', () => {
     // No alias → nothing to resolve and no picker entry.
     expect(out).not.toContain('case"clodex:openai:mystery":return');
     expect(out).not.toContain('value:"clodex:openai:mystery"');
+  });
+
+  it('patches the 2.1.224+ minified enum shape (model:xr([...]))', () => {
+    const modern = CLAUDE_FIXTURE.replace(
+      '.enum(["sonnet","opus","haiku","fable"])',
+      'model:xr(["sonnet","opus","haiku","fable"])',
+    );
+    expect(modern).not.toBe(CLAUDE_FIXTURE);
+    const out = runPatchScript({ 'clodex:openai:mystery': { context: 128_000 } }, modern);
+    expect(out).toContain('model:xr(["sonnet","opus","haiku","fable","clodex:openai:mystery"]).optional().describe(');
   });
 
   it('supports a configured alias that matches an object prototype name', () => {


### PR DESCRIPTION
Claude Code **2.1.224** (shipped 2026-08-06) breaks `PATCH 1: Agent tool model enum`: the build minifies the Agent tool's model zod enum from `.enum(["sonnet","opus","haiku","fable"])` to a bare helper call on the property — `model:xr(["sonnet","opus","haiku","fable"])` — so the anchor misses. Because PATCH 1 is `required`, the whole patch run aborts:

```
■  Patch failed: clodex patch: required patch failed: PATCH 1: Agent tool model enum
●    FAIL PATCH 1: Agent tool model enum — anchor not found
●  clodex patch: 0 applied, 0 skipped, 1 failed
```

Every clodex install with model aliases configured hits this on the first launch after Claude Code auto-updates to ≥2.1.224.

## The fix

Accept both spellings in the transform and in the built-in proof pattern, keyed on the aliases array plus the trailing `.optional().describe(` so the match stays unique:

```
/((?:\.enum|model:[A-Za-z_$][\w$]*)\()(\["sonnet","opus","haiku"(?:,"[^"]+")*\])\)(\.optional\(\)\.describe\()/
```

The alternation cannot double-match on pre-2.1.224 builds: at `model:Ne.enum(`, the `model:<ident>(` alternative dies on the `.` and only `.enum(` fires. `PATCH_TRANSFORMS_VERSION` is bumped to 3 so existing installs re-patch instead of trusting the stale config hash (the deliberate-re-pin digest guard is updated accordingly).

## Verification

- **Uniqueness sweep over 11 real binaries**: ran the exact regex against every pristine backup on hand (2.1.215 → 2.1.224) plus two live patched binaries — exactly one match in every one (`.enum(` through 2.1.223, `model:xr(` at 2.1.224), including already-extended arrays, so re-patch/skip detection keeps working.
- **End to end**: `clodex patch` against a real 2.1.224 applies all 10 patches; a second run reports "already patched — nothing to do" (idempotency intact).
- **Proof-pattern parity**: the updated built-in proof pattern uniquely matches the patched 2.1.224 text, so local-patch-extension postcondition capture keeps working.
- **Mutant check**: reverting the alternation makes the new `model:xr` regression test fail (plus the digest-pin guard), so the fix can't regress silently.
- **Failure-mode note**: a hypothetical binary containing *both* shapes would fail loudly on the >1-match ambiguity check rather than patching the wrong site.

Suite: 84/84 patcher tests, full run and typecheck green.
