### PR TITLE
fix(sdk): strip the volatile Claude Code billing header on every translated route

### DIFF
--- a/src/sdk-adapter.ts
+++ b/src/sdk-adapter.ts
@@ -207,10 +207,12 @@ function translateTopLevelSystemForOpenAi(
 ): ModelMessage[] {
   if (!system) return [];
   if (typeof system === 'string') {
-    return system.trim() ? [{ role: 'system', content: system } as ModelMessage] : [];
+    const stripped = stripClaudeCodeBillingHeader(system);
+    return stripped?.trim() ? [{ role: 'system', content: stripped } as ModelMessage] : [];
   }
   return system.flatMap(block => {
-    const text = typeof block === 'string' ? block : block.text ?? '';
+    const raw = typeof block === 'string' ? block : block.text ?? '';
+    const text = stripClaudeCodeBillingHeader(raw) ?? '';
     if (!text.trim()) return [];
     const cacheControl = typeof block === 'string' ? undefined : block.cache_control;
     return [{
@@ -471,9 +473,15 @@ export function translateRequest(
 
   // Claude Code prepends an Anthropic-only billing attribution block whose
   // `cch` value changes every request. It is envelope metadata, not a model
-  // instruction, and forwarding it to OpenAI would invalidate the stable
-  // prompt prefix. Anthropic passthrough and non-OAuth providers are untouched.
-  const baseSystem = systemToString(body.system, options?.openAiOAuth === true);
+  // instruction, and forwarding it invalidates the stable prompt prefix on
+  // EVERY translated provider — OpenAI-compatible gateways hash the request
+  // prefix for implicit caching, and third-party Anthropic-format providers
+  // cache up to breakpoints, so a volatile first system line caps their cache
+  // hits at the first few hundred tokens (observed live: kimi-k3 via OpenCode
+  // Zen froze at 256-512 cached tokens per call). Strip it on every
+  // SDK-translated route; Anthropic passthrough does not go through
+  // translateRequest and still forwards it.
+  const baseSystem = systemToString(body.system, true);
   const systemText = baseSystem?.trim() || (options?.openAiOAuth ? 'You are a coding assistant.' : undefined);
 
   // resolveUpstreamTools uses the shared proxy types; the adapter keeps its own

--- a/tests/sdk-adapter.test.ts
+++ b/tests/sdk-adapter.test.ts
@@ -205,7 +205,7 @@ describe('translateRequest', () => {
     expect(params.maxOutputTokens).toBeUndefined();
   });
 
-  it('strips Claude Code Anthropic billing attribution from OpenAI OAuth instructions only', () => {
+  it('strips Claude Code Anthropic billing attribution on every translated route', () => {
     const body = {
       model: 'gpt-5.6-terra',
       system: [
@@ -216,6 +216,10 @@ describe('translateRequest', () => {
       ],
       messages: [{ role: 'user' as const, content: 'hello' }],
     };
+    const changedCchSystem = [
+      { text: 'x-anthropic-billing-header: cc_version=2.1.207.9bb; cc_entrypoint=cli; cch=cb57d;' },
+      body.system[1]!,
+    ];
 
     const oauth = translateRequest(body, '@ai-sdk/openai', { openAiOAuth: true });
     expect(oauth.providerOptions?.openai?.instructions)
@@ -223,18 +227,39 @@ describe('translateRequest', () => {
 
     const changedAttribution = translateRequest({
       ...body,
-      system: [
-        { text: 'x-anthropic-billing-header: cc_version=2.1.207.9bb; cc_entrypoint=cli; cch=cb57d;' },
-        body.system[1]!,
-      ],
+      system: changedCchSystem,
     }, '@ai-sdk/openai', { openAiOAuth: true });
     expect(changedAttribution.providerOptions?.openai?.instructions)
       .toBe(oauth.providerOptions?.openai?.instructions);
     expect(changedAttribution.providerOptions?.openai?.promptCacheKey)
       .toBe(oauth.providerOptions?.openai?.promptCacheKey);
 
+    // Public OpenAI API-key route (pre-5.6 → instructions path): the volatile
+    // header must not churn the implicit-cache prefix or the promptCacheKey.
     const publicApi = translateRequest({ ...body, model: 'gpt-5.5' }, '@ai-sdk/openai');
-    expect(publicApi.instructions).toContain('x-anthropic-billing-header:');
+    expect(publicApi.instructions).toBe('You are Claude Code.\nFollow the user instructions.');
+    const publicApiChangedCch = translateRequest(
+      { ...body, model: 'gpt-5.5', system: changedCchSystem }, '@ai-sdk/openai');
+    expect(publicApiChangedCch.providerOptions?.openai?.promptCacheKey)
+      .toBe(publicApi.providerOptions?.openai?.promptCacheKey);
+
+    // OpenAI-compatible gateways hash the request prefix for implicit
+    // caching — the header must never reach them.
+    const compatible = translateRequest({ ...body, model: 'kimi-k3' }, '@ai-sdk/openai-compatible');
+    expect(compatible.instructions).toBe('You are Claude Code.\nFollow the user instructions.');
+
+    // Third-party Anthropic-format providers cache up to breakpoints; a
+    // volatile first system block invalidates every cached prefix.
+    const anthropicCompatible = translateRequest({ ...body, model: 'qwen3.8-max' }, '@ai-sdk/anthropic');
+    expect(anthropicCompatible.instructions).toBe('You are Claude Code.\nFollow the user instructions.');
+
+    // Explicit-breakpoint path (gpt-5.6+ public API) emits top-level system
+    // blocks as system messages — the billing block must be dropped there too.
+    const explicitCaching = translateRequest({ ...body, model: 'gpt-5.6' }, '@ai-sdk/openai');
+    expect(explicitCaching.instructions).toBeUndefined();
+    const systemMessages = explicitCaching.messages.filter(m => m.role === 'system');
+    expect(systemMessages).toHaveLength(1);
+    expect(systemMessages[0]?.content).toBe('You are Claude Code.\nFollow the user instructions.');
   });
 
   it('maps output_config.effort to Google thinking budget without dropping includeThoughts', () => {


### PR DESCRIPTION
## Problem

Claude Code prepends a billing-attribution system block (`x-anthropic-billing-header: …; cch=…;`) whose `cch` value changes on every request. `translateRequest` strips it only when `openAiOAuth` is set, so every API-key route ships a volatile first system line. That caps upstream prompt-prefix caching at the first few hundred tokens: OpenAI-compatible gateways hash the request prefix for implicit caching, and third-party Anthropic-format providers cache up to breakpoints — both diverge at the header on every call.

The explicit-breakpoint path (gpt-5.6+ public API) has the same leak independently: `translateTopLevelSystemForOpenAi` re-emits the raw top-level system blocks as system messages, billing block included.

**Reachability:** every `translateRequest` caller without `openAiOAuth` — API-key `@ai-sdk/openai`, `@ai-sdk/openai-compatible`, third-party `@ai-sdk/anthropic` — receives Claude Code bodies containing the header (it is on every Claude Code request). Observed live before the fix (OpenCode Zen, kimi-k3): cache reads frozen at 256-512 tokens per call while per-call uncached input grew 23k→76k across a session; a direct byte-stable request to the same upstream cached 5888/6104, isolating the divergence to the translated prefix.

## Fix

- `translateRequest`: strip unconditionally (`systemToString(body.system, true)`). OAuth behavior is byte-identical — that route already stripped; only the gate widens. Anthropic passthrough does not go through `translateRequest` and still forwards the header.
- `translateTopLevelSystemForOpenAi`: apply `stripClaudeCodeBillingHeader` per block before emitting system messages.

Side benefit: `openAiPromptCacheKey(baseSystem, …)` now hashes the stripped system, so the API-key fallback cache key stops churning per request too.

## Validation

- Measured after the fix, same churning-`cch` pattern via `clodex server --endpoint`: deepseek-v4-flash second call **58 uncached / 6272 cached** (was all-uncached); kimi-k3 **215 uncached / 5888 cached**; grown-conversation third call keeps the cached prefix.
- `tsc --noEmit` clean; full vitest suite green on this base (90 files / 1296 tests).
- The former OAuth-only strip test now asserts every translated route, promptCacheKey stability under changing `cch` on the API-key route, and billing-block removal from the explicit-breakpoint system messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)