### PR TITLE
feat(providers): support mixed-protocol metadata

### DIFF
--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -54,6 +54,7 @@ export function localModelToRoute(lp: LocalProvider, model: LocalProviderModel):
     interleavedReasoningField: model.interleavedReasoningField,
     useResponsesLite: model.useResponsesLite,
     preferWebSockets: model.preferWebSockets,
+    compatibility: model.compatibility,
   };
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1400,6 +1400,7 @@ export async function runClaudeCommand(parsed: ParsedArgs): Promise<number> {
           interleavedReasoningField: selectedModel.interleavedReasoningField,
           useResponsesLite: selectedModel.useResponsesLite,
           preferWebSockets: selectedModel.preferWebSockets,
+          compatibility: selectedModel.compatibility,
           headers: activeProvider.headers,
         },
         launchApiKey ?? '',

--- a/src/http-proxy/routes.ts
+++ b/src/http-proxy/routes.ts
@@ -45,7 +45,7 @@ export interface ResolvedHttpProxyAlias {
   sourceNames?: string[];
 }
 
-/** Build a positive allowlist: only favorite AI-SDK routes can leave Anthropic's path. */
+/** Build a positive allowlist: only explicitly configured favorite routes can leave Anthropic's path. */
 export function buildHttpProxyRoutes(
   providers: LocalProvider[],
   favorites: FavoriteModel[],
@@ -66,7 +66,10 @@ export function buildHttpProxyRoutes(
       unavailable.push(favorite);
       continue;
     }
-    if (model.modelFormat !== 'openai' || !isSdkMigratedNpm(model.npm)) {
+    const supported = model.modelFormat === 'anthropic'
+      ? Boolean(model.baseUrl)
+      : isSdkMigratedNpm(model.npm);
+    if (!supported) {
       unsupported.push(favorite);
       continue;
     }

--- a/src/model-runtime-compatibility.ts
+++ b/src/model-runtime-compatibility.ts
@@ -1,0 +1,110 @@
+/**
+ * Provider-neutral per-model compatibility hints.
+ *
+ * These describe Chat Completions wire quirks that cannot be inferred safely
+ * from a provider or model family. Runtime adapters consume only the fields
+ * they understand; unknown fields remain inert metadata.
+ */
+export interface ModelRuntimeCompatibility {
+  /** Claude/Codex effort -> upstream reasoning_effort map. null disables that level. */
+  reasoningEffortMap?: Record<string, string | null>;
+  /** Explicitly enable or disable reasoning_effort for this model. */
+  supportsReasoningEffort?: boolean;
+  /** Additional request shape required when reasoning is enabled. */
+  thinkingFormat?: 'deepseek' | 'qwen';
+  /** Replay an empty reasoning_content field when prior assistant reasoning is absent. */
+  requiresReasoningContentOnAssistantMessages?: boolean;
+  /** Whether the upstream accepts the OpenAI `store` request field. */
+  supportsStore?: boolean;
+  /** Whether the upstream accepts Chat Completions `developer` messages. */
+  supportsDeveloperRole?: boolean;
+  /** Output-token field accepted by the upstream Chat Completions endpoint. */
+  maxTokensField?: 'max_tokens' | 'max_completion_tokens';
+  /** Whether the upstream accepts long prompt-cache retention controls. */
+  supportsLongCacheRetention?: boolean;
+}
+
+export type OpenAiCompatibleRequestBody = Record<string, unknown>;
+
+type ChatMessage = Record<string, unknown> & { role?: unknown };
+
+function remapMaxTokensField(
+  body: OpenAiCompatibleRequestBody,
+  field: ModelRuntimeCompatibility['maxTokensField'],
+): void {
+  if (field === 'max_tokens') {
+    if (body.max_tokens === undefined && body.max_completion_tokens !== undefined) {
+      body.max_tokens = body.max_completion_tokens;
+    }
+    delete body.max_completion_tokens;
+    return;
+  }
+  if (field === 'max_completion_tokens') {
+    if (body.max_completion_tokens === undefined && body.max_tokens !== undefined) {
+      body.max_completion_tokens = body.max_tokens;
+    }
+    delete body.max_tokens;
+  }
+}
+
+function transformMessages(
+  messages: unknown,
+  compatibility: ModelRuntimeCompatibility,
+): unknown {
+  if (!Array.isArray(messages)) return messages;
+  const rewriteDeveloper = compatibility.supportsDeveloperRole === false;
+  const replayReasoning = compatibility.requiresReasoningContentOnAssistantMessages === true;
+  if (!rewriteDeveloper && !replayReasoning) return messages;
+
+  let changed = false;
+  const transformed = messages.map(message => {
+    if (!message || typeof message !== 'object' || Array.isArray(message)) return message;
+    const source = message as ChatMessage;
+    const role = source.role;
+    const needsRoleRewrite = rewriteDeveloper && role === 'developer';
+    const needsReasoningReplay = replayReasoning
+      && role === 'assistant'
+      && !Object.prototype.hasOwnProperty.call(source, 'reasoning_content');
+    if (!needsRoleRewrite && !needsReasoningReplay) return message;
+
+    changed = true;
+    return {
+      ...source,
+      ...(needsRoleRewrite ? { role: 'system' } : {}),
+      ...(needsReasoningReplay ? { reasoning_content: '' } : {}),
+    };
+  });
+
+  return changed ? transformed : messages;
+}
+
+/**
+ * Apply model-specific OpenAI-compatible request quirks after the AI SDK has
+ * assembled its Chat Completions payload.
+ */
+export function transformOpenAiCompatibleRequestBody(
+  body: OpenAiCompatibleRequestBody,
+  compatibility: ModelRuntimeCompatibility,
+): OpenAiCompatibleRequestBody {
+  const transformed = { ...body };
+
+  if (compatibility.supportsStore === false) delete transformed.store;
+  if (compatibility.supportsLongCacheRetention === false) {
+    delete transformed.prompt_cache_retention;
+    delete transformed.promptCacheRetention;
+  }
+  remapMaxTokensField(transformed, compatibility.maxTokensField);
+
+  const messages = transformMessages(transformed.messages, compatibility);
+  if (messages !== transformed.messages) transformed.messages = messages;
+
+  const hasReasoningEffort = typeof transformed.reasoning_effort === 'string'
+    && transformed.reasoning_effort.trim().length > 0;
+  if (hasReasoningEffort && compatibility.thinkingFormat === 'deepseek') {
+    if (transformed.thinking === undefined) transformed.thinking = { type: 'enabled' };
+  } else if (hasReasoningEffort && compatibility.thinkingFormat === 'qwen') {
+    if (transformed.enable_thinking === undefined) transformed.enable_thinking = true;
+  }
+
+  return transformed;
+}

--- a/src/patcher.ts
+++ b/src/patcher.ts
@@ -278,6 +278,7 @@ export function buildDesiredPatchConfig(): DesiredPatchConfig {
         reasoning: model.reasoning ?? modelsDev?.reasoning,
         interleavedReasoningField:
           model.interleavedReasoningField ?? modelsDev?.interleaved?.field,
+        compatibility: model.compatibility,
         upstreamModelId,
       });
       meta.set(`${provider.id}:${model.id}`, {

--- a/src/provider-catalog.ts
+++ b/src/provider-catalog.ts
@@ -122,6 +122,7 @@ export function localProvidersToServerModels(localProviders: LocalProvider[]): S
       interleavedReasoningField: model.interleavedReasoningField,
       useResponsesLite: model.useResponsesLite,
       preferWebSockets: model.preferWebSockets,
+      compatibility: model.compatibility,
       headers: provider.headers,
       providerData: provider.providerData,
     }))

--- a/src/provider-factory.ts
+++ b/src/provider-factory.ts
@@ -14,6 +14,10 @@ import {
   injectClaudeIdentity,
 } from './oauth/claude-identity.js';
 import { isCredentialBearingHeader } from './credential-headers.js';
+import {
+  transformOpenAiCompatibleRequestBody,
+  type ModelRuntimeCompatibility,
+} from './model-runtime-compatibility.js';
 
 /** Models that must use /v1/responses instead of /v1/chat/completions. */
 const RESPONSES_ONLY_PREFIXES = [
@@ -110,6 +114,8 @@ export interface ProviderModelSpec {
   useResponsesLite?: boolean;
   /** Backend capability: model must use the WebSocket Responses transport instead of HTTP. */
   preferWebSockets?: boolean;
+  /** Provider-neutral per-model wire quirks. */
+  compatibility?: ModelRuntimeCompatibility;
   /** Optional debug logger (wired to the proxy trace log) for transport-level diagnostics. */
   onDebug?: (msg: string) => void;
   /** Optional privacy-safe structured WebSocket diagnostics. */
@@ -249,6 +255,12 @@ export async function createLanguageModel(spec: ProviderModelSpec): Promise<Lang
       ...(spec.authType !== 'none' && apiKey.trim() ? { apiKey } : {}),
       ...(spec.authType === 'none' ? { fetch: fetchWithoutCredentialHeaders } : {}),
       ...(spec.headers ? { headers: spec.headers } : {}),
+      ...(spec.compatibility
+        ? {
+            transformRequestBody: (body: Record<string, unknown>) =>
+              transformOpenAiCompatibleRequestBody(body, spec.compatibility!),
+          }
+        : {}),
     };
     model = createOpenAICompatible({
       ...options,
@@ -292,6 +304,8 @@ export interface ReasoningMetadata {
   supportedParameters?: string[];
   reasoning?: boolean;
   interleavedReasoningField?: string;
+  /** Provider-neutral per-model wire quirks. */
+  compatibility?: ModelRuntimeCompatibility;
   /**
    * Bare upstream model id (e.g. 'grok-4.5'), distinct from the request's `model`
    * field which may be a gateway alias or catalog slug (e.g. 'xai-oauth__grok-4.5').
@@ -626,6 +640,90 @@ function mapCodexEffortToGeminiBudget(effort: string): number | undefined {
   return GEMINI_25_BUDGETS[level];
 }
 
+function compatibilityReasoningCapabilities(
+  metadata?: ReasoningMetadata,
+): ReasoningCapabilities | undefined {
+  const compatibility = metadata?.compatibility;
+  if (!compatibility) return undefined;
+
+  if (compatibility.supportsReasoningEffort === false) {
+    return metadata?.reasoning === false
+      ? EMPTY_REASONING
+      : {
+          ...EMPTY_REASONING,
+          mode: 'internal-only',
+          source: 'provider-metadata',
+          confidence: 'documented',
+        };
+  }
+
+  if (compatibility.reasoningEffortMap) {
+    const levels = Object.entries(compatibility.reasoningEffortMap)
+      .filter(([, mapped]) => mapped !== null)
+      .map(([level]) => level);
+    if (levels.length === 0) {
+      return metadata?.reasoning === false
+        ? EMPTY_REASONING
+        : {
+            ...EMPTY_REASONING,
+            mode: 'internal-only',
+            source: 'provider-metadata',
+            confidence: 'documented',
+          };
+    }
+
+    const preferredDefault = ['medium', 'high', 'max', 'low'].find(level => levels.includes(level));
+    return {
+      levels,
+      defaultLevel: preferredDefault ?? levels[0]!,
+      supportsSummaries: false,
+      mode: 'controllable',
+      source: 'provider-metadata',
+      confidence: 'documented',
+      wireFormat: compatibility.thinkingFormat === 'deepseek'
+        ? { kind: 'deepseek-thinking' }
+        : { kind: 'openai-reasoning-effort' },
+    };
+  }
+
+  if (
+    compatibility.supportsReasoningEffort === true
+    || compatibility.thinkingFormat !== undefined
+  ) {
+    if (metadata?.reasoning === false) return EMPTY_REASONING;
+    return {
+      levels: ['low', 'medium', 'high'],
+      defaultLevel: 'medium',
+      supportsSummaries: false,
+      mode: 'controllable',
+      source: 'provider-metadata',
+      confidence: 'documented',
+      wireFormat: compatibility.thinkingFormat === 'deepseek'
+        ? { kind: 'deepseek-thinking' }
+        : { kind: 'openai-reasoning-effort' },
+    };
+  }
+
+  return undefined;
+}
+
+function compatibilityReasoningEffort(
+  effort: string,
+  modelId: string,
+  compatibility: ModelRuntimeCompatibility,
+): string | undefined {
+  if (compatibility.supportsReasoningEffort === false) return undefined;
+  const map = compatibility.reasoningEffortMap;
+  if (map) {
+    if (!Object.prototype.hasOwnProperty.call(map, effort)) return undefined;
+    return map[effort] ?? undefined;
+  }
+  if (compatibility.supportsReasoningEffort === true || compatibility.thinkingFormat !== undefined) {
+    return mapCodexEffortToOpenAI(effort, modelId);
+  }
+  return undefined;
+}
+
 /** Per-model reasoning UI + wire metadata for Codex catalog and adapters. */
 export function getReasoningCapabilities(
   npm: string,
@@ -633,6 +731,8 @@ export function getReasoningCapabilities(
   metadata?: ReasoningMetadata,
 ): ReasoningCapabilities {
   const id = modelId.toLowerCase();
+  const compatibilityCapabilities = compatibilityReasoningCapabilities(metadata);
+  if (compatibilityCapabilities) return compatibilityCapabilities;
 
   if (isOpenRouterRoute(npm, metadata)) {
     return openRouterReasoningCapabilities(metadata);
@@ -806,8 +906,12 @@ export function getPatchReasoningCapabilities(
   modelId: string,
   metadata?: ReasoningMetadata,
 ): ReasoningCapabilities {
+  if (metadata?.compatibility?.supportsReasoningEffort === false) {
+    return compatibilityReasoningCapabilities(metadata) ?? EMPTY_REASONING;
+  }
   if (
     metadata?.reasoning === false
+    && !metadata?.compatibility?.reasoningEffortMap
     && !hasSupportedParameter(metadata, 'reasoning_effort')
     && !hasSupportedParameter(metadata, 'reasoning')
   ) {
@@ -848,13 +952,25 @@ export function effortProviderOptions(
 ): Record<string, Record<string, unknown>> | undefined {
   if (!effort) return undefined;
 
+  if (npm === '@ai-sdk/openai-compatible' && modelId && metadata?.compatibility) {
+    const reasoningEffort = compatibilityReasoningEffort(
+      effort,
+      modelId,
+      metadata.compatibility,
+    );
+    if (!reasoningEffort) return undefined;
+    const key = metadata.providerId ? toCamelCase(metadata.providerId) : 'openaiCompatible';
+    return { [key]: { reasoningEffort } };
+  }
+
   if (isOpenRouterRoute(npm, metadata)) {
     const caps = openRouterReasoningCapabilities(metadata);
     if (caps.mode !== 'controllable') return undefined;
     const allowed = new Set(OPENROUTER_EFFORT_LEVELS);
-    const mapped = allowed.has(effort as typeof OPENROUTER_EFFORT_LEVELS[number])
-      ? effort
-      : effort === 'max'
+    const candidate = effort;
+    const mapped = allowed.has(candidate as typeof OPENROUTER_EFFORT_LEVELS[number])
+      ? candidate
+      : candidate === 'max'
         ? 'xhigh'
         : undefined;
     return mapped
@@ -934,9 +1050,10 @@ export function effortProviderOptions(
     }
     if (hasSupportedParameter(metadata, 'reasoning')) {
       const allowed = new Set(OPENROUTER_EFFORT_LEVELS);
-      const mapped = allowed.has(effort as typeof OPENROUTER_EFFORT_LEVELS[number])
-        ? effort
-        : effort === 'max' ? 'xhigh' : undefined;
+      const candidate = effort;
+      const mapped = allowed.has(candidate as typeof OPENROUTER_EFFORT_LEVELS[number])
+        ? candidate
+        : candidate === 'max' ? 'xhigh' : undefined;
       return mapped
         ? { openrouter: { reasoning: { effort: mapped, exclude: false } } }
         : undefined;

--- a/src/provider-templates.ts
+++ b/src/provider-templates.ts
@@ -1,7 +1,12 @@
 // src/provider-templates.ts — builtin provider templates for clodex providers add
 
+import type { CachedModel } from './registry/types.js';
+
 export type ProviderAuthType = 'api' | 'oauth' | 'none';
 export type ProviderModelSource = 'api-list' | 'static-seed' | 'manual-only';
+export type ProviderStaticModelPolicy = 'overlay' | 'allowlist';
+export type ProviderTemplateModel = Pick<CachedModel, 'id' | 'name'>
+  & Partial<Omit<CachedModel, 'id' | 'name'>>;
 
 export interface ProviderTemplate {
   id: string;
@@ -18,7 +23,12 @@ export interface ProviderTemplate {
   /** Static headers this provider requires on every request (model listing and runtime). */
   headers?: Record<string, string>;
   modelSource: ProviderModelSource;
-  staticModels?: Array<{ id: string; name: string }>;
+  /** Curated model metadata layered over live discovery or used as a static seed. */
+  staticModels?: ProviderTemplateModel[];
+  /** `allowlist` hides live models absent from staticModels; `overlay` keeps them. */
+  staticModelPolicy?: ProviderStaticModelPolicy;
+  /** Keep provider/curated costs instead of replacing them with the global pricing cache. */
+  preserveModelPricing?: boolean;
   supported: boolean;
   addable?: boolean;
   hidden?: boolean;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -57,6 +57,7 @@ import {
 import { withResponsesWebSocketDiagnosticContext } from './oauth/responses-websocket.js';
 import { resolveContextWindow } from './context-window.js';
 import { listenTcpServer } from './listener-ready.js';
+import type { ModelRuntimeCompatibility } from './model-runtime-compatibility.js';
 
 type ProxyLog = (message: string | (() => string)) => void;
 
@@ -248,6 +249,8 @@ export interface ProxyRoute {
   useResponsesLite?: boolean;
   /** Backend capability: model must use the WebSocket Responses transport instead of HTTP. */
   preferWebSockets?: boolean;
+  /** Provider-neutral per-model wire quirks. */
+  compatibility?: ModelRuntimeCompatibility;
   /** Static headers sent on every upstream request (e.g. a plan/auth-tracking header a custom endpoint requires). */
   headers?: Record<string, string>;
 }
@@ -531,6 +534,13 @@ export async function startProxyCatalog(
             refreshToken: route.refreshToken,
             onTokenRefreshed: refreshed => { route.apiKey = refreshed; },
             signal: clientAbort.signal,
+            // A route selected through a clodex: id or short alias must echo the
+            // exact requested id back, or patched Claude Code misses the alias
+            // context-window key and can skip auto-compaction.
+            responseModelOverride:
+              typeof originalModel === 'string' && originalModel !== route.realModelId
+                ? originalModel
+                : undefined,
             onUpstreamError: inferenceLogPath
               ? (statusCode, errorContent) => writeInferenceResponseErrorLog(inferenceLogPath, {
                   modelId: originalModel,
@@ -577,6 +587,7 @@ export async function startProxyCatalog(
               supportedParameters: route.supportedParameters,
               reasoning: route.reasoning,
               interleavedReasoningField: route.interleavedReasoningField,
+              compatibility: route.compatibility,
               upstreamModelId: route.realModelId,
             },
           });
@@ -596,6 +607,7 @@ export async function startProxyCatalog(
             headers: route.headers,
             useResponsesLite: route.useResponsesLite,
             preferWebSockets: route.preferWebSockets,
+            compatibility: route.compatibility,
             onDebug: (msg: string) => plog(() => msg),
             onWebSocketDiagnostic: webSocketDiagnosticsLogPath
               ? event => writeWebSocketDiagnosticLog(webSocketDiagnosticsLogPath, event)
@@ -826,6 +838,7 @@ export function startProxy(
     interleavedReasoningField?: string;
     useResponsesLite?: boolean;
     preferWebSockets?: boolean;
+    compatibility?: ModelRuntimeCompatibility;
     headers?: Record<string, string>;
   },
   apiKey?: string,
@@ -851,6 +864,7 @@ export function startProxy(
     interleavedReasoningField: sdk?.interleavedReasoningField,
     useResponsesLite: sdk?.useResponsesLite,
     preferWebSockets: sdk?.preferWebSockets,
+    compatibility: sdk?.compatibility,
     headers: sdk?.headers,
   }], clientModelId, debug);
 }

--- a/src/registry/add-template.ts
+++ b/src/registry/add-template.ts
@@ -116,11 +116,13 @@ export async function addProviderFromTemplate(
 
   const pricingCache = loadPricingCache();
   const platform = pricingPlatformForProvider(template.id, template.id);
-  const pricedModels = enrichModelsWithPricing(
-    usableModels.map(m => ({ ...m, apiUrl: fetched.baseUrl })),
-    buildPricingIndex(pricingCache),
-    platform,
-  );
+  const discoveredModels = usableModels.map(m => ({
+    ...m,
+    apiUrl: m.apiUrl ?? fetched.baseUrl,
+  }));
+  const pricedModels = template.preserveModelPricing
+    ? discoveredModels
+    : enrichModelsWithPricing(discoveredModels, buildPricingIndex(pricingCache), platform);
   const account = `provider:${template.id}`;
   const result: AddTemplateResult = await withProviderMutationLock(template.id, async () => {
     const currentState = await withRegistryWriteLock(() => {
@@ -183,6 +185,7 @@ export async function addProviderFromTemplate(
           enabled: true,
           authRef,
           authType: trimmedKey ? template.authType : 'none',
+          ...(template.preserveModelPricing ? { preserveModelPricing: true } : {}),
           ...(!trimmedKey && template.anonymousFreeModels
             ? { subscriptionFilter: 'free' as const }
             : {}),

--- a/src/registry/convert.ts
+++ b/src/registry/convert.ts
@@ -17,12 +17,14 @@ function modelToCached(model: LocalProviderModel): CachedModel {
     freeStatus: model.freeStatus,
     modelFormat: model.modelFormat,
     npm: model.npm,
-    apiUrl: model.apiBaseUrl,
+    apiUrl: model.apiBaseUrl ?? model.baseUrl,
     supportedParameters: model.supportedParameters,
     reasoning: model.reasoning,
     interleavedReasoningField: model.interleavedReasoningField,
     useResponsesLite: model.useResponsesLite,
     preferWebSockets: model.preferWebSockets,
+    modalities: model.modalities,
+    compatibility: model.compatibility,
   };
 }
 

--- a/src/registry/fetch-template-models.ts
+++ b/src/registry/fetch-template-models.ts
@@ -141,6 +141,103 @@ function parseModelList(body: OpenAiModelListResponse, npm: string): CachedModel
   return models;
 }
 
+function materializeTemplateModel(
+  template: ProviderTemplate,
+  model: NonNullable<ProviderTemplate['staticModels']>[number],
+  baseUrl: string,
+): CachedModel {
+  const npm = model.npm ?? template.npm;
+  const { id, upstreamModelId: normalizedUpstream } = normalizeGoogleModelId(model.id, npm);
+  const family = model.family ?? (id.split(/[-/:]/)[0] ?? id);
+  const freeStatus = model.freeStatus ?? classifyFreeStatus({ model });
+
+  return {
+    ...model,
+    id,
+    name: normalizeGoogleDisplayName(model.name, id),
+    upstreamModelId: model.upstreamModelId ?? normalizedUpstream,
+    family,
+    brand: model.brand ?? deriveBrand(family),
+    contextWindow: model.contextWindow ?? resolveContextWindow(id),
+    isFree: model.isFree ?? isFreeStatus(freeStatus),
+    freeStatus,
+    modelFormat: model.modelFormat ?? modelFormatForNpm(npm),
+    npm,
+    apiUrl: model.apiUrl ?? baseUrl,
+  };
+}
+
+function normalizeTemplateOverlay(
+  template: ProviderTemplate,
+  model: NonNullable<ProviderTemplate['staticModels']>[number],
+): NonNullable<ProviderTemplate['staticModels']>[number] {
+  const npm = model.npm ?? template.npm;
+  const { id } = normalizeGoogleModelId(model.id, npm);
+  const family = model.family;
+  const hasFreeMetadata = model.cost !== undefined
+    || model.isFree !== undefined
+    || model.freeStatus !== undefined;
+  const freeStatus = hasFreeMetadata
+    ? model.freeStatus ?? classifyFreeStatus({ model })
+    : undefined;
+
+  return {
+    ...model,
+    id,
+    name: normalizeGoogleDisplayName(model.name, id),
+    ...(model.upstreamModelId !== undefined
+      ? { upstreamModelId: normalizeGoogleModelId(model.upstreamModelId, npm).upstreamModelId }
+      : {}),
+    ...(model.npm !== undefined ? { npm } : {}),
+    ...(model.modelFormat !== undefined
+      ? { modelFormat: model.modelFormat }
+      : model.npm !== undefined
+        ? { modelFormat: modelFormatForNpm(npm) }
+        : {}),
+    ...(family !== undefined ? { family, brand: model.brand ?? deriveBrand(family) } : {}),
+    ...(freeStatus !== undefined
+      ? {
+          freeStatus,
+          isFree: model.isFree ?? isFreeStatus(freeStatus),
+        }
+      : {}),
+  };
+}
+
+/**
+ * Layer curated per-model metadata over a provider's live model list.
+ *
+ * Mixed-protocol providers expose one discovery endpoint but require different
+ * SDK packages and base URLs per model. `allowlist` also provides a fail-closed
+ * way to exclude protocols the runtime intentionally does not support.
+ */
+export function applyTemplateModelMetadata(
+  template: ProviderTemplate,
+  discovered: CachedModel[],
+  _baseUrl: string,
+): CachedModel[] {
+  const curated = new Map(
+    (template.staticModels ?? [])
+      .map(model => normalizeTemplateOverlay(template, model))
+      .map(model => [model.id, model] as const),
+  );
+
+  const visible = template.staticModelPolicy === 'allowlist'
+    ? discovered.filter(model => curated.has(model.id))
+    : discovered;
+
+  return visible.map(model => {
+    const overlay = curated.get(model.id);
+    if (!overlay) return model;
+    return {
+      ...model,
+      ...overlay,
+      id: model.id,
+      upstreamModelId: overlay.upstreamModelId ?? model.upstreamModelId,
+    };
+  });
+}
+
 export interface FetchTemplateModelsResult {
   models: CachedModel[];
   baseUrl: string;
@@ -166,19 +263,8 @@ export async function fetchTemplateModels(
   }
 
   if (template.modelSource === 'static-seed') {
-    const models: CachedModel[] = (template.staticModels || []).map(sm => {
-      const family = sm.id.split(/[-/:]/)[0] ?? sm.id;
-      return {
-        id: sm.id,
-        name: sm.name,
-        upstreamModelId: sm.id,
-        family,
-        brand: deriveBrand(family),
-        contextWindow: resolveContextWindow(sm.id),
-        modelFormat: modelFormatForNpm(template.npm),
-        npm: template.npm,
-      };
-    });
+    const models = (template.staticModels ?? [])
+      .map(model => materializeTemplateModel(template, model, baseUrl));
     return { models, baseUrl };
   }
 
@@ -260,7 +346,7 @@ export async function fetchTemplateModels(
       // Failed to parse, use empty object
     }
 
-    const models = parseModelList(json, template.npm);
+    const models = applyTemplateModelMetadata(template, parseModelList(json, template.npm), baseUrl);
     if (models.length === 0) {
       return {
         models: [],

--- a/src/registry/io.ts
+++ b/src/registry/io.ts
@@ -101,6 +101,9 @@ function parseProvider(raw: unknown): RegistryProvider | null {
   if (p.subscriptionFilter === 'free') {
     provider.subscriptionFilter = p.subscriptionFilter;
   }
+  if (typeof p.preserveModelPricing === 'boolean') {
+    provider.preserveModelPricing = p.preserveModelPricing;
+  }
   if (p.authType === 'api' || p.authType === 'oauth' || p.authType === 'none') {
     provider.authType = p.authType;
   }
@@ -127,6 +130,9 @@ function hasValidStrictProviderFields(raw: unknown): boolean {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return false;
   const provider = raw as Record<string, unknown>;
   if (hasOwn(provider, 'subscriptionFilter') && provider.subscriptionFilter !== 'free') {
+    return false;
+  }
+  if (hasOwn(provider, 'preserveModelPricing') && typeof provider.preserveModelPricing !== 'boolean') {
     return false;
   }
   if (

--- a/src/registry/materialize.ts
+++ b/src/registry/materialize.ts
@@ -79,6 +79,8 @@ export function cachedModelToLocal(
     interleavedReasoningField: cached.interleavedReasoningField ?? modelsDev?.interleaved?.field,
     useResponsesLite: cached.useResponsesLite,
     preferWebSockets: cached.preferWebSockets,
+    modalities: cached.modalities,
+    compatibility: cached.compatibility,
   };
 }
 

--- a/src/registry/pricing.ts
+++ b/src/registry/pricing.ts
@@ -228,6 +228,7 @@ export function applyPricingToRegistryProviders(
   const index = buildPricingIndex(cache);
   let changed = false;
   for (const provider of registry.providers) {
+    if (provider.preserveModelPricing) continue;
     if (!provider.modelsCache?.models.length) continue;
     const platform = TEMPLATE_TO_PRICING_PLATFORM[provider.templateId] ?? TEMPLATE_TO_PRICING_PLATFORM[provider.id];
     const enriched = enrichModelsWithPricing(provider.modelsCache.models, index, platform);

--- a/src/registry/refresh-models.ts
+++ b/src/registry/refresh-models.ts
@@ -251,7 +251,7 @@ async function refreshApiListProvider(
       return { models: [], error: fetched.error ?? 'No models returned.', baseUrl: fetched.baseUrl };
     }
     return {
-      models: fetched.models.map(m => ({ ...m, apiUrl: fetched.baseUrl })),
+      models: fetched.models.map(m => ({ ...m, apiUrl: m.apiUrl ?? fetched.baseUrl })),
       baseUrl: fetched.baseUrl,
     };
   }
@@ -274,7 +274,7 @@ async function refreshApiListProvider(
   return {
     models: usableModels.map(m => ({
       ...m,
-      apiUrl: fetched.baseUrl,
+      apiUrl: m.apiUrl ?? fetched.baseUrl,
     })),
     baseUrl: fetched.baseUrl,
   };
@@ -421,7 +421,9 @@ export async function refreshProviderModels(
 
     const pricingCache = loadPricingCache();
     const platform = pricingPlatformForProvider(provider.templateId, provider.id);
-    const enriched = enrichModelsWithPricing(models, buildPricingIndex(pricingCache), platform);
+    const enriched = provider.preserveModelPricing
+      ? models
+      : enrichModelsWithPricing(models, buildPricingIndex(pricingCache), platform);
 
     await withRegistryWriteLock(() => {
       const currentRegistry = loadRegistryStrict();

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -1,6 +1,7 @@
 // src/registry/types.ts — native provider registry schema (no secrets)
 
 import type { FreeStatus } from '../free-models.js';
+import type { ModelRuntimeCompatibility } from '../model-runtime-compatibility.js';
 
 export const REGISTRY_SCHEMA_VERSION = 1;
 
@@ -32,6 +33,10 @@ export interface CachedModel {
   useResponsesLite?: boolean;
   /** Backend capability: model must use the WebSocket Responses transport instead of HTTP. */
   preferWebSockets?: boolean;
+  /** Supported input modalities preserved from curated provider metadata. */
+  modalities?: ('text' | 'image')[];
+  /** Provider-neutral per-model wire quirks. */
+  compatibility?: ModelRuntimeCompatibility;
 }
 
 export interface RegistryProvider {
@@ -42,6 +47,8 @@ export interface RegistryProvider {
   authRef: string;
   authType?: 'api' | 'oauth' | 'none';
   subscriptionFilter?: RegistrySubscriptionFilter;
+  /** Keep provider/curated costs instead of replacing them with the global pricing cache. */
+  preserveModelPricing?: boolean;
   api: {
     npm?: string;
     url?: string;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -181,6 +181,7 @@ export function enrichServerModelReasoning(model: ServerModelInfo): ServerModelI
     supportedParameters: model.supportedParameters,
     reasoning: model.reasoning,
     interleavedReasoningField: model.interleavedReasoningField,
+    compatibility: model.compatibility,
   });
   if (!caps.defaultLevel) return model;
   return { ...model, defaultEffort: caps.defaultLevel };

--- a/src/server/models.ts
+++ b/src/server/models.ts
@@ -6,6 +6,7 @@ import { normalizeModelAliases } from '../model-aliases.js';
 import { maskGatewayModelId } from './vendor-mask.js';
 import type { FreeStatus } from '../free-models.js';
 import type { ModelAlias } from '../types.js';
+import type { ModelRuntimeCompatibility } from '../model-runtime-compatibility.js';
 
 export interface GatewayModelOptions {
   maskGatewayIds?: boolean;
@@ -46,6 +47,8 @@ export interface ServerModelInfo {
   useResponsesLite?: boolean;
   /** Backend capability: model must use the WebSocket Responses transport instead of HTTP. */
   preferWebSockets?: boolean;
+  /** Provider-neutral per-model wire quirks. */
+  compatibility?: ModelRuntimeCompatibility;
   /** Fallback reasoning effort when the client omits output_config.effort. */
   defaultEffort?: string;
   contextWindow?: number;

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -353,6 +353,12 @@ async function handleAnthropicMessages(
       extraHeaders: model.headers,
       refreshToken,
       onTokenRefreshed: refreshed => { model.apiKey = refreshed; },
+      // Echo the exact requested id when it differs from the upstream id, so
+      // clients that key context windows on the response model still resolve.
+      responseModelOverride:
+        typeof body.model === 'string' && body.model !== upstreamModelId(model)
+          ? body.model
+          : undefined,
       onUpstreamError: options.inferenceLogPath
         ? (statusCode, errorContent) => writeInferenceResponseErrorLog(options.inferenceLogPath!, {
             requestId,
@@ -406,6 +412,7 @@ async function handleAnthropicMessages(
         supportedParameters: model.supportedParameters,
         reasoning: model.reasoning,
         interleavedReasoningField: model.interleavedReasoningField,
+        compatibility: model.compatibility,
         upstreamModelId: upstreamModelId(model),
       },
       maxTools: npmMaxTools,
@@ -725,6 +732,7 @@ async function getOrInitLanguageModel(
       headers: model.headers,
       useResponsesLite: model.useResponsesLite,
       preferWebSockets: model.preferWebSockets,
+      compatibility: model.compatibility,
       onWebSocketDiagnostic: webSocketDiagnosticsLogPath
         ? event => writeWebSocketDiagnosticLog(webSocketDiagnosticsLogPath, event)
         : undefined,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 // src/types.ts
 
 import type { FreeStatus } from './free-models.js';
+import type { ModelRuntimeCompatibility } from './model-runtime-compatibility.js';
 
 export type ModelFormat = 'anthropic' | 'openai' | 'unsupported';
 
@@ -42,6 +43,8 @@ export interface LocalProviderModel {
   isFree?: boolean;
   freeStatus?: FreeStatus;
   modalities?: ('text' | 'image')[];
+  /** Provider-neutral per-model wire quirks. */
+  compatibility?: ModelRuntimeCompatibility;
 }
 
 export interface LocalProvider {

--- a/src/upstream-forward.ts
+++ b/src/upstream-forward.ts
@@ -1,4 +1,5 @@
-import { Readable } from 'node:stream';
+import { Readable, Transform } from 'node:stream';
+import { StringDecoder } from 'node:string_decoder';
 import type { ServerResponse } from 'node:http';
 import { sanitizeCredential } from './server/auth.js';
 import { CLAUDE_CODE_USER_AGENT } from './oauth/claude-identity.js';
@@ -105,6 +106,51 @@ export interface RelayAnthropicOptions {
   onTokenRefreshed?: (token: string) => void;
   onUpstreamError?: (statusCode: number, body: string) => void;
   signal?: AbortSignal;
+  /**
+   * Echo this exact model id in the relayed response instead of the upstream's.
+   * Claude Code resolves context windows from the response `model` field but
+   * uses the request id for preflight, so a passthrough route selected through
+   * an alias must echo the alias or auto-compaction misses its window config
+   * (see CLAUDE.md "alias response-model echo"). Rewrites the JSON body's
+   * `model` and the SSE `message_start` event; every other byte passes through.
+   */
+  responseModelOverride?: string;
+}
+
+/**
+ * Line-preserving SSE transform that rewrites the `message_start` event's
+ * `message.model` to the requested id. Buffers only up to one line; every
+ * line that is not a parseable `message_start` data line passes through
+ * byte-for-byte.
+ */
+export function anthropicSseModelRewrite(override: string): Transform {
+  const decoder = new StringDecoder('utf8');
+  let tail = '';
+  const rewriteLine = (line: string): string => {
+    if (!line.startsWith('data:') || !line.includes('"message_start"')) return line;
+    try {
+      const parsed = JSON.parse(line.slice(5)) as { type?: string; message?: { model?: unknown } };
+      if (parsed.type === 'message_start' && parsed.message && typeof parsed.message.model === 'string') {
+        parsed.message.model = override;
+        return 'data: ' + JSON.stringify(parsed);
+      }
+    } catch {
+      // Not a single-line JSON payload; relay it untouched.
+    }
+    return line;
+  };
+  return new Transform({
+    transform(chunk: Buffer, _encoding, callback) {
+      const lines = (tail + decoder.write(chunk)).split('\n');
+      tail = lines.pop() ?? '';
+      const rewritten = lines.map(rewriteLine);
+      callback(null, rewritten.length ? rewritten.join('\n') + '\n' : '');
+    },
+    flush(callback) {
+      const rest = tail + decoder.end();
+      callback(null, rest ? rewriteLine(rest) : '');
+    },
+  });
 }
 
 export async function relayAnthropicMessages(
@@ -153,9 +199,16 @@ export async function relayAnthropicMessages(
       'Cache-Control': 'no-cache',
       'Connection': 'keep-alive',
     });
-    Readable.fromWeb(upstreamRes.body as Parameters<typeof Readable.fromWeb>[0])
-      .on('error', () => res.destroy())
-      .pipe(res);
+    const upstream = Readable.fromWeb(upstreamRes.body as Parameters<typeof Readable.fromWeb>[0])
+      .on('error', () => res.destroy());
+    if (options.responseModelOverride) {
+      upstream
+        .pipe(anthropicSseModelRewrite(options.responseModelOverride))
+        .on('error', () => res.destroy())
+        .pipe(res);
+    } else {
+      upstream.pipe(res);
+    }
     return;
   }
 
@@ -165,13 +218,22 @@ export async function relayAnthropicMessages(
     return;
   }
 
-  const text = await upstreamRes.text();
+  let text = await upstreamRes.text();
+  let parsed: unknown;
   try {
-    JSON.parse(text);
+    parsed = JSON.parse(text);
   } catch {
     res.writeHead(502, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ type: 'error', error: { type: 'api_error', message: 'Upstream response was not valid JSON' } }));
     return;
+  }
+  if (
+    options.responseModelOverride
+    && parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+    && typeof (parsed as Record<string, unknown>).model === 'string'
+  ) {
+    (parsed as Record<string, unknown>).model = options.responseModelOverride;
+    text = JSON.stringify(parsed);
   }
   res.writeHead(200, {
     'Content-Type': 'application/json',

--- a/tests/fetch-template-models.test.ts
+++ b/tests/fetch-template-models.test.ts
@@ -198,6 +198,86 @@ describe('fetchTemplateModels', () => {
     );
   });
 
+  it('overlays curated mixed-protocol metadata and allowlists live models', async () => {
+    const mixedTemplate = template({
+      id: 'mixed-provider',
+      name: 'Mixed Provider',
+      npm: '@ai-sdk/openai-compatible',
+      defaultBaseUrl: 'https://mixed.example/v1',
+      staticModelPolicy: 'allowlist',
+      staticModels: [
+        {
+          id: 'qwen-max',
+          name: 'Qwen Max',
+          upstreamModelId: 'qwen-max',
+          modelFormat: 'anthropic',
+          npm: '@ai-sdk/anthropic',
+          apiUrl: 'https://mixed.example/anthropic',
+          contextWindow: 1_000_000,
+          modalities: ['text', 'image'],
+        },
+        {
+          id: 'kimi-code',
+          name: 'Kimi Code',
+          upstreamModelId: 'kimi-code',
+          modelFormat: 'openai',
+          npm: '@ai-sdk/openai-compatible',
+          apiUrl: 'https://mixed.example/v1',
+          contextWindow: 262_144,
+          compatibility: {
+            reasoningEffortMap: { low: null, high: 'max' },
+            thinkingFormat: 'deepseek',
+          },
+        },
+      ],
+    });
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({
+        data: [
+          {
+            id: 'qwen-max',
+            name: 'live qwen',
+            pricing: { input_per_1m_tokens: 2, output_per_1m_tokens: 6 },
+          },
+          {
+            id: 'kimi-code',
+            name: 'live kimi',
+            supported_parameters: ['tools', 'reasoning_effort'],
+          },
+          { id: 'responses-only', name: 'unsupported responses model' },
+        ],
+      }),
+    } as Response);
+
+    const result = await fetchTemplateModels(mixedTemplate, 'sk-test');
+
+    expect(result.error).toBeUndefined();
+    expect(result.models.map(model => model.id)).toEqual(['qwen-max', 'kimi-code']);
+    expect(result.models[0]).toMatchObject({
+      name: 'Qwen Max',
+      modelFormat: 'anthropic',
+      npm: '@ai-sdk/anthropic',
+      apiUrl: 'https://mixed.example/anthropic',
+      contextWindow: 1_000_000,
+      modalities: ['text', 'image'],
+      cost: { input: 2, output: 6 },
+    });
+    expect(result.models[1]).toMatchObject({
+      name: 'Kimi Code',
+      modelFormat: 'openai',
+      npm: '@ai-sdk/openai-compatible',
+      apiUrl: 'https://mixed.example/v1',
+      contextWindow: 262_144,
+      compatibility: {
+        reasoningEffortMap: { low: null, high: 'max' },
+        thinkingFormat: 'deepseek',
+      },
+      supportedParameters: ['tools', 'reasoning_effort'],
+    });
+  });
+
   it('derives verified free status from zero pricing even when provider flag is false', async () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: true,

--- a/tests/http-proxy-routes.test.ts
+++ b/tests/http-proxy-routes.test.ts
@@ -37,22 +37,45 @@ const providers: LocalProvider[] = [
 ];
 
 describe('HTTP proxy routes', () => {
-  it('uses stable provider-prefixed names and includes only AI SDK favorites', () => {
+  it('uses stable provider-prefixed names for SDK and Anthropic passthrough favorites', () => {
     const result = buildHttpProxyRoutes(providers, [
       { providerId: 'groq', modelId: 'llama-3.3-70b' },
       { providerId: 'anthropic', modelId: 'claude-sonnet-4-6' },
       { providerId: 'missing', modelId: 'gone' },
     ]);
 
-    expect(result.routes).toHaveLength(1);
+    expect(result.routes).toHaveLength(2);
     expect(result.routes[0]).toMatchObject({
       aliasId: 'clodex:groq:llama-3.3-70b[1m]',
       realModelId: 'llama-3.3-70b-versatile',
       npm: '@ai-sdk/groq',
       apiKey: 'groq-key',
     });
-    expect(result.unsupported).toEqual([{ providerId: 'anthropic', modelId: 'claude-sonnet-4-6' }]);
+    expect(result.routes[1]).toMatchObject({
+      aliasId: 'clodex:anthropic:claude-sonnet-4-6[1m]',
+      realModelId: 'claude-sonnet-4-6',
+      modelFormat: 'anthropic',
+      upstreamUrl: 'https://api.anthropic.com',
+      apiKey: 'anthropic-key',
+    });
+    expect(result.unsupported).toEqual([]);
     expect(result.unavailable).toEqual([{ providerId: 'missing', modelId: 'gone' }]);
+  });
+
+  it('rejects an Anthropic favorite without a passthrough base URL', () => {
+    const missingBase = [{
+      ...providers[1]!,
+      models: [{ ...providers[1]!.models[0]!, baseUrl: undefined }],
+    }];
+
+    const result = buildHttpProxyRoutes(missingBase, [
+      { providerId: 'anthropic', modelId: 'claude-sonnet-4-6' },
+    ]);
+
+    expect(result.routes).toEqual([]);
+    expect(result.unsupported).toEqual([
+      { providerId: 'anthropic', modelId: 'claude-sonnet-4-6' },
+    ]);
   });
 
   it('does not create a route when the provider credential is empty', () => {

--- a/tests/model-runtime-compatibility.test.ts
+++ b/tests/model-runtime-compatibility.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { transformOpenAiCompatibleRequestBody } from '../src/model-runtime-compatibility.js';
+
+describe('transformOpenAiCompatibleRequestBody', () => {
+  it('applies OpenAI-compatible field and message compatibility rules without mutating input', () => {
+    const input = {
+      store: false,
+      prompt_cache_retention: '24h',
+      max_completion_tokens: 8192,
+      reasoning_effort: 'max',
+      messages: [
+        { role: 'developer', content: 'system instructions' },
+        { role: 'assistant', content: null, tool_calls: [{ id: 'call_1' }] },
+        { role: 'assistant', content: 'answer', reasoning_content: 'kept' },
+      ],
+    };
+
+    const result = transformOpenAiCompatibleRequestBody(input, {
+      supportsStore: false,
+      supportsDeveloperRole: false,
+      supportsLongCacheRetention: false,
+      maxTokensField: 'max_tokens',
+      requiresReasoningContentOnAssistantMessages: true,
+      thinkingFormat: 'deepseek',
+    });
+
+    expect(result).toEqual({
+      max_tokens: 8192,
+      reasoning_effort: 'max',
+      thinking: { type: 'enabled' },
+      messages: [
+        { role: 'system', content: 'system instructions' },
+        {
+          role: 'assistant',
+          content: null,
+          tool_calls: [{ id: 'call_1' }],
+          reasoning_content: '',
+        },
+        { role: 'assistant', content: 'answer', reasoning_content: 'kept' },
+      ],
+    });
+    expect(input).toEqual({
+      store: false,
+      prompt_cache_retention: '24h',
+      max_completion_tokens: 8192,
+      reasoning_effort: 'max',
+      messages: [
+        { role: 'developer', content: 'system instructions' },
+        { role: 'assistant', content: null, tool_calls: [{ id: 'call_1' }] },
+        { role: 'assistant', content: 'answer', reasoning_content: 'kept' },
+      ],
+    });
+  });
+
+  it('enables Qwen thinking only when an effort is present', () => {
+    expect(transformOpenAiCompatibleRequestBody(
+      { reasoning_effort: 'high', messages: [] },
+      { thinkingFormat: 'qwen' },
+    )).toEqual({
+      reasoning_effort: 'high',
+      enable_thinking: true,
+      messages: [],
+    });
+
+    expect(transformOpenAiCompatibleRequestBody(
+      { messages: [] },
+      { thinkingFormat: 'qwen' },
+    )).toEqual({ messages: [] });
+  });
+
+  it('can normalize output tokens in either direction', () => {
+    expect(transformOpenAiCompatibleRequestBody(
+      { max_tokens: 2048 },
+      { maxTokensField: 'max_completion_tokens' },
+    )).toEqual({ max_completion_tokens: 2048 });
+  });
+});

--- a/tests/pricing.test.ts
+++ b/tests/pricing.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  applyPricingToRegistryProviders,
   buildPricingIndex,
   enrichModelsWithPricing,
   loadBundledPricingCache,
@@ -49,6 +50,49 @@ describe('pricing enrich', () => {
     }];
     const enriched = enrichModelsWithPricing(models, index, 'groq');
     expect(enriched[0]?.cost?.input).toBe(0.59);
+  });
+
+  it('preserves provider-owned pricing when the registry opts out of enrichment', () => {
+    const registry = {
+      schemaVersion: 1 as const,
+      providers: [{
+        id: 'mixed-provider',
+        templateId: 'mixed-provider',
+        name: 'Mixed Provider',
+        enabled: true,
+        authRef: 'keyring:provider:mixed-provider',
+        preserveModelPricing: true,
+        api: { npm: '@ai-sdk/openai-compatible' },
+        addedAt: '2026-08-07T00:00:00.000Z',
+        modelsCache: {
+          fetchedAt: '2026-08-07T00:00:00.000Z',
+          models: [{
+            id: 'kimi-k2.7-code',
+            name: 'Kimi K2.7 Code',
+            upstreamModelId: 'kimi-k2.7-code',
+            modelFormat: 'openai' as const,
+            cost: { input: 0.95, output: 4 },
+          }],
+        },
+      }],
+    };
+    const changed = applyPricingToRegistryProviders(registry, {
+      models: [{
+        model_id: 'kimi-k2.7-code',
+        pricing: [{
+          platform: 'openrouter',
+          tier: 'standard',
+          input_per_1m_tokens: 99,
+          output_per_1m_tokens: 199,
+        }],
+      }],
+    });
+
+    expect(changed).toBe(false);
+    expect(registry.providers[0]?.modelsCache?.models[0]?.cost).toEqual({
+      input: 0.95,
+      output: 4,
+    });
   });
 
   it('marks enriched zero-cost models as verified free', () => {

--- a/tests/provider-factory.test.ts
+++ b/tests/provider-factory.test.ts
@@ -275,6 +275,88 @@ describe('getReasoningCapabilities', () => {
     });
     expect(effortProviderOptions('@ai-sdk/openai-compatible', 'low', 'glm-5.2')).toBeUndefined();
   });
+
+
+  it('honors a curated per-model effort map before family defaults', () => {
+    const metadata = {
+      providerId: 'opencode-go',
+      reasoning: true,
+      compatibility: {
+        reasoningEffortMap: { low: null, high: 'max' },
+      },
+    };
+
+    expect(getPatchReasoningCapabilities(
+      '@ai-sdk/openai-compatible',
+      'custom-reasoning-model',
+      metadata,
+    )).toMatchObject({
+      levels: ['high'],
+      defaultLevel: 'high',
+      mode: 'controllable',
+      source: 'provider-metadata',
+    });
+    expect(effortProviderOptions(
+      '@ai-sdk/openai-compatible',
+      'low',
+      'custom-reasoning-model',
+      metadata,
+    )).toBeUndefined();
+    expect(effortProviderOptions(
+      '@ai-sdk/openai-compatible',
+      'high',
+      'custom-reasoning-model',
+      metadata,
+    )).toEqual({ opencodeGo: { reasoningEffort: 'max' } });
+  });
+
+  it('uses generic documented effort controls when compatibility explicitly enables them', () => {
+    const metadata = {
+      providerId: 'opencode-go',
+      reasoning: true,
+      compatibility: {
+        supportsReasoningEffort: true,
+        thinkingFormat: 'qwen' as const,
+      },
+    };
+
+    expect(getPatchReasoningCapabilities(
+      '@ai-sdk/openai-compatible',
+      'qwen-custom',
+      metadata,
+    )).toMatchObject({
+      levels: ['low', 'medium', 'high'],
+      defaultLevel: 'medium',
+      mode: 'controllable',
+      source: 'provider-metadata',
+    });
+    expect(effortProviderOptions(
+      '@ai-sdk/openai-compatible',
+      'high',
+      'qwen-custom',
+      metadata,
+    )).toEqual({ opencodeGo: { reasoningEffort: 'high' } });
+  });
+
+  it('treats an explicit reasoning-effort disable as internal-only reasoning', () => {
+    const metadata = {
+      providerId: 'opencode-go',
+      reasoning: true,
+      compatibility: { supportsReasoningEffort: false },
+    };
+
+    expect(getReasoningCapabilities(
+      '@ai-sdk/openai-compatible',
+      'kimi-custom',
+      metadata,
+    )).toMatchObject({ levels: [], mode: 'internal-only', source: 'provider-metadata' });
+    expect(effortProviderOptions(
+      '@ai-sdk/openai-compatible',
+      'high',
+      'kimi-custom',
+      metadata,
+    )).toBeUndefined();
+  });
 });
 
 describe('effortProviderOptions + deepMergeProviderOptions', () => {
@@ -558,6 +640,49 @@ describe('createLanguageModel', () => {
       apiKey: 'sk-test',
       baseURL: 'https://api.z.ai/api/coding/paas/v4',
       headers: { 'X-Plan': 'coding' },
+    });
+    vi.doUnmock('@ai-sdk/openai-compatible');
+  });
+
+  it('installs the per-model compatibility request transformer for openai-compatible providers', async () => {
+    const factory = vi.fn((modelId: string) => ({ modelId }));
+    const createOpenAICompatible = vi.fn(() => factory);
+    vi.doMock('@ai-sdk/openai-compatible', () => ({ createOpenAICompatible }));
+
+    const { createLanguageModel: create } = await import('../src/provider-factory.js');
+    await create({
+      npm: '@ai-sdk/openai-compatible',
+      modelId: 'deepseek-v4-pro',
+      apiKey: 'sk-test',
+      baseURL: 'https://mixed.example/v1',
+      providerId: 'opencode-go',
+      compatibility: {
+        supportsStore: false,
+        supportsDeveloperRole: false,
+        maxTokensField: 'max_tokens',
+        thinkingFormat: 'deepseek',
+      },
+    });
+
+    expect(createOpenAICompatible).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'opencode-go',
+      apiKey: 'sk-test',
+      baseURL: 'https://mixed.example/v1',
+      transformRequestBody: expect.any(Function),
+    }));
+    const options = createOpenAICompatible.mock.calls[0]?.[0] as {
+      transformRequestBody: (body: Record<string, unknown>) => Record<string, unknown>;
+    };
+    expect(options.transformRequestBody({
+      store: false,
+      max_completion_tokens: 4096,
+      reasoning_effort: 'high',
+      messages: [{ role: 'developer', content: 'instructions' }],
+    })).toEqual({
+      max_tokens: 4096,
+      reasoning_effort: 'high',
+      thinking: { type: 'enabled' },
+      messages: [{ role: 'system', content: 'instructions' }],
     });
     vi.doUnmock('@ai-sdk/openai-compatible');
   });

--- a/tests/registry-convert.test.ts
+++ b/tests/registry-convert.test.ts
@@ -16,6 +16,11 @@ const sampleProvider: LocalProvider = {
     npm: '@ai-sdk/groq',
     isFree: true,
     freeStatus: 'verified_free',
+    modalities: ['text', 'image'],
+    compatibility: {
+      reasoningEffortMap: { high: 'max' },
+      thinkingFormat: 'deepseek',
+    },
   }],
 };
 
@@ -31,6 +36,11 @@ describe('localProviderToRegistry', () => {
     expect(entry?.modelsCache?.models[0]?.upstreamModelId).toBe('llama-3.3-70b');
     expect(entry?.modelsCache?.models[0]?.isFree).toBe(true);
     expect(entry?.modelsCache?.models[0]?.freeStatus).toBe('verified_free');
+    expect(entry?.modelsCache?.models[0]?.modalities).toEqual(['text', 'image']);
+    expect(entry?.modelsCache?.models[0]?.compatibility).toEqual({
+      reasoningEffortMap: { high: 'max' },
+      thinkingFormat: 'deepseek',
+    });
   });
 
   it('rejects invalid provider ids', () => {

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -59,6 +59,7 @@ describe('registry io', () => {
       name: 'Groq',
       enabled: true,
       authRef: 'keyring:provider:groq',
+      preserveModelPricing: true,
       api: { npm: '@ai-sdk/groq' },
       addedAt: '2026-06-09T00:00:00.000Z',
       modelsCache: {
@@ -77,6 +78,7 @@ describe('registry io', () => {
     expect(loaded.providers).toHaveLength(1);
     expect(loaded.providers[0]?.id).toBe('groq');
     expect(loaded.providers[0]?.modelsCache?.models[0]?.npm).toBe('@ai-sdk/groq');
+    expect(loaded.providers[0]?.preserveModelPricing).toBe(true);
   });
 
   it('writes providers.json with restrictive permissions', () => {
@@ -296,12 +298,22 @@ describe('materializeRegistry', () => {
           upstreamModelId: 'gpt-5.5',
           modelFormat: 'openai',
           npm: '@ai-sdk/openai',
+          modalities: ['text', 'image'],
+          compatibility: {
+            reasoningEffortMap: { high: 'max' },
+            thinkingFormat: 'deepseek',
+          },
         }],
       },
     });
     const locals = materializeRegistry(registry, () => 'sk-test');
     expect(locals).toHaveLength(1);
     expect(locals[0]?.models[0]?.upstreamModelId).toBe('gpt-5.5');
+    expect(locals[0]?.models[0]?.modalities).toEqual(['text', 'image']);
+    expect(locals[0]?.models[0]?.compatibility).toEqual({
+      reasoningEffortMap: { high: 'max' },
+      thinkingFormat: 'deepseek',
+    });
     expect(locals[0]?.apiKey).toBe('sk-test');
     expect(locals[0]?.authType).toBe('oauth');
   });

--- a/tests/upstream-forward.test.ts
+++ b/tests/upstream-forward.test.ts
@@ -1,6 +1,12 @@
 // tests/upstream-forward.test.ts
-import { describe, it, expect, vi } from 'vitest';
-import { anthropicUpstreamHeaders, fetchWithOAuthRetry } from '../src/upstream-forward.js';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { Transform } from 'node:stream';
+import {
+  anthropicUpstreamHeaders,
+  fetchWithOAuthRetry,
+  anthropicSseModelRewrite,
+  relayAnthropicMessages,
+} from '../src/upstream-forward.js';
 
 describe('anthropicUpstreamHeaders', () => {
   it('includes bearer and x-api-key', () => {
@@ -123,5 +129,114 @@ describe('fetchWithOAuthRetry', () => {
     expect(result.refreshed).toBe(true);
     expect(request).toHaveBeenCalledTimes(2);
     expect(refreshToken).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('anthropicSseModelRewrite', () => {
+  const collect = async (transform: Transform, chunks: string[]): Promise<string> => {
+    const out: Buffer[] = [];
+    transform.on('data', chunk => out.push(Buffer.from(chunk)));
+    for (const chunk of chunks) transform.write(Buffer.from(chunk, 'utf8'));
+    await new Promise<void>((resolve, reject) => {
+      transform.on('end', resolve);
+      transform.on('error', reject);
+      transform.end();
+    });
+    return Buffer.concat(out).toString('utf8');
+  };
+
+  const messageStart = 'event: message_start\n'
+    + 'data: {"type":"message_start","message":{"id":"msg_1","model":"claude-sonnet-4-5","usage":{"input_tokens":1}}}\n\n';
+  const textDelta = 'event: content_block_delta\n'
+    + 'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"model claude-sonnet-4-5"}}\n\n';
+
+  it('rewrites only the message_start model and passes every other byte through', async () => {
+    const out = await collect(anthropicSseModelRewrite('clodex:acme:sonnet[200k]'), [messageStart + textDelta]);
+    expect(out).toContain('"model":"clodex:acme:sonnet[200k]"');
+    expect(out).not.toContain('"model":"claude-sonnet-4-5"');
+    // Content text mentioning the upstream id is untouched.
+    expect(out).toContain('"text":"model claude-sonnet-4-5"');
+    expect(out.endsWith('\n\n')).toBe(true);
+  });
+
+  it('rewrites a message_start split across chunk boundaries mid-field', async () => {
+    const whole = messageStart + textDelta;
+    const split = whole.indexOf('"model":"claude') + 12;
+    const out = await collect(
+      anthropicSseModelRewrite('alias-x'),
+      [whole.slice(0, split), whole.slice(split)],
+    );
+    expect(out).toContain('"model":"alias-x"');
+    expect(out).not.toContain('"model":"claude-sonnet-4-5"');
+  });
+
+  it('passes malformed data lines through unchanged', async () => {
+    const malformed = 'data: {"type":"message_start","message":{oops\n\n';
+    const out = await collect(anthropicSseModelRewrite('alias-x'), [malformed]);
+    expect(out).toBe(malformed);
+  });
+});
+
+describe('relayAnthropicMessages responseModelOverride', () => {
+  const makeRes = () => {
+    const chunks: Buffer[] = [];
+    let headers: Record<string, string> = {};
+    let status = 0;
+    const res = {
+      writeHead(code: number, hdrs: Record<string, string>) { status = code; headers = hdrs; return res; },
+      write(chunk: unknown) { chunks.push(Buffer.from(chunk as Buffer)); return true; },
+      end(chunk?: unknown) { if (chunk) chunks.push(Buffer.from(chunk as Buffer)); res.finished = true; res.emit?.('finish'); },
+      destroy() { /* noop */ },
+      on() { return res; },
+      once() { return res; },
+      emit() { return false; },
+      removeListener() { return res; },
+      finished: false,
+      body: () => Buffer.concat(chunks).toString('utf8'),
+      status: () => status,
+      headers: () => headers,
+    };
+    return res;
+  };
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('rewrites the JSON body model to the requested id', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(
+      JSON.stringify({ id: 'msg_1', type: 'message', model: 'claude-sonnet-4-5', content: [] }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    )));
+    const res = makeRes();
+    await relayAnthropicMessages(
+      res as never,
+      'https://upstream.example/v1/messages',
+      { model: 'claude-sonnet-4-5' },
+      'key',
+      false,
+      { responseModelOverride: 'clodex:acme:sonnet[200k]' },
+    );
+    expect(res.status()).toBe(200);
+    const body = JSON.parse(res.body()) as { model: string };
+    expect(body.model).toBe('clodex:acme:sonnet[200k]');
+    expect(res.headers()['Content-Length']).toBe(String(Buffer.byteLength(res.body())));
+  });
+
+  it('leaves the JSON body untouched without an override', async () => {
+    const raw = JSON.stringify({ id: 'msg_1', type: 'message', model: 'claude-sonnet-4-5', content: [] });
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(raw, {
+      status: 200, headers: { 'Content-Type': 'application/json' },
+    })));
+    const res = makeRes();
+    await relayAnthropicMessages(
+      res as never,
+      'https://upstream.example/v1/messages',
+      { model: 'claude-sonnet-4-5' },
+      'key',
+      false,
+      {},
+    );
+    expect(res.body()).toBe(raw);
   });
 });


### PR DESCRIPTION
## Summary

- make provider/model metadata carry request and response protocol independently instead of inferring both from one package id
- propagate the representation through registry conversion, materialization, model catalogs, runtime selection, server routes, and upstream forwarding
- validate runtime compatibility before a mixed-protocol model can launch
- preserve the client-requested model identity when an Anthropic passthrough route forwards a different upstream id

This is **OpenCode stack 1/6**, the protocol foundation extracted from #94. It is intentionally provider-generic; the OpenCode Go provider itself is the next stacked PR.

## Reachability

The changed metadata flows from provider templates and registry records into every active launch surface: direct proxy, HTTP proxy, endpoint server, catalog display, and passthrough forwarding. Behavioral tests cover conversion, materialization, compatibility rejection, route selection, model-id echo, chunk-split SSE, and malformed upstream events.

## Validation

- focused protocol suite — 8 files / 126 tests passed
- `pnpm typecheck` — passed
- `pnpm test` — 85 files / 1,332 tests passed
- `pnpm build` — passed
- `git diff --check` — passed

Local validation used Node 22.23.1, the supported runtime floor. CI exercises the repository's pinned Node 24 target. No live provider request was made.

## Stack

1. **This PR:** mixed-protocol provider foundation
2. Base OpenCode Go provider and hardening — targets this branch
3. Pinned CLI resolver contracts and deterministic catalog
4. Anthropic Messages route provenance
5. Global exact-effort policy and native representation
6. Same-target alias preservation

Each successor targets its predecessor so every review diff remains coherent. The final stack will be checked against #94's behavior tree before #94 is superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
