### PR TITLE
feat(patcher): recognize configured identities in the autocompact threshold resolver

### DIFF
--- a/src/built-in-patch-proofs.ts
+++ b/src/built-in-patch-proofs.ts
@@ -159,6 +159,10 @@ export function captureBuiltInPatchProofs(
     effortProofPattern('/*ccpatch:max-effort*/'),
   );
   addPattern(
+    'PATCH 10: autocompact alias recognition',
+    /\/\*ccpatch:acw\*\/if\(Object\.assign\(Object\.create\(null\),\{[^{}]*\}\)\[String\([\w$]+\|\|""\)\.trim\(\)\.toLowerCase\(\)\]!==void 0\)return\{window:[\w$]+,configured:[\w$]+,source:"model-default"\};/,
+  );
+  addPattern(
     'PATCH 9: default effort',
     /\/\*ccpatch:default-effort\*\/var _cce=Object\.assign\(Object\.create\(null\),\{[^{}]*\}\)\[String\([\w$]+\|\|""\)\.trim\(\)\.toLowerCase\(\)\];if\(_cce!==void 0\)return _cce;/,
   );

--- a/src/patch-transforms.ts
+++ b/src/patch-transforms.ts
@@ -33,7 +33,7 @@ import { isReservedModelAlias } from './model-aliases.js';
  * and never receive the new transforms, silently. `tests/patcher.test.ts` pins a
  * hash of this file to force that decision to be made rather than forgotten.
  */
-export const PATCH_TRANSFORMS_VERSION = 3;
+export const PATCH_TRANSFORMS_VERSION = 4;
 
 export interface PatchScriptModelEntry {
   alias?: string;
@@ -428,6 +428,54 @@ export function applyClodexPatches(source: string, config: PatchScriptModelConfi
         /(function [\w$]+\(e,t\)\{)(let [\w$]+=[\w$]+\(\);if\([\w$]+!==void 0\)return [\w$]+;if\([\w$]+\(e,t\)\)return [\w$]+;return [\w$]+\(e,t\)\})/,
         (_m, head, body) => head! + SNIPPET + body!,
         { required: true }
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // PATCH 10 — autocompact alias recognition.
+  //
+  // The autocompact threshold resolver classifies models it does not recognize
+  // as source:"unknown-model" (window enforcement, 2.1.224): the session is
+  // held to an assumed window with an unrecognized-model notice, and a
+  // conversation whose prefix already exceeds that threshold is blocked with a
+  // synthetic "Prompt is too long" instead of being sent. Configured
+  // identities are real models whose true windows PATCH 7 bakes into the
+  // window resolver this same function reads, so short-circuit the
+  // unknown-model branch: a configured identity returns source:"model-default"
+  // with its resolved window — the same treatment a recognized model gets.
+  //
+  // Anchor: the unique unknown-model return inside the threshold resolver. The
+  // env kill-switch name is stable across builds; the minified identifiers are
+  // wildcarded. The injected lookup reuses PATCH 7's key set so the two baked
+  // tables cannot drift, and a null-prototype object keeps prototype-name
+  // aliases (e.g. "constructor") from false-matching.
+  // ---------------------------------------------------------------------------
+  if (Object.keys(CONTEXT_BY_KEY).length) {
+    const MARKER = '/*ccpatch:acw*/';
+    const KEYS = JSON.stringify(Object.fromEntries(Object.keys(CONTEXT_BY_KEY).map((k) => [k, 1])));
+    const snippetFor = (model: string, win: string) =>
+      MARKER + 'if(Object.assign(Object.create(null),' + KEYS + ')[String(' + model + '||"").trim().toLowerCase()]!==void 0)'
+      + 'return{window:' + win + ',configured:' + win + ',source:"model-default"};';
+
+    if (js.includes(MARKER)) {
+      // Re-patching an already-patched binary: refresh the baked key set in
+      // place, preserving the build-specific identifier names.
+      applyOnce(
+        'PATCH 10: autocompact alias recognition (refresh)',
+        /\/\*ccpatch:acw\*\/if\(Object\.assign\(Object\.create\(null\),\{[^{}]*\}\)\[String\(([\w$]+)\|\|""\)\.trim\(\)\.toLowerCase\(\)\]!==void 0\)return\{window:([\w$]+),configured:\2,source:"model-default"\};/,
+        (_m, model, win) => snippetFor(model!, win!),
+        { required: true, noopIsSkip: true }
+      );
+    } else {
+      applyOnce(
+        'PATCH 10: autocompact alias recognition',
+        /(if\([\w$]+\(\)&&![\w$]+(?:\.env)?\.CLAUDE_CODE_DISABLE_UNKNOWN_MODEL_WINDOW_ENFORCEMENT&&![\w$]+\(([\w$]+),[\w$]+\)&&![\w$]+\(\2\)&&![\w$]+\(\2,[\w$]+\)\)return\{window:([\w$]+),configured:\3,source:"unknown-model"\})/,
+        (_m, whole, model, win) => snippetFor(model!, win!) + whole!,
+        // Best-effort by design: if a future build drifts this anchor, losing
+        // alias recognition degrades to the pre-PATCH-10 status quo, which is
+        // far better than aborting every patch (the PATCH 1 lesson).
+        { required: false }
       );
     }
   }

--- a/tests/patcher.test.ts
+++ b/tests/patcher.test.ts
@@ -450,8 +450,8 @@ describe('PATCH_TRANSFORMS_VERSION', () => {
     ).replace(/\r\n/g, '\n');
     const digest = createHash('sha256').update(source).digest('hex');
     expect({ version: PATCH_TRANSFORMS_VERSION, digest }).toEqual({
-      version: 3,
-      digest: '8698e34835e19503f3591284d241f02ea2fb325844d6f5531f514f91ca76554b',
+      version: 4,
+      digest: 'ec54416778c261b5ab35f2b602447664b21d331294e08e0c16680a75fd00668d',
     });
   });
 });
@@ -645,6 +645,7 @@ const CLAUDE_CORE_FIXTURE = [
   'function rz(x){switch(x){case"best":{return "opus"}default:return null}}',
   'function opts(e,t,r){let n=cur(),o=(n==="opus")?[n,r]:[r];for(let i of o)Dlh(e,i,t);return e}',
   'function RS(e,t){let r=FAc();if(r!==void 0)return r;if(EHi(e,t))return Dve;return $Ac(e,t)}',
+  'function QT9(e,t){let n=lw(e),o=RS(e,t);if(gk()&&!EV.CLAUDE_CODE_DISABLE_UNKNOWN_MODEL_WINDOW_ENFORCEMENT&&!isKn(e,t)&&!isBt(e)&&!isOv(e,n))return{window:o,configured:o,source:"unknown-model"};return{window:o,configured:o,source:"auto"}}',
 ].join('\n');
 
 const digestOf = (text: string) => createHash('sha256').update(text).digest('hex');
@@ -1291,6 +1292,7 @@ describe('patch script identity naming', () => {
       ['PATCH 5: model picker options', 'OK'],
       ['PATCH 4: Agent tool model description', 'OK'],
       ['PATCH 7: per-model context window', 'OK'],
+      ['PATCH 10: autocompact alias recognition', 'OK'],
       ['PATCH 8a: effort capability', 'OK'],
       ['PATCH 8b: xhigh effort capability', 'OK'],
       ['PATCH 8c: max effort capability', 'OK'],
@@ -1306,6 +1308,7 @@ describe('patch script identity naming', () => {
       // PATCH 7 re-runs through the in-place refresh path; an unchanged config
       // rewrites the identical table, which reports as already patched.
       ['PATCH 7: per-model context window (refresh)', 'SKIP'],
+      ['PATCH 10: autocompact alias recognition (refresh)', 'SKIP'],
       ['PATCH 8a: effort capability (refresh)', 'SKIP'],
       ['PATCH 8b: xhigh effort capability (refresh)', 'SKIP'],
       ['PATCH 8c: max effort capability (refresh)', 'SKIP'],
@@ -1342,20 +1345,68 @@ describe('patch script identity naming', () => {
 
     expect(patched.content).toContain('.enum(["sonnet","opus","haiku","fable","sol","clodex:openai:mystery"])');
     expect(patched.content).toContain('/*ccpatch:ctx*/');
-    expect(patched.results.slice(0, 6).map(result => [result.name, result.status])).toEqual([
+    expect(patched.results.slice(0, 7).map(result => [result.name, result.status])).toEqual([
       ['PATCH 1: Agent tool model enum', 'OK'],
       ['PATCH 3: known-alias validator list', 'OK'],
       ['PATCH 6: alias resolver switch', 'OK'],
       ['PATCH 5: model picker options', 'OK'],
       ['PATCH 4: Agent tool model description', 'OK'],
       ['PATCH 7: per-model context window', 'OK'],
+      ['PATCH 10: autocompact alias recognition', 'OK'],
     ]);
-    expect(patched.results.slice(6)).toEqual([
+    expect(patched.results.slice(7)).toEqual([
       { status: 'FAIL', name: 'PATCH 8a: effort capability', extra: 'anchor not found' },
       { status: 'FAIL', name: 'PATCH 8b: xhigh effort capability', extra: 'anchor not found' },
       { status: 'FAIL', name: 'PATCH 8c: max effort capability', extra: 'anchor not found' },
       { status: 'FAIL', name: 'PATCH 9: default effort', extra: 'anchor not found' },
     ]);
+  });
+
+  it('recognizes configured identities in the autocompact threshold resolver', () => {
+    const out = runPatchScript(config, CLAUDE_CORE_FIXTURE);
+    expect(out).toContain('/*ccpatch:acw*/');
+    const start = out.indexOf('function QT9');
+    expect(start).toBeGreaterThan(-1);
+    const tail = 'return{window:o,configured:o,source:"auto"}}';
+    const src = out.slice(start, out.indexOf(tail, start) + tail.length);
+    const resolver = new Function(
+      'lw', 'RS', 'gk', 'EV', 'isKn', 'isBt', 'isOv',
+      `${src}; return QT9;`,
+    )(
+      (e: string) => String(e).toLowerCase(),
+      () => 272_000,
+      () => true,
+      {},
+      () => false,
+      () => false,
+      () => false,
+    ) as (e: string, t?: number) => { window: number; configured: number; source: string };
+    // A configured alias and its canonical id are recognized with their window.
+    expect(resolver('sol')).toEqual({ window: 272_000, configured: 272_000, source: 'model-default' });
+    expect(resolver('SOL ')).toEqual({ window: 272_000, configured: 272_000, source: 'model-default' });
+    expect(resolver('clodex:openai:mystery').source).toBe('model-default');
+    // A genuinely unrecognized model still gets the enforcement branch.
+    expect(resolver('some-future-model').source).toBe('unknown-model');
+    // Object prototype names never false-match the baked key set.
+    expect(resolver('constructor').source).toBe('unknown-model');
+  });
+
+  it('refreshes the autocompact recognition key set when the config changes', () => {
+    const once = runPatchScript(config, CLAUDE_CORE_FIXTURE);
+    expect(once).toContain('"clodex:openai:mystery":1');
+    const updatedConfig: Parameters<typeof applyClodexPatches>[1] = {
+      ...config,
+      'clodex:openai:added-later': { alias: 'nova', context: 128_000 },
+    };
+    const refreshed = applyClodexPatches(once, updatedConfig);
+    expect(refreshed.results.map(r => [r.name, r.status])).toContainEqual(
+      ['PATCH 10: autocompact alias recognition (refresh)', 'OK'],
+    );
+    const marker = refreshed.content.indexOf('/*ccpatch:acw*/');
+    const snippet = refreshed.content.slice(marker, refreshed.content.indexOf(';', marker) + 1);
+    expect(snippet).toContain('"nova":1');
+    expect(snippet).toContain('"clodex:openai:added-later":1');
+    expect(snippet).toContain('"sol":1');
   });
 
   it('refreshes every baked effort table when extended capabilities are removed', () => {


### PR DESCRIPTION
Claude Code **2.1.223** introduced unknown-model window enforcement in the autocompact threshold resolver: a model it does not recognize gets `source:"unknown-model"` — the session is held to an assumed window with an unrecognized-model notice, and a conversation whose prefix already exceeds that threshold is **blocked with a synthetic "Prompt is too long"** instead of being sent. Configured clodex identities are exactly such models, despite PATCH 7 baking their true windows into the window resolver this same function reads.

Observed in production: concurrent subagents on a 272K-window alias whose early context was inflated past the threshold (a ~850KB bundled skill) died instantly at turn 2 with `AgentApiErrorTerminationError: Prompt is too long`, preceded by `autocompact: routing through reactive (thresholdSource=unknown-model)` and `level=blocked` — the requests never reached clodex.

## The fix — PATCH 10

Short-circuit the unknown-model branch: a configured identity returns `source:"model-default"` with its resolved window — the same treatment a recognized model gets (correct compaction semantics at its real window, no notice).

- The injected lookup **reuses PATCH 7's key set**, so the two baked tables cannot drift; keys are trimmed/lowercased at build matching the lookup.
- **Null-prototype object** for the lookup, so prototype names (the existing `constructor`-alias test case) cannot false-match.
- **In-place refresh** on re-patch preserves the build-specific identifier names and re-bakes the key set on a config change.
- **Best-effort by design** (`required: false`): on builds without the enforcement feature (≤2.1.222) or a future anchor drift, the patch records a non-fatal FAIL and everything else still applies — losing alias recognition degrades to the pre-PATCH-10 status quo instead of aborting every patch (the failure mode #85 just fixed for PATCH 1).

## Verification

- **Anchor sweep over 11 pristine binaries** (2.1.215 → 2.1.224): exactly one match on 2.1.223 and 2.1.224 (both alternatives of the enforcement code), zero on every earlier build — confirming both uniqueness and when the feature shipped. Also exactly one match on a live already-patched binary, so re-patching resolves correctly.
- **Behavioral test executes the patched resolver**: configured alias (any case/padding) and canonical id resolve `model-default` at their window; a genuinely unknown model still gets the enforcement branch; `constructor` stays unrecognized.
- **Refresh test**: re-patching with an added model rewrites the baked key set in place.
- **Mutant check**: widening the injected gate to always-true fails 9 tests (the unknown-model negative assertions and the deliberate-re-pin digest guard), so the patch cannot silently regress in either direction.
- Applied live: all patches green against a real 2.1.224, marker and key set confirmed in the patched binary; a session on the previously-affected workload shape runs with the aliases recognized.

`PATCH_TRANSFORMS_VERSION` bumped so existing installs re-patch. Based on v2.2.1 (includes #85), single commit, full suite + typecheck green.
