### PR TITLE
feat(providers): add OpenCode Go provider

### DIFF
--- a/.claude/docs/registry-and-server.md
+++ b/.claude/docs/registry-and-server.md
@@ -4,11 +4,25 @@
 
 ## Provider registry
 
-`src/registry/`. The shipped registry has two provider templates in `src/provider-templates.ts`:
-`openai` (API key, `https://api.openai.com/v1`) and `openai-oauth`. `provider-auth.ts` implements
-the OpenAI device-code OAuth flow; `refresh-models.ts` fetches the model list (3-tier fetch for
-OAuth). Materialization (`materialize.ts`) turns registry providers into `LocalProvider`s with
-per-model `npm`/`baseUrl`/`upstreamModelId`.
+`src/registry/`. The shipped registry has three provider templates in `src/provider-templates.ts`:
+`openai` (API key), `openai-oauth`, and `opencode-go`. `provider-auth.ts` implements the OpenAI
+device-code OAuth flow; `refresh-models.ts` fetches the model list (3-tier fetch for OAuth).
+Materialization (`materialize.ts`) turns registry providers into `LocalProvider`s with per-model
+`npm`/`baseUrl`/`upstreamModelId`.
+
+Provider templates can declare reusable controls for non-default behavior:
+
+- **`verifyCredential`** runs an optional template-owned probe before a credential is persisted. It
+  receives only the key: a caller-provided base URL must never redirect a live credential.
+- **`staticModelPolicy` / `preserveModelPricing`** let a template restrict live discovery to its
+  committed allowlist and retain provider-supplied prices. Read pricing preservation through
+  `providerPreservesModelPricing()`, which falls back to the template when persisted state predates
+  the flag.
+
+`ModelRuntimeCompatibility` (`src/model-runtime-compatibility.ts`) holds provider-neutral per-model
+wire quirks consumed by runtime adapters, including reasoning/request-shape controls and whether an
+Anthropic-format upstream supports token counting. An explicit `supportsCountTokens: false` selects
+clodex's local estimate; an unset value preserves forwarding for custom compatible endpoints.
 
 Registry writes use atomic hard-link lock publication, so the filesystem containing `CLODEX_HOME`
 must support hard links. **A parseable lock owned by a live PID is never reclaimed based on age;**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,8 +3,10 @@
 Guidance for coding agents and maintainers working in this repo. Read this file in full; load the
 deeper documents below only when you touch the subsystem they cover.
 
-**clodex** bridges Claude Code to OpenAI models — OpenAI API key (`openai`) or ChatGPT/Codex-plan
-OAuth (`openai-oauth`). It is a trimmed fork of relay-ai (full commit history preserved).
+**clodex** bridges Claude Code to non-Anthropic models — OpenAI API key (`openai`),
+ChatGPT/Codex-plan OAuth (`openai-oauth`), or community-supported OpenCode Go (`opencode-go`).
+Provider support tiers are documented in README. It is a trimmed fork of relay-ai (full commit
+history preserved).
 
 **Prime directive.** The translation, caching, auto-compaction, and OAuth-continuation code encodes
 real production failures that are not visible in the diff. Prefer surgical changes over
@@ -138,7 +140,8 @@ side effects at import time.
 
 - **endpoint** — a local Anthropic-format gateway; the child gets `ANTHROPIC_BASE_URL`.
 - **proxy** — selective MITM of `api.anthropic.com`; Claude Code keeps its normal Anthropic auth and
-  only `clodex:{provider}:{model}` ids and saved aliases route to OpenAI. **This is the default.**
+  only `clodex:{provider}:{model}` ids and saved aliases route to their configured providers. **This
+  is the default.**
 
 Details, including bridge-mode persistence rules, are in `.claude/docs/launch-and-wrapper.md`.
 
@@ -197,8 +200,8 @@ Interactive launch flow and real-provider behavior are verified manually.
 - In endpoint switch-menu mode the displayed context window reflects the **launch** model and does
   not update on live `/model` switch (Claude Code fetches `/v1/models` once at startup). Proxy mode
   + `clodex patch` reports correct per-model windows.
-- Cost display in Claude Code is always inaccurate for OpenAI models (Claude Code applies its own
-  pricing table).
+- Cost display in Claude Code is always inaccurate for routed third-party models (Claude Code applies
+  its own pricing table).
 - `MAX_MODEL_CATALOG = 20` (`constants.ts`) — favorites cap and max catalog routes.
 - OpenAI catalog ids may differ from upstream API ids — `upstreamModelId` carries the real API id.
 - Never commit `dist/` (gitignored, rebuilt by CI), never hardcode a version string

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/%40bman654%2Fclodex.svg)](https://www.npmjs.com/package/@bman654/clodex)
 
-**clodex** lets you use your ChatGPT/Codex plan or OpenAI models with Claude Code as if they were Anthropic models.
+**clodex** lets you use your ChatGPT/Codex plan, OpenAI API models, or OpenCode Go models with Claude Code as first-class model choices.
 You can use them anywhere you use Anthropic models like Opus and Sonnet — as the main session model, and in subagents, workflows, and agent teams. Clodex integrates them directly into Claude Code, using Claude Code's system prompt.
 It works with your existing Claude Code plan as well as your Codex plans WITHOUT violating Anthropic's ToS.
 No messing with CMUX or child codex processes or any of that stuff.
@@ -32,8 +32,22 @@ clodex claude                  # 5. launch Claude Code on an OpenAI model
 1. **Install** — puts the `clodex` command on your PATH.
 2. **Sign in** — opens a device-code OAuth flow for your ChatGPT/Codex plan; the token is stored in your OS credential store. (API-key users: `clodex providers add` instead.)
 3. **Pick models** — an interactive manager for favorites (max 20) and short aliases like `sol` so you do not need to type the long names. Favorites drive the `/model` switch menu, proxy-mode routing, and the patcher.
-4. **Patch** *(optional but recommended for proxy mode)* — bakes your favorites and aliases into the Claude Code binary so they pass model validation, appear in `/model`, and report their real context windows. Re-run after each `claude` update; `clodex patch --restore` undoes it. This step is required if you want to use your OpenAI models as subagents via the Agent tool.
+4. **Patch** *(optional but recommended for proxy mode)* — bakes your favorites and aliases into the Claude Code binary so they pass model validation, appear in `/model`, and report their real context windows. Re-run after each `claude` update; `clodex patch --restore` undoes it. This step is required if you want to use clodex-routed models as subagents via the Agent tool.
 5. **Launch** — starts Claude Code bridged to the model you choose.
+
+## Supported providers
+
+| Provider | Auth | Support |
+|---|---|---|
+| OpenAI | API key | Fully supported by the clodex maintainer |
+| OpenAI (ChatGPT / Codex plan) | OAuth | Fully supported by the clodex maintainer |
+| OpenCode Go | API key | Community-supported — maintained by its contributor |
+
+**Community-supported** means the maintainer holds no account for that service,
+so it cannot be exercised against the live API here or debugged when the vendor
+changes something. Such an integration is reviewed and tested like everything
+else and shipped gladly — it just depends on its contributor when upstream
+moves. New providers land under this tier by default.
 
 ## Difference between Clodex and other solutions
 
@@ -45,8 +59,8 @@ clodex claude                  # 5. launch Claude Code on an OpenAI model
 | Claude Code aware of true model context window size | ✅ | ❌ | ❌ | n/a |
 | Supports Agent tool | ✅ | ❌ | ✅ | ❌ |
 | Supports use in Dynamic Workflows | ✅ | ✅ | ✅ | ❌ |
-| OpenAI models use Claude Code skills/tools | ✅ | ✅ | ✅ | ❌ |
-| OpenAI models use Claude Code system prompt | ✅ | ✅ | ✅ | ❌ |
+| Routed models use Claude Code skills/tools | ✅ | ✅ | ✅ | ❌ |
+| Routed models use Claude Code system prompt | ✅ | ✅ | ✅ | ❌ |
 | Supports use in skill/agent frontmatter | ✅ | ❌ | ✅ | ❌ |
 | Supports OpenAI prompt caching | ✅ | ❌ | ? | ✅ |
 | Uses Websockets to talk to OpenAI API | ✅ | ❌ | ? | ✅ |
@@ -65,17 +79,17 @@ Clodex avoids this. In proxy mode it uses an HTTP proxy to intercept requests bo
 
 Both `clodex claude` and `clodex server` support two bridge modes. A mode flag applies to **that run only**; to change a command's default, add `--save-mode` (e.g. `clodex claude --endpoint --save-mode`). With no flag and nothing saved, both commands default to **proxy** mode, which works with your existing Claude auth.
 
-- **`--proxy`** (the default): a selective man-in-the-middle proxy for `api.anthropic.com`. Claude Code keeps its normal Anthropic login — Anthropic models work untouched — while models named `clodex:<provider-id>:<model-id>` (or their saved aliases) route to OpenAI. Switch with `/model clodex:openai-oauth:gpt-5.6-sol` or `/model sol` after patching.
+- **`--proxy`** (the default): a selective man-in-the-middle proxy for `api.anthropic.com`. Claude Code keeps its normal Anthropic login — Anthropic models work untouched — while models named `clodex:<provider-id>:<model-id>` (or their saved aliases) route to the selected configured provider. Switch with `/model clodex:openai-oauth:gpt-5.6-sol` or `/model sol` after patching.
 - **`--endpoint`**: clodex runs a local Anthropic-format gateway and launches Claude Code with `ANTHROPIC_BASE_URL` pointed at it. All traffic goes through the gateway. With favorites saved, the gateway is multi-route and Claude Code's `/model` menu lists your starting model plus favorites for live switching.
 
 > [!TIP]
-> Proxy mode allows you to continue using your Claude Code plan: login to claude code like normal and the proxy will intercept requests and leave requests for Anthropic models untouched, while requests for your favorite OpenAI models will be re-routed to OpenAI.
+> Proxy mode allows you to continue using your Claude Code plan: login to claude code like normal and the proxy will intercept requests and leave requests for Anthropic models untouched, while requests for your favorite clodex models are routed to their configured providers.
 
 ```mermaid
 flowchart LR
     CC["Claude Code<br/>(own Anthropic login)"] -->|"HTTPS via HTTPS_PROXY,<br/>trusts the clodex CA"| MITM["clodex MITM proxy"]
     MITM --> DEC{"model is clodex:...<br/>or a saved alias?"}
-    DEC -->|"yes — translated request,<br/>clodex-managed OpenAI credentials"| OAI["OpenAI<br/>(OAuth: Responses WebSocket /<br/>API key: HTTPS)"]
+    DEC -->|"yes — routed request,<br/>clodex-managed provider credentials"| UP["Configured provider<br/>(OpenAI / OpenCode Go)"]
     DEC -->|"no — passed through untouched,<br/>Claude Code's Anthropic credentials ride along"| ANT["api.anthropic.com"]
 ```
 
@@ -86,7 +100,7 @@ flowchart LR
     CC["Claude Code<br/>(ANTHROPIC_BASE_URL + local API key,<br/>no Anthropic account credentials)"] -->|"Anthropic-format /v1/messages<br/>+ local API key"| GW["clodex gateway<br/>(:17645/anthropic)"]
     CC -->|"GET /v1/models at startup"| GW
     GW -->|"model catalog with context windows<br/>(feeds the /model menu)"| CC
-    GW -->|"translated request,<br/>clodex-managed OpenAI credentials"| OAI["OpenAI"]
+    GW -->|"routed request,<br/>clodex-managed provider credentials"| UP["Configured provider"]
 ```
 
 > [!TIP]
@@ -96,17 +110,17 @@ flowchart LR
 
 ### `clodex claude [options] [claude-flags]`
 
-Launch Claude Code bridged to OpenAI models. Unrecognized flags (and everything after `--`) pass through to Claude Code (`-c`, `--resume`, `--print`, …).
+Launch Claude Code bridged to configured model providers. Unrecognized flags (and everything after `--`) pass through to Claude Code (`-c`, `--resume`, `--print`, …).
 
 | Flag | Effect |
 | --- | --- |
 | `--endpoint` | Endpoint bridge mode for this run: local gateway + `ANTHROPIC_BASE_URL` |
-| `--proxy` | Proxy bridge mode for this run: keep Claude Code's Anthropic auth; `clodex:` models route to OpenAI (default when nothing is saved) |
+| `--proxy` | Proxy bridge mode for this run: keep Claude Code's Anthropic auth; `clodex:` models route to configured providers (default when nothing is saved) |
 | `--save-mode` | With `--endpoint`/`--proxy`: save that mode as the `claude` default |
 | `--dry-run` | Run the wizard but print a launch preview instead of launching (never persists anything) |
 | `--trace` | Write debug logs to `~/.clodex/logs/` and show errors on exit |
 | `--fast` | Request Codex fast mode (`service_tier=priority`) for ChatGPT/Codex OAuth routes; equivalent to `CLODEX_SERVICE_TIER=fast` |
-| `--provider <id>` | Boot provider id (`openai` or `openai-oauth`); with `--model`, skips the wizard |
+| `--provider <id>` | Boot provider id (`openai`, `openai-oauth`, or `opencode-go`); with `--model`, skips the wizard |
 | `--model <id>` | Boot model id; with `--provider`, skips the wizard |
 | `--help`, `--version` | Help / version |
 
@@ -222,13 +236,13 @@ Manage favorite models (max 20) and short aliases. Favorites feed the endpoint-m
 | Subcommand | Effect |
 | --- | --- |
 | *(none)* | Provider hub wizard |
-| `add` | Add OpenAI with an API key (choose OAuth or API key) |
+| `add` | Add OpenAI or OpenCode Go with an API key, or sign in with ChatGPT |
 | `auth openai` | Sign in with ChatGPT/Codex-plan OAuth (device code) |
 | `list` | Show configured providers |
 | `remove <id>` | Remove a provider by id |
 | `refresh-models [id]` | Update cached model lists |
 
-Providers supported: `openai` (API key, platform.openai.com) and `openai-oauth` (ChatGPT/Codex plan).
+Providers supported: `openai` (API key, platform.openai.com), `openai-oauth` (ChatGPT/Codex plan), and `opencode-go` (OpenCode Go API key). OpenCode Go exposes its Anthropic Messages and Chat Completions models; Responses-only entries are intentionally excluded. See [OpenCode Go provider](docs/opencode-go.md).
 
 ### Root
 
@@ -297,7 +311,7 @@ clodex --version    # version
 
 ## Known limitations
 
-- Cost display inside Claude Code is inaccurate for OpenAI models (Claude Code applies its own pricing table).
+- Cost display inside Claude Code is inaccurate for routed third-party models (Claude Code applies its own pricing table).
 - In the endpoint-mode switch menu, the displayed context window reflects the launch model and does not update on live `/model` switches (Claude Code fetches window metadata once at startup). Proxy mode with `clodex patch` reports correct per-model windows.
 - ChatGPT/Codex OAuth requires `store:false` upstream; some OpenAI cache controls are intentionally omitted on OAuth routes because they returned empty responses during compatibility testing.
 

--- a/docs/opencode-go.md
+++ b/docs/opencode-go.md
@@ -10,7 +10,7 @@ Run:
 clodex providers add
 ```
 
-Choose **OpenCode Go API key**, paste an API key from OpenCode, then use `clodex models` to add the desired models to favorites. The pasted key is verified against the authenticated chat-completions endpoint before it is saved — `/models` alone cannot validate a credential (see below) — so a mistyped key is rejected at add time instead of failing on first inference. Favorites can be assigned short aliases and patched into Claude Code in the same way as OpenAI models.
+Choose **OpenCode Go API key**, paste an API key from OpenCode, then use `clodex models` to add the desired models to favorites. The pasted key is checked against the authenticated chat-completions endpoint before it is saved — `/models` alone cannot validate a credential (see below). The pre-save probe rejects only definite, recognized authentication failures; timeout, network, and unrecognized responses are inconclusive, so a bad key may still be saved and surface an authentication failure on first inference. Favorites can be assigned short aliases and patched into Claude Code in the same way as OpenAI models.
 
 The provider uses one credential with two upstream wire protocols:
 

--- a/docs/opencode-go.md
+++ b/docs/opencode-go.md
@@ -1,0 +1,38 @@
+# OpenCode Go provider
+
+Clodex can expose OpenCode Go models alongside Claude and OpenAI/Codex models in the same Claude Code session.
+
+## Setup
+
+Run:
+
+```bash
+clodex providers add
+```
+
+Choose **OpenCode Go API key**, paste an API key from OpenCode, then use `clodex models` to add the desired models to favorites. The pasted key is verified against the authenticated chat-completions endpoint before it is saved — `/models` alone cannot validate a credential (see below) — so a mistyped key is rejected at add time instead of failing on first inference. Favorites can be assigned short aliases and patched into Claude Code in the same way as OpenAI models.
+
+The provider uses one credential with two upstream wire protocols:
+
+- Anthropic Messages models are passed through to `https://opencode.ai/zen/go/v1/messages`.
+- OpenAI Chat Completions models are translated through the OpenAI-compatible SDK at `https://opencode.ai/zen/go/v1/chat/completions`.
+
+The selective proxy diverts only explicit `clodex:opencode-go:...` model ids or saved aliases. Ordinary Claude model traffic remains on Claude Code's native Anthropic connection.
+
+## Supported transport scope
+
+The upstream OpenCode Go catalog also contains Responses-API models. Clodex intentionally excludes those entries from this provider (currently Grok and mainline GPT; other unmapped ids are reported by the updater until their transport is verified). The supported catalog contains only Anthropic Messages and Chat Completions models.
+
+Live `/models` results are treated as availability data. Clodex layers its committed catalog over those results to supply the correct protocol, endpoint, context window, modalities, pricing, and compatibility behavior per model. Models absent from the committed allowlist are hidden even when the live endpoint advertises them.
+
+## Updating the catalog
+
+The committed catalog is generated directly from OpenCode's own catalog service (`models.dev/api.json`, provider `opencode-go`):
+
+```bash
+pnpm update:opencode-go
+```
+
+The updater takes per-model metadata (name, context window, cost, modalities) from models.dev and merges it with the transport map and compatibility patches maintained in `scripts/update-opencode-go-models.mjs` — models.dev does not publish wire transports, and per-model routing is live-validated clodex knowledge. Only transport-mapped ids enter the catalog; new models on models.dev are reported as unmapped so their transport can be verified against the live endpoint before they ship. The script records the fetch time in `OPENCODE_GO_SOURCE_FETCHED_AT`.
+
+Review catalog, pricing, endpoint, and compatibility changes before committing generated output. In particular, a model changing between Anthropic Messages, Chat Completions, and Responses is a routing change rather than a cosmetic catalog refresh.

--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "publishConfig": {
     "access": "public"
   },
-  "description": "Bridge Claude Code to OpenAI models — OpenAI API key or ChatGPT/Codex-plan OAuth, with prompt caching, auto-compaction, model switching, and a Claude Code binary patcher",
+  "description": "Bridge Claude Code to OpenAI and OpenCode Go models — API keys or ChatGPT/Codex-plan OAuth, with prompt caching, auto-compaction, model switching, and a Claude Code binary patcher",
   "author": "Brandon Wallace",
   "license": "MIT",
   "keywords": [
     "claude",
     "claude-code",
     "openai",
+    "opencode",
     "chatgpt",
     "codex",
     "ai",
@@ -40,7 +41,8 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "prepare": "husky",
-    "prepublishOnly": "pnpm build"
+    "prepublishOnly": "pnpm build",
+    "update:opencode-go": "node scripts/update-opencode-go-models.mjs"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "4.0.12",

--- a/scripts/update-opencode-go-models.mjs
+++ b/scripts/update-opencode-go-models.mjs
@@ -35,7 +35,7 @@ const ANTHROPIC_BASE_URL = 'https://opencode.ai/zen/go';
 // model on models.dev surfaces in the updater's "unmapped" report and is added
 // once its transport is verified against the live endpoint. Responses-only
 // models (grok, mainline gpt) are deliberately absent.
-const TRANSPORTS = {
+const TRANSPORTS = Object.assign(Object.create(null), {
   'deepseek-v4-flash': 'openai-completions',
   'deepseek-v4-pro': 'openai-completions',
   'glm-5.1': 'openai-completions',
@@ -53,7 +53,7 @@ const TRANSPORTS = {
   'qwen3.7-max': 'anthropic-messages',
   'qwen3.7-plus': 'anthropic-messages',
   'qwen3.8-max': 'anthropic-messages',
-};
+});
 
 // Clodex-side compatibility behavior per model, validated against the live
 // endpoint. It travels with the transport map rather than being read from the
@@ -66,7 +66,7 @@ const TRANSPORTS = {
 // entries are validated against, never as their source: `assertEffortLadders`
 // below fails this updater if a map would send an effort value the feed does
 // not publish, and reports the safe direction rather than failing on it.
-const PATCHES = {
+const PATCHES = Object.assign(Object.create(null), {
   'deepseek-v4-flash': {
     reasoningEffortMap: { minimal: null, low: null, medium: null, high: 'high', max: 'max' },
     supportsStore: false,
@@ -210,7 +210,7 @@ const PATCHES = {
     thinkingFormat: 'qwen',
     maxTokensField: 'max_tokens',
   },
-};
+});
 
 /**
  * Cross-check every local effort map against what the feed publishes.
@@ -382,7 +382,7 @@ async function main() {
     supported.push(toClodexModel(id, devModel));
   }
 
-  const missing = Object.keys(TRANSPORTS).filter(id => !devModels[id]);
+  const missing = Object.keys(TRANSPORTS).filter(id => !Object.hasOwn(devModels, id));
   if (missing.length > 0) {
     throw new Error(`Transport-mapped models missing from models.dev: ${missing.join(', ')}`);
   }

--- a/scripts/update-opencode-go-models.mjs
+++ b/scripts/update-opencode-go-models.mjs
@@ -1,0 +1,442 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+// OpenCode's own catalog service (the opencode CLI consumes the same feed).
+// Supplies per-model metadata: name, context window, cost, modalities.
+//
+// WHAT THE FEED CAN AND CANNOT CONTROL — the property that keeps this script's
+// supply-chain surface narrow, and which is not obvious from reading it:
+//
+//   Feed-controlled: name, contextWindow, cost, modalities, reasoning.
+//   Local-only:      apiUrl, npm, modelFormat, the whole compatibility block,
+//                    and which ids exist at all (TRANSPORTS below).
+//
+// `toClodexModel` hardcodes every routing constant locally and filters ids
+// against TRANSPORTS, so a hostile or simply wrong feed cannot produce a bad
+// base URL, a bad SDK package, or any code-execution path — the worst it can
+// do is a wrong display name, price, or context window, and the ingest
+// validation in main() catches the last of those. Keep it that way: never move
+// a routing or compatibility field into the feed-derived half.
+const MODELS_DEV_URL = 'https://models.dev/api.json';
+const PROVIDER_ID = 'opencode-go';
+const MODELS_PATH = resolve('src/data/opencode-go-models.json');
+const CONSTANTS_PATH = resolve('src/data/opencode-go-models.ts');
+
+const COMPLETIONS_BASE_URL = 'https://opencode.ai/zen/go/v1';
+const ANTHROPIC_BASE_URL = 'https://opencode.ai/zen/go';
+
+// models.dev does not publish per-model wire transport, and the family-level
+// summary in the Zen docs is not reliable per model (minimax-m3 is
+// Anthropic-format while minimax-m2.x are Chat Completions; gpt-5.6-luna rides
+// Chat Completions, not Responses). This map is clodex's live-validated
+// routing knowledge: catalog entries only exist for ids mapped here. A new
+// model on models.dev surfaces in the updater's "unmapped" report and is added
+// once its transport is verified against the live endpoint. Responses-only
+// models (grok, mainline gpt) are deliberately absent.
+const TRANSPORTS = {
+  'deepseek-v4-flash': 'openai-completions',
+  'deepseek-v4-pro': 'openai-completions',
+  'glm-5.1': 'openai-completions',
+  'glm-5.2': 'openai-completions',
+  'gpt-5.6-luna': 'openai-completions',
+  'hy3': 'openai-completions',
+  'kimi-k2.6': 'openai-completions',
+  'kimi-k2.7-code': 'openai-completions',
+  'kimi-k3': 'openai-completions',
+  'mimo-v2.5': 'openai-completions',
+  'mimo-v2.5-pro': 'openai-completions',
+  'minimax-m2.7': 'openai-completions',
+  'minimax-m3': 'anthropic-messages',
+  'qwen3.6-plus': 'openai-completions',
+  'qwen3.7-max': 'anthropic-messages',
+  'qwen3.7-plus': 'anthropic-messages',
+  'qwen3.8-max': 'anthropic-messages',
+};
+
+// Clodex-side compatibility behavior per model, validated against the live
+// endpoint. It travels with the transport map rather than being read from the
+// feed, so a hostile or wrong feed cannot change what clodex puts on the wire.
+//
+// models.dev DOES publish a per-model `reasoning_options` (an effort ladder, a
+// bare toggle, or nothing), and it is the closest thing to an authority on
+// what OpenCode's GATEWAY accepts — which is not the same set the upstream
+// vendor documents for its own endpoint. Treat it as the cross-check these
+// entries are validated against, never as their source: `assertEffortLadders`
+// below fails this updater if a map would send an effort value the feed does
+// not publish, and reports the safe direction rather than failing on it.
+const PATCHES = {
+  'deepseek-v4-flash': {
+    reasoningEffortMap: { minimal: null, low: null, medium: null, high: 'high', max: 'max' },
+    supportsStore: false,
+    supportsDeveloperRole: false,
+    maxTokensField: 'max_tokens',
+    requiresReasoningContentOnAssistantMessages: true,
+    thinkingFormat: 'deepseek',
+  },
+  'deepseek-v4-pro': {
+    reasoningEffortMap: { minimal: null, low: null, medium: null, high: 'high', max: 'max' },
+    supportsStore: false,
+    supportsDeveloperRole: false,
+    maxTokensField: 'max_tokens',
+    requiresReasoningContentOnAssistantMessages: true,
+    thinkingFormat: 'deepseek',
+  },
+  'glm-5.1': {
+    // Z.ai: reasoning_effort is "Only supported by GLM-5.2". 5.1 thinks by
+    // default and is controlled by the binary `thinking` field, so it reasons
+    // but has no effort control to advertise.
+    supportsReasoningEffort: false,
+    supportsStore: false,
+    supportsDeveloperRole: false,
+    maxTokensField: 'max_tokens',
+  },
+  'glm-5.2': {
+    // Z.ai's own API documents the full ladder ("max, xhigh, high, medium,
+    // low, minimal, none"), but that describes Z.ai's endpoint, not OpenCode's
+    // gateway in front of it: models.dev — the feed OpenCode itself routes
+    // from — publishes effort=high/max for this model. The gateway is what we
+    // actually talk to, so its narrower set wins until the wider one is
+    // validated live.
+    reasoningEffortMap: { off: null, minimal: null, low: null, medium: null, high: 'high', xhigh: null, max: 'max' },
+    supportsStore: false,
+    supportsDeveloperRole: false,
+    maxTokensField: 'max_tokens',
+  },
+  'gpt-5.6-luna': {
+    // models.dev publishes effort=none/low/medium/high/xhigh/max for OpenCode's
+    // Luna — note: no `minimal`. Distinct from the ChatGPT-OAuth Luna, which is
+    // a different deployment on the Responses transport and says nothing about
+    // what this gateway accepts.
+    reasoningEffortMap: { off: 'none', minimal: null, low: 'low', medium: 'medium', high: 'high', xhigh: 'xhigh', max: 'max' },
+    supportsStore: false,
+    supportsDeveloperRole: false,
+    maxTokensField: 'max_tokens',
+  },
+  'hy3': {
+    reasoningEffortMap: { off: 'none', minimal: null, low: 'low', medium: null, high: 'high', xhigh: null, max: null },
+    supportsStore: false,
+    supportsDeveloperRole: false,
+    maxTokensField: 'max_tokens',
+  },
+  'kimi-k2.6': {
+    reasoningEffortMap: { minimal: null, low: null, medium: null },
+    supportsStore: false,
+    supportsDeveloperRole: false,
+    thinkingFormat: 'deepseek',
+    supportsReasoningEffort: false,
+    maxTokensField: 'max_tokens',
+    supportsLongCacheRetention: false,
+  },
+  'kimi-k2.7-code': {
+    // Moonshot: "thinking is always on and cannot be disabled", driven by the
+    // `thinking` field and NOT `reasoning_effort`, which this model does not
+    // accept. Stated explicitly so the model-name Kimi rule cannot claim it:
+    // reasoning genuinely happens, it just isn't effort-controllable, which is
+    // exactly what `supportsReasoningEffort: false` reports (internal-only).
+    supportsReasoningEffort: false,
+    supportsStore: false,
+    supportsDeveloperRole: false,
+    maxTokensField: 'max_tokens',
+  },
+  'kimi-k3': {
+    // Moonshot's own API documents low/high/max (default max), but models.dev
+    // publishes effort=max for OpenCode's deployment. Same reasoning as
+    // glm-5.2: the gateway's set is the one that reaches the wire.
+    reasoningEffortMap: { off: null, minimal: null, low: null, medium: null, high: null, xhigh: null, max: 'max' },
+    supportsStore: false,
+    supportsDeveloperRole: false,
+    maxTokensField: 'max_tokens',
+  },
+  'mimo-v2.5': {
+    // Xiaomi's OpenAI-compatible reference documents no reasoning_effort; the
+    // request shape carries a `thinking` object ("type": "disabled") like the
+    // GLM and Kimi families. Reasoning happens, it is not graded.
+    supportsReasoningEffort: false,
+    supportsStore: false,
+    supportsDeveloperRole: false,
+    maxTokensField: 'max_tokens',
+  },
+  'mimo-v2.5-pro': {
+    // Same reference, same `thinking` object, no reasoning_effort.
+    supportsReasoningEffort: false,
+    supportsStore: false,
+    supportsDeveloperRole: false,
+    maxTokensField: 'max_tokens',
+  },
+  'minimax-m2.7': {
+    // MiniMax's Chat Completions reference accepts no reasoning_effort at all;
+    // reasoning is the `thinking` object, and "for M2.x models, thinking
+    // cannot be disabled". Always-on and not effort-controllable.
+    supportsReasoningEffort: false,
+    supportsStore: false,
+    supportsDeveloperRole: false,
+    maxTokensField: 'max_tokens',
+  },
+  'minimax-m3': {
+    // Same reference as M2.7: no reasoning_effort. M3's thinking is
+    // "adaptive" by default and can be disabled, but never graded, so there is
+    // no effort ladder to advertise. (Anthropic-format, so the generator also
+    // stamps supportsCountTokens: false below.)
+    supportsReasoningEffort: false,
+  },
+  'qwen3.6-plus': {
+    // Qwen has no reasoning_effort: models.dev publishes a toggle plus a token
+    // budget, and DashScope's control is the boolean `enable_thinking`. But
+    // `thinkingFormat: 'qwen'` only injects that boolean when a
+    // reasoning_effort is PRESENT, so the effort value is load-bearing as an
+    // internal signal even though the upstream ignores its value.
+    //
+    // Without a map, mapCodexEffortToOpenAI dropped `off`, `minimal` and also
+    // `max` — so choosing MAX silently disabled thinking while `low` enabled
+    // it. Every level except `off` now maps to something, which is what fixes
+    // that: any level thinks, `off` does not.
+    //
+    // DISTINCT values, not one repeated. Collapsing them to a single value is
+    // tempting — the grades are cosmetic while the upstream control is a
+    // boolean — but getPatchReasoningCapabilities dedups identical provider
+    // options, and `projectNativeEffort` in patch-transforms.ts discards any
+    // capability missing low/medium/high. A one-level capability therefore
+    // leaves a patched client with NO effort control at all, which is worse
+    // than cosmetic grades. The upstream ignores the string either way.
+    //
+    // Grading this for real means sending enable_thinking + thinking_budget
+    // and dropping reasoning_effort. That changes the wire and needs a live
+    // key to validate, so it is tracked separately rather than guessed here.
+    reasoningEffortMap: { low: 'low', medium: 'medium', high: 'high', xhigh: 'xhigh', max: 'max', minimal: null, off: null },
+    supportsStore: false,
+    supportsDeveloperRole: false,
+    thinkingFormat: 'qwen',
+    maxTokensField: 'max_tokens',
+  },
+};
+
+/**
+ * Cross-check every local effort map against what the feed publishes.
+ *
+ * The invariant is a SUBSET, not equality, and the asymmetry is the point.
+ * Sending a value the gateway does not publish risks a rejected request, so it
+ * fails the update. Sending fewer than it publishes is merely conservative —
+ * `deepseek-v4-flash` omits a `low` the feed lists — so that is reported and
+ * left to a human, because widening a ladder is exactly the change that wants
+ * live validation rather than a script's confidence.
+ *
+ * This exists because the vendor's own API and OpenCode's gateway disagree:
+ * Z.ai documents seven effort levels for GLM-5.2 and Moonshot documents three
+ * for K3, while the feed publishes `high/max` and `max`. Two entries were
+ * briefly widened to the vendor ladders before that was understood.
+ */
+function assertEffortLadders(supported, devModels) {
+  const errors = [];
+  const notes = [];
+  for (const model of supported) {
+    const options = devModels[model.id]?.reasoning_options;
+    const published = new Set(
+      (Array.isArray(options) ? options : [])
+        .filter(option => option?.type === 'effort')
+        .flatMap(option => option.values ?? []),
+    );
+    const compatibility = model.compatibility ?? {};
+    if (compatibility.supportsReasoningEffort === false) {
+      if (published.size > 0) {
+        notes.push(`${model.id}: suppressed locally, feed publishes ${[...published].sort().join('/')}`);
+      }
+      continue;
+    }
+    const map = compatibility.reasoningEffortMap;
+    if (!map) {
+      notes.push(`${model.id}: no local map — falls back to generic rules, cannot be cross-checked`);
+      continue;
+    }
+    const sent = new Set(Object.values(map).filter(value => value !== null));
+    // A model the feed describes as a bare TOGGLE, mapped locally with a
+    // thinkingFormat, is the one legitimate way to send an effort the feed does
+    // not publish: the value is an internal signal that makes the transform
+    // inject the upstream's real control (`enable_thinking`), and the upstream
+    // ignores the effort string itself. Recognised by shape rather than by id,
+    // so any future toggle-only model gets the same treatment — and still
+    // reported, because the honest fix is to send the vendor's own field.
+    const togglesOnly = published.size === 0
+      && (Array.isArray(options) ? options : []).some(option => option?.type === 'toggle')
+      && compatibility.thinkingFormat !== undefined;
+    if (togglesOnly) {
+      notes.push(
+        `${model.id}: effort is a toggle proxy (feed publishes a toggle, not a ladder) — `
+        + 'the value is an internal signal for the thinkingFormat transform',
+      );
+      continue;
+    }
+    const unpublished = [...sent].filter(value => !published.has(value)).sort();
+    if (unpublished.length > 0) {
+      errors.push(
+        `${model.id}: maps to ${unpublished.join('/')}, which models.dev does not publish `
+        + `(feed: ${[...published].sort().join('/') || 'no effort ladder'})`,
+      );
+      continue;
+    }
+    const unused = [...published].filter(value => !sent.has(value)).sort();
+    if (unused.length > 0) {
+      notes.push(`${model.id}: feed also publishes ${unused.join('/')}, not sent locally`);
+    }
+  }
+  return { errors, notes };
+}
+
+async function fetchJson(url) {
+  const response = await fetch(url, {
+    headers: { 'User-Agent': 'clodex-opencode-go-catalog-updater' },
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} fetching ${url}`);
+  }
+  return response.json();
+}
+
+function toClodexModel(id, devModel) {
+  const transport = TRANSPORTS[id];
+  const anthropic = transport === 'anthropic-messages';
+  const devCost = devModel.cost ?? {};
+  const cost = {
+    input: devCost.input ?? 0,
+    output: devCost.output ?? 0,
+    ...(devCost.cache_read ? { cache_read: devCost.cache_read } : {}),
+    ...(devCost.cache_write ? { cache_write: devCost.cache_write } : {}),
+  };
+  // OpenCode Zen documents /v1/responses, /v1/chat/completions and
+  // /v1/messages, and no token-counting endpoint. Marked on the anthropic-
+  // format entries so the proxy answers count_tokens from its local estimate
+  // instead of forwarding to a path that 404s into the client's token
+  // accounting. Hardcoded here, like every other routing constant, so the
+  // upstream feed cannot influence it.
+  // Defaults every anthropic-format entry carries, overridable per model.
+  //
+  // supportsCountTokens: OpenCode Zen documents /v1/responses,
+  // /v1/chat/completions and /v1/messages, and no token-counting endpoint, so
+  // the proxy answers count_tokens from its local estimate instead of
+  // forwarding to a path that 404s into the client's token accounting.
+  //
+  // supportsReasoningEffort: structural, not a vendor claim. Effort reaches an
+  // upstream through `effortProviderOptions` and the `thinkingFormat`
+  // transform, both of which act on an OpenAiCompatibleRequestBody. A
+  // passthrough Messages body is forwarded untouched, so there is no way to
+  // send a graded effort on this route however the vendor spells it — these
+  // models still reason, via whatever `thinking` the client itself sends.
+  // Advertising a control clodex cannot operate is what this prevents.
+  const compatibility = anthropic
+    ? { supportsCountTokens: false, supportsReasoningEffort: false, ...(PATCHES[id] ?? {}) }
+    : PATCHES[id];
+  const modalities = (devModel.modalities?.input ?? ['text'])
+    .filter(value => value === 'text' || value === 'image');
+
+  return {
+    id,
+    name: devModel.name ?? id,
+    contextWindow: devModel.limit?.context,
+    cost,
+    modelFormat: anthropic ? 'anthropic' : 'openai',
+    npm: anthropic ? '@ai-sdk/anthropic' : '@ai-sdk/openai-compatible',
+    apiUrl: anthropic ? ANTHROPIC_BASE_URL : COMPLETIONS_BASE_URL,
+    reasoning: devModel.reasoning === true,
+    modalities,
+    ...(compatibility ? { compatibility } : {}),
+    upstreamModelId: id,
+    family: id.split('-')[0] ?? id,
+  };
+}
+
+/**
+ * Resolve the new constants file content WITHOUT writing it.
+ *
+ * Ordering alone cannot make two file writes atomic — whichever goes first, an
+ * interruption leaves the other stale. What it can do is move the one failure
+ * that is actually likely, the regex ceasing to match after an unrelated edit
+ * to the constants file, ahead of every write. Both writes then fail only on
+ * real I/O trouble, and the catalog goes first so the timestamp is a commit
+ * marker for a catalog already on disk rather than a promise about one.
+ */
+async function prepareSourceConstant(fetchedAt) {
+  const source = await readFile(CONSTANTS_PATH, 'utf8');
+  const pattern = /export const OPENCODE_GO_SOURCE_FETCHED_AT = '[^']*';/;
+  if (!pattern.test(source)) {
+    throw new Error('Could not find OPENCODE_GO_SOURCE_FETCHED_AT in opencode-go-models.ts');
+  }
+  return source.replace(pattern, `export const OPENCODE_GO_SOURCE_FETCHED_AT = '${fetchedAt}';`);
+}
+
+async function main() {
+  const catalog = await fetchJson(MODELS_DEV_URL);
+  const provider = catalog?.[PROVIDER_ID];
+  const devModels = provider?.models;
+  if (!devModels || typeof devModels !== 'object') {
+    throw new Error(`models.dev catalog has no "${PROVIDER_ID}" provider models`);
+  }
+
+  const supported = [];
+  const unmapped = [];
+  for (const [id, devModel] of Object.entries(devModels).sort(([a], [b]) => a.localeCompare(b))) {
+    if (!TRANSPORTS[id]) {
+      unmapped.push(id);
+      continue;
+    }
+    supported.push(toClodexModel(id, devModel));
+  }
+
+  const missing = Object.keys(TRANSPORTS).filter(id => !devModels[id]);
+  if (missing.length > 0) {
+    throw new Error(`Transport-mapped models missing from models.dev: ${missing.join(', ')}`);
+  }
+  if (supported.length === 0) {
+    throw new Error('models.dev catalog produced no supported models');
+  }
+
+  // Validate at ingest, before anything is written. contextWindow flows into
+  // the patched client's context map, where a bad value breaks auto-compaction
+  // silently rather than failing here; a name with control characters or
+  // newlines corrupts every list that renders it.
+  const invalid = [];
+  for (const model of supported) {
+    if (!Number.isInteger(model.contextWindow) || model.contextWindow <= 0 || model.contextWindow > 10_000_000) {
+      invalid.push(`${model.id}: contextWindow=${JSON.stringify(model.contextWindow)}`);
+    }
+    // eslint-disable-next-line no-control-regex
+    if (typeof model.name !== 'string' || model.name.trim() === '' || /[\x00-\x1f\x7f]/.test(model.name)) {
+      invalid.push(`${model.id}: name=${JSON.stringify(model.name)}`);
+    }
+  }
+  if (invalid.length > 0) {
+    throw new Error(`models.dev returned unusable metadata:\n  ${invalid.join('\n  ')}`);
+  }
+
+  const ladders = assertEffortLadders(supported, devModels);
+  if (ladders.errors.length > 0) {
+    throw new Error(
+      'Local effort maps send values models.dev does not publish for the OpenCode gateway:\n  '
+      + ladders.errors.join('\n  '),
+    );
+  }
+
+  // Resolve the constants content before either write, so the likely failure —
+  // the regex no longer matching — aborts with both files untouched rather
+  // than stranding one of them. Catalog first, timestamp second: the timestamp
+  // then marks a catalog that is already on disk.
+  const constantsContent = await prepareSourceConstant(new Date().toISOString());
+  await writeFile(MODELS_PATH, `${JSON.stringify(supported, null, 2)}\n`);
+  await writeFile(CONSTANTS_PATH, constantsContent);
+
+  console.log(`Updated ${supported.length} OpenCode Go models from ${MODELS_DEV_URL} (${PROVIDER_ID}).`);
+  for (const note of ladders.notes) {
+    console.log(`Effort ladder note — ${note}`);
+  }
+  if (unmapped.length > 0) {
+    console.log(
+      'Present on models.dev but not transport-mapped (verify wire protocol '
+      + `against the live endpoint, then add to TRANSPORTS): ${unmapped.join(', ')}`,
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -344,7 +344,7 @@ export function parseArgs(args: string[]): ParsedArgs {
 
 export function rootHelpText(): string {
   return `${pc.bold('clodex')} v${VERSION}
-Bridge Claude Code to OpenAI models — OpenAI API key or ChatGPT/Codex-plan OAuth.
+Bridge Claude Code to OpenAI and OpenCode Go models.
 
 ${pc.bold('Usage:')}
   clodex claude [options] [claude-flags]
@@ -361,18 +361,18 @@ ${pc.bold('Root options:')}
   -v, --version    Show version
 
 ${pc.bold('Commands:')}
-  claude      Launch Claude Code bridged to OpenAI models
+  claude      Launch Claude Code bridged to configured model providers
   server      Run a foreground gateway (endpoint or proxy mode)
   patch       Patch the Claude Code binary so clodex models are first-class
   models      Manage favorite models and aliases (max ${MAX_MODEL_CATALOG})
   favorites   Alias for models
-  providers   Add or sign in to your OpenAI providers
+  providers   Add or sign in to model providers
 
 ${pc.bold('Bridge modes (claude and server):')}
   --endpoint   Local Anthropic-format gateway; Claude Code launches with
                ANTHROPIC_BASE_URL pointed at it
   --proxy      Selective MITM of api.anthropic.com; Claude Code keeps its
-               normal Anthropic auth, clodex: models route to OpenAI
+               normal Anthropic auth, clodex: models route to configured providers
                (default when nothing is saved)
   --save-mode  Persist the mode given by --endpoint/--proxy as that
                command's default. Without --save-mode a mode flag applies
@@ -390,7 +390,7 @@ ${pc.bold('Examples:')}
 
 export function claudeHelpText(): string {
   return `${pc.bold('clodex claude')} v${VERSION}
-Launch Claude Code bridged to OpenAI models.
+Launch Claude Code bridged to configured model providers.
 
 ${pc.bold('Usage:')}
   clodex claude [options] [claude-flags]
@@ -400,7 +400,7 @@ ${pc.bold('Usage:')}
 ${pc.bold('Options:')}
   --endpoint   Endpoint bridge mode for this run: local gateway + ANTHROPIC_BASE_URL
   --proxy      Proxy bridge mode for this run: keep Claude Code's Anthropic auth;
-               route clodex: models to OpenAI (default when nothing is saved)
+               route clodex: models to configured providers (default when nothing is saved)
   --save-mode  With --endpoint/--proxy: save that mode as the claude default
   --dry-run    Run the wizard but show a preview instead of launching Claude Code
   --trace      Write debug logs to ~/.clodex/logs/ and show errors on exit
@@ -414,6 +414,7 @@ ${pc.bold('Options:')}
 ${pc.bold('Providers:')}
   openai         OpenAI API key (platform.openai.com)
   openai-oauth   ChatGPT/Codex plan OAuth — sign in with clodex providers auth openai
+  opencode-go    OpenCode Go API key — add with clodex providers add
 
 ${pc.bold('Model switching:')}
   Run clodex models to save favorites (max ${MAX_MODEL_CATALOG}).
@@ -423,7 +424,7 @@ ${pc.bold('Model switching:')}
 
 ${pc.bold('Proxy mode:')}
   clodex claude --proxy leaves ANTHROPIC_BASE_URL unset and launches
-  Claude Code with its normal Anthropic login. Favorite OpenAI models are
+  Claude Code with its normal Anthropic login. Favorite clodex models are
   available by typing /model clodex:<provider-id>:<model-id>.
   Save short names with clodex models --alias, and run --list to print them.
   Run clodex patch to make those names first-class inside Claude Code.
@@ -447,10 +448,10 @@ ${pc.bold('Examples:')}
 
 export function serverHelpText(): string {
   return `${pc.bold('clodex server')} v${VERSION}
-Run a foreground gateway bridging Anthropic-format requests to OpenAI models.
+Run a foreground gateway bridging Anthropic-format requests to configured providers.
 Two modes: ${pc.bold('endpoint')} (an Anthropic-format HTTP gateway you point clients at) and
 ${pc.bold('proxy')} (a selective api.anthropic.com MITM proxy; clients keep their Anthropic
-auth while clodex: models route to OpenAI).
+auth while clodex: models route to configured providers).
 
 ${pc.bold('Usage:')}
   clodex server [--endpoint | --proxy] [options]

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1320,10 +1320,19 @@ export async function runClaudeCommand(parsed: ParsedArgs): Promise<number> {
 
   // ── Single-model path ──
 
+  const anonymousProvider = activeProvider.authType === 'none';
+  const isOAuthAnthropic = selectedModel.modelFormat === 'anthropic' && activeProvider.authType === 'oauth';
+  const requiresLocalCountEstimate = selectedModel.modelFormat === 'anthropic'
+    && selectedModel.compatibility?.supportsCountTokens === false;
+  const usesAnthropicProxy = selectedModel.modelFormat === 'anthropic' &&
+    (isOAuthAnthropic || anonymousProvider || requiresLocalCountEstimate);
+
   if (dryRun) {
-    const formatDesc = selectedModel.modelFormat === 'anthropic'
-      ? 'direct passthrough'
-      : 'via SDK adapter proxy';
+    const formatDesc = usesAnthropicProxy
+      ? 'via local passthrough proxy'
+      : selectedModel.modelFormat === 'anthropic'
+        ? 'direct passthrough'
+        : 'via SDK adapter proxy';
     const endpoint = selectedModel.modelFormat === 'anthropic'
       ? (selectedModel.baseUrl ?? '(unknown)')
       : (selectedModel.npm ?? 'SDK');
@@ -1342,7 +1351,6 @@ export async function runClaudeCommand(parsed: ParsedArgs): Promise<number> {
   }
 
   const launchApiKey = await resolveLocalProviderApiKey(activeProvider);
-  const anonymousProvider = activeProvider.authType === 'none';
   if (!anonymousProvider && !launchApiKey?.trim()) {
     p.log.error(
       `No credential found for ${activeProvider.name}. Add a key or sign in with clodex providers.`,
@@ -1352,10 +1360,6 @@ export async function runClaudeCommand(parsed: ParsedArgs): Promise<number> {
 
   let proxyHandle: ProxyHandle | null = null;
   let childEnv: NodeJS.ProcessEnv;
-
-  const isOAuthAnthropic = selectedModel.modelFormat === 'anthropic' && activeProvider.authType === 'oauth';
-  const usesAnthropicProxy = selectedModel.modelFormat === 'anthropic' &&
-    (isOAuthAnthropic || anonymousProvider);
 
   // Static provider headers remain part of the proxied endpoint contract,
   // including OAuth routes. Anonymous dispatch filters credential-bearing
@@ -1375,6 +1379,7 @@ export async function runClaudeCommand(parsed: ParsedArgs): Promise<number> {
           oauthAccountId: activeProvider.oauthAccountId,
           providerData: activeProvider.providerData,
           modelFormat: 'anthropic',
+          compatibility: selectedModel.compatibility,
           headers: activeProvider.headers,
         },
         launchApiKey ?? '',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,15 @@ export const CODEX_RESPONSES_LITE_VERSION = '0.144.1';
 // OpenAI-Beta opt-in for the WebSocket Responses transport.
 export const CODEX_RESPONSES_WEBSOCKETS_BETA = 'responses_websockets=2026-02-06';
 
+/**
+ * Ceiling for every credential/catalog probe a provider add performs. Kept in
+ * one place so a newly added probe cannot quietly become the only unbounded
+ * call on that path: these run under a spinner, and an upstream that accepts
+ * and then stalls (captive portal, egress filter, a proxy that never answers)
+ * otherwise hangs the CLI with no way out but Ctrl-C.
+ */
+export const TEST_TIMEOUT_MS = 10_000;
+
 // These must be removed from the child process environment to avoid conflicts
 // with Vertex AI, Bedrock, AWS, Foundry, and any stale Anthropic config.
 export const CONFLICTING_ENV_VARS = [

--- a/src/data/opencode-go-models.json
+++ b/src/data/opencode-go-models.json
@@ -1,0 +1,497 @@
+[
+  {
+    "id": "deepseek-v4-flash",
+    "name": "DeepSeek V4 Flash (2x usage)",
+    "contextWindow": 1000000,
+    "cost": {
+      "input": 0.07,
+      "output": 0.14,
+      "cache_read": 0.0014
+    },
+    "modelFormat": "openai",
+    "npm": "@ai-sdk/openai-compatible",
+    "apiUrl": "https://opencode.ai/zen/go/v1",
+    "reasoning": true,
+    "modalities": [
+      "text"
+    ],
+    "compatibility": {
+      "reasoningEffortMap": {
+        "minimal": null,
+        "low": null,
+        "medium": null,
+        "high": "high",
+        "max": "max"
+      },
+      "supportsStore": false,
+      "supportsDeveloperRole": false,
+      "maxTokensField": "max_tokens",
+      "requiresReasoningContentOnAssistantMessages": true,
+      "thinkingFormat": "deepseek"
+    },
+    "upstreamModelId": "deepseek-v4-flash",
+    "family": "deepseek"
+  },
+  {
+    "id": "deepseek-v4-pro",
+    "name": "DeepSeek V4 Pro",
+    "contextWindow": 1000000,
+    "cost": {
+      "input": 0.435,
+      "output": 0.87,
+      "cache_read": 0.003625
+    },
+    "modelFormat": "openai",
+    "npm": "@ai-sdk/openai-compatible",
+    "apiUrl": "https://opencode.ai/zen/go/v1",
+    "reasoning": true,
+    "modalities": [
+      "text"
+    ],
+    "compatibility": {
+      "reasoningEffortMap": {
+        "minimal": null,
+        "low": null,
+        "medium": null,
+        "high": "high",
+        "max": "max"
+      },
+      "supportsStore": false,
+      "supportsDeveloperRole": false,
+      "maxTokensField": "max_tokens",
+      "requiresReasoningContentOnAssistantMessages": true,
+      "thinkingFormat": "deepseek"
+    },
+    "upstreamModelId": "deepseek-v4-pro",
+    "family": "deepseek"
+  },
+  {
+    "id": "glm-5.1",
+    "name": "GLM-5.1",
+    "contextWindow": 202752,
+    "cost": {
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26
+    },
+    "modelFormat": "openai",
+    "npm": "@ai-sdk/openai-compatible",
+    "apiUrl": "https://opencode.ai/zen/go/v1",
+    "reasoning": true,
+    "modalities": [
+      "text"
+    ],
+    "compatibility": {
+      "supportsStore": false,
+      "supportsDeveloperRole": false,
+      "maxTokensField": "max_tokens",
+      "supportsReasoningEffort": false
+    },
+    "upstreamModelId": "glm-5.1",
+    "family": "glm"
+  },
+  {
+    "id": "glm-5.2",
+    "name": "GLM-5.2",
+    "contextWindow": 1000000,
+    "cost": {
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26
+    },
+    "modelFormat": "openai",
+    "npm": "@ai-sdk/openai-compatible",
+    "apiUrl": "https://opencode.ai/zen/go/v1",
+    "reasoning": true,
+    "modalities": [
+      "text"
+    ],
+    "compatibility": {
+      "reasoningEffortMap": {
+        "off": null,
+        "minimal": null,
+        "low": null,
+        "medium": null,
+        "high": "high",
+        "xhigh": null,
+        "max": "max"
+      },
+      "supportsStore": false,
+      "supportsDeveloperRole": false,
+      "maxTokensField": "max_tokens"
+    },
+    "upstreamModelId": "glm-5.2",
+    "family": "glm"
+  },
+  {
+    "id": "gpt-5.6-luna",
+    "name": "GPT-5.6 Luna (2x usage)",
+    "contextWindow": 1050000,
+    "cost": {
+      "input": 0.1,
+      "output": 0.6,
+      "cache_read": 0.01,
+      "cache_write": 0.125
+    },
+    "modelFormat": "openai",
+    "npm": "@ai-sdk/openai-compatible",
+    "apiUrl": "https://opencode.ai/zen/go/v1",
+    "reasoning": true,
+    "modalities": [
+      "text",
+      "image"
+    ],
+    "upstreamModelId": "gpt-5.6-luna",
+    "family": "gpt",
+    "compatibility": {
+      "reasoningEffortMap": {
+        "off": "none",
+        "minimal": null,
+        "low": "low",
+        "medium": "medium",
+        "high": "high",
+        "xhigh": "xhigh",
+        "max": "max"
+      },
+      "supportsStore": false,
+      "supportsDeveloperRole": false,
+      "maxTokensField": "max_tokens"
+    }
+  },
+  {
+    "id": "hy3",
+    "name": "Hy3",
+    "contextWindow": 256000,
+    "cost": {
+      "input": 0.14,
+      "output": 0.58,
+      "cache_read": 0.035
+    },
+    "modelFormat": "openai",
+    "npm": "@ai-sdk/openai-compatible",
+    "apiUrl": "https://opencode.ai/zen/go/v1",
+    "reasoning": true,
+    "modalities": [
+      "text"
+    ],
+    "compatibility": {
+      "reasoningEffortMap": {
+        "off": "none",
+        "minimal": null,
+        "low": "low",
+        "medium": null,
+        "high": "high",
+        "xhigh": null,
+        "max": null
+      },
+      "supportsStore": false,
+      "supportsDeveloperRole": false,
+      "maxTokensField": "max_tokens"
+    },
+    "upstreamModelId": "hy3",
+    "family": "hy3"
+  },
+  {
+    "id": "kimi-k2.6",
+    "name": "Kimi K2.6",
+    "contextWindow": 262144,
+    "cost": {
+      "input": 0.95,
+      "output": 4,
+      "cache_read": 0.16
+    },
+    "modelFormat": "openai",
+    "npm": "@ai-sdk/openai-compatible",
+    "apiUrl": "https://opencode.ai/zen/go/v1",
+    "reasoning": true,
+    "modalities": [
+      "text",
+      "image"
+    ],
+    "compatibility": {
+      "reasoningEffortMap": {
+        "minimal": null,
+        "low": null,
+        "medium": null
+      },
+      "supportsStore": false,
+      "supportsDeveloperRole": false,
+      "thinkingFormat": "deepseek",
+      "supportsReasoningEffort": false,
+      "maxTokensField": "max_tokens",
+      "supportsLongCacheRetention": false
+    },
+    "upstreamModelId": "kimi-k2.6",
+    "family": "kimi"
+  },
+  {
+    "id": "kimi-k2.7-code",
+    "name": "Kimi K2.7 Code",
+    "contextWindow": 262144,
+    "cost": {
+      "input": 0.95,
+      "output": 4,
+      "cache_read": 0.19
+    },
+    "modelFormat": "openai",
+    "npm": "@ai-sdk/openai-compatible",
+    "apiUrl": "https://opencode.ai/zen/go/v1",
+    "reasoning": true,
+    "modalities": [
+      "text",
+      "image"
+    ],
+    "compatibility": {
+      "supportsStore": false,
+      "supportsDeveloperRole": false,
+      "maxTokensField": "max_tokens",
+      "supportsReasoningEffort": false
+    },
+    "upstreamModelId": "kimi-k2.7-code",
+    "family": "kimi"
+  },
+  {
+    "id": "kimi-k3",
+    "name": "Kimi K3",
+    "contextWindow": 1048576,
+    "cost": {
+      "input": 3,
+      "output": 15,
+      "cache_read": 0.3
+    },
+    "modelFormat": "openai",
+    "npm": "@ai-sdk/openai-compatible",
+    "apiUrl": "https://opencode.ai/zen/go/v1",
+    "reasoning": true,
+    "modalities": [
+      "text",
+      "image"
+    ],
+    "compatibility": {
+      "reasoningEffortMap": {
+        "off": null,
+        "minimal": null,
+        "low": null,
+        "medium": null,
+        "high": null,
+        "xhigh": null,
+        "max": "max"
+      },
+      "supportsStore": false,
+      "supportsDeveloperRole": false,
+      "maxTokensField": "max_tokens"
+    },
+    "upstreamModelId": "kimi-k3",
+    "family": "kimi"
+  },
+  {
+    "id": "mimo-v2.5",
+    "name": "MiMo V2.5",
+    "contextWindow": 1000000,
+    "cost": {
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.0028
+    },
+    "modelFormat": "openai",
+    "npm": "@ai-sdk/openai-compatible",
+    "apiUrl": "https://opencode.ai/zen/go/v1",
+    "reasoning": true,
+    "modalities": [
+      "text",
+      "image"
+    ],
+    "compatibility": {
+      "supportsStore": false,
+      "supportsDeveloperRole": false,
+      "maxTokensField": "max_tokens",
+      "supportsReasoningEffort": false
+    },
+    "upstreamModelId": "mimo-v2.5",
+    "family": "mimo"
+  },
+  {
+    "id": "mimo-v2.5-pro",
+    "name": "MiMo V2.5 Pro",
+    "contextWindow": 1048576,
+    "cost": {
+      "input": 0.435,
+      "output": 0.87,
+      "cache_read": 0.003625
+    },
+    "modelFormat": "openai",
+    "npm": "@ai-sdk/openai-compatible",
+    "apiUrl": "https://opencode.ai/zen/go/v1",
+    "reasoning": true,
+    "modalities": [
+      "text"
+    ],
+    "compatibility": {
+      "supportsStore": false,
+      "supportsDeveloperRole": false,
+      "maxTokensField": "max_tokens",
+      "supportsReasoningEffort": false
+    },
+    "upstreamModelId": "mimo-v2.5-pro",
+    "family": "mimo"
+  },
+  {
+    "id": "minimax-m2.7",
+    "name": "MiniMax-M2.7",
+    "contextWindow": 204800,
+    "cost": {
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.06
+    },
+    "modelFormat": "openai",
+    "npm": "@ai-sdk/openai-compatible",
+    "apiUrl": "https://opencode.ai/zen/go/v1",
+    "reasoning": true,
+    "modalities": [
+      "text"
+    ],
+    "compatibility": {
+      "supportsStore": false,
+      "supportsDeveloperRole": false,
+      "maxTokensField": "max_tokens",
+      "supportsReasoningEffort": false
+    },
+    "upstreamModelId": "minimax-m2.7",
+    "family": "minimax"
+  },
+  {
+    "id": "minimax-m3",
+    "name": "MiniMax-M3",
+    "contextWindow": 1000000,
+    "cost": {
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.06
+    },
+    "modelFormat": "anthropic",
+    "npm": "@ai-sdk/anthropic",
+    "apiUrl": "https://opencode.ai/zen/go",
+    "reasoning": true,
+    "modalities": [
+      "text",
+      "image"
+    ],
+    "upstreamModelId": "minimax-m3",
+    "family": "minimax",
+    "compatibility": {
+      "supportsCountTokens": false,
+      "supportsReasoningEffort": false
+    }
+  },
+  {
+    "id": "qwen3.6-plus",
+    "name": "Qwen3.6 Plus",
+    "contextWindow": 1000000,
+    "cost": {
+      "input": 0.5,
+      "output": 3,
+      "cache_read": 0.05,
+      "cache_write": 0.625
+    },
+    "modelFormat": "openai",
+    "npm": "@ai-sdk/openai-compatible",
+    "apiUrl": "https://opencode.ai/zen/go/v1",
+    "reasoning": true,
+    "modalities": [
+      "text",
+      "image"
+    ],
+    "compatibility": {
+      "supportsStore": false,
+      "supportsDeveloperRole": false,
+      "thinkingFormat": "qwen",
+      "maxTokensField": "max_tokens",
+      "reasoningEffortMap": {
+        "low": "low",
+        "medium": "medium",
+        "high": "high",
+        "xhigh": "xhigh",
+        "max": "max",
+        "minimal": null,
+        "off": null
+      }
+    },
+    "upstreamModelId": "qwen3.6-plus",
+    "family": "qwen3.6"
+  },
+  {
+    "id": "qwen3.7-max",
+    "name": "Qwen3.7 Max",
+    "contextWindow": 1000000,
+    "cost": {
+      "input": 2.5,
+      "output": 7.5,
+      "cache_read": 0.5,
+      "cache_write": 3.125
+    },
+    "modelFormat": "anthropic",
+    "npm": "@ai-sdk/anthropic",
+    "apiUrl": "https://opencode.ai/zen/go",
+    "reasoning": true,
+    "modalities": [
+      "text"
+    ],
+    "upstreamModelId": "qwen3.7-max",
+    "family": "qwen3.7",
+    "compatibility": {
+      "supportsCountTokens": false,
+      "supportsReasoningEffort": false
+    }
+  },
+  {
+    "id": "qwen3.7-plus",
+    "name": "Qwen3.7 Plus",
+    "contextWindow": 1000000,
+    "cost": {
+      "input": 0.4,
+      "output": 1.6,
+      "cache_read": 0.04,
+      "cache_write": 0.5
+    },
+    "modelFormat": "anthropic",
+    "npm": "@ai-sdk/anthropic",
+    "apiUrl": "https://opencode.ai/zen/go",
+    "reasoning": true,
+    "modalities": [
+      "text",
+      "image"
+    ],
+    "upstreamModelId": "qwen3.7-plus",
+    "family": "qwen3.7",
+    "compatibility": {
+      "supportsCountTokens": false,
+      "supportsReasoningEffort": false
+    }
+  },
+  {
+    "id": "qwen3.8-max",
+    "name": "Qwen3.8 Max",
+    "contextWindow": 1000000,
+    "cost": {
+      "input": 2,
+      "output": 6,
+      "cache_read": 0.25,
+      "cache_write": 2.5
+    },
+    "modelFormat": "anthropic",
+    "npm": "@ai-sdk/anthropic",
+    "apiUrl": "https://opencode.ai/zen/go",
+    "reasoning": true,
+    "modalities": [
+      "text",
+      "image"
+    ],
+    "upstreamModelId": "qwen3.8-max",
+    "family": "qwen3.8",
+    "compatibility": {
+      "supportsCountTokens": false,
+      "supportsReasoningEffort": false
+    }
+  }
+]

--- a/src/data/opencode-go-models.ts
+++ b/src/data/opencode-go-models.ts
@@ -1,0 +1,27 @@
+import models from './opencode-go-models.json';
+import type { CachedModel } from '../registry/types.js';
+
+export const OPENCODE_GO_PROVIDER_ID = 'opencode-go';
+export const OPENCODE_GO_PROVIDER_NAME = 'OpenCode Go';
+export const OPENCODE_GO_COMPLETIONS_BASE_URL = 'https://opencode.ai/zen/go/v1';
+export const OPENCODE_GO_ANTHROPIC_BASE_URL = 'https://opencode.ai/zen/go';
+export const OPENCODE_GO_SOURCE = 'https://models.dev/api.json';
+export const OPENCODE_GO_SOURCE_FETCHED_AT = '2026-08-08T20:10:24.208Z';
+
+type OpenCodeGoModel = Pick<CachedModel, 'id' | 'name'>
+  & Partial<Omit<CachedModel, 'id' | 'name'>>;
+
+/**
+ * Curated OpenCode Go models supported by Clodex.
+ *
+ * Metadata (name, context, cost, modalities) comes from OpenCode's own
+ * catalog (models.dev); per-model wire transport and compatibility behavior
+ * are clodex's live-validated knowledge in the updater script. The upstream
+ * catalog mixes Anthropic Messages, Chat Completions, and Responses
+ * transports. Clodex intentionally publishes only the first two;
+ * Responses-only entries (currently Grok and mainline GPT) never enter the
+ * provider allowlist.
+ */
+export function buildOpenCodeGoModels(): OpenCodeGoModel[] {
+  return structuredClone(models) as unknown as OpenCodeGoModel[];
+}

--- a/src/model-runtime-compatibility.ts
+++ b/src/model-runtime-compatibility.ts
@@ -22,6 +22,17 @@ export interface ModelRuntimeCompatibility {
   maxTokensField?: 'max_tokens' | 'max_completion_tokens';
   /** Whether the upstream accepts long prompt-cache retention controls. */
   supportsLongCacheRetention?: boolean;
+  /**
+   * Whether an anthropic-format upstream implements
+   * `POST /v1/messages/count_tokens`. Speaking the Messages API does not imply
+   * it — OpenCode Zen documents `/v1/responses`, `/v1/chat/completions` and
+   * `/v1/messages` and no token-counting endpoint — and forwarding a count to
+   * an upstream without it answers the client's token accounting with a 404
+   * instead of a number. Only an explicit `false` diverts to the local
+   * estimate; unset keeps forwarding, so a custom Anthropic-compatible
+   * endpoint that does implement it is unaffected.
+   */
+  supportsCountTokens?: boolean;
 }
 
 export type OpenAiCompatibleRequestBody = Record<string, unknown>;

--- a/src/patcher.ts
+++ b/src/patcher.ts
@@ -51,6 +51,8 @@ import {
   type BuiltInPatchProof,
 } from './built-in-patch-proofs.js';
 import { loadRegistry } from './registry/io.js';
+import { projectProviderCachedModels } from './registry/materialize.js';
+import { isRetainedOpenCodeGoProvider } from './registry/resolve-template.js';
 import { findModelsDevModel } from './registry/models-dev.js';
 import { findClaudeBinary, getClaudeVersionForBinary } from './launch.js';
 import {
@@ -265,9 +267,13 @@ export function buildDesiredPatchConfig(): DesiredPatchConfig {
   const aliases = prefs.modelAliases;
   const registry = loadRegistry();
 
+  const providerById = new Map(registry.providers.map(provider => [provider.id, provider]));
+  const projectedModelsByProvider = new Map<string, ReturnType<typeof projectProviderCachedModels>>();
   const meta = new Map<string, PatchModelMeta>();
   for (const provider of registry.providers) {
-    for (const model of provider.modelsCache?.models ?? []) {
+    const projectedModels = projectProviderCachedModels(provider);
+    projectedModelsByProvider.set(provider.id, projectedModels);
+    for (const model of projectedModels) {
       const npm = model.npm ?? provider.api.npm ?? '';
       const upstreamModelId = model.upstreamModelId ?? model.id;
       const modelsDev = findModelsDevModel(provider.id, model.id);
@@ -292,8 +298,14 @@ export function buildDesiredPatchConfig(): DesiredPatchConfig {
     }
   }
 
+  const projectedFavorites = favorites.filter(favorite => {
+    const provider = providerById.get(favorite.providerId);
+    if (!provider || !isRetainedOpenCodeGoProvider(provider)) return true;
+    return projectedModelsByProvider.get(provider.id)?.some(model => model.id === favorite.modelId) ?? false;
+  });
+
   return buildPatchModelConfig(
-    favorites,
+    projectedFavorites,
     aliases,
     (providerId, modelId) => meta.get(`${providerId}:${modelId}`),
   );

--- a/src/provider-catalog.ts
+++ b/src/provider-catalog.ts
@@ -7,7 +7,11 @@ import type { CompatibilityAgent } from './model-compatibility.js';
 import { oauthAuthRef } from './registry/import-build.js';
 import { loadRegistry } from './registry/io.js';
 import { loadRegistryProviders, type LoadedRegistryProviders } from './registry/load.js';
-import { isAnonymousProvider, projectSelectedOAuthAccount } from './registry/materialize.js';
+import {
+  isAnonymousProvider,
+  projectProviderCachedModels,
+  projectSelectedOAuthAccount,
+} from './registry/materialize.js';
 import { OAUTH_ACCOUNT_ENV } from './oauth-account-selection.js';
 import { getTemplateById } from './provider-templates.js';
 import type { LocalProvider } from './types.js';
@@ -357,7 +361,7 @@ export async function resolveProvidersForDisplay(): Promise<ProviderDisplayEntry
         // cache. Runtime materialization fails closed for the same reason.
         if (credentialOverrideWins) return 0;
         try {
-          return projectSelectedOAuthAccount(provider).modelsCache?.models.length ?? 0;
+          return projectProviderCachedModels(projectSelectedOAuthAccount(provider)).length;
         } catch {
           return 0;
         }

--- a/src/provider-factory.ts
+++ b/src/provider-factory.ts
@@ -640,11 +640,33 @@ function mapCodexEffortToGeminiBudget(effort: string): number | undefined {
   return GEMINI_25_BUDGETS[level];
 }
 
+/**
+ * Whether a compatibility block says anything at all about reasoning.
+ *
+ * A block carrying only wire-shape fields (`supportsStore`, `maxTokensField`,
+ * …) has no opinion and must fall through to the model-name rules. Both
+ * reasoning paths have to agree on that: the capability path answers
+ * `undefined` and falls through, so an effort path that treated mere presence
+ * of the block as "suppress" would advertise a control that never reaches the
+ * wire. Shared here so the two cannot drift apart again.
+ */
+function compatibilityExpressesReasoningIntent(
+  compatibility: ModelRuntimeCompatibility,
+): boolean {
+  return compatibility.supportsReasoningEffort !== undefined
+    || compatibility.reasoningEffortMap !== undefined
+    || compatibility.thinkingFormat !== undefined;
+}
+
 function compatibilityReasoningCapabilities(
   metadata?: ReasoningMetadata,
 ): ReasoningCapabilities | undefined {
   const compatibility = metadata?.compatibility;
   if (!compatibility) return undefined;
+  // Behaviour-preserving: every branch below already requires one of these.
+  // Stated up front so the predicate is visibly the same one the effort path
+  // gates on.
+  if (!compatibilityExpressesReasoningIntent(compatibility)) return undefined;
 
   if (compatibility.supportsReasoningEffort === false) {
     return metadata?.reasoning === false
@@ -952,7 +974,17 @@ export function effortProviderOptions(
 ): Record<string, Record<string, unknown>> | undefined {
   if (!effort) return undefined;
 
-  if (npm === '@ai-sdk/openai-compatible' && modelId && metadata?.compatibility) {
+  // Only when the block expresses reasoning intent. On a wire-shape-only block
+  // `compatibilityReasoningEffort` answers "no opinion", and returning here on
+  // that would skip the model-name rules the capability path still applies —
+  // the model would advertise controllable reasoning, show no levels in a
+  // patched client, and never put `reasoning_effort` on the wire.
+  if (
+    npm === '@ai-sdk/openai-compatible'
+    && modelId
+    && metadata?.compatibility
+    && compatibilityExpressesReasoningIntent(metadata.compatibility)
+  ) {
     const reasoningEffort = compatibilityReasoningEffort(
       effort,
       modelId,

--- a/src/provider-factory.ts
+++ b/src/provider-factory.ts
@@ -640,33 +640,11 @@ function mapCodexEffortToGeminiBudget(effort: string): number | undefined {
   return GEMINI_25_BUDGETS[level];
 }
 
-/**
- * Whether a compatibility block says anything at all about reasoning.
- *
- * A block carrying only wire-shape fields (`supportsStore`, `maxTokensField`,
- * …) has no opinion and must fall through to the model-name rules. Both
- * reasoning paths have to agree on that: the capability path answers
- * `undefined` and falls through, so an effort path that treated mere presence
- * of the block as "suppress" would advertise a control that never reaches the
- * wire. Shared here so the two cannot drift apart again.
- */
-function compatibilityExpressesReasoningIntent(
-  compatibility: ModelRuntimeCompatibility,
-): boolean {
-  return compatibility.supportsReasoningEffort !== undefined
-    || compatibility.reasoningEffortMap !== undefined
-    || compatibility.thinkingFormat !== undefined;
-}
-
 function compatibilityReasoningCapabilities(
   metadata?: ReasoningMetadata,
 ): ReasoningCapabilities | undefined {
   const compatibility = metadata?.compatibility;
   if (!compatibility) return undefined;
-  // Behaviour-preserving: every branch below already requires one of these.
-  // Stated up front so the predicate is visibly the same one the effort path
-  // gates on.
-  if (!compatibilityExpressesReasoningIntent(compatibility)) return undefined;
 
   if (compatibility.supportsReasoningEffort === false) {
     return metadata?.reasoning === false
@@ -974,17 +952,7 @@ export function effortProviderOptions(
 ): Record<string, Record<string, unknown>> | undefined {
   if (!effort) return undefined;
 
-  // Only when the block expresses reasoning intent. On a wire-shape-only block
-  // `compatibilityReasoningEffort` answers "no opinion", and returning here on
-  // that would skip the model-name rules the capability path still applies —
-  // the model would advertise controllable reasoning, show no levels in a
-  // patched client, and never put `reasoning_effort` on the wire.
-  if (
-    npm === '@ai-sdk/openai-compatible'
-    && modelId
-    && metadata?.compatibility
-    && compatibilityExpressesReasoningIntent(metadata.compatibility)
-  ) {
+  if (npm === '@ai-sdk/openai-compatible' && modelId && metadata?.compatibility) {
     const reasoningEffort = compatibilityReasoningEffort(
       effort,
       modelId,

--- a/src/provider-templates.ts
+++ b/src/provider-templates.ts
@@ -101,7 +101,7 @@ export async function verifyOpenCodeGoCredential(apiKey: string): Promise<string
         // "Unauthorized" and would reject that key at add time, blaming the
         // key for an entitlement problem. Only a type that IS an auth error,
         // or a message that talks about the key itself, counts.
-        authRejected = /^(?:auth|authentication|authorization)(?:_?error)?$/i.test(errorType)
+        authRejected = /^(?:auth|authentication)(?:_?error)?$/i.test(errorType)
           || /\b(?:invalid|bad|missing|expired|incorrect)\b[^.]{0,40}\bapi[ _-]?key\b/i.test(message)
           || /\bapi[ _-]?key\b[^.]{0,40}\b(?:invalid|not valid|expired|incorrect|missing)\b/i.test(message)
           || /\bauthentication (?:failed|error)\b/i.test(message);

--- a/src/provider-templates.ts
+++ b/src/provider-templates.ts
@@ -1,6 +1,13 @@
 // src/provider-templates.ts — builtin provider templates for clodex providers add
 
+import { TEST_TIMEOUT_MS } from './constants.js';
 import type { CachedModel } from './registry/types.js';
+import {
+  buildOpenCodeGoModels,
+  OPENCODE_GO_COMPLETIONS_BASE_URL,
+  OPENCODE_GO_PROVIDER_ID,
+  OPENCODE_GO_PROVIDER_NAME,
+} from './data/opencode-go-models.js';
 
 export type ProviderAuthType = 'api' | 'oauth' | 'none';
 export type ProviderModelSource = 'api-list' | 'static-seed' | 'manual-only';
@@ -29,13 +36,93 @@ export interface ProviderTemplate {
   staticModelPolicy?: ProviderStaticModelPolicy;
   /** Keep provider/curated costs instead of replacing them with the global pricing cache. */
   preserveModelPricing?: boolean;
+  /**
+   * Authenticated probe run before a pasted key is persisted. Required when the
+   * provider's models endpoint answers without authentication (so a models
+   * fetch cannot validate the credential). Returns an error message to reject
+   * the key, or null when the key is accepted or the probe is inconclusive —
+   * only a definite auth rejection may block the add.
+   *
+   * Deliberately takes no base-URL argument. The probe destination is a
+   * property of the template, so no caller can redirect a live credential to
+   * an address the template did not declare.
+   */
+  verifyCredential?: (apiKey: string) => Promise<string | null>;
   supported: boolean;
   addable?: boolean;
   hidden?: boolean;
   unsupportedReason?: string;
 }
 
-/** clodex ships exactly two provider templates: OpenAI (API key) and OpenAI OAuth (ChatGPT plan). */
+/**
+ * OpenCode Go's /models endpoint is availability data and answers without
+ * authentication, so the shared api-list flow's models fetch cannot validate a
+ * pasted key. Probe the authenticated chat-completions endpoint instead.
+ *
+ * The destination is the template's own reviewed literal, never an argument:
+ * this function sends a live credential, so the address it reaches must not be
+ * reachable from caller input.
+ *
+ * The gateway resolves the request's model BEFORE evaluating the key: a body
+ * without a supported model returns 401 ModelError for every key, valid or
+ * not, so the probe must name a model from the committed catalog. Even then,
+ * only an auth-shaped rejection (401/403 whose error reads as AuthError /
+ * invalid key) rejects the credential; every other outcome — validation
+ * errors, unparseable bodies, an unreachable upstream — is inconclusive and
+ * passes, so the probe can only ever reject keys the upstream itself
+ * rejected as keys.
+ */
+export async function verifyOpenCodeGoCredential(apiKey: string): Promise<string | null> {
+  const model = buildOpenCodeGoModels().find(entry => entry.modelFormat === 'openai');
+  if (!model) return null;
+  try {
+    const response = await fetch(`${OPENCODE_GO_COMPLETIONS_BASE_URL}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({ model: model.upstreamModelId ?? model.id }),
+      // This is the FIRST thing a user hits after pasting a key, and it runs
+      // under a spinner. Without a deadline an upstream that accepts and then
+      // stalls leaves no exit but Ctrl-C. The catch below already treats an
+      // abort as inconclusive, so fail-open semantics are unchanged.
+      signal: AbortSignal.timeout(TEST_TIMEOUT_MS),
+    });
+    if (response.status === 401 || response.status === 403) {
+      let authRejected = false;
+      try {
+        const parsed = JSON.parse(await response.text()) as { error?: { type?: string; message?: string } };
+        const errorType = String(parsed.error?.type ?? '');
+        const message = String(parsed.error?.message ?? '');
+        // Anchored: the probe names one fixed model, so a plan-gated model
+        // answers 403 UnauthorizedModelError ("your plan does not include …")
+        // on a perfectly good key. An unanchored /auth/i matches inside
+        // "Unauthorized" and would reject that key at add time, blaming the
+        // key for an entitlement problem. Only a type that IS an auth error,
+        // or a message that talks about the key itself, counts.
+        authRejected = /^(?:auth|authentication|authorization)(?:_?error)?$/i.test(errorType)
+          || /\b(?:invalid|bad|missing|expired|incorrect)\b[^.]{0,40}\bapi[ _-]?key\b/i.test(message)
+          || /\bapi[ _-]?key\b[^.]{0,40}\b(?:invalid|not valid|expired|incorrect|missing)\b/i.test(message)
+          || /\bauthentication (?:failed|error)\b/i.test(message);
+      } catch {
+        // An unparseable 401 is inconclusive, not proof of a bad key.
+      }
+      if (authRejected) {
+        return 'OpenCode Go rejected this API key (authentication failed). Check the key and try again.';
+      }
+    } else {
+      try {
+        await response.body?.cancel?.();
+      } catch { /* only auth rejections matter to the probe */ }
+    }
+  } catch {
+    // Unreachable probe is inconclusive; the models fetch surfaces network errors.
+  }
+  return null;
+}
+
+/** Built-in providers available through `clodex providers add` or OAuth authentication. */
 export const PROVIDER_TEMPLATES: ProviderTemplate[] = [
   {
     id: 'openai',
@@ -45,6 +132,27 @@ export const PROVIDER_TEMPLATES: ProviderTemplate[] = [
     defaultBaseUrl: 'https://api.openai.com/v1',
     signupUrl: 'https://platform.openai.com/api-keys',
     modelSource: 'api-list',
+    supported: true,
+  },
+  {
+    id: OPENCODE_GO_PROVIDER_ID,
+    name: OPENCODE_GO_PROVIDER_NAME,
+    authType: 'api',
+    npm: '@ai-sdk/openai-compatible',
+    defaultBaseUrl: OPENCODE_GO_COMPLETIONS_BASE_URL,
+    modelsPath: '/models',
+    signupUrl: 'https://opencode.ai',
+    modelSource: 'api-list',
+    // /models is availability data (answers without auth), so the shared
+    // api-list validation cannot catch a bad key; probe before persisting.
+    verifyCredential: verifyOpenCodeGoCredential,
+    // A getter, not a value: PROVIDER_TEMPLATES is a module-level literal, so
+    // an eager call would deep-clone the catalog entries on every single CLI
+    // invocation — `clodex --help` included — for a list most commands never
+    // read. Still returns an isolated copy per access, as callers expect.
+    get staticModels() { return buildOpenCodeGoModels(); },
+    staticModelPolicy: 'allowlist',
+    preserveModelPricing: true,
     supported: true,
   },
   {

--- a/src/providers-command.ts
+++ b/src/providers-command.ts
@@ -30,7 +30,11 @@ import { refreshAllProviderModels, refreshProviderModelsWithCredential } from '.
 import { authenticateProvider, providerAuthHelpText, validateOAuthAccountName, type ProviderAuthMethod } from './registry/provider-auth.js';
 import { supportsNativeOAuth } from './oauth/types.js';
 import { browseAllModels } from './prompts.js';
-import { cachedModelToLocal, projectSelectedOAuthAccount } from './registry/materialize.js';
+import {
+  cachedModelToLocal,
+  projectProviderCachedModels,
+  projectSelectedOAuthAccount,
+} from './registry/materialize.js';
 import { OAUTH_ACCOUNT_ENV } from './oauth-account-selection.js';
 import { loadPreferences } from './config.js';
 import type { LocalProvider } from './types.js';
@@ -731,7 +735,7 @@ async function runProviderDetail(id: string): Promise<'back' | 'removed'> {
     delete modelProvider.modelsCache;
     delete modelProvider.refreshedAt;
   }
-  const modelCount = modelProvider.modelsCache?.models.length ?? 0;
+  const modelCount = projectProviderCachedModels(modelProvider).length;
   const authLabel = (await resolveProvidersForDisplay()).find(entry => entry.id === id)?.authLabel
     ?? formatRegistryAuthLabel(provider);
   printProviderDetailPanel(provider.name, modelCount, authLabel);
@@ -793,7 +797,7 @@ async function runProviderDetail(id: string): Promise<'back' | 'removed'> {
   if (p.isCancel(action) || action === 'back') return 'back';
 
   if (action === 'browse') {
-    const cachedModels = modelProvider.modelsCache?.models ?? [];
+    const cachedModels = projectProviderCachedModels(modelProvider);
     const localModels = cachedModels
       .map(m => cachedModelToLocal(m, modelProvider))
       .filter((m): m is NonNullable<typeof m> => m !== null);
@@ -883,7 +887,7 @@ async function runProviderDetail(id: string): Promise<'back' | 'removed'> {
         result.account,
         resolveActiveAccount(currentProvider),
       );
-      const selectedCatalogReady = Boolean(currentProvider.modelsCache?.models.length);
+      const selectedCatalogReady = projectProviderCachedModels(currentProvider).length > 0;
       if (
         outcome.ok
         && currentProvider.enabled

--- a/src/providers-command.ts
+++ b/src/providers-command.ts
@@ -35,6 +35,7 @@ import { OAUTH_ACCOUNT_ENV } from './oauth-account-selection.js';
 import { loadPreferences } from './config.js';
 import type { LocalProvider } from './types.js';
 import { readLiveServerRuntimeStates } from './server-runtime.js';
+import { isProviderConfiguredForTemplate } from './registry/resolve-template.js';
 import {
   fmtEnabledStar,
   fmtProvider,
@@ -548,14 +549,19 @@ export async function runProvidersList(): Promise<number> {
   return 0;
 }
 
+function listRegistryAddableTemplates(providers: RegistryProvider[]) {
+  return listAddableTemplates().filter(template =>
+    !providers.some(provider => isProviderConfiguredForTemplate(provider, template.id)));
+}
+
 /** Add one API-key provider from a built-in template. */
 async function runTemplateAddFlow(
   templateId: string,
   cleanupState?: ProviderCommandCleanupState,
 ): Promise<number> {
   const registry = loadRegistry();
-  const configuredIds = registry.providers.map(provider => provider.id);
-  const template = listAddableTemplates(configuredIds).find(candidate => candidate.id === templateId);
+  const template = listRegistryAddableTemplates(registry.providers)
+    .find(candidate => candidate.id === templateId);
   if (!template) {
     const known = getTemplateById(templateId);
     p.log.info(known ? `${known.name} is already configured.` : `Unknown provider template: ${templateId}`);
@@ -602,7 +608,8 @@ async function runTemplateAddFlow(
 async function runProvidersAddWithCleanupState(
   cleanupState?: ProviderCommandCleanupState,
 ): Promise<number> {
-  const configuredIds = loadRegistry().providers.map(provider => provider.id);
+  const providers = loadRegistry().providers;
+  const configuredIds = providers.map(provider => provider.id);
   const options: Array<{ value: string; label: string; hint: string }> = [];
 
   if (!configuredIds.includes('openai-oauth')) {
@@ -612,7 +619,7 @@ async function runProvidersAddWithCleanupState(
       hint: 'OAuth device code — no API key needed',
     });
   }
-  for (const template of listAddableTemplates(configuredIds)) {
+  for (const template of listRegistryAddableTemplates(providers)) {
     options.push({
       value: `api:${template.id}`,
       label: `${template.name} API key`,

--- a/src/providers-command.ts
+++ b/src/providers-command.ts
@@ -155,7 +155,7 @@ export function parseProvidersArgs(args: string[]): {
 }
 
 export function providersHelpText(): string {
-  return `${pc.bold('clodex providers')} — manage your OpenAI providers
+  return `${pc.bold('clodex providers')} — manage model providers
 
 ${pc.bold('Usage:')}
   clodex providers
@@ -167,7 +167,7 @@ ${pc.bold('Usage:')}
 
 ${pc.bold('Subcommands:')}
   (none)      Provider hub wizard
-  add         Add OpenAI with an API key
+  add         Add a built-in provider or sign in with ChatGPT
   auth        Sign in with ChatGPT/Codex-plan OAuth (device code)
   list        Show configured providers
   remove      Remove a provider by id
@@ -548,15 +548,18 @@ export async function runProvidersList(): Promise<number> {
   return 0;
 }
 
-/** Add the OpenAI API-key provider (the only addable template in clodex). */
-async function runTemplateAddFlow(cleanupState?: ProviderCommandCleanupState): Promise<number> {
+/** Add one API-key provider from a built-in template. */
+async function runTemplateAddFlow(
+  templateId: string,
+  cleanupState?: ProviderCommandCleanupState,
+): Promise<number> {
   const registry = loadRegistry();
-  const configuredIds = registry.providers.map(p => p.id);
-  const template = listAddableTemplates(configuredIds).find(t => t.id === 'openai')
-    ?? getTemplateById('openai');
-  if (!template || configuredIds.includes('openai')) {
-    p.log.info('OpenAI is already configured. Use clodex providers auth openai for ChatGPT OAuth.');
-    return 0;
+  const configuredIds = registry.providers.map(provider => provider.id);
+  const template = listAddableTemplates(configuredIds).find(candidate => candidate.id === templateId);
+  if (!template) {
+    const known = getTemplateById(templateId);
+    p.log.info(known ? `${known.name} is already configured.` : `Unknown provider template: ${templateId}`);
+    return known ? 0 : 1;
   }
 
   if (template.signupUrl) {
@@ -599,20 +602,34 @@ async function runTemplateAddFlow(cleanupState?: ProviderCommandCleanupState): P
 async function runProvidersAddWithCleanupState(
   cleanupState?: ProviderCommandCleanupState,
 ): Promise<number> {
+  const configuredIds = loadRegistry().providers.map(provider => provider.id);
+  const options: Array<{ value: string; label: string; hint: string }> = [];
+
+  if (!configuredIds.includes('openai-oauth')) {
+    options.push({
+      value: 'oauth',
+      label: 'Sign in with ChatGPT (Plus/Pro plan)',
+      hint: 'OAuth device code — no API key needed',
+    });
+  }
+  for (const template of listAddableTemplates(configuredIds)) {
+    options.push({
+      value: `api:${template.id}`,
+      label: `${template.name} API key`,
+      hint: template.id === 'openai'
+        ? 'platform.openai.com key (usage-billed)'
+        : 'provider API key (usage-billed)',
+    });
+  }
+
+  if (options.length === 0) {
+    p.log.info('All built-in providers are already configured.');
+    return 0;
+  }
+
   const choice = await p.select({
     message: 'Add a provider',
-    options: [
-      {
-        value: 'oauth',
-        label: 'Sign in with ChatGPT (Plus/Pro plan)',
-        hint: 'OAuth device code — no API key needed',
-      },
-      {
-        value: 'apikey',
-        label: 'OpenAI API key',
-        hint: 'platform.openai.com key (usage-billed)',
-      },
-    ],
+    options,
   });
   if (p.isCancel(choice)) {
     p.cancel('Cancelled.');
@@ -622,7 +639,9 @@ async function runProvidersAddWithCleanupState(
   if (choice === 'oauth') {
     return runProvidersAuthWithCleanupState('openai', undefined, cleanupState);
   }
-  if (choice === 'apikey') return runTemplateAddFlow(cleanupState);
+  if (typeof choice === 'string' && choice.startsWith('api:')) {
+    return runTemplateAddFlow(choice.slice('api:'.length), cleanupState);
+  }
   return 0;
 }
 
@@ -932,7 +951,7 @@ export async function runProvidersHub(): Promise<number> {
     options.push({ value: 'done', label: 'Done', hint: '' });
 
     const choice = await p.select({
-      message: entries.length > 0 ? 'Your OpenAI providers' : 'Get started',
+      message: entries.length > 0 ? 'Your providers' : 'Get started',
       options,
     });
     if (p.isCancel(choice) || choice === 'done') {
@@ -1018,6 +1037,6 @@ export async function runProvidersCommand(args: string[]): Promise<number> {
       runProvidersAuthWithCleanupState(parsed.removeId!, parsed.authMethod, state, parsed.authAccount));
   }
 
-  relayIntro('Your OpenAI providers');
+  relayIntro('Your providers');
   return runProvidersHub();
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -434,6 +434,17 @@ export async function startProxyCatalog(
         return;
       }
       const route = resolvedRoute ?? defaultRoute;
+      // The identity a translated response reports. A request that named a
+      // route we honoured keeps its public id — patched Claude Code preflights
+      // with the request alias and resolves context windows from the response
+      // `model`, so rewriting it there would break auto-compaction. On the
+      // default-route fallback the requested id names no route we honoured, so
+      // reporting the real target is the only honest answer; the Anthropic
+      // passthrough already refuses to echo there and the translated path has
+      // to agree.
+      const responseModelId = resolvedRoute && typeof originalModel === 'string'
+        ? originalModel
+        : route.realModelId;
       // Anthropic-format is not the same question as "implements
       // count_tokens". Before third-party anthropic-format routes existed the
       // local path was the only one ever taken; now a route whose upstream
@@ -681,7 +692,7 @@ export async function startProxyCatalog(
                 () => streamAnthropicResponse(
                   model,
                   params,
-                  originalModel,
+                  responseModelId,
                   writeStreamChunk,
                   plog,
                   {
@@ -709,7 +720,7 @@ export async function startProxyCatalog(
               () => generateAnthropicResponse(
                 model,
                 params,
-                originalModel,
+                responseModelId,
                 {
                   forceStream: openAiOAuth,
                   abortSignal: clientAbort.signal,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -437,11 +437,10 @@ export async function startProxyCatalog(
       // The identity a translated response reports. A request that named a
       // route we honoured keeps its public id — patched Claude Code preflights
       // with the request alias and resolves context windows from the response
-      // `model`, so rewriting it there would break auto-compaction. On the
-      // default-route fallback the requested id names no route we honoured, so
-      // reporting the real target is the only honest answer; the Anthropic
-      // passthrough already refuses to echo there and the translated path has
-      // to agree.
+      // `model`, so rewriting it there would break auto-compaction.
+      // On a default-route fallback, report the answering/default model rather
+      // than the unresolved requested id. Built-in Anthropic-format fallback is
+      // routine in this PR, so the translated path must make that identity explicit.
       const responseModelId = resolvedRoute && typeof originalModel === 'string'
         ? originalModel
         : route.realModelId;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -434,7 +434,18 @@ export async function startProxyCatalog(
         return;
       }
       const route = resolvedRoute ?? defaultRoute;
-      if (messagesEndpoint === 'count_tokens' && route.modelFormat !== 'anthropic') {
+      // Anthropic-format is not the same question as "implements
+      // count_tokens". Before third-party anthropic-format routes existed the
+      // local path was the only one ever taken; now a route whose upstream
+      // documents no token-counting endpoint would forward the count and
+      // answer Claude Code's token accounting with a 404. Only an explicit
+      // `false` diverts — an unset capability keeps forwarding, so a custom
+      // Anthropic-compatible endpoint that does implement it is unaffected.
+      if (
+        messagesEndpoint === 'count_tokens'
+        && (route.modelFormat !== 'anthropic'
+          || route.compatibility?.supportsCountTokens === false)
+      ) {
         const inputTokens = estimateAnthropicInputTokens(anthropicBody);
         plog(() => `token-count: local estimate model=${originalModel} input_tokens=${inputTokens}`);
         res.setHeader('x-relay-token-count-source', 'local-estimate');
@@ -543,8 +554,16 @@ export async function startProxyCatalog(
             // A route selected through a clodex: id or short alias must echo the
             // exact requested id back, or patched Claude Code misses the alias
             // context-window key and can skip auto-compaction.
+            //
+            // Only when the alias actually resolved. On the default-route
+            // fallback the requested id names no route we honoured, so echoing
+            // it would report the request's identity as the answering model —
+            // the client would believe it reached a model it never reached, and
+            // would key its context window off that phantom id.
             responseModelOverride:
-              typeof originalModel === 'string' && originalModel !== route.realModelId
+              resolvedRoute
+                && typeof originalModel === 'string'
+                && originalModel !== route.realModelId
                 ? originalModel
                 : undefined,
             onUpstreamError: inferenceLogPath

--- a/src/registry/add-template.ts
+++ b/src/registry/add-template.ts
@@ -26,6 +26,7 @@ import {
   loadPricingCache,
   pricingPlatformForProvider,
 } from './pricing.js';
+import { isProviderConfiguredForTemplate } from './resolve-template.js';
 import type { RegistryProvider } from './types.js';
 
 export interface AddTemplateResult {
@@ -44,8 +45,8 @@ function existingProviderError(
   replaceExisting: boolean | undefined,
 ): AddTemplateResult | null {
   if (!existing) return null;
-  const removeFirst = `Remove it first with: clodex providers remove ${template.id}`;
-  if (!replaceExisting) {
+  const removeFirst = `Remove it first with: clodex providers remove ${existing.id}`;
+  if (!replaceExisting || existing.id !== template.id) {
     return {
       added: false,
       error: `${template.name} is already configured.`,
@@ -111,7 +112,8 @@ export async function addProviderFromTemplate(
 
   const existingState = await withRegistryWriteLock(() => {
     const registry = loadRegistryStrict();
-    const existing = registry.providers.find(p => p.id === template.id);
+    const existing = registry.providers.find(provider =>
+      isProviderConfiguredForTemplate(provider, template.id));
     const error = existingProviderError(template, existing, opts?.replaceExisting);
     if (error) {
       return {
@@ -171,7 +173,8 @@ export async function addProviderFromTemplate(
   const result: AddTemplateResult = await withProviderMutationLock(template.id, async () => {
     const currentState = await withRegistryWriteLock(() => {
       const registry = loadRegistryStrict();
-      const existing = registry.providers.find(p => p.id === template.id);
+      const existing = registry.providers.find(provider =>
+        isProviderConfiguredForTemplate(provider, template.id));
       const error = existingProviderError(template, existing, opts?.replaceExisting);
       if (error) {
         return {
@@ -202,7 +205,8 @@ export async function addProviderFromTemplate(
 
       return withRegistryWriteLock(async () => {
         const registry = loadRegistryStrict();
-        const existing = registry.providers.find(p => p.id === template.id);
+        const existing = registry.providers.find(provider =>
+          isProviderConfiguredForTemplate(provider, template.id));
         const existingError = existingProviderError(template, existing, opts?.replaceExisting);
         if (existingError) return existingError;
         if ((existing?.authRef ?? null) !== currentState.existingAuthRef) {

--- a/src/registry/add-template.ts
+++ b/src/registry/add-template.ts
@@ -3,6 +3,7 @@
 import { provisionProviderCredential, saveProviderCredential } from '../env.js';
 import { credentialInstanceAuthRef } from '../credential-helper.js';
 import { isSdkMigratedNpm } from '../provider-factory.js';
+import { registerTraceSecret } from '../trace-log.js';
 import type { ProviderTemplate } from '../provider-templates.js';
 import { classifyFreeStatus, isFreeStatus } from '../free-models.js';
 import {
@@ -120,6 +121,23 @@ export async function addProviderFromTemplate(
     return { authRef: existing?.authRef ?? null, error: null };
   });
   if (existingState.error) return existingState.error;
+
+  // Registered before the first authenticated request rather than inside
+  // fetchTemplateModels, which runs after the probe: nothing leaks today (the
+  // probe logs nothing and its error string is a fixed literal), but the
+  // invariant worth holding is "registered before first use", not "registered
+  // before the first call that happens to log".
+  if (trimmedKey) registerTraceSecret(trimmedKey);
+
+  // The probe destination comes from the template alone — `verifyCredential`
+  // takes no base URL — so `opts.baseUrl` deliberately does not reach it. A
+  // caller-supplied address must never receive a live credential.
+  if (trimmedKey && template.verifyCredential) {
+    const credentialError = await template.verifyCredential(trimmedKey);
+    if (credentialError) {
+      return { added: false, error: credentialError };
+    }
+  }
 
   const fetched = await fetchTemplateModels(template, trimmedKey, opts?.baseUrl);
   if (fetched.error || fetched.models.length === 0) {

--- a/src/registry/fetch-template-models.ts
+++ b/src/registry/fetch-template-models.ts
@@ -1,6 +1,7 @@
 // src/registry/fetch-template-models.ts — test connection and list models for template providers
 
 import { TEST_TIMEOUT_MS } from '../constants.js';
+import { OPENCODE_GO_PROVIDER_ID } from '../data/opencode-go-models.js';
 import { deriveBrand } from '../models.js';
 import { resolveContextWindow } from '../context-window.js';
 import type { ProviderTemplate } from '../provider-templates.js';
@@ -101,8 +102,19 @@ function parseNativePricing(pricing: ProviderModelListRow['pricing']): CachedMod
   return cost;
 }
 
-function parseModelList(body: OpenAiModelListResponse, npm: string): CachedModel[] {
-  const rows = Array.isArray(body) ? body : body.data ?? body.models ?? [];
+function parseModelList(
+  body: OpenAiModelListResponse,
+  npm: string,
+  allowBareArray: boolean,
+): CachedModel[] {
+  // A bare top-level array is OpenCode Go's documented `/models` shape, and
+  // only its call site opts in. Every other template was reviewed against the
+  // object envelope, so an upstream that starts answering with an array of
+  // something else keeps reporting "no models" instead of turning unreviewed
+  // rows into catalog entries.
+  const rows = Array.isArray(body)
+    ? (allowBareArray ? body : [])
+    : body.data ?? body.models ?? [];
   const format = modelFormatForNpm(npm);
   const models: CachedModel[] = [];
 
@@ -261,6 +273,26 @@ export async function fetchTemplateModels(
     };
   }
 
+  // OpenCode Go's endpoints are the reviewed literals in its own template, and
+  // this call puts a live credential on the wire. `verifyCredential` is
+  // already structurally unredirectable because it takes no URL; discovery
+  // took one, and `refreshApiListProvider` feeds the provider record's stored
+  // `api.url` straight back in here, so a registry that was hand-edited or
+  // imported with a different address was enough to re-aim the key. Refuse
+  // rather than quietly substitute the default: a caller that believed it had
+  // redirected discovery should find out that it had not.
+  if (
+    template.id === OPENCODE_GO_PROVIDER_ID
+    && baseUrl !== template.defaultBaseUrl?.replace(/\/$/, '')
+  ) {
+    return {
+      models: [],
+      baseUrl: '',
+      error: `${template.name} does not support a custom API base URL.`,
+      hint: 'This provider always uses its own endpoint. Remove the custom URL and try again.',
+    };
+  }
+
   // No template declares `static-seed` today, so this arm and
   // `materializeTemplateModel` are unreachable — kept deliberately, not
   // overlooked. `static-seed` is a member of ProviderModelSource, and deleting
@@ -350,7 +382,11 @@ export async function fetchTemplateModels(
       // Failed to parse, use empty object
     }
 
-    const discovered = parseModelList(json, template.npm);
+    const discovered = parseModelList(
+      json,
+      template.npm,
+      template.id === OPENCODE_GO_PROVIDER_ID,
+    );
     const models = applyTemplateModelMetadata(template, discovered);
     if (models.length === 0) {
       // An allowlist template can end up empty for two very different reasons,

--- a/src/registry/fetch-template-models.ts
+++ b/src/registry/fetch-template-models.ts
@@ -1,5 +1,6 @@
 // src/registry/fetch-template-models.ts — test connection and list models for template providers
 
+import { TEST_TIMEOUT_MS } from '../constants.js';
 import { deriveBrand } from '../models.js';
 import { resolveContextWindow } from '../context-window.js';
 import type { ProviderTemplate } from '../provider-templates.js';
@@ -12,12 +13,11 @@ import {
 } from '../trace-log.js';
 import { classifyFreeStatus, isFreeStatus } from '../free-models.js';
 
-const TEST_TIMEOUT_MS = 10_000;
 
-interface OpenAiModelListResponse {
+type OpenAiModelListResponse = ProviderModelListRow[] | {
   data?: ProviderModelListRow[];
   models?: ProviderModelListRow[];
-}
+};
 
 interface ProviderModelListRow {
   id?: string;
@@ -102,7 +102,7 @@ function parseNativePricing(pricing: ProviderModelListRow['pricing']): CachedMod
 }
 
 function parseModelList(body: OpenAiModelListResponse, npm: string): CachedModel[] {
-  const rows = body.data ?? body.models ?? [];
+  const rows = Array.isArray(body) ? body : body.data ?? body.models ?? [];
   const format = modelFormatForNpm(npm);
   const models: CachedModel[] = [];
 
@@ -214,7 +214,6 @@ function normalizeTemplateOverlay(
 export function applyTemplateModelMetadata(
   template: ProviderTemplate,
   discovered: CachedModel[],
-  _baseUrl: string,
 ): CachedModel[] {
   const curated = new Map(
     (template.staticModels ?? [])
@@ -262,6 +261,11 @@ export async function fetchTemplateModels(
     };
   }
 
+  // No template declares `static-seed` today, so this arm and
+  // `materializeTemplateModel` are unreachable — kept deliberately, not
+  // overlooked. `static-seed` is a member of ProviderModelSource, and deleting
+  // the arm would make a template that adopts it fall through to the api-list
+  // path and try to fetch a catalog it does not have.
   if (template.modelSource === 'static-seed') {
     const models = (template.staticModels ?? [])
       .map(model => materializeTemplateModel(template, model, baseUrl));
@@ -346,13 +350,23 @@ export async function fetchTemplateModels(
       // Failed to parse, use empty object
     }
 
-    const models = applyTemplateModelMetadata(template, parseModelList(json, template.npm), baseUrl);
+    const discovered = parseModelList(json, template.npm);
+    const models = applyTemplateModelMetadata(template, discovered);
     if (models.length === 0) {
+      // An allowlist template can end up empty for two very different reasons,
+      // and "no models were returned" points at the wrong one when upstream
+      // answered with a healthy list that simply shares no ids with the
+      // curated catalog — an upstream rename, or a catalog gone stale.
+      const filteredOut = template.staticModelPolicy === 'allowlist' && discovered.length > 0;
       return {
         models: [],
         baseUrl,
-        error: 'Connected but no models were returned.',
-        hint: 'The API key may be valid but model listing is unavailable for this provider.',
+        error: filteredOut
+          ? `Connected, but none of the ${discovered.length} models upstream returned are in this provider's supported list.`
+          : 'Connected but no models were returned.',
+        hint: filteredOut
+          ? 'The upstream catalog may have renamed its models, or clodex\'s list may be out of date.'
+          : 'The API key may be valid but model listing is unavailable for this provider.',
       };
     }
 

--- a/src/registry/fetch-template-models.ts
+++ b/src/registry/fetch-template-models.ts
@@ -7,6 +7,7 @@ import { resolveContextWindow } from '../context-window.js';
 import type { ProviderTemplate } from '../provider-templates.js';
 import { normalizeGoogleDisplayName, normalizeGoogleModelId } from './google-model-id.js';
 import type { CachedModel } from './types.js';
+import { openCodeGoPinnedApiUrl } from './resolve-template.js';
 import {
   getProviderDebugLogPath,
   makeTraceLogger,
@@ -273,24 +274,32 @@ export async function fetchTemplateModels(
     };
   }
 
-  // OpenCode Go's endpoints are the reviewed literals in its own template, and
-  // this call puts a live credential on the wire. `verifyCredential` is
+  // OpenCode Go's endpoints are the reviewed package/destination pairs in the
+  // retained identity authority, and this call puts a live credential on the
+  // wire. `verifyCredential` is
   // already structurally unredirectable because it takes no URL; discovery
   // took one, and `refreshApiListProvider` feeds the provider record's stored
   // `api.url` straight back in here, so a registry that was hand-edited or
   // imported with a different address was enough to re-aim the key. Refuse
   // rather than quietly substitute the default: a caller that believed it had
   // redirected discovery should find out that it had not.
-  if (
-    template.id === OPENCODE_GO_PROVIDER_ID
-    && baseUrl !== template.defaultBaseUrl?.replace(/\/$/, '')
-  ) {
-    return {
-      models: [],
-      baseUrl: '',
-      error: `${template.name} does not support a custom API base URL.`,
-      hint: 'This provider always uses its own endpoint. Remove the custom URL and try again.',
-    };
+  if (template.id === OPENCODE_GO_PROVIDER_ID) {
+    const pinned = openCodeGoPinnedApiUrl(template.npm);
+    if (!pinned) {
+      return {
+        models: [],
+        baseUrl: '',
+        error: `${template.name} does not support the ${template.npm || '(missing)'} SDK package.`,
+      };
+    }
+    if (baseUrl !== pinned) {
+      return {
+        models: [],
+        baseUrl: '',
+        error: `${template.name} does not support a custom API base URL.`,
+        hint: 'This provider always uses its own endpoint. Remove the custom URL and try again.',
+      };
+    }
   }
 
   // No template declares `static-seed` today, so this arm and

--- a/src/registry/materialize.ts
+++ b/src/registry/materialize.ts
@@ -6,11 +6,13 @@ import { resolveContextWindow } from '../context-window.js';
 import type { LocalProvider, LocalProviderModel } from '../types.js';
 import { normalizeGoogleDisplayName, normalizeGoogleModelId } from './google-model-id.js';
 import { findModelsDevModel } from './models-dev.js';
+import { applyTemplateModelMetadata } from './fetch-template-models.js';
 import type { CachedModel, ProviderRegistry, RegistryProvider } from './types.js';
 import { isValidProviderId } from './validate.js';
 import {
   isRetainedOpenCodeGoProvider,
   openCodeGoPinnedApiUrl,
+  retainedOpenCodeGoTemplate,
 } from './resolve-template.js';
 import { classifyFreeStatus, isFreeStatus } from '../free-models.js';
 import { OAUTH_ACCOUNT_ENV } from '../oauth-account-selection.js';
@@ -47,6 +49,18 @@ export interface MaterializeOptions {
 }
 
 export { openCodeGoPinnedApiUrl } from './resolve-template.js';
+
+/**
+ * Project persisted model caches onto the authority that owns their provider identity.
+ * Ordinary and custom providers retain their cache array unchanged; retained OpenCode
+ * identities are fail-closed against the committed template catalog.
+ */
+export function projectProviderCachedModels(provider: RegistryProvider): CachedModel[] {
+  const cached = provider.modelsCache?.models ?? [];
+  if (!isRetainedOpenCodeGoProvider(provider)) return cached;
+  const template = retainedOpenCodeGoTemplate();
+  return template ? applyTemplateModelMetadata(template, cached) : [];
+}
 
 function resolveMaterializedApiUrl(
   cached: CachedModel,
@@ -240,7 +254,7 @@ function materializeOne(
   const anonymous = explicitAnonymous || legacyAnonymous;
   const apiKey = anonymous ? '' : credential ?? '';
   const models: LocalProviderModel[] = [];
-  for (const cached of provider.modelsCache?.models ?? []) {
+  for (const cached of projectProviderCachedModels(provider)) {
     const freeStatus = classifyFreeStatus({
       model: cached,
       providerId: provider.id,

--- a/src/registry/materialize.ts
+++ b/src/registry/materialize.ts
@@ -8,6 +8,7 @@ import { normalizeGoogleDisplayName, normalizeGoogleModelId } from './google-mod
 import { findModelsDevModel } from './models-dev.js';
 import type { CachedModel, ProviderRegistry, RegistryProvider } from './types.js';
 import { isValidProviderId } from './validate.js';
+import { resolveProviderTemplate } from './resolve-template.js';
 import { classifyFreeStatus, isFreeStatus } from '../free-models.js';
 import { OAUTH_ACCOUNT_ENV } from '../oauth-account-selection.js';
 import {
@@ -47,17 +48,48 @@ export interface MaterializeOptions {
   agent?: CompatibilityAgent;
 }
 
+/**
+ * Recognize the retained OpenCode Go built-in by its canonical template
+ * relationship rather than by one mutable field.
+ *
+ * The registry file is data, not an authority: `parseProvider` accepts `id`,
+ * `templateId`, `api.npm`, and `api.url` as written, and nothing couples `id`
+ * to `templateId`. So a persisted or imported record can drift its `id` while
+ * keeping `templateId: 'opencode-go'` — and it keeps the OpenCode credential,
+ * because `authRef` still names the keyring slot the user filled in for
+ * OpenCode Go. Matching on `id` alone let exactly that record escape the
+ * pinned endpoints and pair the secret with a stored address.
+ *
+ * `resolveProviderTemplate` is the existing resolver for that relationship
+ * (it already understands the legacy alias table), and the explicit `id` arm
+ * retains the original behaviour for a record that keeps the canonical id
+ * while naming some other template.
+ */
+export function isRetainedOpenCodeGoProvider(provider: RegistryProvider): boolean {
+  return provider.id === OPENCODE_GO_PROVIDER_ID
+    || resolveProviderTemplate(provider)?.id === OPENCODE_GO_PROVIDER_ID;
+}
+
+/**
+ * The single immutable endpoint the retained built-in allows for an SDK
+ * package. `null` means the package is not one OpenCode Go serves, and every
+ * caller must fail closed rather than fall back to a stored address.
+ */
+export function openCodeGoPinnedApiUrl(npm: string): string | null {
+  if (npm === '@ai-sdk/openai-compatible') return OPENCODE_GO_COMPLETIONS_BASE_URL;
+  if (npm === '@ai-sdk/anthropic') return OPENCODE_GO_ANTHROPIC_BASE_URL;
+  return null;
+}
+
 function resolveMaterializedApiUrl(
   cached: CachedModel,
   provider: RegistryProvider,
   npm: string,
 ): string | null {
-  if (provider.id !== OPENCODE_GO_PROVIDER_ID) {
+  if (!isRetainedOpenCodeGoProvider(provider)) {
     return cached.apiUrl ?? provider.api.url ?? '';
   }
-  if (npm === '@ai-sdk/openai-compatible') return OPENCODE_GO_COMPLETIONS_BASE_URL;
-  if (npm === '@ai-sdk/anthropic') return OPENCODE_GO_ANTHROPIC_BASE_URL;
-  return null;
+  return openCodeGoPinnedApiUrl(npm);
 }
 
 export function cachedModelToLocal(

--- a/src/registry/materialize.ts
+++ b/src/registry/materialize.ts
@@ -8,13 +8,12 @@ import { normalizeGoogleDisplayName, normalizeGoogleModelId } from './google-mod
 import { findModelsDevModel } from './models-dev.js';
 import type { CachedModel, ProviderRegistry, RegistryProvider } from './types.js';
 import { isValidProviderId } from './validate.js';
-import { isRetainedOpenCodeGoProvider } from './resolve-template.js';
+import {
+  isRetainedOpenCodeGoProvider,
+  openCodeGoPinnedApiUrl,
+} from './resolve-template.js';
 import { classifyFreeStatus, isFreeStatus } from '../free-models.js';
 import { OAUTH_ACCOUNT_ENV } from '../oauth-account-selection.js';
-import {
-  OPENCODE_GO_ANTHROPIC_BASE_URL,
-  OPENCODE_GO_COMPLETIONS_BASE_URL,
-} from '../data/opencode-go-models.js';
 
 export { OAUTH_ACCOUNT_ENV } from '../oauth-account-selection.js';
 
@@ -47,16 +46,7 @@ export interface MaterializeOptions {
   agent?: CompatibilityAgent;
 }
 
-/**
- * The single immutable endpoint the retained built-in allows for an SDK
- * package. `null` means the package is not one OpenCode Go serves, and every
- * caller must fail closed rather than fall back to a stored address.
- */
-export function openCodeGoPinnedApiUrl(npm: string): string | null {
-  if (npm === '@ai-sdk/openai-compatible') return OPENCODE_GO_COMPLETIONS_BASE_URL;
-  if (npm === '@ai-sdk/anthropic') return OPENCODE_GO_ANTHROPIC_BASE_URL;
-  return null;
-}
+export { openCodeGoPinnedApiUrl } from './resolve-template.js';
 
 function resolveMaterializedApiUrl(
   cached: CachedModel,

--- a/src/registry/materialize.ts
+++ b/src/registry/materialize.ts
@@ -8,13 +8,12 @@ import { normalizeGoogleDisplayName, normalizeGoogleModelId } from './google-mod
 import { findModelsDevModel } from './models-dev.js';
 import type { CachedModel, ProviderRegistry, RegistryProvider } from './types.js';
 import { isValidProviderId } from './validate.js';
-import { resolveProviderTemplate } from './resolve-template.js';
+import { isRetainedOpenCodeGoProvider } from './resolve-template.js';
 import { classifyFreeStatus, isFreeStatus } from '../free-models.js';
 import { OAUTH_ACCOUNT_ENV } from '../oauth-account-selection.js';
 import {
   OPENCODE_GO_ANTHROPIC_BASE_URL,
   OPENCODE_GO_COMPLETIONS_BASE_URL,
-  OPENCODE_GO_PROVIDER_ID,
 } from '../data/opencode-go-models.js';
 
 export { OAUTH_ACCOUNT_ENV } from '../oauth-account-selection.js';
@@ -46,28 +45,6 @@ export function resolveEndpoint(
 
 export interface MaterializeOptions {
   agent?: CompatibilityAgent;
-}
-
-/**
- * Recognize the retained OpenCode Go built-in by its canonical template
- * relationship rather than by one mutable field.
- *
- * The registry file is data, not an authority: `parseProvider` accepts `id`,
- * `templateId`, `api.npm`, and `api.url` as written, and nothing couples `id`
- * to `templateId`. So a persisted or imported record can drift its `id` while
- * keeping `templateId: 'opencode-go'` — and it keeps the OpenCode credential,
- * because `authRef` still names the keyring slot the user filled in for
- * OpenCode Go. Matching on `id` alone let exactly that record escape the
- * pinned endpoints and pair the secret with a stored address.
- *
- * `resolveProviderTemplate` is the existing resolver for that relationship
- * (it already understands the legacy alias table), and the explicit `id` arm
- * retains the original behaviour for a record that keeps the canonical id
- * while naming some other template.
- */
-export function isRetainedOpenCodeGoProvider(provider: RegistryProvider): boolean {
-  return provider.id === OPENCODE_GO_PROVIDER_ID
-    || resolveProviderTemplate(provider)?.id === OPENCODE_GO_PROVIDER_ID;
 }
 
 /**

--- a/src/registry/materialize.ts
+++ b/src/registry/materialize.ts
@@ -10,6 +10,11 @@ import type { CachedModel, ProviderRegistry, RegistryProvider } from './types.js
 import { isValidProviderId } from './validate.js';
 import { classifyFreeStatus, isFreeStatus } from '../free-models.js';
 import { OAUTH_ACCOUNT_ENV } from '../oauth-account-selection.js';
+import {
+  OPENCODE_GO_ANTHROPIC_BASE_URL,
+  OPENCODE_GO_COMPLETIONS_BASE_URL,
+  OPENCODE_GO_PROVIDER_ID,
+} from '../data/opencode-go-models.js';
 
 export { OAUTH_ACCOUNT_ENV } from '../oauth-account-selection.js';
 
@@ -42,6 +47,19 @@ export interface MaterializeOptions {
   agent?: CompatibilityAgent;
 }
 
+function resolveMaterializedApiUrl(
+  cached: CachedModel,
+  provider: RegistryProvider,
+  npm: string,
+): string | null {
+  if (provider.id !== OPENCODE_GO_PROVIDER_ID) {
+    return cached.apiUrl ?? provider.api.url ?? '';
+  }
+  if (npm === '@ai-sdk/openai-compatible') return OPENCODE_GO_COMPLETIONS_BASE_URL;
+  if (npm === '@ai-sdk/anthropic') return OPENCODE_GO_ANTHROPIC_BASE_URL;
+  return null;
+}
+
 export function cachedModelToLocal(
   cached: CachedModel,
   provider: RegistryProvider,
@@ -53,7 +71,8 @@ export function cachedModelToLocal(
   });
 
   const npm = cached.npm ?? provider.api.npm ?? '';
-  const apiUrl = cached.apiUrl ?? provider.api.url ?? '';
+  const apiUrl = resolveMaterializedApiUrl(cached, provider, npm);
+  if (apiUrl === null) return null;
   const endpoint = resolveEndpoint(npm, apiUrl);
   if (endpoint === null) return null;
 

--- a/src/registry/model-source.ts
+++ b/src/registry/model-source.ts
@@ -1,7 +1,11 @@
 // src/registry/model-source.ts — resolve how a registry provider refreshes its model list
 
 import { getTemplateById, type ProviderModelSource } from '../provider-templates.js';
-import { resolveProviderTemplate } from './resolve-template.js';
+import {
+  isRetainedOpenCodeGoProvider,
+  retainedOpenCodeGoTemplate,
+  resolveProviderTemplate,
+} from './resolve-template.js';
 import type { RegistryProvider } from './types.js';
 
 const MANUAL_ONLY_TEMPLATE_IDS = new Set(['vertex', 'bedrock', 'azure']);
@@ -13,6 +17,9 @@ const MANUAL_ONLY_NPMS = new Set([
 ]);
 
 export function resolveModelSource(provider: RegistryProvider): ProviderModelSource {
+  if (isRetainedOpenCodeGoProvider(provider)) {
+    return retainedOpenCodeGoTemplate()?.modelSource ?? 'api-list';
+  }
   if (
     MANUAL_ONLY_PROVIDER_IDS.has(provider.id) ||
     MANUAL_ONLY_PROVIDER_IDS.has(provider.templateId) ||

--- a/src/registry/pricing.ts
+++ b/src/registry/pricing.ts
@@ -21,6 +21,7 @@ import { dirname, join } from 'node:path';
 import bundledPricing from '../data/pricing-cache.json';
 import { getAppHome } from '../paths.js';
 import { getTemplateById } from '../provider-templates.js';
+import { isRetainedOpenCodeGoProvider, retainedOpenCodeGoTemplate } from './resolve-template.js';
 import type { CachedModel, RegistryModelsCache, RegistryProvider } from './types.js';
 import { loadRegistryStrict, saveRegistry } from './io.js';
 import { withRegistryWriteLock, withRegistryWriteLockSync } from './lock.js';
@@ -81,13 +82,27 @@ export const TEMPLATE_TO_PRICING_PLATFORM: Record<string, string> = {
  * write and a curated price is silently replaced by a cache guess. The
  * consequence is cost display only, which is exactly why it would go
  * unnoticed; reading through to the template makes the flag idempotent.
+ *
+ * The fallback resolves the retained OpenCode built-in by its COMPLETE
+ * identity, not by `templateId` alone. A record that keeps the canonical id
+ * while naming another template is still that built-in — same credential
+ * lineage, same curated catalog — but `getTemplateById` would answer for a
+ * provider that never asked to keep its prices, and the curated costs would be
+ * overwritten by a cache guess.
+ *
+ * An explicit persisted value always wins, in both directions: this decides
+ * only what an ABSENT flag means, so a user who deliberately opted a retained
+ * record back into cache pricing keeps that choice.
  */
 export function providerPreservesModelPricing(
-  provider: Pick<RegistryProvider, 'preserveModelPricing' | 'templateId'>,
+  provider: Pick<RegistryProvider, 'preserveModelPricing' | 'templateId'>
+    & Partial<Pick<RegistryProvider, 'id'>>,
 ): boolean {
-  return provider.preserveModelPricing
-    ?? getTemplateById(provider.templateId)?.preserveModelPricing
-    ?? false;
+  if (provider.preserveModelPricing !== undefined) return provider.preserveModelPricing;
+  if (isRetainedOpenCodeGoProvider(provider)) {
+    return retainedOpenCodeGoTemplate()?.preserveModelPricing ?? false;
+  }
+  return getTemplateById(provider.templateId)?.preserveModelPricing ?? false;
 }
 
 export function loadBundledPricingCache(): PricingCacheFile {

--- a/src/registry/pricing.ts
+++ b/src/registry/pricing.ts
@@ -20,7 +20,8 @@ import {
 import { dirname, join } from 'node:path';
 import bundledPricing from '../data/pricing-cache.json';
 import { getAppHome } from '../paths.js';
-import type { CachedModel, RegistryModelsCache } from './types.js';
+import { getTemplateById } from '../provider-templates.js';
+import type { CachedModel, RegistryModelsCache, RegistryProvider } from './types.js';
 import { loadRegistryStrict, saveRegistry } from './io.js';
 import { withRegistryWriteLock, withRegistryWriteLockSync } from './lock.js';
 import { classifyFreeStatus, isFreeStatus } from '../free-models.js';
@@ -70,6 +71,24 @@ export const TEMPLATE_TO_PRICING_PLATFORM: Record<string, string> = {
   nvidia: 'nvidia',
   venice: 'openrouter',
 };
+
+/**
+ * Whether provider-supplied prices must survive the global pricing cache.
+ *
+ * Falls back to the TEMPLATE when the provider record does not carry the flag.
+ * An older clodex that parses and re-saves `providers.json` drops fields it
+ * does not know, so without this the setting is lost permanently on the next
+ * write and a curated price is silently replaced by a cache guess. The
+ * consequence is cost display only, which is exactly why it would go
+ * unnoticed; reading through to the template makes the flag idempotent.
+ */
+export function providerPreservesModelPricing(
+  provider: Pick<RegistryProvider, 'preserveModelPricing' | 'templateId'>,
+): boolean {
+  return provider.preserveModelPricing
+    ?? getTemplateById(provider.templateId)?.preserveModelPricing
+    ?? false;
+}
 
 export function loadBundledPricingCache(): PricingCacheFile {
   return bundledPricing as unknown as PricingCacheFile;
@@ -228,7 +247,7 @@ export function applyPricingToRegistryProviders(
   const index = buildPricingIndex(cache);
   let changed = false;
   for (const provider of registry.providers) {
-    if (provider.preserveModelPricing) continue;
+    if (providerPreservesModelPricing(provider)) continue;
     const platform = TEMPLATE_TO_PRICING_PLATFORM[provider.templateId] ?? TEMPLATE_TO_PRICING_PLATFORM[provider.id];
     const enrichCache = (modelsCache: RegistryModelsCache | undefined) => {
       if (!modelsCache?.models.length) return modelsCache;

--- a/src/registry/refresh-models.ts
+++ b/src/registry/refresh-models.ts
@@ -263,7 +263,17 @@ async function refreshApiListProvider(
   const retained = isRetainedOpenCodeGoProvider(provider);
   const catalogTemplate = (retained ? retainedOpenCodeGoTemplate() : undefined)
     ?? resolveProviderTemplate(provider);
-  const baseUrl = effectiveProviderBaseUrl(provider, catalogTemplate);
+  const pinned = retained ? openCodeGoPinnedApiUrl(npm) : undefined;
+  if (retained && pinned === null) {
+    return {
+      models: [],
+      error: `${OPENCODE_GO_PROVIDER_NAME} does not support the ${npm} SDK package.`,
+    };
+  }
+  const configuredUrl = provider.api.url?.trim();
+  const baseUrl = retained
+    ? configuredUrl || pinned || undefined
+    : effectiveProviderBaseUrl(provider, catalogTemplate);
 
   if (!baseUrl) {
     return { models: [], error: 'Provider has no API base URL configured.' };
@@ -282,13 +292,6 @@ async function refreshApiListProvider(
   // Refuse rather than silently substitute the pinned URL: a caller that
   // believed it had redirected discovery should find out that it had not.
   if (retained) {
-    const pinned = openCodeGoPinnedApiUrl(npm);
-    if (!pinned) {
-      return {
-        models: [],
-        error: `${OPENCODE_GO_PROVIDER_NAME} does not support the ${npm} SDK package.`,
-      };
-    }
     if (baseUrl.replace(/\/$/, '') !== pinned) {
       return {
         models: [],
@@ -298,7 +301,6 @@ async function refreshApiListProvider(
   }
 
   let safeBaseUrl = baseUrl;
-  const configuredUrl = provider.api.url?.trim();
   const templateDefault = catalogTemplate?.defaultBaseUrl?.trim();
   if (configuredUrl && configuredUrl !== templateDefault) {
     const urlCheck = await validateCustomEndpointUrl(baseUrl, {

--- a/src/registry/refresh-models.ts
+++ b/src/registry/refresh-models.ts
@@ -38,7 +38,12 @@ import { deriveBrand } from '../models.js';
 import { resolveContextWindow } from '../context-window.js';
 import { getInstalledClaudeVersion } from '../launch.js';
 import { classifyFreeStatus, isFreeStatus } from '../free-models.js';
-import { isLegacyAnonymousCustomEndpoint } from './materialize.js';
+import {
+  isLegacyAnonymousCustomEndpoint,
+  isRetainedOpenCodeGoProvider,
+  openCodeGoPinnedApiUrl,
+} from './materialize.js';
+import { OPENCODE_GO_PROVIDER_NAME } from '../data/opencode-go-models.js';
 
 export interface RefreshProviderResult {
   id: string;
@@ -255,6 +260,34 @@ async function refreshApiListProvider(
 
   if (!baseUrl) {
     return { models: [], error: 'Provider has no API base URL configured.' };
+  }
+
+  // The retained built-in's destination is decided HERE, before any
+  // npm-specific branch below can put the credential on the wire.
+  //
+  // `fetchTemplateModels` enforces the same pin, but only the
+  // openai-compatible branch reaches it: a record storing
+  // `api.npm: '@ai-sdk/anthropic'` took the branch below and handed the key to
+  // `fetchAnthropicModels` at its stored address first. Ordering the check
+  // ahead of the branch — and ahead of `validateCustomEndpointUrl`, so a forged
+  // address is not even resolved — is what makes the pin unconditional.
+  //
+  // Refuse rather than silently substitute the pinned URL: a caller that
+  // believed it had redirected discovery should find out that it had not.
+  if (isRetainedOpenCodeGoProvider(provider)) {
+    const pinned = openCodeGoPinnedApiUrl(npm);
+    if (!pinned) {
+      return {
+        models: [],
+        error: `${OPENCODE_GO_PROVIDER_NAME} does not support the ${npm} SDK package.`,
+      };
+    }
+    if (baseUrl.replace(/\/$/, '') !== pinned) {
+      return {
+        models: [],
+        error: `${OPENCODE_GO_PROVIDER_NAME} does not support a custom API base URL.`,
+      };
+    }
   }
 
   let safeBaseUrl = baseUrl;

--- a/src/registry/refresh-models.ts
+++ b/src/registry/refresh-models.ts
@@ -12,6 +12,7 @@ import {
   effectiveProviderBaseUrl,
   isRetainedOpenCodeGoProvider,
   resolveProviderTemplate,
+  retainedOpenCodeGoTemplate,
   syntheticTemplate,
 } from './resolve-template.js';
 import {
@@ -255,7 +256,15 @@ async function refreshApiListProvider(
   apiKey: string,
 ): Promise<{ models: CachedModel[]; baseUrl?: string; error?: string }> {
   const npm = provider.api.npm ?? '@ai-sdk/openai-compatible';
-  const catalogTemplate = resolveProviderTemplate(provider);
+  // Resolve the retained built-in's OWN template first. `resolveProviderTemplate`
+  // reads `templateId` ahead of `id`, so a retained record that names another
+  // template resolves to that stranger's entry — and the entry is what carries
+  // OpenCode's committed allowlist, its bare-array parse flag, and the default
+  // URL the pin below compares against. Resolving it here also keeps a drifted
+  // record from being refused for a base URL its real template does allow.
+  const retained = isRetainedOpenCodeGoProvider(provider);
+  const catalogTemplate = (retained ? retainedOpenCodeGoTemplate() : undefined)
+    ?? resolveProviderTemplate(provider);
   const baseUrl = effectiveProviderBaseUrl(provider, catalogTemplate);
 
   if (!baseUrl) {
@@ -274,7 +283,7 @@ async function refreshApiListProvider(
   //
   // Refuse rather than silently substitute the pinned URL: a caller that
   // believed it had redirected discovery should find out that it had not.
-  if (isRetainedOpenCodeGoProvider(provider)) {
+  if (retained) {
     const pinned = openCodeGoPinnedApiUrl(npm);
     if (!pinned) {
       return {
@@ -305,7 +314,15 @@ async function refreshApiListProvider(
 
   const template = catalogTemplate ?? syntheticTemplate(provider, safeBaseUrl);
 
-  if (npm === '@ai-sdk/anthropic') {
+  // The pin above decides WHERE the key goes; it says nothing about which
+  // routine reads the answer. A retained record storing
+  // `api.npm: '@ai-sdk/anthropic'` at the pinned OpenCode Anthropic address
+  // clears the pin and then falls in here, where `fetchAnthropicModels`
+  // expects an Anthropic `{ data: [...] }` envelope that OpenCode does not
+  // send and applies none of the committed allowlist/metadata overlay. The
+  // retained built-in discovers through its template whatever npm it names;
+  // ordinary Anthropic providers keep this branch unchanged.
+  if (!retained && npm === '@ai-sdk/anthropic') {
     const fetched = await fetchAnthropicModels(safeBaseUrl, apiKey);
     if (fetched.error || fetched.models.length === 0) {
       return { models: [], error: fetched.error ?? 'No models returned.', baseUrl: fetched.baseUrl };

--- a/src/registry/refresh-models.ts
+++ b/src/registry/refresh-models.ts
@@ -11,6 +11,7 @@ import { validateCustomEndpointUrl } from './url-security.js';
 import {
   effectiveProviderBaseUrl,
   isRetainedOpenCodeGoProvider,
+  openCodeGoPinnedApiUrl,
   resolveProviderTemplate,
   retainedOpenCodeGoTemplate,
   syntheticTemplate,
@@ -40,10 +41,7 @@ import { deriveBrand } from '../models.js';
 import { resolveContextWindow } from '../context-window.js';
 import { getInstalledClaudeVersion } from '../launch.js';
 import { classifyFreeStatus, isFreeStatus } from '../free-models.js';
-import {
-  isLegacyAnonymousCustomEndpoint,
-  openCodeGoPinnedApiUrl,
-} from './materialize.js';
+import { isLegacyAnonymousCustomEndpoint } from './materialize.js';
 import { OPENCODE_GO_PROVIDER_NAME } from '../data/opencode-go-models.js';
 
 export interface RefreshProviderResult {
@@ -312,7 +310,9 @@ async function refreshApiListProvider(
     safeBaseUrl = urlCheck.normalizedUrl;
   }
 
-  const template = catalogTemplate ?? syntheticTemplate(provider, safeBaseUrl);
+  const template = catalogTemplate
+    ? (retained ? { ...catalogTemplate, npm } : catalogTemplate)
+    : syntheticTemplate(provider, safeBaseUrl);
 
   // The pin above decides WHERE the key goes; it says nothing about which
   // routine reads the answer. A retained record storing

--- a/src/registry/refresh-models.ts
+++ b/src/registry/refresh-models.ts
@@ -10,6 +10,7 @@ import { resolveModelSource } from './model-source.js';
 import { validateCustomEndpointUrl } from './url-security.js';
 import {
   effectiveProviderBaseUrl,
+  isRetainedOpenCodeGoProvider,
   resolveProviderTemplate,
   syntheticTemplate,
 } from './resolve-template.js';
@@ -40,7 +41,6 @@ import { getInstalledClaudeVersion } from '../launch.js';
 import { classifyFreeStatus, isFreeStatus } from '../free-models.js';
 import {
   isLegacyAnonymousCustomEndpoint,
-  isRetainedOpenCodeGoProvider,
   openCodeGoPinnedApiUrl,
 } from './materialize.js';
 import { OPENCODE_GO_PROVIDER_NAME } from '../data/opencode-go-models.js';

--- a/src/registry/refresh-models.ts
+++ b/src/registry/refresh-models.ts
@@ -19,6 +19,7 @@ import {
   enrichPricingAsync,
   loadPricingCache,
   pricingPlatformForProvider,
+  providerPreservesModelPricing,
 } from './pricing.js';
 import {
   cachedModelCount,
@@ -584,7 +585,7 @@ export async function refreshProviderModels(
 
     const pricingCache = loadPricingCache();
     const platform = pricingPlatformForProvider(provider.templateId, provider.id);
-    const enriched = provider.preserveModelPricing
+    const enriched = providerPreservesModelPricing(provider)
       ? models
       : enrichModelsWithPricing(models, buildPricingIndex(pricingCache), platform);
 

--- a/src/registry/resolve-template.ts
+++ b/src/registry/resolve-template.ts
@@ -1,5 +1,6 @@
 // src/registry/resolve-template.ts — map imported OpenCode ids to builtin templates + default URLs
 
+import { OPENCODE_GO_PROVIDER_ID } from '../data/opencode-go-models.js';
 import { getTemplateById, type ProviderTemplate } from '../provider-templates.js';
 import type { RegistryProvider } from './types.js';
 
@@ -25,6 +26,32 @@ export function resolveProviderTemplate(provider: RegistryProvider): ProviderTem
     if (template) return template;
   }
   return undefined;
+}
+
+/**
+ * Recognize the retained OpenCode Go built-in by its canonical template
+ * relationship rather than by one mutable field.
+ *
+ * The explicit id arm preserves records that keep the canonical id while
+ * naming another template. The resolver arm preserves imported or migrated
+ * records whose id drifted while `templateId: 'opencode-go'` and its credential
+ * lineage remained. This intentionally does not generalize template identity
+ * to ordinary providers: custom records may name an ordinary template without
+ * occupying that built-in's add slot.
+ */
+export function isRetainedOpenCodeGoProvider(provider: RegistryProvider): boolean {
+  return provider.id === OPENCODE_GO_PROVIDER_ID
+    || resolveProviderTemplate(provider)?.id === OPENCODE_GO_PROVIDER_ID;
+}
+
+/** Whether a configured record occupies a built-in template's add slot. */
+export function isProviderConfiguredForTemplate(
+  provider: RegistryProvider,
+  templateId: string,
+): boolean {
+  if (provider.id === templateId) return true;
+  return templateId === OPENCODE_GO_PROVIDER_ID
+    && isRetainedOpenCodeGoProvider(provider);
 }
 
 export function effectiveProviderBaseUrl(provider: RegistryProvider, template?: ProviderTemplate): string | undefined {

--- a/src/registry/resolve-template.ts
+++ b/src/registry/resolve-template.ts
@@ -13,11 +13,23 @@ const NPM_DEFAULT_BASE_URL: Record<string, string> = {
   '@ai-sdk/anthropic': 'https://api.anthropic.com',
 };
 
-export function resolveProviderTemplate(provider: RegistryProvider): ProviderTemplate | undefined {
+/**
+ * The identity fields template resolution reads.
+ *
+ * Accepting this pair instead of a whole `RegistryProvider` lets a caller that
+ * only holds the persisted policy fields — pricing's
+ * `providerPreservesModelPricing` — ask the SAME identity question. The
+ * alternative was a second, partial predicate keyed on `templateId` alone,
+ * which is exactly the drift this module exists to prevent.
+ */
+export type ProviderTemplateIdentity = Pick<RegistryProvider, 'templateId'>
+  & Partial<Pick<RegistryProvider, 'id'>>;
+
+export function resolveProviderTemplate(provider: ProviderTemplateIdentity): ProviderTemplate | undefined {
   const candidates = [
     TEMPLATE_ID_ALIASES[provider.templateId],
     provider.templateId,
-    TEMPLATE_ID_ALIASES[provider.id],
+    provider.id ? TEMPLATE_ID_ALIASES[provider.id] : undefined,
     provider.id,
   ].filter(Boolean) as string[];
 
@@ -39,9 +51,22 @@ export function resolveProviderTemplate(provider: RegistryProvider): ProviderTem
  * to ordinary providers: custom records may name an ordinary template without
  * occupying that built-in's add slot.
  */
-export function isRetainedOpenCodeGoProvider(provider: RegistryProvider): boolean {
+export function isRetainedOpenCodeGoProvider(provider: ProviderTemplateIdentity): boolean {
   return provider.id === OPENCODE_GO_PROVIDER_ID
     || resolveProviderTemplate(provider)?.id === OPENCODE_GO_PROVIDER_ID;
+}
+
+/**
+ * The retained built-in's own template, for callers that must discover or
+ * price a record by its real identity rather than the template it names.
+ *
+ * A retained record whose `templateId` drifted resolves to somebody else's
+ * template, and that template carries the wrong catalog: OpenCode's committed
+ * allowlist, its bare-array parse, and its curated costs all hang off THIS
+ * entry. Callers pair it with `isRetainedOpenCodeGoProvider`.
+ */
+export function retainedOpenCodeGoTemplate(): ProviderTemplate | undefined {
+  return getTemplateById(OPENCODE_GO_PROVIDER_ID);
 }
 
 /** Whether a configured record occupies a built-in template's add slot. */

--- a/src/registry/resolve-template.ts
+++ b/src/registry/resolve-template.ts
@@ -1,6 +1,10 @@
 // src/registry/resolve-template.ts — map imported OpenCode ids to builtin templates + default URLs
 
-import { OPENCODE_GO_PROVIDER_ID } from '../data/opencode-go-models.js';
+import {
+  OPENCODE_GO_ANTHROPIC_BASE_URL,
+  OPENCODE_GO_COMPLETIONS_BASE_URL,
+  OPENCODE_GO_PROVIDER_ID,
+} from '../data/opencode-go-models.js';
 import { getTemplateById, type ProviderTemplate } from '../provider-templates.js';
 import type { RegistryProvider } from './types.js';
 
@@ -67,6 +71,16 @@ export function isRetainedOpenCodeGoProvider(provider: ProviderTemplateIdentity)
  */
 export function retainedOpenCodeGoTemplate(): ProviderTemplate | undefined {
   return getTemplateById(OPENCODE_GO_PROVIDER_ID);
+}
+
+/**
+ * The one immutable destination allowed for each SDK package served by the
+ * retained built-in. `null` means the package is not part of that product.
+ */
+export function openCodeGoPinnedApiUrl(npm: string): string | null {
+  if (npm === '@ai-sdk/openai-compatible') return OPENCODE_GO_COMPLETIONS_BASE_URL;
+  if (npm === '@ai-sdk/anthropic') return OPENCODE_GO_ANTHROPIC_BASE_URL;
+  return null;
 }
 
 /** Whether a configured record occupies a built-in template's add slot. */

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -245,6 +245,11 @@ async function routeRequest(req: IncomingMessage, res: ServerResponse, options: 
       return;
     }
 
+    if (req.method === 'POST' && pathname === '/anthropic/v1/messages/count_tokens') {
+      await handleAnthropicCountTokens(req, res, options, plog);
+      return;
+    }
+
     if (req.method === 'POST' && pathname === '/openai/v1/chat/completions') {
       await handleOpenAIChatCompletions(req, res, options, modelCache, plog);
       return;
@@ -526,6 +531,97 @@ async function handleAnthropicMessages(
   }
 
   sendJson(res, 400, { error: { message: `Unsupported model format: ${model.modelFormat}` } });
+}
+
+/**
+ * `POST /anthropic/v1/messages/count_tokens`.
+ *
+ * Claude Code preflights its token accounting here, so the gateway has to
+ * answer it on every launch mode that points ANTHROPIC_BASE_URL at this server
+ * (`clodex server --endpoint`, the clodex-claude wrapper's endpoint gateway).
+ * The routing rule is the one the adapter proxy already applies in
+ * `src/proxy.ts`: speaking the Messages API is not the same question as
+ * implementing count_tokens. A translated (SDK) model has no such endpoint at
+ * all, and an Anthropic-format model whose upstream documents none is marked
+ * with an explicit `supportsCountTokens: false`. Both answer from the shared
+ * local estimator. An unset or `true` capability keeps forwarding, so a custom
+ * Anthropic-compatible endpoint that does implement it is unaffected.
+ */
+async function handleAnthropicCountTokens(
+  req: IncomingMessage,
+  res: ServerResponse,
+  options: ServerOptions,
+  plog: PLog,
+): Promise<void> {
+  const body = await readJson(req);
+  if (!body) {
+    sendJson(res, 400, { error: { message: 'Invalid JSON body' } });
+    return;
+  }
+
+  const model = lookupModel(res, options.catalog, body.model);
+  if (!model) {
+    plog(`model not found: ${body.model}`);
+    return;
+  }
+
+  // Keep the sibling messages route's format contract: a catalog entry this
+  // server cannot serve must not be answered with a token count either.
+  if (model.modelFormat !== 'anthropic' && model.modelFormat !== 'openai') {
+    sendJson(res, 400, { error: { message: `Unsupported model format: ${model.modelFormat}` } });
+    return;
+  }
+
+  if (model.modelFormat !== 'anthropic' || model.compatibility?.supportsCountTokens === false) {
+    const inputTokens = estimateAnthropicInputTokens(body);
+    plog(() => `token-count: local estimate model=${body.model} input_tokens=${inputTokens}`);
+    res.setHeader('x-relay-token-count-source', 'local-estimate');
+    sendJson(res, 200, { input_tokens: inputTokens });
+    return;
+  }
+
+  if (model.baseUrl && !/^https?:\/\//i.test(model.baseUrl)) {
+    sendJson(res, 400, { error: { message: `Invalid provider baseUrl: must be http:// or https://` } });
+    return;
+  }
+  if (!model.baseUrl) {
+    sendJson(res, 400, { error: { message: `Model ${model.id} has no Anthropic baseUrl configured` } });
+    return;
+  }
+
+  let apiKey: string;
+  try {
+    apiKey = await resolveModelApiKey(model, options.apiKey);
+  } catch (err) {
+    sendJson(res, 401, {
+      error: { message: err instanceof Error ? err.message : String(err) },
+    });
+    return;
+  }
+
+  const betaHeaderRaw = req.headers['anthropic-beta'];
+  const inboundBeta = Array.isArray(betaHeaderRaw) ? betaHeaderRaw.join(',') : betaHeaderRaw;
+  const authType = model.authType ?? 'api';
+  const isOAuth = authType === 'oauth';
+  const forwardBody: Record<string, unknown> = { ...body, model: upstreamModelId(model) };
+  const refreshToken = isOAuth && model.providerId && model.authRef
+    ? (rejectedAccessToken: string) => resolveModelApiKey(
+        model,
+        options.apiKey,
+        rejectedAccessToken,
+      )
+    : undefined;
+
+  const countTokensUrl = `${model.baseUrl}/v1/messages/count_tokens`;
+  plog(() => `anthropic-count-tokens → ${countTokensUrl} oauth=${isOAuth}`);
+  await relayAnthropicMessages(res, countTokensUrl, forwardBody, apiKey, false, {
+    inboundBeta,
+    authType,
+    log: message => plog(message),
+    extraHeaders: model.headers,
+    refreshToken,
+    onTokenRefreshed: refreshed => { model.apiKey = refreshed; },
+  });
 }
 
 async function handleOpenAIChatCompletions(

--- a/src/upstream-forward.ts
+++ b/src/upstream-forward.ts
@@ -127,12 +127,22 @@ export function anthropicSseModelRewrite(override: string): Transform {
   const decoder = new StringDecoder('utf8');
   let tail = '';
   const rewriteLine = (line: string): string => {
-    if (!line.startsWith('data:') || !line.includes('"message_start"')) return line;
+    // Splitting on \n leaves the \r of a CRLF stream on the end of every line.
+    // JSON.parse tolerates it, so without stripping and restoring it a
+    // rewritten line would quietly lose its \r while every neighbouring line
+    // kept one — a stream with mixed endings. Anthropic sends LF, so this is
+    // insurance rather than an observed case.
+    const cr = line.endsWith('\r') ? '\r' : '';
+    const bare = cr ? line.slice(0, -1) : line;
+    if (!bare.startsWith('data:') || !bare.includes('"message_start"')) return line;
     try {
-      const parsed = JSON.parse(line.slice(5)) as { type?: string; message?: { model?: unknown } };
+      // A multi-line `data:` payload (legal SSE, never emitted by Anthropic)
+      // fails to parse here and relays untouched — fail-open, so the worst
+      // case is an un-rewritten model id rather than a corrupted stream.
+      const parsed = JSON.parse(bare.slice(5)) as { type?: string; message?: { model?: unknown } };
       if (parsed.type === 'message_start' && parsed.message && typeof parsed.message.model === 'string') {
         parsed.message.model = override;
-        return 'data: ' + JSON.stringify(parsed);
+        return 'data: ' + JSON.stringify(parsed) + cr;
       }
     } catch {
       // Not a single-line JSON payload; relay it untouched.
@@ -227,9 +237,15 @@ export async function relayAnthropicMessages(
     res.end(JSON.stringify({ type: 'error', error: { type: 'api_error', message: 'Upstream response was not valid JSON' } }));
     return;
   }
+  // Narrowed to an Anthropic Message, matching what the SSE path already
+  // requires of `message_start`. Any JSON object with a string `model` used to
+  // qualify, so an error envelope or a count_tokens-shaped body that happened
+  // to carry one had its `model` rewritten too — the two directions of the same
+  // relay disagreed about what they were allowed to touch.
   if (
     options.responseModelOverride
     && parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+    && (parsed as Record<string, unknown>).type === 'message'
     && typeof (parsed as Record<string, unknown>).model === 'string'
   ) {
     (parsed as Record<string, unknown>).model = options.responseModelOverride;

--- a/src/upstream-forward.ts
+++ b/src/upstream-forward.ts
@@ -118,47 +118,70 @@ export interface RelayAnthropicOptions {
 }
 
 /**
+ * An event-stream line ends with CRLF, LF, or a bare CR. Splitting on \n alone
+ * finds no boundary at all in a CR-framed stream: every byte accumulates in the
+ * tail buffer and the client sees nothing until the upstream closes, which
+ * stalls the relay rather than merely missing a rewrite. Capturing the
+ * separator lets each line be re-emitted with the exact ending it arrived with.
+ */
+const SSE_LINE_SPLIT = /(\r\n|\r|\n)/;
+
+/**
  * Line-preserving SSE transform that rewrites the `message_start` event's
  * `message.model` to the requested id. Buffers only up to one line; every
  * line that is not a parseable `message_start` data line passes through
- * byte-for-byte.
+ * byte-for-byte, with its original line ending.
  */
 export function anthropicSseModelRewrite(override: string): Transform {
   const decoder = new StringDecoder('utf8');
   let tail = '';
   const rewriteLine = (line: string): string => {
-    // Splitting on \n leaves the \r of a CRLF stream on the end of every line.
-    // JSON.parse tolerates it, so without stripping and restoring it a
-    // rewritten line would quietly lose its \r while every neighbouring line
-    // kept one — a stream with mixed endings. Anthropic sends LF, so this is
-    // insurance rather than an observed case.
-    const cr = line.endsWith('\r') ? '\r' : '';
-    const bare = cr ? line.slice(0, -1) : line;
-    if (!bare.startsWith('data:') || !bare.includes('"message_start"')) return line;
+    if (!line.startsWith('data:') || !line.includes('"message_start"')) return line;
     try {
       // A multi-line `data:` payload (legal SSE, never emitted by Anthropic)
       // fails to parse here and relays untouched — fail-open, so the worst
       // case is an un-rewritten model id rather than a corrupted stream.
-      const parsed = JSON.parse(bare.slice(5)) as { type?: string; message?: { model?: unknown } };
+      const parsed = JSON.parse(line.slice(5)) as { type?: string; message?: { model?: unknown } };
       if (parsed.type === 'message_start' && parsed.message && typeof parsed.message.model === 'string') {
         parsed.message.model = override;
-        return 'data: ' + JSON.stringify(parsed) + cr;
+        return 'data: ' + JSON.stringify(parsed);
       }
     } catch {
       // Not a single-line JSON payload; relay it untouched.
     }
     return line;
   };
+  // Split preserves separators at odd indices, so a line and its exact ending
+  // are re-joined unchanged; the final element is the unterminated remainder.
+  const rewriteTerminated = (parts: string[]): string => {
+    let out = '';
+    for (let i = 0; i + 1 < parts.length; i += 2) out += rewriteLine(parts[i]!) + parts[i + 1]!;
+    return out;
+  };
   return new Transform({
     transform(chunk: Buffer, _encoding, callback) {
-      const lines = (tail + decoder.write(chunk)).split('\n');
-      tail = lines.pop() ?? '';
-      const rewritten = lines.map(rewriteLine);
-      callback(null, rewritten.length ? rewritten.join('\n') + '\n' : '');
+      let buffered = tail + decoder.write(chunk);
+      // A trailing CR may be the first half of a CRLF whose LF is in the next
+      // chunk. Framing it as a bare-CR terminator now would split one line
+      // ending into two and insert a blank line, which in SSE ends the event.
+      let heldCr = '';
+      if (buffered.endsWith('\r')) {
+        heldCr = '\r';
+        buffered = buffered.slice(0, -1);
+      }
+      const parts = buffered.split(SSE_LINE_SPLIT);
+      tail = (parts.pop() ?? '') + heldCr;
+      callback(null, rewriteTerminated(parts));
     },
     flush(callback) {
       const rest = tail + decoder.end();
-      callback(null, rest ? rewriteLine(rest) : '');
+      if (!rest) {
+        callback(null, '');
+        return;
+      }
+      const parts = rest.split(SSE_LINE_SPLIT);
+      const remainder = parts.length % 2 === 1 ? parts.pop()! : '';
+      callback(null, rewriteTerminated(parts) + (remainder ? rewriteLine(remainder) : ''));
     },
   });
 }

--- a/src/upstream-forward.ts
+++ b/src/upstream-forward.ts
@@ -161,9 +161,8 @@ export function anthropicSseModelRewrite(override: string): Transform {
   return new Transform({
     transform(chunk: Buffer, _encoding, callback) {
       let buffered = tail + decoder.write(chunk);
-      // A trailing CR may be the first half of a CRLF whose LF is in the next
-      // chunk. Framing it as a bare-CR terminator now would split one line
-      // ending into two and insert a blank line, which in SSE ends the event.
+      // Holding a trailing CR keeps a split CRLF as one internal delimiter in
+      // spec-shaped framing. The emitted bytes are equivalent without this guard.
       let heldCr = '';
       if (buffered.endsWith('\r')) {
         heldCr = '\r';

--- a/src/upstream-forward.ts
+++ b/src/upstream-forward.ts
@@ -160,16 +160,13 @@ export function anthropicSseModelRewrite(override: string): Transform {
   };
   return new Transform({
     transform(chunk: Buffer, _encoding, callback) {
-      let buffered = tail + decoder.write(chunk);
-      // Holding a trailing CR keeps a split CRLF as one internal delimiter in
-      // spec-shaped framing. The emitted bytes are equivalent without this guard.
-      let heldCr = '';
-      if (buffered.endsWith('\r')) {
-        heldCr = '\r';
-        buffered = buffered.slice(0, -1);
-      }
+      const buffered = tail + decoder.write(chunk);
+      // Emit every observed line ending immediately. If a CRLF is split across
+      // chunks, the CR and later LF still pass through in their original order;
+      // treating the LF as an empty internal line is harmless because this
+      // transform carries no event-level state.
       const parts = buffered.split(SSE_LINE_SPLIT);
-      tail = (parts.pop() ?? '') + heldCr;
+      tail = parts.pop() ?? '';
       callback(null, rewriteTerminated(parts));
     },
     flush(callback) {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -3,11 +3,27 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import * as p from '@clack/prompts';
 import { parseArgs, rootHelpText, claudeHelpText, serverHelpText, modelsHelpText, patchHelpText, main, runClaudeCommand } from '../src/cli.js';
 import { VERSION } from '../src/constants.js';
-import { fetchProviderCatalog } from '../src/provider-catalog.js';
+import { fetchProviderCatalog, resolveLocalProviderApiKey } from '../src/provider-catalog.js';
+import { startProxy } from '../src/proxy.js';
+import { launchClaude } from '../src/launch.js';
 
 vi.mock('../src/launch.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../src/launch.js')>();
-  return { ...actual, findClaudeBinary: vi.fn(() => '/fake/claude') };
+  return {
+    ...actual,
+    findClaudeBinary: vi.fn(() => '/fake/claude'),
+    launchClaude: vi.fn(async () => 0),
+  };
+});
+
+vi.mock('../src/proxy.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/proxy.js')>();
+  return { ...actual, startProxy: vi.fn() };
+});
+
+vi.mock('../src/first-run.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/first-run.js')>();
+  return { ...actual, needsFirstRunSetup: vi.fn(async () => false) };
 });
 
 vi.mock('../src/patcher.js', async importOriginal => {
@@ -17,7 +33,11 @@ vi.mock('../src/patcher.js', async importOriginal => {
 
 vi.mock('../src/provider-catalog.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../src/provider-catalog.js')>();
-  return { ...actual, fetchProviderCatalog: vi.fn() };
+  return {
+    ...actual,
+    fetchProviderCatalog: vi.fn(),
+    resolveLocalProviderApiKey: vi.fn(),
+  };
 });
 
 afterEach(() => {
@@ -349,6 +369,107 @@ describe('main dispatch', () => {
       '--model', 'llama-test',
     ])).resolves.toBe(0);
     expect(log.mock.calls.flat().join('\n')).toContain('DRY RUN — would execute');
+  });
+
+  it('routes API-key Anthropic models without count_tokens support through the local estimator proxy', async () => {
+    vi.clearAllMocks();
+    const compatibility = { supportsCountTokens: false };
+    const model = {
+      id: 'opencode-go/qwen3.8-max',
+      name: 'Qwen 3.8 Max',
+      family: 'qwen',
+      brand: 'Qwen',
+      modelFormat: 'anthropic' as const,
+      upstreamModelId: 'qwen3.8-max',
+      baseUrl: 'https://api.opencode.ai',
+      compatibility,
+    };
+    const provider = {
+      id: 'opencode-go',
+      name: 'OpenCode Go',
+      apiKey: 'catalog-api-key',
+      authType: 'api' as const,
+      models: [model],
+    };
+    const catalog = Object.assign([provider], { blockedProviders: new Map() });
+    const close = vi.fn();
+    vi.mocked(fetchProviderCatalog).mockResolvedValue(catalog);
+    vi.mocked(resolveLocalProviderApiKey).mockResolvedValue('opencode-api-key');
+    vi.mocked(startProxy).mockResolvedValue({ port: 43123, token: 'proxy-token', close });
+    vi.mocked(launchClaude).mockResolvedValue(0);
+
+    const code = await runClaudeCommand(parseArgs([
+      'claude',
+      '--endpoint',
+      '--provider', 'opencode-go',
+      '--model', 'opencode-go/qwen3.8-max',
+    ]));
+
+    expect(code).toBe(0);
+    expect(startProxy).toHaveBeenCalledWith(
+      'https://api.opencode.ai',
+      'opencode-go/qwen3.8-max',
+      false,
+      undefined,
+      expect.objectContaining({
+        authType: 'api',
+        modelFormat: 'anthropic',
+        compatibility,
+      }),
+      'opencode-api-key',
+    );
+    expect(launchClaude).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ANTHROPIC_BASE_URL: 'http://127.0.0.1:43123',
+        ANTHROPIC_API_KEY: 'proxy-token',
+      }),
+      'opencode-go/qwen3.8-max',
+      [],
+    );
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it('keeps API-key Anthropic models with unset count_tokens capability direct and beta-gated', async () => {
+    vi.clearAllMocks();
+    const model = {
+      id: 'anthropic-direct-model',
+      name: 'Anthropic Direct Model',
+      family: 'claude',
+      brand: 'Anthropic',
+      modelFormat: 'anthropic' as const,
+      upstreamModelId: 'anthropic-direct-model',
+      baseUrl: 'https://api.anthropic.com',
+    };
+    const provider = {
+      id: 'anthropic-api',
+      name: 'Anthropic API',
+      apiKey: 'anthropic-api-key',
+      authType: 'api' as const,
+      models: [model],
+    };
+    const catalog = Object.assign([provider], { blockedProviders: new Map() });
+    vi.mocked(fetchProviderCatalog).mockResolvedValue(catalog);
+    vi.mocked(resolveLocalProviderApiKey).mockResolvedValue('anthropic-api-key');
+    vi.mocked(launchClaude).mockResolvedValue(0);
+
+    const code = await runClaudeCommand(parseArgs([
+      'claude',
+      '--endpoint',
+      '--provider', 'anthropic-api',
+      '--model', 'anthropic-direct-model',
+    ]));
+
+    expect(code).toBe(0);
+    expect(startProxy).not.toHaveBeenCalled();
+    expect(launchClaude).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ANTHROPIC_BASE_URL: 'https://api.anthropic.com',
+        ANTHROPIC_API_KEY: 'anthropic-api-key',
+        CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: '1',
+      }),
+      'anthropic-direct-model',
+      [],
+    );
   });
 
   it('prints patch help', async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -254,7 +254,6 @@ describe('help text', () => {
     for (const help of helps) {
       expect(help).not.toContain('antigravity');
       expect(help).not.toContain('Gemini');
-      expect(help).not.toContain('OpenCode');
       expect(help).not.toContain('Zen');
       expect(help).not.toContain('--vertex');
       expect(help).not.toContain('subscription tier');
@@ -268,6 +267,7 @@ describe('help text', () => {
     expect(root).toContain('clodex patch');
     expect(root).toContain('clodex models');
     expect(root).toContain('clodex providers');
+    expect(root).toContain('OpenCode Go');
     expect(root).toContain('--endpoint');
     expect(root).toContain('--proxy');
     expect(root).toContain('--save-mode');

--- a/tests/fetch-template-models.test.ts
+++ b/tests/fetch-template-models.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fetchTemplateModels } from '../src/registry/fetch-template-models.js';
-import type { ProviderTemplate } from '../src/provider-templates.js';
+import { getTemplateById, type ProviderTemplate } from '../src/provider-templates.js';
 import { clearTraceSecrets, getProviderDebugLogPath } from '../src/trace-log.js';
 
 function template(partial: Partial<ProviderTemplate> & Pick<ProviderTemplate, 'id' | 'name' | 'npm'>): ProviderTemplate {
@@ -194,6 +194,40 @@ describe('fetchTemplateModels', () => {
         headers: expect.not.objectContaining({
           Authorization: expect.any(String),
         }),
+      }),
+    );
+  });
+
+  it('accepts a bare model array for OpenCode Go discovery and applies its allowlist', async () => {
+    const openCodeGo = getTemplateById('opencode-go')!;
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify([
+        { id: 'qwen3.8-max', name: 'live qwen' },
+        { id: 'deepseek-v4-pro', name: 'live deepseek' },
+        { id: 'grok-4.5', name: 'responses only' },
+      ]),
+    } as Response);
+
+    const result = await fetchTemplateModels(openCodeGo, 'go-key');
+
+    expect(result.error).toBeUndefined();
+    expect(result.models.map(model => model.id)).toEqual(['qwen3.8-max', 'deepseek-v4-pro']);
+    expect(result.models[0]).toMatchObject({
+      modelFormat: 'anthropic',
+      npm: '@ai-sdk/anthropic',
+      apiUrl: 'https://opencode.ai/zen/go',
+    });
+    expect(result.models[1]).toMatchObject({
+      modelFormat: 'openai',
+      npm: '@ai-sdk/openai-compatible',
+      apiUrl: 'https://opencode.ai/zen/go/v1',
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      'https://opencode.ai/zen/go/v1/models',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer go-key' }),
       }),
     );
   });

--- a/tests/fetch-template-models.test.ts
+++ b/tests/fetch-template-models.test.ts
@@ -337,3 +337,100 @@ describe('fetchTemplateModels', () => {
     });
   });
 });
+
+describe('fetchTemplateModels fixed OpenCode Go destination', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    clearTraceSecrets();
+    vi.unstubAllGlobals();
+  });
+
+  const openCodeGo = () => getTemplateById('opencode-go')!;
+
+  it('refuses a caller-supplied base URL instead of sending the key to it', async () => {
+    // Discovery carries a live credential. `verifyCredential` is already
+    // structurally unredirectable (it takes no URL), but discovery took one,
+    // so the same credential still had a caller-reachable destination. The
+    // refusal has to happen before the request: an "ignored" override would
+    // leave a caller believing it had redirected discovery.
+    const result = await fetchTemplateModels(openCodeGo(), 'go-key', 'https://attacker.example/v1');
+
+    expect(result.models).toEqual([]);
+    expect(result.error).toContain('does not support a custom API base URL');
+    expect(fetch).not.toHaveBeenCalled();
+    // Nothing about the key or the address was put on the wire.
+    expect(JSON.stringify(vi.mocked(fetch).mock.calls)).not.toContain('attacker.example');
+  });
+
+  it('refuses a persisted base URL that drifted off the template literal', async () => {
+    // This is the reachable shape: `refreshApiListProvider` passes the
+    // provider record's stored `api.url` back in as the override, so a
+    // registry edited or imported with a different address would re-send the
+    // credential there on every refresh.
+    const result = await fetchTemplateModels(openCodeGo(), 'go-key', 'https://opencode.ai.evil.example/v1');
+
+    expect(result.error).toContain('does not support a custom API base URL');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('still discovers against the template literal, with or without a matching override', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify([{ id: 'deepseek-v4-pro', name: 'live deepseek' }]),
+    } as Response);
+
+    for (const override of [undefined, 'https://opencode.ai/zen/go/v1', 'https://opencode.ai/zen/go/v1/']) {
+      vi.mocked(fetch).mockClear();
+      const result = await fetchTemplateModels(openCodeGo(), 'go-key', override);
+      expect(result.error, `override=${override}`).toBeUndefined();
+      expect(result.models.map(m => m.id)).toEqual(['deepseek-v4-pro']);
+      expect(fetch).toHaveBeenCalledWith(
+        'https://opencode.ai/zen/go/v1/models',
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer go-key' }),
+        }),
+      );
+    }
+  });
+
+  it('leaves every other template free to use a caller-supplied base URL', async () => {
+    // Conservation: the fixed destination is a property of this one named
+    // template, not a new rule for template providers in general.
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ data: [{ id: 'model-a', name: 'Model A' }] }),
+    } as Response);
+
+    const result = await fetchTemplateModels(openaiCompatTemplate, 'sk-test', 'https://self-hosted.example/v1');
+
+    expect(result.error).toBeUndefined();
+    expect(result.baseUrl).toBe('https://self-hosted.example/v1');
+    expect(fetch).toHaveBeenCalledWith(
+      'https://self-hosted.example/v1/models',
+      expect.anything(),
+    );
+  });
+
+  it('accepts a bare model array only for the named OpenCode Go template', async () => {
+    // The bare-array body is OpenCode Go's documented `/models` shape. Every
+    // other template keeps the object-envelope contract it was reviewed
+    // against, so an upstream that starts answering with a bare array of
+    // something else still reports "no models" rather than parsing rows
+    // nobody checked.
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify([{ id: 'model-a', name: 'Model A' }]),
+    } as Response);
+
+    const result = await fetchTemplateModels(openaiCompatTemplate, 'sk-test');
+
+    expect(result.models).toEqual([]);
+    expect(result.error).toBe('Connected but no models were returned.');
+  });
+});

--- a/tests/fetch-template-models.test.ts
+++ b/tests/fetch-template-models.test.ts
@@ -5,6 +5,10 @@ import { join } from 'node:path';
 import { fetchTemplateModels } from '../src/registry/fetch-template-models.js';
 import { getTemplateById, type ProviderTemplate } from '../src/provider-templates.js';
 import { clearTraceSecrets, getProviderDebugLogPath } from '../src/trace-log.js';
+import {
+  OPENCODE_GO_ANTHROPIC_BASE_URL,
+  OPENCODE_GO_COMPLETIONS_BASE_URL,
+} from '../src/data/opencode-go-models.js';
 
 function template(partial: Partial<ProviderTemplate> & Pick<ProviderTemplate, 'id' | 'name' | 'npm'>): ProviderTemplate {
   return {
@@ -395,6 +399,58 @@ describe('fetchTemplateModels fixed OpenCode Go destination', () => {
         }),
       );
     }
+  });
+
+  it('discovers and overlays the allowlist at the approved Anthropic destination', async () => {
+    const anthropicOpenCodeGo = {
+      ...openCodeGo(),
+      npm: '@ai-sdk/anthropic',
+    };
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify([
+        { id: 'qwen3.8-max', name: 'live qwen' },
+        { id: 'grok-4.5', name: 'responses only' },
+      ]),
+    } as Response);
+
+    const result = await fetchTemplateModels(
+      anthropicOpenCodeGo,
+      'go-key',
+      OPENCODE_GO_ANTHROPIC_BASE_URL,
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.models.map(model => model.id)).toEqual(['qwen3.8-max']);
+    expect(result.models[0]).toMatchObject({
+      name: 'Qwen3.8 Max',
+      modelFormat: 'anthropic',
+      npm: '@ai-sdk/anthropic',
+      apiUrl: OPENCODE_GO_ANTHROPIC_BASE_URL,
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      `${OPENCODE_GO_ANTHROPIC_BASE_URL}/models`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'x-api-key': 'go-key',
+          'anthropic-version': '2023-06-01',
+        }),
+      }),
+    );
+  });
+
+  it.each([
+    ['@ai-sdk/openai-compatible', OPENCODE_GO_ANTHROPIC_BASE_URL],
+    ['@ai-sdk/anthropic', OPENCODE_GO_COMPLETIONS_BASE_URL],
+    ['@ai-sdk/openai', OPENCODE_GO_COMPLETIONS_BASE_URL],
+    ['', OPENCODE_GO_COMPLETIONS_BASE_URL],
+  ])('refuses the OpenCode package/destination mismatch %s at %s before fetch', async (npm, url) => {
+    const result = await fetchTemplateModels({ ...openCodeGo(), npm }, 'go-key', url);
+
+    expect(result.models).toEqual([]);
+    expect(result.error).toMatch(/does not support/i);
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   it('leaves every other template free to use a caller-supplied base URL', async () => {

--- a/tests/model-source.test.ts
+++ b/tests/model-source.test.ts
@@ -26,6 +26,40 @@ describe('resolveModelSource', () => {
     expect(resolveModelSource(stub({ id: 'bedrock', templateId: 'bedrock' }))).toBe('manual-only');
   });
 
+  it.each(['bedrock', 'vertex', 'azure'])(
+    'keeps canonical OpenCode identity ahead of the foreign %s manual-only template',
+    templateId => {
+      expect(resolveModelSource(stub({ id: 'opencode-go', templateId }))).toBe('api-list');
+    },
+  );
+
+  it.each(['@ai-sdk/amazon-bedrock', '@ai-sdk/google-vertex', '@ai-sdk/azure'])(
+    'keeps canonical OpenCode identity ahead of foreign manual-only npm %s',
+    npm => {
+      expect(resolveModelSource(stub({
+        id: 'opencode-go',
+        templateId: 'bedrock',
+        api: { npm },
+      }))).toBe('api-list');
+    },
+  );
+
+  it('recognizes a supported retained-template migration before manual-only npm metadata', () => {
+    expect(resolveModelSource(stub({
+      id: 'opencode-go-imported',
+      templateId: 'opencode-go',
+      api: { npm: '@ai-sdk/amazon-bedrock' },
+    }))).toBe('api-list');
+  });
+
+  it('keeps an ordinary provider with manual-only npm metadata manual-only', () => {
+    expect(resolveModelSource(stub({
+      id: 'imported-bedrock',
+      templateId: 'custom-openai',
+      api: { npm: '@ai-sdk/amazon-bedrock' },
+    }))).toBe('manual-only');
+  });
+
   it('returns api-list for custom endpoints', () => {
     expect(resolveModelSource(stub({ id: 'my-server', templateId: 'custom-openai' }))).toBe('api-list');
   });

--- a/tests/opencode-go-catalog-invariants.test.ts
+++ b/tests/opencode-go-catalog-invariants.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { buildOpenCodeGoModels } from '../src/data/opencode-go-models.js';
+
+/**
+ * Structural invariants over the WHOLE catalog, not a spot-check of two
+ * entries. `buildOpenCodeGoModels()` blind-casts generated JSON, so a botched
+ * regeneration would otherwise ship: these assertions are what stands between
+ * a bad feed day and a broken base URL, SDK package, or effort ladder.
+ */
+describe('opencode-go catalog invariants', () => {
+  const models = buildOpenCodeGoModels();
+
+  it('every entry routes to opencode.ai over https', () => {
+    expect(models.length).toBeGreaterThan(0);
+    for (const model of models) {
+      const url = new URL(model.apiUrl!);
+      expect(url.protocol, model.id).toBe('https:');
+      expect(url.hostname, model.id).toBe('opencode.ai');
+    }
+  });
+
+  it('npm and apiUrl agree with modelFormat on every entry', () => {
+    // The pairing is what makes protocol selection safe: an anthropic-format
+    // entry pointed at the completions URL, or an openai-format entry on the
+    // Anthropic SDK, is a request built for the wrong protocol.
+    for (const model of models) {
+      if (model.modelFormat === 'anthropic') {
+        expect(model.npm, model.id).toBe('@ai-sdk/anthropic');
+        expect(model.apiUrl, model.id).toBe('https://opencode.ai/zen/go');
+      } else {
+        expect(model.modelFormat, model.id).toBe('openai');
+        expect(model.npm, model.id).toBe('@ai-sdk/openai-compatible');
+        expect(model.apiUrl, model.id).toBe('https://opencode.ai/zen/go/v1');
+      }
+    }
+  });
+
+  it('every entry carries a usable context window and a printable name', () => {
+    // contextWindow flows into the patched client's context map, where a
+    // garbage value breaks auto-compaction rather than failing loudly.
+    for (const model of models) {
+      expect(Number.isInteger(model.contextWindow), model.id).toBe(true);
+      expect(model.contextWindow!, model.id).toBeGreaterThan(0);
+      expect(model.contextWindow!, model.id).toBeLessThanOrEqual(10_000_000);
+      expect(model.name?.trim(), model.id).toBeTruthy();
+      // eslint-disable-next-line no-control-regex
+      expect(/[\x00-\x1f\x7f]/.test(model.name ?? ''), model.id).toBe(false);
+    }
+  });
+
+  it('no anthropic-format entry advertises an effort ladder it cannot send', () => {
+    // Effort reaches an upstream through effortProviderOptions and the
+    // thinkingFormat transform, both of which act on an
+    // OpenAiCompatibleRequestBody. A passthrough Messages body is forwarded
+    // untouched, so a graded effort on this route can never reach the wire.
+    for (const model of models.filter(entry => entry.modelFormat === 'anthropic')) {
+      expect(model.compatibility?.supportsReasoningEffort, model.id).toBe(false);
+      // The same route cannot answer count_tokens upstream either.
+      expect(model.compatibility?.supportsCountTokens, model.id).toBe(false);
+    }
+  });
+
+  it('no entry maps an effort level to a value outside its own ladder', () => {
+    // Guards the shape rather than the contents: a mapped value must be a
+    // non-empty string, so a typo like `high: ''` cannot silently drop a level
+    // into "no opinion" while the level still shows in the picker.
+    for (const model of models) {
+      for (const [level, mapped] of Object.entries(model.compatibility?.reasoningEffortMap ?? {})) {
+        if (mapped === null) continue;
+        expect(typeof mapped, `${model.id}.${level}`).toBe('string');
+        expect(mapped.trim(), `${model.id}.${level}`).not.toBe('');
+      }
+    }
+  });
+});

--- a/tests/opencode-go-catalog-invariants.test.ts
+++ b/tests/opencode-go-catalog-invariants.test.ts
@@ -1,3 +1,8 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { buildOpenCodeGoModels } from '../src/data/opencode-go-models.js';
 
@@ -70,6 +75,81 @@ describe('opencode-go catalog invariants', () => {
         expect(typeof mapped, `${model.id}.${level}`).toBe('string');
         expect(mapped.trim(), `${model.id}.${level}`).not.toBe('');
       }
+    }
+  });
+
+  it('keeps prototype names unmapped while regenerating every reviewed model', () => {
+    const mappedIds = [
+      'deepseek-v4-flash', 'deepseek-v4-pro', 'glm-5.1', 'glm-5.2', 'gpt-5.6-luna',
+      'hy3', 'kimi-k2.6', 'kimi-k2.7-code', 'kimi-k3', 'mimo-v2.5', 'mimo-v2.5-pro',
+      'minimax-m2.7', 'minimax-m3', 'qwen3.6-plus', 'qwen3.7-max', 'qwen3.7-plus',
+      'qwen3.8-max',
+    ];
+    const hostileNames = ['constructor', 'toString', '__proto__', 'hasOwnProperty'];
+    const effortValues = {
+      'deepseek-v4-flash': ['high', 'max'],
+      'deepseek-v4-pro': ['high', 'max'],
+      'glm-5.2': ['high', 'max'],
+      'gpt-5.6-luna': ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
+      hy3: ['none', 'low', 'high'],
+      'kimi-k3': ['max'],
+    };
+    const feedModels = Object.fromEntries([
+      ...mappedIds.map(id => [id, {
+        name: `Fixture ${id}`,
+        limit: { context: 128_000 },
+        cost: { input: 0.1, output: 0.2 },
+        modalities: { input: ['text'] },
+        reasoning: false,
+        ...(effortValues[id as keyof typeof effortValues]
+          ? { reasoning_options: [{ type: 'effort', values: effortValues[id as keyof typeof effortValues] }] }
+          : id === 'qwen3.6-plus' ? { reasoning_options: [{ type: 'toggle' }] } : {}),
+      }]),
+      ...hostileNames.map(id => [id, {
+        name: `Hostile ${id}`,
+        limit: { context: 128_000 },
+        cost: { input: 0.1, output: 0.2 },
+        modalities: { input: ['text'] },
+        reasoning: false,
+      }]),
+    ]);
+    const feed = { 'opencode-go': { models: feedModels } };
+    const workspace = mkdtempSync(join(tmpdir(), 'clodex-opencode-go-updater-'));
+    const updaterPath = fileURLToPath(new URL('../scripts/update-opencode-go-models.mjs', import.meta.url));
+    try {
+      mkdirSync(join(workspace, 'src', 'data'), { recursive: true });
+      writeFileSync(
+        join(workspace, 'src', 'data', 'opencode-go-models.ts'),
+        "export const OPENCODE_GO_SOURCE_FETCHED_AT = 'before';\n",
+      );
+      const childScript = [
+        'globalThis.fetch = async () => ({',
+        '  ok: true,',
+        '  json: async () => JSON.parse(process.env.CLODEX_TEST_FEED),',
+        '});',
+        `await import(${JSON.stringify(updaterPath)});`,
+      ].join('\n');
+      const result = spawnSync(process.execPath, ['--input-type=module', '-e', childScript], {
+        cwd: workspace,
+        encoding: 'utf8',
+        env: { ...process.env, CLODEX_TEST_FEED: JSON.stringify(feed) },
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain('not transport-mapped');
+      for (const hostileName of hostileNames) {
+        expect(result.stdout).toContain(hostileName);
+      }
+      const regenerated = JSON.parse(
+        readFileSync(join(workspace, 'src', 'data', 'opencode-go-models.json'), 'utf8'),
+      ) as Array<{ id: string }>;
+      expect(regenerated.map(model => model.id).sort()).toEqual([...mappedIds].sort());
+      for (const hostileName of hostileNames) {
+        expect(regenerated.some(model => model.id === hostileName)).toBe(false);
+      }
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
     }
   });
 });

--- a/tests/opencode-go.test.ts
+++ b/tests/opencode-go.test.ts
@@ -1,0 +1,354 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildOpenCodeGoModels,
+  OPENCODE_GO_ANTHROPIC_BASE_URL,
+  OPENCODE_GO_COMPLETIONS_BASE_URL,
+  OPENCODE_GO_SOURCE,
+  OPENCODE_GO_SOURCE_FETCHED_AT,
+} from '../src/data/opencode-go-models.js';
+import { TEST_TIMEOUT_MS } from '../src/constants.js';
+import { buildHttpProxyRoutes } from '../src/http-proxy/routes.js';
+import { getTemplateById, verifyOpenCodeGoCredential } from '../src/provider-templates.js';
+import { effortProviderOptions, getPatchReasoningCapabilities } from '../src/provider-factory.js';
+import { transformOpenAiCompatibleRequestBody } from '../src/model-runtime-compatibility.js';
+import { projectNativeEffort } from '../src/patch-transforms.js';
+import { applyTemplateModelMetadata } from '../src/registry/fetch-template-models.js';
+import { materializeRegistry } from '../src/registry/materialize.js';
+import type { CachedModel, ProviderRegistry } from '../src/registry/types.js';
+
+function liveModel(id: string): CachedModel {
+  return {
+    id,
+    name: `live ${id}`,
+    upstreamModelId: id,
+    family: id.split('-')[0] ?? id,
+    brand: 'OpenCode',
+    modelFormat: 'openai',
+    npm: '@ai-sdk/openai-compatible',
+  };
+}
+
+describe('OpenCode Go catalog', () => {
+  /**
+   * The exact literals below — the total, the 4/13 format split, and
+   * gpt-5.6-luna's precise cost — are deliberate tripwires, not incidental
+   * assertions. The catalog is generated, so a regeneration that silently
+   * adds, drops, or reprices a model should FAIL here and be re-read by a
+   * human rather than shipped. If you are here after `npm run
+   * update:opencode-go`, the right move is to check the diff and update these
+   * numbers on purpose — not to loosen them.
+   */
+  it('records its OpenCode catalog source and excludes Responses-only models', () => {
+    const models = buildOpenCodeGoModels();
+    const ids = models.map(model => model.id);
+
+    expect(OPENCODE_GO_SOURCE).toBe('https://models.dev/api.json');
+    expect(new Date(OPENCODE_GO_SOURCE_FETCHED_AT).toISOString()).toBe(OPENCODE_GO_SOURCE_FETCHED_AT);
+    expect(models).toHaveLength(17);
+    expect(new Set(ids).size).toBe(models.length);
+    expect(ids).not.toContain('grok-4.5');
+    expect(new Set(models.map(model => model.modelFormat))).toEqual(new Set(['anthropic', 'openai']));
+    expect(models.filter(model => model.modelFormat === 'anthropic')).toHaveLength(4);
+    expect(models.filter(model => model.modelFormat === 'openai')).toHaveLength(13);
+  });
+
+  it('assigns per-model protocol, endpoint, context, vision, pricing, and compatibility metadata', () => {
+    const byId = new Map(buildOpenCodeGoModels().map(model => [model.id, model]));
+
+    expect(byId.get('qwen3.8-max')).toMatchObject({
+      modelFormat: 'anthropic',
+      npm: '@ai-sdk/anthropic',
+      apiUrl: OPENCODE_GO_ANTHROPIC_BASE_URL,
+      contextWindow: 1_000_000,
+      modalities: ['text', 'image'],
+    });
+    expect(byId.get('deepseek-v4-pro')).toMatchObject({
+      modelFormat: 'openai',
+      npm: '@ai-sdk/openai-compatible',
+      apiUrl: OPENCODE_GO_COMPLETIONS_BASE_URL,
+      contextWindow: 1_000_000,
+      compatibility: {
+        reasoningEffortMap: {
+          minimal: null,
+          low: null,
+          medium: null,
+          high: 'high',
+          max: 'max',
+        },
+        requiresReasoningContentOnAssistantMessages: true,
+        thinkingFormat: 'deepseek',
+        maxTokensField: 'max_tokens',
+      },
+    });
+    expect(byId.get('qwen3.6-plus')?.compatibility?.thinkingFormat).toBe('qwen');
+    expect(byId.get('kimi-k2.6')?.compatibility?.supportsReasoningEffort).toBe(false);
+    expect(byId.get('gpt-5.6-luna')?.cost).toEqual({
+      input: 0.1,
+      output: 0.6,
+      cache_read: 0.01,
+      cache_write: 0.125,
+    });
+  });
+
+  it('uses live discovery only for availability and fails closed on unsupported models', () => {
+    const template = getTemplateById('opencode-go')!;
+    const result = applyTemplateModelMetadata(template, [
+      liveModel('qwen3.8-max'),
+      liveModel('deepseek-v4-pro'),
+      liveModel('grok-4.5'),
+      liveModel('unknown-future-model'),
+    ]);
+
+    expect(result.map(model => model.id)).toEqual(['qwen3.8-max', 'deepseek-v4-pro']);
+    expect(result[0]).toMatchObject({
+      name: 'Qwen3.8 Max',
+      modelFormat: 'anthropic',
+      npm: '@ai-sdk/anthropic',
+      apiUrl: OPENCODE_GO_ANTHROPIC_BASE_URL,
+    });
+    expect(result[1]).toMatchObject({
+      name: 'DeepSeek V4 Pro',
+      modelFormat: 'openai',
+      npm: '@ai-sdk/openai-compatible',
+      apiUrl: OPENCODE_GO_COMPLETIONS_BASE_URL,
+    });
+  });
+
+  it('materializes Anthropic passthrough and Chat Completions routes under one credential', () => {
+    const template = getTemplateById('opencode-go')!;
+    const models = applyTemplateModelMetadata(template, [
+      liveModel('qwen3.8-max'),
+      liveModel('deepseek-v4-pro'),
+    ]);
+    const registry: ProviderRegistry = {
+      schemaVersion: 1,
+      providers: [{
+        id: 'opencode-go',
+        templateId: 'opencode-go',
+        name: 'OpenCode Go',
+        enabled: true,
+        authRef: 'keyring:provider:opencode-go',
+        authType: 'api',
+        preserveModelPricing: true,
+        api: {
+          npm: '@ai-sdk/openai-compatible',
+          url: OPENCODE_GO_COMPLETIONS_BASE_URL,
+        },
+        modelsCache: {
+          fetchedAt: '2026-08-07T00:00:00.000Z',
+          models,
+        },
+        addedAt: '2026-08-07T00:00:00.000Z',
+      }],
+    };
+
+    const providers = materializeRegistry(registry, () => 'go-key');
+    const routes = buildHttpProxyRoutes(providers, [
+      { providerId: 'opencode-go', modelId: 'qwen3.8-max' },
+      { providerId: 'opencode-go', modelId: 'deepseek-v4-pro' },
+    ]).routes;
+
+    expect(routes).toHaveLength(2);
+    expect(routes[0]).toMatchObject({
+      modelFormat: 'anthropic',
+      upstreamUrl: OPENCODE_GO_ANTHROPIC_BASE_URL,
+      apiKey: 'go-key',
+    });
+    expect(routes[1]).toMatchObject({
+      modelFormat: 'openai',
+      npm: '@ai-sdk/openai-compatible',
+      baseURL: OPENCODE_GO_COMPLETIONS_BASE_URL,
+      apiKey: 'go-key',
+    });
+  });
+
+  it('returns isolated catalog copies', () => {
+    const first = buildOpenCodeGoModels();
+    first[0]!.name = 'mutated';
+    expect(buildOpenCodeGoModels()[0]!.name).not.toBe('mutated');
+  });
+});
+
+describe('verifyOpenCodeGoCredential', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const authError = '{"type":"error","error":{"type":"AuthError","message":"Invalid API key."}}';
+  const modelError = '{"type":"error","error":{"type":"ModelError","message":"Model {{model}} is not supported"}}';
+
+  it('rejects a key the upstream answers with an auth-shaped 401, probing with a catalog model', async () => {
+    const fetchMock = vi.fn(async () => new Response(authError, { status: 401 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const error = await verifyOpenCodeGoCredential('bad-key');
+    expect(error).toContain('authentication failed');
+    const [url, init] = fetchMock.mock.calls[0]! as [string, RequestInit];
+    expect(url).toBe(`${OPENCODE_GO_COMPLETIONS_BASE_URL}/chat/completions`);
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer bad-key');
+    // The gateway resolves the model BEFORE the key, so the probe must name a
+    // committed catalog model or every key looks rejected.
+    const body = JSON.parse(String(init.body)) as { model?: string };
+    const catalogIds = buildOpenCodeGoModels()
+      .filter(entry => entry.modelFormat === 'openai')
+      .map(entry => entry.upstreamModelId ?? entry.id);
+    expect(catalogIds).toContain(body.model);
+  });
+
+  it('rejects an auth-shaped 403 as well', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(authError, { status: 403 })));
+    expect(await verifyOpenCodeGoCredential('bad-key')).not.toBeNull();
+  });
+
+  it('treats a 401 ModelError as inconclusive, never a key rejection', async () => {
+    // Live behavior that broke the original empty-body probe: the gateway
+    // returns 401 ModelError for an unsupported model REGARDLESS of the key.
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(modelError, { status: 401 })));
+    expect(await verifyOpenCodeGoCredential('good-key')).toBeNull();
+  });
+
+  it('treats an unparseable 401 as inconclusive', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('<html>gateway</html>', { status: 401 })));
+    expect(await verifyOpenCodeGoCredential('good-key')).toBeNull();
+  });
+
+  it('accepts a key whose probe fails ordinary request validation', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('{"error":"messages required"}', { status: 400 })));
+    expect(await verifyOpenCodeGoCredential('good-key')).toBeNull();
+  });
+
+  it('treats an unreachable upstream as inconclusive', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('ECONNREFUSED'); }));
+    expect(await verifyOpenCodeGoCredential('any-key')).toBeNull();
+  });
+
+  it('is wired on the template so the add flow probes before persisting', () => {
+    expect(getTemplateById('opencode-go')?.verifyCredential).toBe(verifyOpenCodeGoCredential);
+  });
+
+  it('sends the credential only to the reviewed literal endpoint', async () => {
+    // PO2. Asserted against the spelled-out address rather than the constant:
+    // comparing the constant with itself would still pass if the constant were
+    // repointed, and this probe carries a live API key.
+    const fetchMock = vi.fn(async () => new Response('{}', { status: 400 }));
+    vi.stubGlobal('fetch', fetchMock);
+    await verifyOpenCodeGoCredential('live-key');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0]! as [string, RequestInit];
+    expect(url).toBe('https://opencode.ai/zen/go/v1/chat/completions');
+  });
+
+  it('takes no argument that could redirect the probe', () => {
+    // The destination is structurally template-bound: the function accepts the
+    // key and nothing else, so no caller — CLI flag, import, or config — can
+    // point a live credential somewhere the template never declared.
+    expect(verifyOpenCodeGoCredential).toHaveLength(1);
+  });
+
+  it('bounds the probe on the shared deadline so a stalled upstream cannot hang the CLI', async () => {
+    // This is the first thing a user hits after pasting a key, under a
+    // spinner: without a deadline an upstream that accepts and then never
+    // answers leaves no exit but Ctrl-C. Asserted on the deadline itself
+    // rather than by waiting one out — fake timers do not reach
+    // AbortSignal.timeout's internal timer, and a real 10s wait in the suite
+    // is exactly the kind of cost this test exists to prevent.
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+    const seen: Array<AbortSignal | null | undefined> = [];
+    vi.stubGlobal('fetch', vi.fn(async (_url: string, init: RequestInit) => {
+      seen.push(init.signal);
+      return new Response('{}', { status: 400 });
+    }));
+
+    try {
+      await verifyOpenCodeGoCredential('any-key');
+      expect(timeoutSpy).toHaveBeenCalledWith(TEST_TIMEOUT_MS);
+      expect(seen[0], 'probe must carry the deadline signal').toBeInstanceOf(AbortSignal);
+    } finally {
+      timeoutSpy.mockRestore();
+    }
+  });
+
+  it('treats an aborted probe as inconclusive rather than a bad key', async () => {
+    // The other half of the deadline contract: hitting it must not reject the
+    // credential, or a stalled network would look like a wrong key.
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw Object.assign(new Error('This operation was aborted'), { name: 'TimeoutError' });
+    }));
+    expect(await verifyOpenCodeGoCredential('good-key')).toBeNull();
+  });
+
+  it('does not read an entitlement rejection as a bad key', async () => {
+    // The probe names ONE fixed model. If that model is ever plan-gated, a
+    // perfectly good key answers 403 here — and an unanchored /auth/i matches
+    // inside "Unauthorized", rejecting the key at add time for a plan problem.
+    const entitlement = '{"error":{"type":"UnauthorizedModelError","message":"Your plan does not include deepseek-v4-flash."}}';
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(entitlement, { status: 403 })));
+    expect(await verifyOpenCodeGoCredential('good-key')).toBeNull();
+  });
+
+  it('still rejects the key when upstream names the key itself', async () => {
+    // The other half: anchoring must not blunt the real case.
+    for (const body of [
+      '{"error":{"type":"authentication_error","message":"nope"}}',
+      '{"error":{"type":"ServerError","message":"Invalid API key provided."}}',
+      '{"error":{"type":"ServerError","message":"The API key is expired."}}',
+      '{"error":{"type":"ServerError","message":"Authentication failed."}}',
+    ]) {
+      vi.stubGlobal('fetch', vi.fn(async () => new Response(body, { status: 401 })));
+      expect(await verifyOpenCodeGoCredential('bad-key'), body)
+        .toContain('authentication failed');
+    }
+  });
+});
+
+describe('qwen3.6-plus reasoning toggle', () => {
+  const model = buildOpenCodeGoModels().find(entry => entry.id === 'qwen3.6-plus')!;
+  const meta = {
+    reasoning: model.reasoning,
+    compatibility: model.compatibility,
+    providerId: 'opencode-go',
+  };
+
+  it('turns thinking on for every selectable level, max included', () => {
+    // Qwen accepts no reasoning_effort — `thinkingFormat: 'qwen'` injects the
+    // boolean `enable_thinking` and only does so when an effort is PRESENT, so
+    // the effort value is an internal signal rather than a wire control.
+    // Before the map, mapCodexEffortToOpenAI dropped `max` along with `off`
+    // and `minimal`, so choosing MAX silently disabled thinking while `low`
+    // enabled it — backwards, and invisible.
+    for (const level of ['low', 'medium', 'high', 'xhigh', 'max']) {
+      const options = effortProviderOptions(model.npm!, level, model.id, meta as never) as
+        Record<string, Record<string, unknown>> | undefined;
+      const effort = options?.opencodeGo?.reasoningEffort as string | undefined;
+      expect(effort, level).toBeTruthy();
+      const body = transformOpenAiCompatibleRequestBody(
+        { model: model.id, reasoning_effort: effort },
+        model.compatibility,
+      ) as Record<string, unknown>;
+      expect(body.enable_thinking, level).toBe(true);
+    }
+  });
+
+  it('leaves thinking off when the user asks for off', () => {
+    const options = effortProviderOptions(model.npm!, 'off', model.id, meta as never);
+    expect(options).toBeUndefined();
+    const body = transformOpenAiCompatibleRequestBody(
+      { model: model.id },
+      model.compatibility,
+    ) as Record<string, unknown>;
+    expect(body.enable_thinking).toBeUndefined();
+  });
+
+  it('keeps a capability the patcher will actually accept', () => {
+    // The grades are cosmetic while the upstream control is a boolean, so
+    // collapsing them to one level is tempting — but getPatchReasoningCapabilities
+    // dedups identical provider options, and projectNativeEffort DISCARDS any
+    // capability missing low/medium/high. A one-level capability therefore
+    // leaves a patched client with no effort control at all, which is worse
+    // than cosmetic grades.
+    const patch = getPatchReasoningCapabilities(model.npm!, model.id, meta as never);
+    expect(patch.levels).toContain(patch.defaultLevel);
+    for (const base of ['low', 'medium', 'high']) expect(patch.levels).toContain(base);
+    expect(projectNativeEffort({ levels: patch.levels, defaultLevel: patch.defaultLevel! }))
+      .toBeTruthy();
+  });
+});

--- a/tests/opencode-go.test.ts
+++ b/tests/opencode-go.test.ts
@@ -13,7 +13,10 @@ import { effortProviderOptions, getPatchReasoningCapabilities } from '../src/pro
 import { transformOpenAiCompatibleRequestBody } from '../src/model-runtime-compatibility.js';
 import { projectNativeEffort } from '../src/patch-transforms.js';
 import { applyTemplateModelMetadata } from '../src/registry/fetch-template-models.js';
-import { materializeRegistry } from '../src/registry/materialize.js';
+import {
+  materializeRegistry,
+  projectProviderCachedModels,
+} from '../src/registry/materialize.js';
 import type { CachedModel, ProviderRegistry } from '../src/registry/types.js';
 
 function liveModel(id: string): CachedModel {
@@ -160,6 +163,96 @@ describe('OpenCode Go catalog', () => {
       baseURL: OPENCODE_GO_COMPLETIONS_BASE_URL,
       apiKey: 'go-key',
     });
+  });
+
+  it('projects both retained identities onto curated mixed-protocol authority', () => {
+    const cached = [
+      liveModel('qwen3.8-max'),
+      liveModel('deepseek-v4-pro'),
+      liveModel('grok-4.5'),
+      liveModel('unknown-future-model'),
+    ];
+    const providers = [
+      {
+        id: 'opencode-go',
+        templateId: 'opencode-go',
+      },
+      {
+        id: 'imported-opencode',
+        templateId: 'opencode-go',
+      },
+    ];
+
+    for (const identity of providers) {
+      const projected = projectProviderCachedModels({
+        ...identity,
+        name: 'OpenCode Go',
+        enabled: true,
+        authRef: `keyring:provider:${identity.id}`,
+        authType: 'api',
+        api: { npm: '@ai-sdk/openai-compatible', url: OPENCODE_GO_COMPLETIONS_BASE_URL },
+        modelsCache: { fetchedAt: '2026-08-12T00:00:00.000Z', models: cached },
+        addedAt: '2026-08-12T00:00:00.000Z',
+      });
+
+      expect(projected.map(model => model.id)).toEqual(['qwen3.8-max', 'deepseek-v4-pro']);
+      expect(projected[0]).toMatchObject({
+        modelFormat: 'anthropic',
+        npm: '@ai-sdk/anthropic',
+        apiUrl: OPENCODE_GO_ANTHROPIC_BASE_URL,
+        contextWindow: 1_000_000,
+      });
+      expect(projected[1]).toMatchObject({
+        modelFormat: 'openai',
+        npm: '@ai-sdk/openai-compatible',
+        apiUrl: OPENCODE_GO_COMPLETIONS_BASE_URL,
+        contextWindow: 1_000_000,
+      });
+    }
+  });
+
+  it('fails closed for unknown-only retained caches without a provider or route', () => {
+    const registry: ProviderRegistry = {
+      schemaVersion: 1,
+      providers: [{
+        id: 'imported-opencode',
+        templateId: 'opencode-go',
+        name: 'Imported OpenCode Go',
+        enabled: true,
+        authRef: 'keyring:provider:imported-opencode',
+        authType: 'api',
+        api: { npm: '@ai-sdk/openai-compatible', url: OPENCODE_GO_COMPLETIONS_BASE_URL },
+        modelsCache: {
+          fetchedAt: '2026-08-12T00:00:00.000Z',
+          models: [liveModel('unknown-future-model')],
+        },
+        addedAt: '2026-08-12T00:00:00.000Z',
+      }],
+    };
+
+    expect(projectProviderCachedModels(registry.providers[0]!)).toEqual([]);
+    const providers = materializeRegistry(registry, () => 'go-key');
+    expect(providers).toEqual([]);
+    expect(buildHttpProxyRoutes(providers, [
+      { providerId: 'imported-opencode', modelId: 'unknown-future-model' },
+    ]).routes).toEqual([]);
+  });
+
+  it('leaves ordinary custom cached models unchanged', () => {
+    const cached = [liveModel('unknown-custom-model')];
+    const provider: RegistryProvider = {
+      id: 'custom-provider',
+      templateId: 'custom-openai',
+      name: 'Custom provider',
+      enabled: true,
+      authRef: 'keyring:provider:custom-provider',
+      authType: 'api',
+      api: { npm: '@ai-sdk/openai-compatible', url: 'https://custom.invalid/v1' },
+      modelsCache: { fetchedAt: '2026-08-12T00:00:00.000Z', models: cached },
+      addedAt: '2026-08-12T00:00:00.000Z',
+    };
+
+    expect(projectProviderCachedModels(provider)).toBe(cached);
   });
 
   it('returns isolated catalog copies', () => {

--- a/tests/opencode-go.test.ts
+++ b/tests/opencode-go.test.ts
@@ -292,6 +292,12 @@ describe('verifyOpenCodeGoCredential', () => {
     expect(await verifyOpenCodeGoCredential('bad-key')).not.toBeNull();
   });
 
+  it('treats a 403 authorization_error as inconclusive', async () => {
+    const authorizationError = '{"error":{"type":"authorization_error","message":"Authorization failed."}}';
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(authorizationError, { status: 403 })));
+    expect(await verifyOpenCodeGoCredential('good-key')).toBeNull();
+  });
+
   it('treats a 401 ModelError as inconclusive, never a key rejection', async () => {
     // Live behavior that broke the original empty-body probe: the gateway
     // returns 401 ModelError for an unsupported model REGARDLESS of the key.

--- a/tests/patcher.test.ts
+++ b/tests/patcher.test.ts
@@ -266,6 +266,113 @@ describe('buildDesiredPatchConfig', () => {
     );
   }
 
+  it('filters only stale retained favorites while preserving ordinary unknowns and input order', () => {
+    const favorites = [
+      { providerId: 'opencode-go', modelId: 'stale-future-model' },
+      { providerId: 'imported-opencode', modelId: 'deepseek-v4-pro' },
+      { providerId: 'custom-provider', modelId: 'custom-unknown-model' },
+      { providerId: 'imported-opencode', modelId: 'stale-future-model' },
+      { providerId: 'opencode-go', modelId: 'qwen3.8-max' },
+    ];
+    const aliases = [
+      { name: 'stale', providerId: 'opencode-go', modelId: 'stale-future-model' },
+      { name: 'deep', providerId: 'imported-opencode', modelId: 'deepseek-v4-pro' },
+      { name: 'custom', providerId: 'custom-provider', modelId: 'custom-unknown-model' },
+      { name: 'stale-imported', providerId: 'imported-opencode', modelId: 'stale-future-model' },
+      { name: 'qwen', providerId: 'opencode-go', modelId: 'qwen3.8-max' },
+    ];
+    writeFileSync(join(home, 'config.json'), JSON.stringify({ favoriteModels: favorites, modelAliases: aliases }));
+    writeFileSync(join(home, 'providers.json'), JSON.stringify({
+      schemaVersion: 1,
+      providers: [{
+        id: 'opencode-go',
+        templateId: 'opencode-go',
+        name: 'OpenCode Go',
+        enabled: true,
+        authRef: 'keyring:provider:opencode-go',
+        authType: 'api',
+        api: { npm: '@ai-sdk/openai-compatible', url: 'https://opencode.ai/zen/go/v1' },
+        modelsCache: {
+          fetchedAt: '2026-08-12T00:00:00.000Z',
+          models: [{
+            id: 'qwen3.8-max',
+            upstreamModelId: 'qwen3.8-max',
+            name: 'Qwen 3.8 Max',
+            modelFormat: 'openai',
+          }, {
+            id: 'stale-future-model',
+            upstreamModelId: 'stale-future-model',
+            name: 'Stale future model',
+            modelFormat: 'openai',
+          }],
+        },
+        addedAt: '2026-08-12T00:00:00.000Z',
+      }, {
+        id: 'imported-opencode',
+        templateId: 'opencode-go',
+        name: 'Imported OpenCode Go',
+        enabled: true,
+        authRef: 'keyring:provider:imported-opencode',
+        authType: 'api',
+        api: { npm: '@ai-sdk/openai-compatible', url: 'https://opencode.ai/zen/go/v1' },
+        modelsCache: {
+          fetchedAt: '2026-08-12T00:00:00.000Z',
+          models: [{
+            id: 'deepseek-v4-pro',
+            upstreamModelId: 'deepseek-v4-pro',
+            name: 'DeepSeek V4 Pro',
+            modelFormat: 'openai',
+          }, {
+            id: 'stale-future-model',
+            upstreamModelId: 'stale-future-model',
+            name: 'Stale future model',
+            modelFormat: 'openai',
+          }],
+        },
+        addedAt: '2026-08-12T00:00:00.000Z',
+      }, {
+        id: 'custom-provider',
+        templateId: 'custom-openai',
+        name: 'Custom provider',
+        enabled: true,
+        authRef: 'keyring:provider:custom-provider',
+        authType: 'api',
+        api: { npm: '@ai-sdk/openai-compatible', url: 'https://custom.invalid/v1' },
+        modelsCache: {
+          fetchedAt: '2026-08-12T00:00:00.000Z',
+          models: [{
+            id: 'custom-unknown-model',
+            upstreamModelId: 'custom-unknown-model',
+            name: 'Custom unknown model',
+            modelFormat: 'openai',
+          }],
+        },
+        addedAt: '2026-08-12T00:00:00.000Z',
+      }],
+    }));
+    const configBefore = readFileSync(join(home, 'config.json'), 'utf8');
+    const providersBefore = readFileSync(join(home, 'providers.json'), 'utf8');
+
+    const desired = buildDesiredPatchConfig();
+
+    expect(Object.keys(desired.config)).toEqual([
+      'clodex:imported-opencode:deepseek-v4-pro',
+      'clodex:custom-provider:custom-unknown-model',
+      'clodex:opencode-go:qwen3.8-max',
+    ]);
+    expect(desired.config['clodex:imported-opencode:deepseek-v4-pro']?.alias).toBe('deep');
+    expect(desired.config['clodex:custom-provider:custom-unknown-model']?.alias).toBe('custom');
+    expect(desired.config['clodex:opencode-go:qwen3.8-max']?.alias).toBe('qwen');
+    expect(desired.config['clodex:opencode-go:stale-future-model']).toBeUndefined();
+    expect(desired.config['clodex:imported-opencode:stale-future-model']).toBeUndefined();
+    expect(desired.rejectedAliases).toEqual(expect.arrayContaining([
+      aliases[0],
+      aliases[3],
+    ]));
+    expect(readFileSync(join(home, 'config.json'), 'utf8')).toBe(configBefore);
+    expect(readFileSync(join(home, 'providers.json'), 'utf8')).toBe(providersBefore);
+  });
+
   it('preserves the native high default when provider metadata defaults to medium', () => {
     writeInputs({
       id: 'gpt-5.6-sol',

--- a/tests/pricing.test.ts
+++ b/tests/pricing.test.ts
@@ -7,6 +7,7 @@ import {
   lookupModelCost,
   normalizeModelIdCandidates,
   pickPricingRow,
+  providerPreservesModelPricing,
 } from '../src/registry/pricing.js';
 import type { CachedModel } from '../src/registry/types.js';
 
@@ -93,6 +94,89 @@ describe('pricing enrich', () => {
       input: 0.95,
       output: 4,
     });
+  });
+
+  it('reads the opt-out through the template when a record lost the flag, without disturbing ordinary providers', () => {
+    // PO4, both directions in one registry. The OpenCode Go record has no
+    // `preserveModelPricing` — the field an older clodex drops on round trip —
+    // so only the template fallback can save its curated prices. The groq
+    // record alongside it must still be enriched exactly as #98 enriches it,
+    // across the top-level and named-account caches.
+    const fetchedAt = '2026-08-09T00:00:00.000Z';
+    const curated = {
+      id: 'claude-sonnet-4-5',
+      name: 'Claude Sonnet 4.5',
+      upstreamModelId: 'claude-sonnet-4-5',
+      modelFormat: 'anthropic' as const,
+      cost: { input: 3, output: 15 },
+    };
+    const ordinary = {
+      id: 'llama-3.3-70b-versatile',
+      name: 'Llama 3.3 70B',
+      upstreamModelId: 'llama-3.3-70b-versatile',
+      modelFormat: 'openai' as const,
+    };
+    const registry = {
+      schemaVersion: 1 as const,
+      providers: [
+        {
+          id: 'opencode-go',
+          templateId: 'opencode-go',
+          name: 'OpenCode Go',
+          enabled: true,
+          authRef: 'keyring:provider:opencode-go',
+          // deliberately no preserveModelPricing field
+          api: { npm: '@ai-sdk/openai-compatible' },
+          addedAt: fetchedAt,
+          modelsCache: { fetchedAt, models: [{ ...curated }] },
+        },
+        {
+          id: 'groq',
+          templateId: 'groq',
+          name: 'Groq',
+          enabled: true,
+          authRef: 'keyring:provider:groq',
+          api: { npm: '@ai-sdk/groq' },
+          addedAt: fetchedAt,
+          modelsCache: { fetchedAt, models: [{ ...ordinary }] },
+          authAccounts: {
+            work: {
+              authRef: 'keyring:provider:groq-work',
+              addedAt: fetchedAt,
+              modelsCache: { fetchedAt, models: [{ ...ordinary }] },
+            },
+          },
+        },
+      ],
+    };
+
+    // A cache that genuinely collides with BOTH models, so preservation and
+    // enrichment are each observable rather than vacuously true.
+    const changed = applyPricingToRegistryProviders(registry, {
+      models: [
+        {
+          model_id: 'claude-sonnet-4-5',
+          pricing: [{ tier: 'standard', input_per_1m_tokens: 99, output_per_1m_tokens: 199 }],
+        },
+        {
+          model_id: 'llama-3.3-70b-versatile',
+          pricing: [{
+            platform: 'groq',
+            tier: 'standard',
+            input_per_1m_tokens: 0.59,
+            output_per_1m_tokens: 0.79,
+          }],
+        },
+      ],
+    });
+
+    // Curated OpenCode prices survive purely on the template fallback: the
+    // colliding 99/199 row must NOT land.
+    expect(registry.providers[0]?.modelsCache?.models[0]?.cost).toEqual({ input: 3, output: 15 });
+    // The ordinary provider keeps #98 enrichment on both cache locations.
+    expect(changed).toBe(true);
+    expect(registry.providers[1]?.modelsCache?.models[0]?.cost?.input).toBe(0.59);
+    expect(registry.providers[1]?.authAccounts?.work?.modelsCache?.models[0]?.cost?.input).toBe(0.59);
   });
 
   it('composes provider-owned pricing with account-cache enrichment', () => {
@@ -200,5 +284,26 @@ describe('pricing enrich', () => {
       isFree: true,
       freeStatus: 'verified_free',
     });
+  });
+});
+
+describe('providerPreservesModelPricing', () => {
+  it('honours an explicit flag on the provider record', () => {
+    expect(providerPreservesModelPricing({ templateId: 'openai', preserveModelPricing: true })).toBe(true);
+    expect(providerPreservesModelPricing({ templateId: 'opencode-go', preserveModelPricing: false })).toBe(false);
+  });
+
+  it('falls back to the template when the record lost the field', () => {
+    // The regression this closes: an older clodex parses providers.json,
+    // drops the field it does not know, and saves it back. Without the
+    // fallback the setting is gone for good and a curated price is silently
+    // replaced by a cache guess on the next enrich — cost display only, which
+    // is exactly why nobody would notice.
+    expect(providerPreservesModelPricing({ templateId: 'opencode-go' })).toBe(true);
+  });
+
+  it('defaults to false for a template that does not ask to keep its prices', () => {
+    expect(providerPreservesModelPricing({ templateId: 'openai' })).toBe(false);
+    expect(providerPreservesModelPricing({ templateId: 'no-such-template' })).toBe(false);
   });
 });

--- a/tests/pricing.test.ts
+++ b/tests/pricing.test.ts
@@ -306,4 +306,49 @@ describe('providerPreservesModelPricing', () => {
     expect(providerPreservesModelPricing({ templateId: 'openai' })).toBe(false);
     expect(providerPreservesModelPricing({ templateId: 'no-such-template' })).toBe(false);
   });
+
+  // The template fallback above reads ONE mutable field. A record that keeps
+  // the canonical OpenCode id while naming another template is still the
+  // retained built-in — same credential lineage, same curated catalog — but
+  // `getTemplateById('openai')` answers for a provider that never asked to
+  // keep its prices, so the curated OpenCode costs are overwritten by a cache
+  // guess. Identity has to be the complete one the rest of the registry uses.
+  it('keeps curated prices for a retained OpenCode record that names another template', () => {
+    expect(providerPreservesModelPricing({ id: 'opencode-go', templateId: 'openai' })).toBe(true);
+  });
+
+  it('keeps curated prices for a retained OpenCode record whose id drifted on import', () => {
+    expect(providerPreservesModelPricing({ id: 'opencode-go-mirror', templateId: 'opencode-go' })).toBe(true);
+  });
+
+  // Explicit policy outranks identity in BOTH directions: the fallback only
+  // decides what an absent flag means, so a user who deliberately opted a
+  // retained record back into cache pricing keeps that choice.
+  it('lets an explicit false outrank retained OpenCode identity', () => {
+    expect(providerPreservesModelPricing({
+      id: 'opencode-go',
+      templateId: 'openai',
+      preserveModelPricing: false,
+    })).toBe(false);
+    expect(providerPreservesModelPricing({
+      id: 'opencode-go',
+      templateId: 'opencode-go',
+      preserveModelPricing: false,
+    })).toBe(false);
+  });
+
+  it('lets an explicit true outrank an ordinary template that does not preserve', () => {
+    expect(providerPreservesModelPricing({
+      id: 'ordinary',
+      templateId: 'openai',
+      preserveModelPricing: true,
+    })).toBe(true);
+  });
+
+  // Negative: complete identity must not generalize to ordinary providers.
+  it('does not preserve prices for ordinary providers or partial records', () => {
+    expect(providerPreservesModelPricing({ id: 'my-openai', templateId: 'openai' })).toBe(false);
+    expect(providerPreservesModelPricing({ id: 'my-custom', templateId: '' })).toBe(false);
+    expect(providerPreservesModelPricing({ id: 'opencode-go-lookalike', templateId: 'no-such-template' })).toBe(false);
+  });
 });

--- a/tests/provider-catalog-display.test.ts
+++ b/tests/provider-catalog-display.test.ts
@@ -145,6 +145,26 @@ describe('provider-catalog-display', () => {
     expect(models[0]?.authRef).toBe(TEST_HELPER_REF);
   });
 
+  it('propagates count-token compatibility to standalone server models', () => {
+    const models = localProvidersToServerModels([{
+      id: 'anthropic-compatible',
+      name: 'Anthropic Compatible',
+      apiKey: 'api-key',
+      models: [{
+        id: 'claude-count-tokens-disabled',
+        name: 'Claude Count Tokens Disabled',
+        family: 'claude',
+        brand: 'Anthropic',
+        modelFormat: 'anthropic',
+        upstreamModelId: 'claude-count-tokens-disabled',
+        compatibility: { supportsCountTokens: false },
+      }],
+    }]);
+
+    expect(models[0]?.compatibility).toEqual({ supportsCountTokens: false });
+    expect(models[0]?.id).toBe('claude-count-tokens-disabled');
+  });
+
   describe('formatRegistryAuthLabel', () => {
     it('distinguishes OAuth, API key, and env refs', () => {
       expect(formatRegistryAuthLabel({

--- a/tests/provider-catalog-display.test.ts
+++ b/tests/provider-catalog-display.test.ts
@@ -322,6 +322,58 @@ describe('provider-catalog-display', () => {
       },
     );
 
+    it('counts only authority-backed retained models while preserving ordinary unknown models', async () => {
+      const registry = emptyRegistry();
+      registry.providers.push({
+        id: 'imported-opencode',
+        templateId: 'opencode-go',
+        name: 'Imported OpenCode Go',
+        enabled: true,
+        authRef: 'keyring:provider:imported-opencode',
+        authType: 'api',
+        api: { npm: '@ai-sdk/openai-compatible', url: 'https://opencode.ai/zen/go/v1' },
+        modelsCache: {
+          fetchedAt: '2026-08-12T00:00:00.000Z',
+          models: [{
+            id: 'deepseek-v4-pro',
+            name: 'DeepSeek V4 Pro',
+            upstreamModelId: 'deepseek-v4-pro',
+            modelFormat: 'openai',
+          }, {
+            id: 'stale-future-model',
+            name: 'Stale future model',
+            upstreamModelId: 'stale-future-model',
+            modelFormat: 'openai',
+          }],
+        },
+        addedAt: '2026-08-12T00:00:00.000Z',
+      });
+      registry.providers.push({
+        id: 'custom-provider',
+        templateId: 'custom-openai',
+        name: 'Custom provider',
+        enabled: true,
+        authRef: 'keyring:provider:custom-provider',
+        authType: 'api',
+        api: { npm: '@ai-sdk/openai-compatible', url: 'https://custom.invalid/v1' },
+        modelsCache: {
+          fetchedAt: '2026-08-12T00:00:00.000Z',
+          models: [{
+            id: 'custom-unknown-model',
+            name: 'Custom unknown model',
+            upstreamModelId: 'custom-unknown-model',
+            modelFormat: 'openai',
+          }],
+        },
+        addedAt: '2026-08-12T00:00:00.000Z',
+      });
+      withRegistryWriteLockSync(() => saveRegistry(registry));
+
+      const entries = await resolveProvidersForDisplay();
+      expect(entries.find(entry => entry.id === 'imported-opencode')?.modelCount).toBe(1);
+      expect(entries.find(entry => entry.id === 'custom-provider')?.modelCount).toBe(1);
+    });
+
     it('does not count an OAuth account cache for a provider-key credential', async () => {
       const registry = emptyRegistry();
       registry.schemaVersion = 4;

--- a/tests/provider-factory.test.ts
+++ b/tests/provider-factory.test.ts
@@ -12,6 +12,7 @@ import {
   thinkingProviderOptions,
 } from '../src/provider-factory.js';
 import { VERTEX_ANTHROPIC_NPM } from '../src/constants.js';
+import { buildOpenCodeGoModels } from '../src/data/opencode-go-models.js';
 
 async function expectCredentialHeadersStripped(
   fetchImpl: typeof fetch,
@@ -274,6 +275,41 @@ describe('getReasoningCapabilities', () => {
       openaiCompatible: { reasoningEffort: 'max' },
     });
     expect(effortProviderOptions('@ai-sdk/openai-compatible', 'low', 'glm-5.2')).toBeUndefined();
+  });
+
+  it('lets a wire-shape-only compatibility block keep suppressing effort options', () => {
+    // Conservation. A compatibility block that says nothing about reasoning
+    // still owns the answer for an openai-compatible route: the compatibility
+    // path returns "no effort", and the model-name rules below must not get a
+    // second vote. Treating such a block as "no opinion" would start emitting
+    // DeepSeek/Kimi/GLM options for custom providers that had none, which is a
+    // wire change to routes this work never looked at.
+    for (const modelId of ['deepseek-v4-pro', 'kimi-k3', 'glm-5.2']) {
+      expect(
+        effortProviderOptions('@ai-sdk/openai-compatible', 'high', modelId, {
+          providerId: 'some-custom-provider',
+          compatibility: { supportsStore: false, maxTokensField: 'max_tokens' },
+        }),
+        modelId,
+      ).toBeUndefined();
+    }
+  });
+
+  it('keeps every OpenCode Go catalog block expressing an explicit reasoning opinion', () => {
+    // Why the conservation above costs OpenCode Go nothing: each shipped entry
+    // states supportsReasoningEffort, a reasoningEffortMap, or a
+    // thinkingFormat, so none of them is a wire-shape-only block and none
+    // depends on the model-name fallback.
+    for (const model of buildOpenCodeGoModels()) {
+      const compatibility = model.compatibility;
+      expect(compatibility, model.id).toBeDefined();
+      expect(
+        compatibility!.supportsReasoningEffort !== undefined
+        || compatibility!.reasoningEffortMap !== undefined
+        || compatibility!.thinkingFormat !== undefined,
+        model.id,
+      ).toBe(true);
+    }
   });
 
 

--- a/tests/provider-templates.test.ts
+++ b/tests/provider-templates.test.ts
@@ -9,19 +9,20 @@ import {
 import { fetchTemplateModels } from '../src/registry/fetch-template-models.js';
 
 describe('provider templates', () => {
-  it('offers exactly the OpenAI API-key template as addable', () => {
-    expect(listSupportedTemplates().map(t => t.id)).toEqual(['openai']);
+  it('offers OpenAI and OpenCode Go API-key templates as addable', () => {
+    expect(listSupportedTemplates().map(t => t.id)).toEqual(['openai', 'opencode-go']);
   });
 
   it('filters templates by search query', () => {
     const templates = listSupportedTemplates();
-    expect(filterTemplates(templates, 'open').map(t => t.id)).toEqual(['openai']);
+    expect(filterTemplates(templates, 'open').map(t => t.id)).toEqual(['openai', 'opencode-go']);
     expect(filterTemplates(templates, 'groq')).toEqual([]);
   });
 
   it('looks up template by id', () => {
     expect(getTemplateById('openai')?.npm).toBe('@ai-sdk/openai');
     expect(getTemplateById('openai-oauth')?.authType).toBe('oauth');
+    expect(getTemplateById('opencode-go')?.staticModelPolicy).toBe('allowlist');
     expect(getTemplateById('groq')).toBeUndefined();
   });
 
@@ -31,8 +32,9 @@ describe('provider templates', () => {
   });
 
   it('excludes already-configured providers from addable list', () => {
-    expect(listAddableTemplates(['openai']).map(t => t.id)).toEqual([]);
-    expect(listAddableTemplates([]).map(t => t.id)).toEqual(['openai']);
+    expect(listAddableTemplates(['openai']).map(t => t.id)).toEqual(['opencode-go']);
+    expect(listAddableTemplates(['openai', 'opencode-go']).map(t => t.id)).toEqual([]);
+    expect(listAddableTemplates([]).map(t => t.id)).toEqual(['openai', 'opencode-go']);
   });
 });
 

--- a/tests/providers-command.test.ts
+++ b/tests/providers-command.test.ts
@@ -962,6 +962,74 @@ describe('providers add menu', () => {
     expect(addTemplateMock.mock.calls[0]?.[1]).toBe('go-key');
   });
 
+  it('omits OpenCode Go when a migrated provider retains its built-in template identity', async () => {
+    const registry = emptyRegistry();
+    registry.providers.push({
+      id: 'imported-opencode',
+      templateId: 'opencode-go',
+      name: 'Imported OpenCode Go',
+      enabled: true,
+      authRef: 'keyring:provider:imported-opencode',
+      authType: 'api',
+      api: { npm: '@ai-sdk/openai-compatible', url: 'https://custom.invalid/v1' },
+      addedAt: '2026-08-11T00:00:00.000Z',
+    });
+    withRegistryWriteLockSync(() => saveRegistry(registry));
+    selectMock.mockResolvedValue('noop');
+
+    await expect(runProvidersAdd()).resolves.toBe(0);
+
+    const options = selectMock.mock.calls[0]?.[0].options.map((option: { value: string }) => option.value);
+    expect(options).toEqual(['oauth', 'api:openai']);
+    expect(passwordMock).not.toHaveBeenCalled();
+    expect(addTemplateMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { id: 'opencode-go', name: 'canonical' },
+    { id: 'imported-opencode', name: 'migrated' },
+  ])('refuses a direct OpenCode Go add for an already configured $name identity', async ({ id }) => {
+    const registry = emptyRegistry();
+    registry.providers.push({
+      id,
+      templateId: 'opencode-go',
+      name: 'Configured OpenCode Go',
+      enabled: true,
+      authRef: `keyring:provider:${id}`,
+      authType: 'api',
+      api: { npm: '@ai-sdk/openai-compatible', url: 'https://custom.invalid/v1' },
+      addedAt: '2026-08-11T00:00:00.000Z',
+    });
+    withRegistryWriteLockSync(() => saveRegistry(registry));
+    selectMock.mockResolvedValue('api:opencode-go');
+
+    await expect(runProvidersAdd()).resolves.toBe(0);
+
+    expect(passwordMock).not.toHaveBeenCalled();
+    expect(addTemplateMock).not.toHaveBeenCalled();
+  });
+
+  it('does not treat an ordinary custom provider template as the configured built-in', async () => {
+    const registry = emptyRegistry();
+    registry.providers.push({
+      id: 'custom-openai-endpoint',
+      templateId: 'openai',
+      name: 'Custom OpenAI endpoint',
+      enabled: true,
+      authRef: 'keyring:provider:custom-openai-endpoint',
+      authType: 'api',
+      api: { npm: '@ai-sdk/openai-compatible', url: 'https://custom.invalid/v1' },
+      addedAt: '2026-08-11T00:00:00.000Z',
+    });
+    withRegistryWriteLockSync(() => saveRegistry(registry));
+    selectMock.mockResolvedValue('noop');
+
+    await expect(runProvidersAdd()).resolves.toBe(0);
+
+    const options = selectMock.mock.calls[0]?.[0].options.map((option: { value: string }) => option.value);
+    expect(options).toEqual(['oauth', 'api:openai', 'api:opencode-go']);
+  });
+
   it('reports pending cleanup after an API-key provider is committed', async () => {
     selectMock.mockResolvedValue('api:openai');
     passwordMock.mockResolvedValue('api-key');

--- a/tests/providers-command.test.ts
+++ b/tests/providers-command.test.ts
@@ -692,6 +692,84 @@ describe('interactive OAuth account switching', () => {
     expect(detailOptions.map(option => option.value)).not.toContain('browse');
     expect(browseAllModelsMock).not.toHaveBeenCalled();
   });
+
+  it('browses only retained models present in the projected authority', async () => {
+    const registry = emptyRegistry();
+    registry.providers.push({
+      id: 'opencode-go',
+      templateId: 'opencode-go',
+      name: 'OpenCode Go',
+      enabled: true,
+      authRef: 'keyring:provider:opencode-go',
+      authType: 'api',
+      api: { npm: '@ai-sdk/openai-compatible', url: 'https://opencode.ai/zen/go/v1' },
+      modelsCache: {
+        fetchedAt: '2026-08-12T00:00:00.000Z',
+        models: [{
+          id: 'deepseek-v4-pro',
+          name: 'stale name',
+          upstreamModelId: 'deepseek-v4-pro',
+          modelFormat: 'openai',
+        }, {
+          id: 'stale-future-model',
+          name: 'Stale future model',
+          upstreamModelId: 'stale-future-model',
+          modelFormat: 'openai',
+        }],
+      },
+      addedAt: '2026-08-12T00:00:00.000Z',
+    });
+    withRegistryWriteLockSync(() => saveRegistry(registry));
+    selectMock
+      .mockResolvedValueOnce('provider:opencode-go')
+      .mockResolvedValueOnce('browse')
+      .mockResolvedValueOnce('done');
+
+    await expect(runProvidersCommand([])).resolves.toBe(0);
+
+    expect(browseAllModelsMock.mock.calls[0]?.[0].models.map((model: { id: string }) => model.id))
+      .toEqual(['deepseek-v4-pro']);
+  });
+
+  it('excludes stale retained models from browse and readiness while preserving the cache', async () => {
+    const registry = emptyRegistry();
+    const provider = slottedProvider('work');
+    provider.id = 'imported-opencode';
+    provider.templateId = 'opencode-go';
+    provider.name = 'Imported OpenCode Go';
+    provider.api = { npm: '@ai-sdk/openai-compatible', url: 'https://opencode.ai/zen/go/v1' };
+    provider.modelsCache = {
+      fetchedAt: '2026-08-12T00:00:00.000Z',
+      models: [{
+        id: 'stale-future-model',
+        name: 'Stale future model',
+        upstreamModelId: 'stale-future-model',
+        modelFormat: 'openai',
+      }],
+    };
+    provider.authAccounts!.work!.modelsCache = provider.modelsCache;
+    registry.providers.push(provider);
+    withRegistryWriteLockSync(() => saveRegistry(registry));
+    selectMock
+      .mockResolvedValueOnce('provider:imported-opencode')
+      .mockResolvedValueOnce('account')
+      .mockResolvedValueOnce('work')
+      .mockResolvedValueOnce('done');
+    refreshProviderModelsWithCredentialMock.mockResolvedValue({
+      id: 'imported-opencode',
+      name: 'Imported OpenCode Go',
+      ok: true,
+      modelCount: 1,
+    });
+
+    await expect(runProvidersCommand([])).resolves.toBe(0);
+
+    const detailOptions = selectMock.mock.calls[1]?.[0].options as Array<{ value: string }>;
+    expect(detailOptions.map(option => option.value)).not.toContain('browse');
+    expect(browseAllModelsMock).not.toHaveBeenCalled();
+    expect(warnMock).toHaveBeenCalledWith(expect.stringContaining('did not produce a usable catalog'));
+    expect(loadRegistry().providers[0]?.modelsCache?.models[0]?.id).toBe('stale-future-model');
+  });
 });
 
 describe('provider removal cleanup', () => {

--- a/tests/providers-command.test.ts
+++ b/tests/providers-command.test.ts
@@ -155,7 +155,7 @@ describe('parseProvidersArgs', () => {
     expect(help).toContain('refresh-models');
     expect(help).toContain('auth openai');
     expect(help).not.toContain('import');
-    expect(help).not.toContain('OpenCode');
+    expect(help).toContain('built-in provider');
   });
 
   it('mentions only openai in auth help', () => {
@@ -805,7 +805,7 @@ describe('provider command cleanup reconciliation', () => {
     const authRef = helperRef('provider:retired');
     await queueCredentialDelete(authRef);
     const deleteSpy = vi.spyOn(env, 'deleteProviderCredential').mockResolvedValue(true);
-    selectMock.mockResolvedValue('apikey');
+    selectMock.mockResolvedValue('api:openai');
     passwordMock.mockResolvedValue('test-key');
     addTemplateMock.mockResolvedValue({
       added: false,
@@ -868,7 +868,7 @@ describe('provider command cleanup reconciliation', () => {
     const authRef = helperRef('provider:replaced');
     selectMock
       .mockResolvedValueOnce('add')
-      .mockResolvedValueOnce('apikey');
+      .mockResolvedValueOnce('api:openai');
     passwordMock.mockResolvedValue('test-key');
     addTemplateMock.mockImplementation(async () => {
       await queueCredentialDelete(authRef);
@@ -937,17 +937,33 @@ describe('providers add menu', () => {
     vi.restoreAllMocks();
   });
 
-  it('offers ChatGPT OAuth first and API key second', async () => {
+  it('offers ChatGPT OAuth followed by OpenAI and OpenCode Go API keys', async () => {
     selectMock.mockResolvedValue('noop');
 
     await runProvidersAdd();
 
     const options = selectMock.mock.calls[0]?.[0].options.map((option: { value: string }) => option.value);
-    expect(options).toEqual(['oauth', 'apikey']);
+    expect(options).toEqual(['oauth', 'api:openai', 'api:opencode-go']);
+  });
+
+  it('adds OpenCode Go through the shared API-key flow', async () => {
+    selectMock.mockResolvedValue('api:opencode-go');
+    passwordMock.mockResolvedValue('go-key');
+    addTemplateMock.mockResolvedValue({ added: true, modelCount: 17 });
+
+    await expect(runProvidersAdd()).resolves.toBe(0);
+
+    expect(addTemplateMock).toHaveBeenCalledOnce();
+    expect(addTemplateMock.mock.calls[0]?.[0]).toMatchObject({
+      id: 'opencode-go',
+      name: 'OpenCode Go',
+      staticModelPolicy: 'allowlist',
+    });
+    expect(addTemplateMock.mock.calls[0]?.[1]).toBe('go-key');
   });
 
   it('reports pending cleanup after an API-key provider is committed', async () => {
-    selectMock.mockResolvedValue('apikey');
+    selectMock.mockResolvedValue('api:openai');
     passwordMock.mockResolvedValue('api-key');
     addTemplateMock.mockResolvedValue({
       added: true,

--- a/tests/proxy-sdk-provider-id.test.ts
+++ b/tests/proxy-sdk-provider-id.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import http from 'node:http';
 import { createLanguageModel } from '../src/provider-factory.js';
-import { generateAnthropicResponse } from '../src/sdk-adapter.js';
+import { generateAnthropicResponse, streamAnthropicResponse } from '../src/sdk-adapter.js';
 import { startProxyCatalog, type ProxyRoute } from '../src/proxy.js';
 
 vi.mock('../src/provider-factory.js', async (importOriginal) => {
@@ -25,6 +25,12 @@ vi.mock('../src/sdk-adapter.js', async (importOriginal) => {
       stop_reason: 'end_turn',
       usage: { input_tokens: 1, output_tokens: 1 },
     }),
+    streamAnthropicResponse: vi.fn(async (
+      _model: unknown,
+      _params: unknown,
+      _modelId: string,
+      write: (chunk: string) => void,
+    ) => { write('event: ping\ndata: {"type":"ping"}\n\n'); }),
   };
 });
 
@@ -89,5 +95,91 @@ describe('SDK proxy provider identity', () => {
     expect(createLanguageModel).toHaveBeenCalledWith(expect.objectContaining({
       providerId: 'kilo',
     }));
+  });
+});
+
+describe('translated route response identity', () => {
+  const route: ProxyRoute = {
+    aliasId: 'clodex:kilo:tencent/hy3',
+    realModelId: 'tencent/hy3',
+    displayName: 'Tencent Hy3',
+    upstreamUrl: '',
+    apiKey: '',
+    modelFormat: 'openai',
+    npm: '@ai-sdk/openai-compatible',
+    baseURL: 'https://api.kilo.ai/api/gateway',
+    providerId: 'kilo',
+    authType: 'none',
+  };
+
+  afterEach(() => {
+    vi.mocked(createLanguageModel).mockClear();
+    vi.mocked(generateAnthropicResponse).mockClear();
+    vi.mocked(streamAnthropicResponse).mockClear();
+  });
+
+  // The third positional argument is the id `sdk-adapter` stamps into the
+  // response `message.model` (streaming) and `model` (non-streaming), so it is
+  // exactly the identity the client is told answered.
+  const respondedModelId = (mock: { mock: { calls: unknown[][] } }): unknown =>
+    mock.mock.calls[0]?.[2];
+
+  it('reports the routed model, not the request id, on a non-stream default-route fallback', async () => {
+    // The requested id named no route we honoured, so the default route
+    // answered. Echoing the request back would tell the client it reached a
+    // model it never reached — and patched Claude Code keys its context window
+    // off that id. The Anthropic passthrough already refuses to do this; the
+    // translated path has to agree.
+    const handle = await startProxyCatalog([route], route.aliasId, false);
+    const res = await postToProxy(handle.port, handle.token, {
+      model: 'some-unconfigured-model',
+      max_tokens: 100,
+      messages: [{ role: 'user', content: 'hi' }],
+      stream: false,
+    });
+    handle.close();
+
+    expect(res.status, res.body).toBe(200);
+    expect(respondedModelId(vi.mocked(generateAnthropicResponse))).toBe('tencent/hy3');
+  });
+
+  it('reports the routed model on a streaming default-route fallback too', async () => {
+    // Same invariant on the other constructor: `streamAnthropicResponse`
+    // stamps `message_start`, so a stream that fell back must not announce the
+    // phantom id either.
+    const handle = await startProxyCatalog([route], route.aliasId, false);
+    const res = await postToProxy(handle.port, handle.token, {
+      model: 'some-unconfigured-model',
+      max_tokens: 100,
+      messages: [{ role: 'user', content: 'hi' }],
+      stream: true,
+    });
+    handle.close();
+
+    expect(res.status, res.body).toBe(200);
+    expect(respondedModelId(vi.mocked(streamAnthropicResponse))).toBe('tencent/hy3');
+  });
+
+  it('still echoes an explicitly resolved alias in both directions', async () => {
+    // The other half: a request that named a route we honoured keeps its
+    // public identity, which is the behaviour the echo exists for.
+    for (const stream of [false, true]) {
+      vi.mocked(generateAnthropicResponse).mockClear();
+      vi.mocked(streamAnthropicResponse).mockClear();
+      const handle = await startProxyCatalog([route], route.aliasId, false);
+      const res = await postToProxy(handle.port, handle.token, {
+        model: route.aliasId,
+        max_tokens: 100,
+        messages: [{ role: 'user', content: 'hi' }],
+        stream,
+      });
+      handle.close();
+
+      expect(res.status, res.body).toBe(200);
+      const mock = stream
+        ? vi.mocked(streamAnthropicResponse)
+        : vi.mocked(generateAnthropicResponse);
+      expect(respondedModelId(mock), `stream=${stream}`).toBe(route.aliasId);
+    }
   });
 });

--- a/tests/proxy-sdk-provider-id.test.ts
+++ b/tests/proxy-sdk-provider-id.test.ts
@@ -126,10 +126,9 @@ describe('translated route response identity', () => {
 
   it('reports the routed model, not the request id, on a non-stream default-route fallback', async () => {
     // The requested id named no route we honoured, so the default route
-    // answered. Echoing the request back would tell the client it reached a
-    // model it never reached — and patched Claude Code keys its context window
-    // off that id. The Anthropic passthrough already refuses to do this; the
-    // translated path has to agree.
+    // answered. Report that answering/default model rather than the unresolved
+    // requested id; patched Claude Code keys its context window off that id,
+    // and built-in Anthropic-format fallback is routine in this PR.
     const handle = await startProxyCatalog([route], route.aliasId, false);
     const res = await postToProxy(handle.port, handle.token, {
       model: 'some-unconfigured-model',

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -251,6 +251,44 @@ describe('SDK anonymous route handling', () => {
       vi.unstubAllGlobals();
     }
   });
+
+  it('answers count_tokens locally when the route declares no upstream support', async () => {
+    // Speaking the Messages API does not imply implementing count_tokens.
+    // Forwarding it to an upstream without the endpoint answers Claude Code's
+    // token accounting with a 404 instead of a number, which is the failure
+    // this capability exists to avoid.
+    const fetchMock = vi.fn(async () => new Response('not found', { status: 404 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const handle = await startProxy(
+      'https://anonymous.example',
+      'anonymous-model',
+      false,
+      undefined,
+      {
+        providerId: 'local',
+        authType: 'none',
+        modelFormat: 'anthropic',
+        compatibility: { supportsCountTokens: false },
+      },
+      '',
+    );
+
+    try {
+      const tokens = await postToProxy(handle.port, handle.token, {
+        model: 'anonymous-model',
+        messages: [{ role: 'user', content: 'count this' }],
+      }, undefined, '/v1/messages/count_tokens');
+
+      expect(tokens.status).toBe(200);
+      expect(JSON.parse(tokens.body).input_tokens).toBeGreaterThan(0);
+      // The point of the capability: upstream is never asked.
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      handle.close();
+      vi.unstubAllGlobals();
+    }
+  });
 });
 
 describe('catalog model aliases', () => {
@@ -556,6 +594,100 @@ describe('catalog model aliases', () => {
         ).on('error', reject);
       });
       expect(modelLookup).toBe(200);
+    } finally {
+      handle.close();
+    }
+  });
+
+  it('does not echo the requested id when the request fell back to the default route', async () => {
+    // The alias did not resolve, so the default route answered. Echoing the
+    // requested id here would report a model the request never reached, and
+    // patched Claude Code keys its context window off that id.
+    const defaultRoute: ProxyRoute = {
+      aliasId: 'anthropic-test-provider__default-model',
+      realModelId: 'default-model',
+      displayName: 'Default Model',
+      upstreamUrl: 'https://upstream-default.example',
+      apiKey: 'provider-key',
+      modelFormat: 'anthropic',
+      npm: '@ai-sdk/anthropic',
+      providerId: 'test-provider',
+    };
+    const fetchMock = vi.fn(async () => new Response(
+      JSON.stringify({ id: 'msg_1', type: 'message', role: 'assistant', model: 'default-model', content: [], usage: { input_tokens: 1, output_tokens: 1 } }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const handle = await startProxyCatalog([defaultRoute], defaultRoute.aliasId, false);
+    try {
+      const res = await postToProxy(handle.port, handle.token, {
+        model: 'some-unconfigured-model',
+        max_tokens: 100,
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: false,
+      });
+      expect(res.status).toBe(200);
+      // The upstream still receives the route's real model id.
+      const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+      expect(JSON.parse(init.body as string).model).toBe('default-model');
+      // The response reports what actually answered, not what was asked for.
+      const body = JSON.parse(res.body) as { model: string };
+      expect(body.model).toBe('default-model');
+      expect(body.model).not.toBe('some-unconfigured-model');
+    } finally {
+      handle.close();
+    }
+  });
+
+  it('still echoes the requested id when an alias actually resolved', async () => {
+    // The other half of the guard: adding `resolvedRoute &&` must not stop a
+    // genuinely resolved alias from echoing, which is the behaviour the
+    // override exists for.
+    const providers: LocalProvider[] = [{
+      id: 'Test-Provider',
+      name: 'Test Provider',
+      apiKey: 'provider-key',
+      models: [{
+        id: 'Solver-V1',
+        name: 'Solver V1',
+        family: 'test',
+        brand: 'Other',
+        modelFormat: 'anthropic',
+        upstreamModelId: 'Solver-V1',
+        baseUrl: 'https://upstream-solver.example',
+        contextWindow: 1_000_000,
+      }],
+    }];
+    const resolveRoute = makeRouteResolver(providers);
+    const aliasTarget = resolveRoute('Test-Provider', 'Solver-V1')!;
+    const modelAliases = resolveCatalogModelAliases(
+      [{ name: 'sol', providerId: 'Test-Provider', modelId: 'Solver-V1' }],
+      resolveRoute,
+    );
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(
+      JSON.stringify({ id: 'msg_1', type: 'message', role: 'assistant', model: 'Solver-V1', content: [], usage: { input_tokens: 1, output_tokens: 1 } }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    )));
+
+    const handle = await startProxyCatalog(
+      [aliasTarget],
+      aliasTarget.aliasId,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      modelAliases,
+    );
+    try {
+      const res = await postToProxy(handle.port, handle.token, {
+        model: 'sol',
+        max_tokens: 100,
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: false,
+      });
+      expect(res.status).toBe(200);
+      expect((JSON.parse(res.body) as { model: string }).model).toBe('sol');
     } finally {
       handle.close();
     }

--- a/tests/refresh-models.test.ts
+++ b/tests/refresh-models.test.ts
@@ -1001,6 +1001,37 @@ describe('refreshProviderModels', () => {
   );
 
   it.each([
+    ['opencode-go', 'openai', '@ai-sdk/openai-compatible', OPENCODE_GO_COMPLETIONS_BASE_URL],
+    ['opencode-go', 'openai', '@ai-sdk/anthropic', OPENCODE_GO_ANTHROPIC_BASE_URL],
+    ['opencode-go-mirror', 'opencode-go', '@ai-sdk/openai-compatible', OPENCODE_GO_COMPLETIONS_BASE_URL],
+    ['opencode-go-mirror', 'opencode-go', '@ai-sdk/anthropic', OPENCODE_GO_ANTHROPIC_BASE_URL],
+  ])(
+    'uses the retained template and package pin when %s names %s without a URL (%s)',
+    async (id, templateId, npm, url) => {
+      const registry = openCodeRegistry({ id, templateId, npm });
+      delete registry.providers[0]!.api.url;
+      vi.mocked(fetchTemplateModels).mockResolvedValue({
+        baseUrl: url,
+        models: openCodeTemplateModels,
+      });
+      vi.mocked(loadRegistryStrict).mockReturnValue(registry);
+
+      const result = await refreshProviderModels(id, 'oc-real-key', registry);
+
+      expect(fetchAnthropicModels).not.toHaveBeenCalled();
+      expect(fetchTemplateModels).toHaveBeenCalledOnce();
+      expect(vi.mocked(fetchTemplateModels).mock.calls[0]?.[0]).toMatchObject({
+        id: 'opencode-go',
+        staticModelPolicy: 'allowlist',
+        npm,
+      });
+      expect(vi.mocked(fetchTemplateModels).mock.calls[0]?.[2]).toBe(url);
+      expect(saveRegistry).toHaveBeenCalledOnce();
+      expect(result).toMatchObject({ ok: true, modelCount: 1 });
+    },
+  );
+
+  it.each([
     ['@ai-sdk/openai-compatible', OPENCODE_GO_COMPLETIONS_BASE_URL],
     ['@ai-sdk/anthropic', OPENCODE_GO_ANTHROPIC_BASE_URL],
   ])('routes a retained OpenCode template migration with %s through template discovery', async (npm, url) => {

--- a/tests/refresh-models.test.ts
+++ b/tests/refresh-models.test.ts
@@ -848,6 +848,21 @@ describe('refreshProviderModels', () => {
     expect(result.reason).toMatch(/does not support the @ai-sdk\/openai SDK package/i);
   });
 
+  it.each([
+    ['@ai-sdk/openai-compatible', OPENCODE_GO_ANTHROPIC_BASE_URL],
+    ['@ai-sdk/anthropic', OPENCODE_GO_COMPLETIONS_BASE_URL],
+  ])('refuses mismatched OpenCode package/destination pair %s before network or writes', async (npm, url) => {
+    const registry = openCodeRegistry({ npm, url });
+
+    const result = await refreshProviderModels('opencode-go', 'oc-real-key', registry);
+
+    expect(fetchAnthropicModels).not.toHaveBeenCalled();
+    expect(fetchTemplateModels).not.toHaveBeenCalled();
+    expect(saveRegistry).not.toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/does not support a custom API base URL/i);
+  });
+
   it('still refreshes an unmodified OpenCode record against its pinned endpoint', async () => {
     const registry = openCodeRegistry();
     vi.mocked(fetchTemplateModels).mockResolvedValue({
@@ -934,6 +949,7 @@ describe('refreshProviderModels', () => {
     // retained template — not the record's named one — must be what is passed.
     expect(vi.mocked(fetchTemplateModels).mock.calls[0]?.[0]?.id).toBe('opencode-go');
     expect(vi.mocked(fetchTemplateModels).mock.calls[0]?.[0]?.staticModelPolicy).toBe('allowlist');
+    expect(vi.mocked(fetchTemplateModels).mock.calls[0]?.[0]?.npm).toBe('@ai-sdk/anthropic');
     expect(vi.mocked(fetchTemplateModels).mock.calls[0]?.[2]).toBe(OPENCODE_GO_ANTHROPIC_BASE_URL);
     expect(result).toMatchObject({ ok: true, modelCount: 1 });
   });
@@ -959,14 +975,38 @@ describe('refreshProviderModels', () => {
     expect(result).toMatchObject({ ok: true, modelCount: 1 });
   });
 
-  it('routes a retained OpenCode record whose id drifted with Anthropic npm through template discovery', async () => {
-    const registry = openCodeRegistry({
-      id: 'opencode-go-mirror',
-      npm: '@ai-sdk/anthropic',
-      url: OPENCODE_GO_ANTHROPIC_BASE_URL,
-    });
+  it.each([
+    ['@ai-sdk/openai-compatible', OPENCODE_GO_COMPLETIONS_BASE_URL],
+    ['@ai-sdk/anthropic', OPENCODE_GO_ANTHROPIC_BASE_URL],
+  ])(
+    'refreshes canonical OpenCode identity with %s before a foreign manual-only template can preempt it',
+    async (npm, url) => {
+      const registry = openCodeRegistry({ templateId: 'bedrock', npm, url });
+      vi.mocked(fetchTemplateModels).mockResolvedValue({
+        baseUrl: url,
+        models: openCodeTemplateModels,
+      });
+      vi.mocked(loadRegistryStrict).mockReturnValue(registry);
+
+      const result = await refreshProviderModels('opencode-go', 'oc-real-key', registry);
+
+      expect(fetchTemplateModels).toHaveBeenCalledOnce();
+      expect(vi.mocked(fetchTemplateModels).mock.calls[0]?.[0]).toMatchObject({
+        id: 'opencode-go',
+        npm,
+      });
+      expect(saveRegistry).toHaveBeenCalledOnce();
+      expect(result).toMatchObject({ ok: true, modelCount: 1 });
+    },
+  );
+
+  it.each([
+    ['@ai-sdk/openai-compatible', OPENCODE_GO_COMPLETIONS_BASE_URL],
+    ['@ai-sdk/anthropic', OPENCODE_GO_ANTHROPIC_BASE_URL],
+  ])('routes a retained OpenCode template migration with %s through template discovery', async (npm, url) => {
+    const registry = openCodeRegistry({ id: 'opencode-go-mirror', npm, url });
     vi.mocked(fetchTemplateModels).mockResolvedValue({
-      baseUrl: OPENCODE_GO_ANTHROPIC_BASE_URL,
+      baseUrl: url,
       models: openCodeTemplateModels,
     });
     vi.mocked(loadRegistryStrict).mockReturnValue(registry);
@@ -974,7 +1014,10 @@ describe('refreshProviderModels', () => {
     const result = await refreshProviderModels('opencode-go-mirror', 'oc-real-key', registry);
 
     expect(fetchAnthropicModels).not.toHaveBeenCalled();
-    expect(vi.mocked(fetchTemplateModels).mock.calls[0]?.[0]?.id).toBe('opencode-go');
+    expect(vi.mocked(fetchTemplateModels).mock.calls[0]?.[0]).toMatchObject({
+      id: 'opencode-go',
+      npm,
+    });
     expect(result).toMatchObject({ ok: true, modelCount: 1 });
   });
 

--- a/tests/refresh-models.test.ts
+++ b/tests/refresh-models.test.ts
@@ -701,7 +701,7 @@ describe('refreshProviderModels', () => {
 
   it('rejects restricted provider API URLs before refreshing models', async () => {
     const registry: ProviderRegistry = {
-      version: 1,
+      schemaVersion: 1,
       providers: [{
         id: 'bad',
         templateId: 'custom-openai',
@@ -724,7 +724,7 @@ describe('refreshProviderModels', () => {
 
   it('does not report an imported snapshot as a model-count change on first live refresh', async () => {
     const registry: ProviderRegistry = {
-      version: 1,
+      schemaVersion: 1,
       providers: [{
         id: 'groq',
         templateId: 'groq',
@@ -785,7 +785,7 @@ describe('refreshProviderModels', () => {
     npm?: string;
     url?: string;
   } = {}): ProviderRegistry => ({
-    version: 1,
+    schemaVersion: 1,
     providers: [{
       id: overrides.id ?? 'opencode-go',
       templateId: overrides.templateId ?? 'opencode-go',
@@ -884,7 +884,7 @@ describe('refreshProviderModels', () => {
 
   it('leaves an ordinary Anthropic provider refreshing against its own configured endpoint', async () => {
     const registry: ProviderRegistry = {
-      version: 1,
+      schemaVersion: 1,
       providers: [{
         id: 'ordinary-anthropic',
         templateId: 'custom-anthropic',

--- a/tests/refresh-models.test.ts
+++ b/tests/refresh-models.test.ts
@@ -33,12 +33,15 @@ vi.mock('../src/registry/lock.js', () => ({
 }));
 
 import { fetchTemplateModels } from '../src/registry/fetch-template-models.js';
+import { fetchAnthropicModels } from '../src/registry/custom-endpoint.js';
 import { loadRegistryStrict, saveRegistry } from '../src/registry/io.js';
+import { OPENCODE_GO_COMPLETIONS_BASE_URL } from '../src/data/opencode-go-models.js';
 
 describe('refreshProviderModels', () => {
   beforeEach(() => {
     providerMutationState.active = false;
     vi.mocked(fetchTemplateModels).mockReset();
+    vi.mocked(fetchAnthropicModels).mockReset();
     vi.mocked(loadRegistryStrict).mockReset();
     vi.mocked(saveRegistry).mockClear();
   });
@@ -761,5 +764,133 @@ describe('refreshProviderModels', () => {
     expect(first).toMatchObject({ ok: true, modelCount: 2 });
     expect(first.previousModelCount).toBeUndefined();
     expect(second).toMatchObject({ ok: true, modelCount: 2, previousModelCount: 2 });
+  });
+
+  // The retained OpenCode Go built-in ships one immutable endpoint per SDK
+  // package. These records forge only the routing fields — `authRef` still
+  // names the keyring slot holding the user's real OpenCode credential, which
+  // is exactly what makes a redirected destination an exfiltration channel.
+  //
+  // The forged addresses are RFC 5737 TEST-NET literals so the SSRF guard
+  // resolves them without DNS: before the pin they sail through it, which is
+  // the point.
+  const OPENCODE_EXFIL_URL = 'https://192.0.2.1/v1';
+
+  const openCodeRegistry = (overrides: {
+    id?: string;
+    npm?: string;
+    url?: string;
+  } = {}): ProviderRegistry => ({
+    version: 1,
+    providers: [{
+      id: overrides.id ?? 'opencode-go',
+      templateId: 'opencode-go',
+      name: 'OpenCode Go',
+      enabled: true,
+      authRef: 'keyring:provider:opencode-go',
+      authType: 'api',
+      api: {
+        npm: overrides.npm ?? '@ai-sdk/openai-compatible',
+        url: overrides.url ?? OPENCODE_GO_COMPLETIONS_BASE_URL,
+      },
+      addedAt: '2026-08-11T00:00:00.000Z',
+    }],
+  });
+
+  it('refuses a forged OpenCode Anthropic endpoint before the npm branch sends the key', async () => {
+    const registry = openCodeRegistry({
+      npm: '@ai-sdk/anthropic',
+      url: OPENCODE_EXFIL_URL,
+    });
+
+    const result = await refreshProviderModels('opencode-go', 'oc-real-key', registry);
+
+    // Collaborator assertions come first: they name the leak directly instead
+    // of letting a downstream unwrap error mask which call put the key on the wire.
+    expect(fetchAnthropicModels).not.toHaveBeenCalled();
+    expect(fetchTemplateModels).not.toHaveBeenCalled();
+    expect(saveRegistry).not.toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/does not support a custom API base URL/i);
+  });
+
+  it('refuses a forged endpoint on a record that drifts its id but keeps the template', async () => {
+    const registry = openCodeRegistry({
+      id: 'opencode-go-mirror',
+      npm: '@ai-sdk/anthropic',
+      url: OPENCODE_EXFIL_URL,
+    });
+
+    const result = await refreshProviderModels('opencode-go-mirror', 'oc-real-key', registry);
+
+    // Collaborator assertions come first: they name the leak directly instead
+    // of letting a downstream unwrap error mask which call put the key on the wire.
+    expect(fetchAnthropicModels).not.toHaveBeenCalled();
+    expect(fetchTemplateModels).not.toHaveBeenCalled();
+    expect(saveRegistry).not.toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/does not support a custom API base URL/i);
+  });
+
+  it('fails closed when an OpenCode record names an SDK package the provider does not serve', async () => {
+    const registry = openCodeRegistry({ npm: '@ai-sdk/openai' });
+
+    const result = await refreshProviderModels('opencode-go', 'oc-real-key', registry);
+
+    expect(fetchAnthropicModels).not.toHaveBeenCalled();
+    expect(fetchTemplateModels).not.toHaveBeenCalled();
+    expect(saveRegistry).not.toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/does not support the @ai-sdk\/openai SDK package/i);
+  });
+
+  it('still refreshes an unmodified OpenCode record against its pinned endpoint', async () => {
+    const registry = openCodeRegistry();
+    vi.mocked(fetchTemplateModels).mockResolvedValue({
+      baseUrl: OPENCODE_GO_COMPLETIONS_BASE_URL,
+      models: [{
+        id: 'oc-model',
+        name: 'OC Model',
+        upstreamModelId: 'oc-model',
+        modelFormat: 'openai',
+      }],
+    });
+    vi.mocked(loadRegistryStrict).mockReturnValue(registry);
+
+    const result = await refreshProviderModels('opencode-go', 'oc-real-key', registry);
+
+    expect(result).toMatchObject({ ok: true, modelCount: 1 });
+    expect(vi.mocked(fetchTemplateModels).mock.calls[0]?.[2]).toBe(OPENCODE_GO_COMPLETIONS_BASE_URL);
+  });
+
+  it('leaves an ordinary Anthropic provider refreshing against its own configured endpoint', async () => {
+    const registry: ProviderRegistry = {
+      version: 1,
+      providers: [{
+        id: 'ordinary-anthropic',
+        templateId: 'custom-anthropic',
+        name: 'Ordinary Anthropic',
+        enabled: true,
+        authRef: 'keyring:provider:ordinary-anthropic',
+        authType: 'api',
+        api: { npm: '@ai-sdk/anthropic', url: 'https://192.0.2.2/v1' },
+        addedAt: '2026-08-11T00:00:00.000Z',
+      }],
+    };
+    vi.mocked(fetchAnthropicModels).mockResolvedValue({
+      baseUrl: 'https://192.0.2.2/v1',
+      models: [{
+        id: 'ordinary-model',
+        name: 'Ordinary Model',
+        upstreamModelId: 'ordinary-model',
+        modelFormat: 'anthropic',
+      }],
+    });
+    vi.mocked(loadRegistryStrict).mockReturnValue(registry);
+
+    const result = await refreshProviderModels('ordinary-anthropic', 'sk-ant-real-key', registry);
+
+    expect(result).toMatchObject({ ok: true, modelCount: 1 });
+    expect(fetchAnthropicModels).toHaveBeenCalledWith('https://192.0.2.2/v1', 'sk-ant-real-key');
   });
 });

--- a/tests/refresh-models.test.ts
+++ b/tests/refresh-models.test.ts
@@ -35,7 +35,10 @@ vi.mock('../src/registry/lock.js', () => ({
 import { fetchTemplateModels } from '../src/registry/fetch-template-models.js';
 import { fetchAnthropicModels } from '../src/registry/custom-endpoint.js';
 import { loadRegistryStrict, saveRegistry } from '../src/registry/io.js';
-import { OPENCODE_GO_COMPLETIONS_BASE_URL } from '../src/data/opencode-go-models.js';
+import {
+  OPENCODE_GO_ANTHROPIC_BASE_URL,
+  OPENCODE_GO_COMPLETIONS_BASE_URL,
+} from '../src/data/opencode-go-models.js';
 
 describe('refreshProviderModels', () => {
   beforeEach(() => {
@@ -778,13 +781,14 @@ describe('refreshProviderModels', () => {
 
   const openCodeRegistry = (overrides: {
     id?: string;
+    templateId?: string;
     npm?: string;
     url?: string;
   } = {}): ProviderRegistry => ({
     version: 1,
     providers: [{
       id: overrides.id ?? 'opencode-go',
-      templateId: 'opencode-go',
+      templateId: overrides.templateId ?? 'opencode-go',
       name: 'OpenCode Go',
       enabled: true,
       authRef: 'keyring:provider:opencode-go',
@@ -892,5 +896,103 @@ describe('refreshProviderModels', () => {
 
     expect(result).toMatchObject({ ok: true, modelCount: 1 });
     expect(fetchAnthropicModels).toHaveBeenCalledWith('https://192.0.2.2/v1', 'sk-ant-real-key');
+  });
+
+  // The destination pin above only decides WHERE the key goes. It says nothing
+  // about which discovery routine reads the answer, and a record storing
+  // `api.npm: '@ai-sdk/anthropic'` at the pinned OpenCode Anthropic address
+  // clears the pin and then falls into the ordinary Anthropic npm branch.
+  // `fetchAnthropicModels` expects an Anthropic `{ data: [...] }` envelope,
+  // while OpenCode answers a bare array, and it applies none of the committed
+  // allowlist/metadata overlay — so the retained catalog silently degrades.
+  // Retained identity has to pick the discovery route before npm does.
+  const openCodeTemplateModels = [{
+    id: 'oc-model',
+    name: 'OC Model',
+    upstreamModelId: 'oc-model',
+    modelFormat: 'openai' as const,
+  }];
+
+  it('routes a retained OpenCode record with Anthropic npm through template discovery', async () => {
+    const registry = openCodeRegistry({
+      npm: '@ai-sdk/anthropic',
+      url: OPENCODE_GO_ANTHROPIC_BASE_URL,
+    });
+    vi.mocked(fetchTemplateModels).mockResolvedValue({
+      baseUrl: OPENCODE_GO_ANTHROPIC_BASE_URL,
+      models: openCodeTemplateModels,
+    });
+    vi.mocked(loadRegistryStrict).mockReturnValue(registry);
+
+    const result = await refreshProviderModels('opencode-go', 'oc-real-key', registry);
+
+    // Naming the wrong collaborator first: this is the assertion that fails
+    // when the npm branch wins, and it says which routine read the catalog.
+    expect(fetchAnthropicModels).not.toHaveBeenCalled();
+    expect(fetchTemplateModels).toHaveBeenCalled();
+    // The template carries the allowlist and the bare-array parse flag, so the
+    // retained template — not the record's named one — must be what is passed.
+    expect(vi.mocked(fetchTemplateModels).mock.calls[0]?.[0]?.id).toBe('opencode-go');
+    expect(vi.mocked(fetchTemplateModels).mock.calls[0]?.[0]?.staticModelPolicy).toBe('allowlist');
+    expect(vi.mocked(fetchTemplateModels).mock.calls[0]?.[2]).toBe(OPENCODE_GO_ANTHROPIC_BASE_URL);
+    expect(result).toMatchObject({ ok: true, modelCount: 1 });
+  });
+
+  it('routes a retained OpenCode record that names another template through the retained template', async () => {
+    const registry = openCodeRegistry({
+      templateId: 'openai',
+      url: OPENCODE_GO_COMPLETIONS_BASE_URL,
+    });
+    vi.mocked(fetchTemplateModels).mockResolvedValue({
+      baseUrl: OPENCODE_GO_COMPLETIONS_BASE_URL,
+      models: openCodeTemplateModels,
+    });
+    vi.mocked(loadRegistryStrict).mockReturnValue(registry);
+
+    const result = await refreshProviderModels('opencode-go', 'oc-real-key', registry);
+
+    // Without complete identity the OpenAI template is resolved instead: its
+    // absent staticModels turn the committed allowlist into a no-op overlay
+    // and `fetchTemplateModels`'s own OpenCode pin re-check never fires.
+    expect(vi.mocked(fetchTemplateModels).mock.calls[0]?.[0]?.id).toBe('opencode-go');
+    expect(vi.mocked(fetchTemplateModels).mock.calls[0]?.[0]?.staticModelPolicy).toBe('allowlist');
+    expect(result).toMatchObject({ ok: true, modelCount: 1 });
+  });
+
+  it('routes a retained OpenCode record whose id drifted with Anthropic npm through template discovery', async () => {
+    const registry = openCodeRegistry({
+      id: 'opencode-go-mirror',
+      npm: '@ai-sdk/anthropic',
+      url: OPENCODE_GO_ANTHROPIC_BASE_URL,
+    });
+    vi.mocked(fetchTemplateModels).mockResolvedValue({
+      baseUrl: OPENCODE_GO_ANTHROPIC_BASE_URL,
+      models: openCodeTemplateModels,
+    });
+    vi.mocked(loadRegistryStrict).mockReturnValue(registry);
+
+    const result = await refreshProviderModels('opencode-go-mirror', 'oc-real-key', registry);
+
+    expect(fetchAnthropicModels).not.toHaveBeenCalled();
+    expect(vi.mocked(fetchTemplateModels).mock.calls[0]?.[0]?.id).toBe('opencode-go');
+    expect(result).toMatchObject({ ok: true, modelCount: 1 });
+  });
+
+  // Ordering conservation: complete identity must not weaken the refusal, and
+  // the refusal must still land before anything reaches the network.
+  it('still refuses a forged endpoint on a retained record that names another template', async () => {
+    const registry = openCodeRegistry({
+      templateId: 'openai',
+      npm: '@ai-sdk/anthropic',
+      url: OPENCODE_EXFIL_URL,
+    });
+
+    const result = await refreshProviderModels('opencode-go', 'oc-real-key', registry);
+
+    expect(fetchAnthropicModels).not.toHaveBeenCalled();
+    expect(fetchTemplateModels).not.toHaveBeenCalled();
+    expect(saveRegistry).not.toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/does not support a custom API base URL/i);
   });
 });

--- a/tests/registry-add-template.test.ts
+++ b/tests/registry-add-template.test.ts
@@ -207,6 +207,47 @@ describe('registry/add-template', () => {
     expect(res.error).toBe('API key cannot be empty.');
   });
 
+  it('rejects the add when the template credential probe fails, before any models fetch', async () => {
+    const tpl: ProviderTemplate = {
+      ...dummyTemplate,
+      verifyCredential: vi.fn(async () => 'Provider rejected this API key.'),
+    };
+    const res = await addProviderFromTemplate(tpl, 'bad-key');
+    expect(res.added).toBe(false);
+    expect(res.error).toBe('Provider rejected this API key.');
+    expect(tpl.verifyCredential).toHaveBeenCalledWith('bad-key');
+    expect(fetchTemplate.fetchTemplateModels).not.toHaveBeenCalled();
+    expect(registryState.providers).toHaveLength(0);
+  });
+
+  it('never hands the credential probe a caller-supplied base URL', async () => {
+    const tpl: ProviderTemplate = {
+      ...dummyTemplate,
+      defaultBaseUrl: 'https://template-declared.example/v1',
+      verifyCredential: vi.fn(async () => null),
+    };
+    await addProviderFromTemplate(tpl, 'live-key', {
+      baseUrl: 'https://attacker.example/v1',
+    });
+    // The probe sends a live credential, so its destination must come from the
+    // template alone. Passing only the key is what makes that structural: there
+    // is no argument through which a caller could redirect it.
+    expect(tpl.verifyCredential).toHaveBeenCalledWith('live-key');
+    const [call] = vi.mocked(tpl.verifyCredential!).mock.calls;
+    expect(call).toHaveLength(1);
+    expect(JSON.stringify(call)).not.toContain('attacker.example');
+  });
+
+  it('proceeds when the template credential probe accepts the key', async () => {
+    const tpl: ProviderTemplate = {
+      ...dummyTemplate,
+      verifyCredential: vi.fn(async () => null),
+    };
+    const res = await addProviderFromTemplate(tpl, 'good-key');
+    expect(res.added).toBe(true);
+    expect(fetchTemplate.fetchTemplateModels).toHaveBeenCalled();
+  });
+
   it('fails if provider already exists and replaceExisting is not set', async () => {
     registryState = {
       schemaVersion: 1,

--- a/tests/registry-add-template.test.ts
+++ b/tests/registry-add-template.test.ts
@@ -268,6 +268,77 @@ describe('registry/add-template', () => {
     expect(res.error).toContain('is already configured');
   });
 
+  it('rejects a retained OpenCode template identity before probes, discovery, or credential writes', async () => {
+    const verifyCredential = vi.fn(async () => null);
+    const openCodeTemplate: ProviderTemplate = {
+      ...dummyTemplate,
+      id: 'opencode-go',
+      name: 'OpenCode Go',
+      verifyCredential,
+    };
+    registryState = {
+      schemaVersion: 1,
+      providers: [{
+        id: 'imported-opencode',
+        templateId: 'opencode-go',
+        name: 'Imported OpenCode Go',
+        enabled: true,
+        authType: 'api',
+        authRef: 'keyring:provider:imported-opencode',
+        api: { npm: '@ai-sdk/openai-compatible', url: 'https://custom.invalid/v1' },
+        addedAt: '2026-08-11T00:00:00.000Z',
+      }],
+    };
+
+    const res = await addProviderFromTemplate(openCodeTemplate, 'new-key');
+    const replace = await addProviderFromTemplate(openCodeTemplate, 'replacement-key', {
+      replaceExisting: true,
+    });
+
+    expect(res).toMatchObject({ added: false, error: expect.stringContaining('already configured') });
+    expect(replace).toMatchObject({
+      added: false,
+      error: expect.stringContaining('already configured'),
+      hint: 'Remove it first with: clodex providers remove imported-opencode',
+    });
+    expect(verifyCredential).not.toHaveBeenCalled();
+    expect(fetchTemplate.fetchTemplateModels).not.toHaveBeenCalled();
+    expect(env.provisionProviderCredential).not.toHaveBeenCalled();
+    expect(env.saveProviderCredential).not.toHaveBeenCalled();
+    expect(io.saveRegistry).not.toHaveBeenCalled();
+  });
+
+  it('revalidates a retained OpenCode identity that appears during discovery', async () => {
+    const openCodeTemplate: ProviderTemplate = {
+      ...dummyTemplate,
+      id: 'opencode-go',
+      name: 'OpenCode Go',
+    };
+    vi.mocked(io.loadRegistryStrict)
+      .mockReturnValueOnce({ schemaVersion: 1, providers: [] })
+      .mockReturnValueOnce({
+        schemaVersion: 1,
+        providers: [{
+          id: 'imported-opencode',
+          templateId: 'opencode-go',
+          name: 'Concurrent imported OpenCode Go',
+          enabled: true,
+          authType: 'api',
+          authRef: 'keyring:provider:imported-opencode',
+          api: { npm: '@ai-sdk/openai-compatible', url: 'https://custom.invalid/v1' },
+          addedAt: '2026-08-11T00:00:00.000Z',
+        }],
+      });
+
+    const res = await addProviderFromTemplate(openCodeTemplate, 'new-key');
+
+    expect(res).toMatchObject({ added: false, error: expect.stringContaining('already configured') });
+    expect(fetchTemplate.fetchTemplateModels).toHaveBeenCalledOnce();
+    expect(env.provisionProviderCredential).not.toHaveBeenCalled();
+    expect(env.saveProviderCredential).not.toHaveBeenCalled();
+    expect(io.saveRegistry).not.toHaveBeenCalled();
+  });
+
   it('fails if fetching models returns an error', async () => {
     vi.mocked(fetchTemplate.fetchTemplateModels).mockResolvedValue({
       models: [],

--- a/tests/registry-refresh-models.test.ts
+++ b/tests/registry-refresh-models.test.ts
@@ -15,6 +15,11 @@ vi.mock('../src/registry/pricing.js', () => ({
   enrichPricingAsync: vi.fn(),
   pricingPlatformForProvider: vi.fn(),
   buildPricingIndex: vi.fn(),
+  // Reads through to the template when the provider record omits the flag, so
+  // an older clodex round trip cannot drop the setting permanently.
+  providerPreservesModelPricing: vi.fn(
+    (provider: { preserveModelPricing?: boolean }) => provider.preserveModelPricing ?? false,
+  ),
 }));
 
 describe('registry/refresh-models', () => {

--- a/tests/registry-refresh-models.test.ts
+++ b/tests/registry-refresh-models.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { refreshProviderModels } from '../src/registry/refresh-models.js';
 import * as io from '../src/registry/io.js';
-import type { ProviderRegistry } from '../src/registry/types.js';
+import * as pricing from '../src/registry/pricing.js';
+import type { CachedModel, ProviderRegistry } from '../src/registry/types.js';
 
 vi.mock('../src/registry/io.js', () => ({
   loadRegistry: vi.fn(),
@@ -9,17 +10,22 @@ vi.mock('../src/registry/io.js', () => ({
   saveRegistry: vi.fn(),
 }));
 
-vi.mock('../src/registry/pricing.js', () => ({
-  loadPricingCache: vi.fn(),
-  enrichModelsWithPricing: vi.fn((models) => models),
-  enrichPricingAsync: vi.fn(),
-  pricingPlatformForProvider: vi.fn(),
-  buildPricingIndex: vi.fn(),
-  // Preserve an explicit flag while defaulting omitted fields for this mock.
-  providerPreservesModelPricing: vi.fn(
-    (provider: { preserveModelPricing?: boolean }) => provider.preserveModelPricing ?? false,
-  ),
-}));
+vi.mock('../src/registry/pricing.js', async () => {
+  const actual = await vi.importActual<typeof import('../src/registry/pricing.js')>(
+    '../src/registry/pricing.js',
+  );
+  return {
+    ...actual,
+    loadPricingCache: vi.fn(),
+    enrichModelsWithPricing: vi.fn((models: CachedModel[]) => models.map(model => ({
+      ...model,
+      cost: { input: 999, output: 999 },
+    }))),
+    enrichPricingAsync: vi.fn(),
+    pricingPlatformForProvider: vi.fn(),
+    buildPricingIndex: vi.fn(),
+  };
+});
 
 describe('registry/refresh-models', () => {
   const originalFetch = global.fetch;
@@ -316,6 +322,39 @@ describe('registry/refresh-models', () => {
       expect(result.ok).toBe(false);
       expect(result.reason).toContain('OAuth token not available');
     });
+  });
+
+  it('preserves curated OpenCode pricing when the provider flag is absent', async () => {
+    const mockRegistry: ProviderRegistry = {
+      schemaVersion: 1,
+      providers: [{
+        id: 'opencode-go',
+        templateId: 'opencode-go',
+        name: 'OpenCode Go',
+        enabled: true,
+        authRef: 'keyring:provider:opencode-go',
+        authType: 'api',
+        api: {
+          npm: '@ai-sdk/openai-compatible',
+          url: 'https://opencode.ai/zen/go/v1',
+        },
+        addedAt: '2026-08-12T00:00:00.000Z',
+      }],
+    };
+    vi.mocked(io.loadRegistryStrict).mockReturnValue(mockRegistry);
+    vi.mocked(pricing.loadPricingCache).mockReturnValue({ models: [] });
+    vi.mocked(global.fetch).mockResolvedValueOnce(new Response(JSON.stringify([
+      { id: 'deepseek-v4-pro', name: 'DeepSeek V4 Pro' },
+    ]), { status: 200 }));
+
+    expect(pricing.providerPreservesModelPricing(mockRegistry.providers[0]!)).toBe(true);
+    const result = await refreshProviderModels('opencode-go', 'oc-real-key', mockRegistry);
+
+    const savedRegistry = vi.mocked(io.saveRegistry).mock.calls[0]?.[0] as ProviderRegistry;
+    const savedModel = savedRegistry.providers[0]?.modelsCache?.models[0];
+    expect(result).toMatchObject({ ok: true, modelCount: 1 });
+    expect(savedModel?.cost).toEqual({ input: 0.435, output: 0.87, cache_read: 0.003625 });
+    expect(pricing.enrichModelsWithPricing).not.toHaveBeenCalled();
   });
 
     });

--- a/tests/registry-refresh-models.test.ts
+++ b/tests/registry-refresh-models.test.ts
@@ -15,8 +15,7 @@ vi.mock('../src/registry/pricing.js', () => ({
   enrichPricingAsync: vi.fn(),
   pricingPlatformForProvider: vi.fn(),
   buildPricingIndex: vi.fn(),
-  // Reads through to the template when the provider record omits the flag, so
-  // an older clodex round trip cannot drop the setting permanently.
+  // Preserve an explicit flag while defaulting omitted fields for this mock.
   providerPreservesModelPricing: vi.fn(
     (provider: { preserveModelPricing?: boolean }) => provider.preserveModelPricing ?? false,
   ),

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -663,6 +663,8 @@ describe('materializeRegistry', () => {
         models: [{
           id: 'compatible-sentinel',
           name: 'Compatible Sentinel',
+          upstreamModelId: 'compatible-sentinel',
+          modelFormat: 'openai',
           npm: '@ai-sdk/openai-compatible',
           apiUrl: 'https://model-sentinel.invalid/v1',
         }],
@@ -691,6 +693,8 @@ describe('materializeRegistry', () => {
         models: [{
           id: 'anthropic-sentinel',
           name: 'Anthropic Sentinel',
+          upstreamModelId: 'anthropic-sentinel',
+          modelFormat: 'anthropic',
           npm: '@ai-sdk/anthropic',
           apiUrl: 'https://model-sentinel.invalid/v1',
         }],
@@ -719,6 +723,8 @@ describe('materializeRegistry', () => {
         models: [{
           id: 'unsupported-sentinel',
           name: 'Unsupported Sentinel',
+          upstreamModelId: 'unsupported-sentinel',
+          modelFormat: 'openai',
           npm: '@ai-sdk/openai',
           apiUrl: 'https://model-sentinel.invalid/v1',
         }],
@@ -745,6 +751,8 @@ describe('materializeRegistry', () => {
           models: [{
             id: 'opencode-sentinel',
             name: 'OpenCode Sentinel',
+            upstreamModelId: 'opencode-sentinel',
+            modelFormat: 'openai',
             npm: '@ai-sdk/openai-compatible',
             apiUrl: 'https://opencode-model-sentinel.invalid/v1',
           }],
@@ -764,6 +772,8 @@ describe('materializeRegistry', () => {
           models: [{
             id: 'ordinary-sentinel',
             name: 'Ordinary Sentinel',
+            upstreamModelId: 'ordinary-sentinel',
+            modelFormat: 'openai',
             npm: '@ai-sdk/openai-compatible',
             apiUrl: 'https://ordinary-model.invalid/v1',
           }],
@@ -798,18 +808,24 @@ describe('materializeRegistry', () => {
           {
             id: 'compatible-sentinel',
             name: 'Compatible Sentinel',
+            upstreamModelId: 'compatible-sentinel',
+            modelFormat: 'openai',
             npm: '@ai-sdk/openai-compatible',
             apiUrl: 'https://model-sentinel.invalid/v1',
           },
           {
             id: 'anthropic-sentinel',
             name: 'Anthropic Sentinel',
+            upstreamModelId: 'anthropic-sentinel',
+            modelFormat: 'anthropic',
             npm: '@ai-sdk/anthropic',
             apiUrl: 'https://model-sentinel.invalid/v1',
           },
           {
             id: 'unsupported-sentinel',
             name: 'Unsupported Sentinel',
+            upstreamModelId: 'unsupported-sentinel',
+            modelFormat: 'openai',
             npm: '@ai-sdk/openai',
             apiUrl: 'https://model-sentinel.invalid/v1',
           },

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -13,6 +13,10 @@ import {
 } from '../src/registry/index.js';
 import { loadRegistryStrict } from '../src/registry/io.js';
 import { withRegistryWriteLockSync } from '../src/registry/lock.js';
+import {
+  OPENCODE_GO_ANTHROPIC_BASE_URL,
+  OPENCODE_GO_COMPLETIONS_BASE_URL,
+} from '../src/data/opencode-go-models.js';
 
 describe('provider id validation', () => {
   it('accepts stable slugs', () => {
@@ -641,6 +645,137 @@ describe('materializeRegistry', () => {
       isFree: true,
       freeStatus: 'free_provider',
     });
+  });
+
+  it('pins OpenCode OpenAI-compatible models to the reviewed completions authority', () => {
+    const registry = emptyRegistry();
+    registry.providers.push({
+      id: 'opencode-go',
+      templateId: 'opencode-go',
+      name: 'OpenCode Go',
+      enabled: true,
+      authRef: 'keyring:provider:opencode-go',
+      authType: 'api',
+      api: { npm: '@ai-sdk/openai-compatible', url: 'https://provider-sentinel.invalid/v1' },
+      addedAt: '2026-08-11T00:00:00.000Z',
+      modelsCache: {
+        fetchedAt: '2026-08-11T00:00:00.000Z',
+        models: [{
+          id: 'compatible-sentinel',
+          name: 'Compatible Sentinel',
+          npm: '@ai-sdk/openai-compatible',
+          apiUrl: 'https://model-sentinel.invalid/v1',
+        }],
+      },
+    });
+
+    const model = materializeRegistry(registry, () => 'credential-sentinel')[0]?.models[0];
+
+    expect(model?.apiBaseUrl).toBe(OPENCODE_GO_COMPLETIONS_BASE_URL);
+    expect(model?.completionsUrl).toBe(`${OPENCODE_GO_COMPLETIONS_BASE_URL}/chat/completions`);
+  });
+
+  it('pins OpenCode Anthropic models to the reviewed Anthropic authority', () => {
+    const registry = emptyRegistry();
+    registry.providers.push({
+      id: 'opencode-go',
+      templateId: 'opencode-go',
+      name: 'OpenCode Go',
+      enabled: true,
+      authRef: 'keyring:provider:opencode-go',
+      authType: 'api',
+      api: { npm: '@ai-sdk/openai-compatible', url: 'https://provider-sentinel.invalid/v1' },
+      addedAt: '2026-08-11T00:00:00.000Z',
+      modelsCache: {
+        fetchedAt: '2026-08-11T00:00:00.000Z',
+        models: [{
+          id: 'anthropic-sentinel',
+          name: 'Anthropic Sentinel',
+          npm: '@ai-sdk/anthropic',
+          apiUrl: 'https://model-sentinel.invalid/v1',
+        }],
+      },
+    });
+
+    const model = materializeRegistry(registry, () => 'credential-sentinel')[0]?.models[0];
+
+    expect(model?.apiBaseUrl).toBe(OPENCODE_GO_ANTHROPIC_BASE_URL);
+    expect(model?.baseUrl).toBe(OPENCODE_GO_ANTHROPIC_BASE_URL);
+  });
+
+  it('fails closed for an unsupported OpenCode SDK package', () => {
+    const registry = emptyRegistry();
+    registry.providers.push({
+      id: 'opencode-go',
+      templateId: 'opencode-go',
+      name: 'OpenCode Go',
+      enabled: true,
+      authRef: 'keyring:provider:opencode-go',
+      authType: 'api',
+      api: { npm: '@ai-sdk/openai-compatible', url: 'https://provider-sentinel.invalid/v1' },
+      addedAt: '2026-08-11T00:00:00.000Z',
+      modelsCache: {
+        fetchedAt: '2026-08-11T00:00:00.000Z',
+        models: [{
+          id: 'unsupported-sentinel',
+          name: 'Unsupported Sentinel',
+          npm: '@ai-sdk/openai',
+          apiUrl: 'https://model-sentinel.invalid/v1',
+        }],
+      },
+    });
+
+    expect(materializeRegistry(registry, () => 'credential-sentinel')).toEqual([]);
+  });
+
+  it('scopes immutable endpoint selection to OpenCode while preserving ordinary custom endpoints', () => {
+    const registry = emptyRegistry();
+    registry.providers.push(
+      {
+        id: 'opencode-go',
+        templateId: 'opencode-go',
+        name: 'OpenCode Go',
+        enabled: true,
+        authRef: 'keyring:provider:opencode-go',
+        authType: 'api',
+        api: { npm: '@ai-sdk/openai-compatible', url: 'https://opencode-provider-sentinel.invalid/v1' },
+        addedAt: '2026-08-11T00:00:00.000Z',
+        modelsCache: {
+          fetchedAt: '2026-08-11T00:00:00.000Z',
+          models: [{
+            id: 'opencode-sentinel',
+            name: 'OpenCode Sentinel',
+            npm: '@ai-sdk/openai-compatible',
+            apiUrl: 'https://opencode-model-sentinel.invalid/v1',
+          }],
+        },
+      },
+      {
+        id: 'ordinary-provider',
+        templateId: 'custom-openai',
+        name: 'Ordinary Provider',
+        enabled: true,
+        authRef: 'keyring:provider:ordinary-provider',
+        authType: 'api',
+        api: { npm: '@ai-sdk/openai-compatible', url: 'https://ordinary-provider.invalid/v1' },
+        addedAt: '2026-08-11T00:00:00.000Z',
+        modelsCache: {
+          fetchedAt: '2026-08-11T00:00:00.000Z',
+          models: [{
+            id: 'ordinary-sentinel',
+            name: 'Ordinary Sentinel',
+            npm: '@ai-sdk/openai-compatible',
+            apiUrl: 'https://ordinary-model.invalid/v1',
+          }],
+        },
+      },
+    );
+
+    const locals = materializeRegistry(registry, () => 'credential-sentinel');
+
+    expect(locals[0]?.models[0]?.apiBaseUrl).toBe(OPENCODE_GO_COMPLETIONS_BASE_URL);
+    expect(locals[1]?.models[0]?.apiBaseUrl).toBe('https://ordinary-model.invalid/v1');
+    expect(locals[1]?.models[0]?.completionsUrl).toBe('https://ordinary-model.invalid/v1/chat/completions');
   });
 
   it('honors per-model npm and apiUrl overrides', () => {

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -661,9 +661,9 @@ describe('materializeRegistry', () => {
       modelsCache: {
         fetchedAt: '2026-08-11T00:00:00.000Z',
         models: [{
-          id: 'compatible-sentinel',
-          name: 'Compatible Sentinel',
-          upstreamModelId: 'compatible-sentinel',
+          id: 'deepseek-v4-pro',
+          name: 'DeepSeek V4 Pro',
+          upstreamModelId: 'deepseek-v4-pro',
           modelFormat: 'openai',
           npm: '@ai-sdk/openai-compatible',
           apiUrl: 'https://model-sentinel.invalid/v1',
@@ -691,9 +691,9 @@ describe('materializeRegistry', () => {
       modelsCache: {
         fetchedAt: '2026-08-11T00:00:00.000Z',
         models: [{
-          id: 'anthropic-sentinel',
-          name: 'Anthropic Sentinel',
-          upstreamModelId: 'anthropic-sentinel',
+          id: 'qwen3.8-max',
+          name: 'Qwen3.8 Max',
+          upstreamModelId: 'qwen3.8-max',
           modelFormat: 'anthropic',
           npm: '@ai-sdk/anthropic',
           apiUrl: 'https://model-sentinel.invalid/v1',
@@ -749,9 +749,9 @@ describe('materializeRegistry', () => {
         modelsCache: {
           fetchedAt: '2026-08-11T00:00:00.000Z',
           models: [{
-            id: 'opencode-sentinel',
-            name: 'OpenCode Sentinel',
-            upstreamModelId: 'opencode-sentinel',
+            id: 'deepseek-v4-pro',
+            name: 'DeepSeek V4 Pro',
+            upstreamModelId: 'deepseek-v4-pro',
             modelFormat: 'openai',
             npm: '@ai-sdk/openai-compatible',
             apiUrl: 'https://opencode-model-sentinel.invalid/v1',
@@ -806,17 +806,17 @@ describe('materializeRegistry', () => {
         fetchedAt: '2026-08-11T00:00:00.000Z',
         models: [
           {
-            id: 'compatible-sentinel',
-            name: 'Compatible Sentinel',
-            upstreamModelId: 'compatible-sentinel',
+            id: 'deepseek-v4-pro',
+            name: 'DeepSeek V4 Pro',
+            upstreamModelId: 'deepseek-v4-pro',
             modelFormat: 'openai',
             npm: '@ai-sdk/openai-compatible',
             apiUrl: 'https://model-sentinel.invalid/v1',
           },
           {
-            id: 'anthropic-sentinel',
-            name: 'Anthropic Sentinel',
-            upstreamModelId: 'anthropic-sentinel',
+            id: 'qwen3.8-max',
+            name: 'Qwen3.8 Max',
+            upstreamModelId: 'qwen3.8-max',
             modelFormat: 'anthropic',
             npm: '@ai-sdk/anthropic',
             apiUrl: 'https://model-sentinel.invalid/v1',
@@ -841,7 +841,7 @@ describe('materializeRegistry', () => {
     expect(models?.[0]?.completionsUrl).toBe(`${OPENCODE_GO_COMPLETIONS_BASE_URL}/chat/completions`);
     expect(models?.[1]?.apiBaseUrl).toBe(OPENCODE_GO_ANTHROPIC_BASE_URL);
     expect(models?.[1]?.baseUrl).toBe(OPENCODE_GO_ANTHROPIC_BASE_URL);
-    expect(models?.map(model => model.id)).toEqual(['compatible-sentinel', 'anthropic-sentinel']);
+    expect(models?.map(model => model.id)).toEqual(['deepseek-v4-pro', 'qwen3.8-max']);
   });
 
   it('honors per-model npm and apiUrl overrides', () => {

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -778,6 +778,56 @@ describe('materializeRegistry', () => {
     expect(locals[1]?.models[0]?.completionsUrl).toBe('https://ordinary-model.invalid/v1/chat/completions');
   });
 
+  it('pins OpenCode endpoints for a record that drifts its id but keeps the template', () => {
+    // Nothing couples `id` to `templateId`, and `authRef` still names the
+    // keyring slot holding the OpenCode credential — so an id-drifted record
+    // is the same secret pointed at a different address.
+    const registry = emptyRegistry();
+    registry.providers.push({
+      id: 'opencode-go-mirror',
+      templateId: 'opencode-go',
+      name: 'OpenCode Go',
+      enabled: true,
+      authRef: 'keyring:provider:opencode-go',
+      authType: 'api',
+      api: { npm: '@ai-sdk/openai-compatible', url: 'https://provider-sentinel.invalid/v1' },
+      addedAt: '2026-08-11T00:00:00.000Z',
+      modelsCache: {
+        fetchedAt: '2026-08-11T00:00:00.000Z',
+        models: [
+          {
+            id: 'compatible-sentinel',
+            name: 'Compatible Sentinel',
+            npm: '@ai-sdk/openai-compatible',
+            apiUrl: 'https://model-sentinel.invalid/v1',
+          },
+          {
+            id: 'anthropic-sentinel',
+            name: 'Anthropic Sentinel',
+            npm: '@ai-sdk/anthropic',
+            apiUrl: 'https://model-sentinel.invalid/v1',
+          },
+          {
+            id: 'unsupported-sentinel',
+            name: 'Unsupported Sentinel',
+            npm: '@ai-sdk/openai',
+            apiUrl: 'https://model-sentinel.invalid/v1',
+          },
+        ],
+      },
+    });
+
+    const models = materializeRegistry(registry, () => 'credential-sentinel')[0]?.models;
+
+    // Destination assertions first, so a regression names the address the
+    // credential would have reached rather than the fail-closed count.
+    expect(models?.[0]?.apiBaseUrl).toBe(OPENCODE_GO_COMPLETIONS_BASE_URL);
+    expect(models?.[0]?.completionsUrl).toBe(`${OPENCODE_GO_COMPLETIONS_BASE_URL}/chat/completions`);
+    expect(models?.[1]?.apiBaseUrl).toBe(OPENCODE_GO_ANTHROPIC_BASE_URL);
+    expect(models?.[1]?.baseUrl).toBe(OPENCODE_GO_ANTHROPIC_BASE_URL);
+    expect(models?.map(model => model.id)).toEqual(['compatible-sentinel', 'anthropic-sentinel']);
+  });
+
   it('honors per-model npm and apiUrl overrides', () => {
     const registry = emptyRegistry();
     registry.providers.push({

--- a/tests/resolve-template.test.ts
+++ b/tests/resolve-template.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { effectiveProviderBaseUrl, resolveProviderTemplate } from '../src/registry/resolve-template.js';
+import {
+  effectiveProviderBaseUrl,
+  isProviderConfiguredForTemplate,
+  isRetainedOpenCodeGoProvider,
+  resolveProviderTemplate,
+} from '../src/registry/resolve-template.js';
 import type { RegistryProvider } from '../src/registry/types.js';
 
 function stub(partial: Partial<RegistryProvider> & Pick<RegistryProvider, 'id' | 'templateId'>): RegistryProvider {
@@ -21,6 +26,28 @@ describe('resolveProviderTemplate', () => {
 
   it('returns undefined for unknown templates', () => {
     expect(resolveProviderTemplate(stub({ id: 'groq', templateId: 'groq' }))).toBeUndefined();
+  });
+});
+
+describe('configured built-in template identity', () => {
+  it('retains OpenCode Go across either canonical identity field', () => {
+    const canonicalId = stub({ id: 'opencode-go', templateId: 'custom-openai' });
+    const retainedTemplate = stub({ id: 'imported-opencode', templateId: 'opencode-go' });
+
+    expect(isRetainedOpenCodeGoProvider(canonicalId)).toBe(true);
+    expect(isRetainedOpenCodeGoProvider(retainedTemplate)).toBe(true);
+    expect(isProviderConfiguredForTemplate(canonicalId, 'opencode-go')).toBe(true);
+    expect(isProviderConfiguredForTemplate(retainedTemplate, 'opencode-go')).toBe(true);
+  });
+
+  it('keeps ordinary templates keyed only to their exact provider id', () => {
+    const custom = stub({ id: 'custom-openai-endpoint', templateId: 'openai' });
+
+    expect(isProviderConfiguredForTemplate(custom, 'openai')).toBe(false);
+    expect(isProviderConfiguredForTemplate(
+      stub({ id: 'openai', templateId: 'custom-openai' }),
+      'openai',
+    )).toBe(true);
   });
 });
 

--- a/tests/server-router.test.ts
+++ b/tests/server-router.test.ts
@@ -1414,3 +1414,216 @@ describe('server router', () => {
     });
   });
 });
+
+describe('anthropic count_tokens', () => {
+  // `clodex server --endpoint` and the clodex-claude wrapper both point
+  // ANTHROPIC_BASE_URL at this gateway (src/wrapper-env.ts), so Claude Code's
+  // token-accounting preflight lands here. Before the route existed it fell
+  // through to the catch-all 404 and Claude Code got no number at all.
+
+  it('answers count_tokens locally when the model declares no upstream support', async () => {
+    const upstream = await startUpstream({ input_tokens: 999 });
+    handles.push(upstream);
+    const server = await startTestServer({
+      catalog: createGatewayModelCatalog([{
+        ...model('opencode-anthropic', 'anthropic', 'go', { baseUrl: upstream.baseUrl }),
+        compatibility: { supportsCountTokens: false },
+      }]),
+    });
+
+    const response = await fetch(`${server.url}/anthropic/v1/messages/count_tokens`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'opencode-anthropic',
+        messages: [{ role: 'user', content: 'count this' }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-relay-token-count-source')).toBe('local-estimate');
+    const payload = await response.json() as { input_tokens: number };
+    expect(payload.input_tokens).toBeGreaterThan(0);
+    // The point of the capability: the upstream is never asked.
+    expect(upstream.requests).toHaveLength(0);
+  });
+
+  it('answers count_tokens locally for translated (SDK) models', async () => {
+    const upstream = await startUpstream({ input_tokens: 999 });
+    handles.push(upstream);
+    const server = await startTestServer({
+      catalog: createGatewayModelCatalog([
+        model('openai-format', 'openai', 'go', { completionsUrl: `${upstream.baseUrl}/v1/chat/completions` }),
+      ]),
+    });
+
+    const response = await fetch(`${server.url}/anthropic/v1/messages/count_tokens`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'openai-format',
+        messages: [{ role: 'user', content: 'count this' }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-relay-token-count-source')).toBe('local-estimate');
+    expect((await response.json() as { input_tokens: number }).input_tokens).toBeGreaterThan(0);
+    expect(upstream.requests).toHaveLength(0);
+  });
+
+  it('forwards count_tokens upstream when the capability is unset', async () => {
+    const upstream = await startUpstream({ input_tokens: 42 });
+    handles.push(upstream);
+    const server = await startTestServer({
+      catalog: createGatewayModelCatalog([
+        model('claude-native', 'anthropic', 'zen', { baseUrl: upstream.baseUrl }),
+      ]),
+    });
+
+    const response = await fetch(`${server.url}/anthropic/v1/messages/count_tokens`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'claude-native', messages: [{ role: 'user', content: 'hi' }] }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ input_tokens: 42 });
+    expect(response.headers.get('x-relay-token-count-source')).toBeNull();
+    expect(upstream.requests).toHaveLength(1);
+    expect(upstream.requests[0]).toMatchObject({
+      method: 'POST',
+      url: '/v1/messages/count_tokens',
+      authorization: 'Bearer real-opencode-key',
+      body: { model: 'claude-native', messages: [{ role: 'user', content: 'hi' }] },
+    });
+  });
+
+  it('forwards count_tokens upstream when the capability is explicitly true', async () => {
+    const upstream = await startUpstream({ input_tokens: 7 });
+    handles.push(upstream);
+    const server = await startTestServer({
+      catalog: createGatewayModelCatalog([{
+        ...model('claude-supported', 'anthropic', 'zen', { baseUrl: upstream.baseUrl }),
+        compatibility: { supportsCountTokens: true },
+      }]),
+    });
+
+    const response = await fetch(`${server.url}/anthropic/v1/messages/count_tokens`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'claude-supported', messages: [{ role: 'user', content: 'hi' }] }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ input_tokens: 7 });
+    expect(upstream.requests).toHaveLength(1);
+    expect(upstream.requests[0]!.url).toBe('/v1/messages/count_tokens');
+  });
+
+  it('sends the upstream wire id, not the catalog id, when forwarding', async () => {
+    const upstream = await startUpstream({ input_tokens: 3 });
+    handles.push(upstream);
+    const server = await startTestServer({
+      catalog: createGatewayModelCatalog([{
+        ...model('catalog-id', 'anthropic', 'zen', { baseUrl: upstream.baseUrl }),
+        upstreamModelId: 'wire-id',
+      }]),
+    });
+
+    const response = await fetch(`${server.url}/anthropic/v1/messages/count_tokens`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'catalog-id', messages: [{ role: 'user', content: 'hi' }] }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(upstream.requests[0]).toMatchObject({ body: { model: 'wire-id' } });
+  });
+
+  it('rejects an unknown model on the count_tokens route', async () => {
+    const server = await startTestServer();
+
+    const response = await fetch(`${server.url}/anthropic/v1/messages/count_tokens`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'nope', messages: [] }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: { message: 'Unknown model: nope' } });
+  });
+
+  it('rejects an unsupported model format on the count_tokens route', async () => {
+    const server = await startTestServer();
+
+    const response = await fetch(`${server.url}/anthropic/v1/messages/count_tokens`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'bad-format', messages: [] }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: { message: 'Unsupported model format: unsupported' },
+    });
+  });
+
+  it('rejects invalid JSON on the count_tokens route', async () => {
+    const server = await startTestServer();
+
+    const response = await fetch(`${server.url}/anthropic/v1/messages/count_tokens`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not json',
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: { message: 'Invalid JSON body' } });
+  });
+
+  it('does not widen routing to neighbouring paths or other methods', async () => {
+    const server = await startTestServer({
+      catalog: createGatewayModelCatalog([{
+        ...model('opencode-anthropic', 'anthropic', 'go', { baseUrl: 'http://127.0.0.1:1' }),
+        compatibility: { supportsCountTokens: false },
+      }]),
+    });
+    const body = JSON.stringify({ model: 'opencode-anthropic', messages: [] });
+
+    const suffixed = await fetch(`${server.url}/anthropic/v1/messages/count_tokens/extra`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    });
+    expect(suffixed.status).toBe(404);
+
+    const unprefixed = await fetch(`${server.url}/v1/messages/count_tokens`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    });
+    expect(unprefixed.status).toBe(404);
+
+    const wrongMethod = await fetch(`${server.url}/anthropic/v1/messages/count_tokens`);
+    expect(wrongMethod.status).toBe(404);
+  });
+
+  it('requires authorization before answering count_tokens', async () => {
+    const server = await startTestServer({
+      serverPassword: 'secret',
+      catalog: createGatewayModelCatalog([{
+        ...model('opencode-anthropic', 'anthropic', 'go', { baseUrl: 'http://127.0.0.1:1' }),
+        compatibility: { supportsCountTokens: false },
+      }]),
+    });
+
+    const response = await fetch(`${server.url}/anthropic/v1/messages/count_tokens`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'opencode-anthropic', messages: [] }),
+    });
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/tests/upstream-forward.test.ts
+++ b/tests/upstream-forward.test.ts
@@ -234,10 +234,8 @@ describe('anthropicSseModelRewrite', () => {
   });
 
   it('does not split a CRLF whose halves land in different chunks', async () => {
-    // The hazard the CR terminator introduces: a trailing \r may be the first
-    // half of a CRLF. Framing it as a bare-CR terminator would turn one line
-    // ending into two and insert a phantom blank line, which in SSE ends the
-    // event.
+    // Holding the trailing CR keeps a split CRLF as one internal delimiter in
+    // spec-shaped framing; the emitted bytes are equivalent without the guard.
     const crlf = 'event: message_start\r\n'
       + 'data: {"type":"message_start","message":{"id":"msg_1","model":"claude-sonnet-4-5"}}\r\n\r\n';
     const boundary = crlf.indexOf('\r\n') + 1;

--- a/tests/upstream-forward.test.ts
+++ b/tests/upstream-forward.test.ts
@@ -224,6 +224,13 @@ describe('anthropicSseModelRewrite', () => {
     expect(streamed).toContain('"model":"alias-x"');
   });
 
+  it('emits a complete CR-delimited event before the upstream closes', async () => {
+    const event = 'event: message_start\r'
+      + 'data: {"type":"message_start","message":{"id":"msg_1","model":"claude-sonnet-4-5"}}\r\r';
+    const { streamed } = await collectBeforeEnd(anthropicSseModelRewrite('alias-x'), [event]);
+    expect(streamed).toBe(event.replace('"model":"claude-sonnet-4-5"', '"model":"alias-x"'));
+  });
+
   it('keeps CR-only line endings on the line it rewrites', async () => {
     const out = await collect(anthropicSseModelRewrite('alias-x'), [crOnly]);
     expect(out).toContain('"model":"alias-x"');

--- a/tests/upstream-forward.test.ts
+++ b/tests/upstream-forward.test.ts
@@ -189,6 +189,74 @@ describe('anthropicSseModelRewrite', () => {
     expect(out.split('\n').length).toBe(crlf.split('\n').length);
     expect(out.replace(/\r\n/g, '')).not.toContain('\n');
   });
+
+  // Collect what reached the client *before* the stream ended, which is what a
+  // relay is for. `collect` cannot see a stall: it ends the transform, so a
+  // transform that emitted nothing until flush still returns the whole body.
+  const collectBeforeEnd = async (
+    transform: Transform,
+    chunks: string[],
+  ): Promise<{ streamed: string; total: string }> => {
+    const out: Buffer[] = [];
+    transform.on('data', chunk => out.push(Buffer.from(chunk)));
+    for (const chunk of chunks) transform.write(Buffer.from(chunk, 'utf8'));
+    await new Promise(resolve => setImmediate(resolve));
+    const streamed = Buffer.concat(out).toString('utf8');
+    await new Promise<void>((resolve, reject) => {
+      transform.on('end', resolve);
+      transform.on('error', reject);
+      transform.end();
+    });
+    return { streamed, total: Buffer.concat(out).toString('utf8') };
+  };
+
+  const crOnly = 'event: message_start\r'
+    + 'data: {"type":"message_start","message":{"id":"msg_1","model":"claude-sonnet-4-5"}}\r\r'
+    + 'event: ping\rdata: {"type":"ping"}\r\r';
+
+  it('frames a CR-delimited stream instead of holding it until the upstream closes', async () => {
+    // SSE terminates a line with CRLF, LF, or a bare CR. Splitting on \n alone
+    // finds no line boundary at all in a CR-framed stream, so every byte
+    // accumulates in the tail buffer and the client receives nothing until the
+    // upstream closes — a stalled relay, not just a missed rewrite.
+    const { streamed } = await collectBeforeEnd(anthropicSseModelRewrite('alias-x'), [crOnly]);
+    expect(streamed).not.toBe('');
+    expect(streamed).toContain('"model":"alias-x"');
+  });
+
+  it('keeps CR-only line endings on the line it rewrites', async () => {
+    const out = await collect(anthropicSseModelRewrite('alias-x'), [crOnly]);
+    expect(out).toContain('"model":"alias-x"');
+    expect(out).not.toContain('"model":"claude-sonnet-4-5"');
+    // Framing is preserved exactly: no \n was introduced and no \r was lost.
+    expect(out).not.toContain('\n');
+    expect(out.split('\r').length).toBe(crOnly.split('\r').length);
+  });
+
+  it('does not split a CRLF whose halves land in different chunks', async () => {
+    // The hazard the CR terminator introduces: a trailing \r may be the first
+    // half of a CRLF. Framing it as a bare-CR terminator would turn one line
+    // ending into two and insert a phantom blank line, which in SSE ends the
+    // event.
+    const crlf = 'event: message_start\r\n'
+      + 'data: {"type":"message_start","message":{"id":"msg_1","model":"claude-sonnet-4-5"}}\r\n\r\n';
+    const boundary = crlf.indexOf('\r\n') + 1;
+    const out = await collect(
+      anthropicSseModelRewrite('alias-x'),
+      [crlf.slice(0, boundary), crlf.slice(boundary)],
+    );
+    expect(out).toContain('"model":"alias-x"');
+    expect(out.replace(/\r\n/g, '')).not.toContain('\r');
+    expect(out.replace(/\r\n/g, '')).not.toContain('\n');
+    expect(out.split('\r\n').length).toBe(crlf.split('\r\n').length);
+  });
+
+  it('passes an LF stream through with its framing byte-for-byte', async () => {
+    // Conservation for the ending Anthropic actually sends.
+    const out = await collect(anthropicSseModelRewrite('alias-x'), [messageStart + textDelta]);
+    expect(out).not.toContain('\r');
+    expect(out).toBe((messageStart + textDelta).replace('"model":"claude-sonnet-4-5"', '"model":"alias-x"'));
+  });
 });
 
 describe('relayAnthropicMessages responseModelOverride', () => {

--- a/tests/upstream-forward.test.ts
+++ b/tests/upstream-forward.test.ts
@@ -1,6 +1,6 @@
 // tests/upstream-forward.test.ts
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import type { Transform } from 'node:stream';
+import { Writable, type Transform } from 'node:stream';
 import {
   anthropicUpstreamHeaders,
   fetchWithOAuthRetry,
@@ -175,6 +175,20 @@ describe('anthropicSseModelRewrite', () => {
     const out = await collect(anthropicSseModelRewrite('alias-x'), [malformed]);
     expect(out).toBe(malformed);
   });
+
+  it('keeps CRLF line endings on the line it rewrites', async () => {
+    // Splitting on \n leaves the \r on every line. Dropping it only from the
+    // rewritten line would emit a stream with mixed endings, which is a framing
+    // change rather than a model-id change.
+    const crlf = 'event: message_start\r\n'
+      + 'data: {"type":"message_start","message":{"id":"msg_1","model":"claude-sonnet-4-5"}}\r\n\r\n';
+    const out = await collect(anthropicSseModelRewrite('alias-x'), [crlf]);
+    expect(out).toContain('"model":"alias-x"');
+    expect(out).not.toContain('"model":"claude-sonnet-4-5"');
+    // Every original line ending survives: no bare \n was introduced.
+    expect(out.split('\n').length).toBe(crlf.split('\n').length);
+    expect(out.replace(/\r\n/g, '')).not.toContain('\n');
+  });
 });
 
 describe('relayAnthropicMessages responseModelOverride', () => {
@@ -238,5 +252,142 @@ describe('relayAnthropicMessages responseModelOverride', () => {
       {},
     );
     expect(res.body()).toBe(raw);
+  });
+
+  it('leaves a non-message JSON envelope untouched even with an override', async () => {
+    // The SSE path only ever rewrites `message_start`; the JSON path must agree
+    // and only rewrite an Anthropic Message. An error envelope that happens to
+    // carry a `model` is not the assistant's answer, and rewriting it would
+    // misreport which model produced the failure.
+    const raw = JSON.stringify({
+      type: 'error',
+      model: 'claude-sonnet-4-5',
+      error: { type: 'overloaded_error', message: 'upstream busy' },
+    });
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(raw, {
+      status: 200, headers: { 'Content-Type': 'application/json' },
+    })));
+    const res = makeRes();
+    await relayAnthropicMessages(
+      res as never,
+      'https://upstream.example/v1/messages',
+      { model: 'claude-sonnet-4-5' },
+      'key',
+      false,
+      { responseModelOverride: 'clodex:acme:sonnet[200k]' },
+    );
+    expect(res.body()).toBe(raw);
+    expect(res.body()).not.toContain('clodex:acme:sonnet[200k]');
+  });
+
+  it('leaves a count_tokens-shaped body untouched even with an override', async () => {
+    const raw = JSON.stringify({ input_tokens: 42, model: 'claude-sonnet-4-5' });
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(raw, {
+      status: 200, headers: { 'Content-Type': 'application/json' },
+    })));
+    const res = makeRes();
+    await relayAnthropicMessages(
+      res as never,
+      'https://upstream.example/v1/messages/count_tokens',
+      { model: 'claude-sonnet-4-5' },
+      'key',
+      false,
+      { responseModelOverride: 'clodex:acme:sonnet[200k]' },
+    );
+    expect(res.body()).toBe(raw);
+  });
+});
+
+describe('relayAnthropicMessages streaming', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  /**
+   * A REAL Writable, unlike the object mock above: the streaming path reaches
+   * the client through `.pipe(res)`, so a plain object never exercises it.
+   * That is the gap this suite had — `anthropicSseModelRewrite` was well
+   * covered directly, but deleting the `.pipe(...)` that installs it in the
+   * relay left every test green.
+   */
+  function makeStreamRes() {
+    const chunks: Buffer[] = [];
+    let status = 0;
+    let headers: Record<string, string> = {};
+    const res = new Writable({
+      write(chunk: Buffer, _enc, cb) { chunks.push(Buffer.from(chunk)); cb(); },
+    }) as Writable & {
+      writeHead: (code: number, hdrs?: Record<string, string>) => unknown;
+      body: () => string;
+      status: () => number;
+      headers: () => Record<string, string>;
+    };
+    res.writeHead = (code, hdrs) => { status = code; headers = hdrs ?? {}; return res; };
+    res.body = () => Buffer.concat(chunks).toString('utf8');
+    res.status = () => status;
+    res.headers = () => headers;
+    return res;
+  }
+
+  const SSE = [
+    'event: message_start',
+    'data: {"type":"message_start","message":{"id":"msg_1","model":"qwen3.8-max","content":[]}}',
+    '',
+    'event: content_block_delta',
+    'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"hi"}}',
+    '',
+    'event: message_stop',
+    'data: {"type":"message_stop"}',
+    '',
+  ].join('\n');
+
+  it('pipes the streaming body through the model rewrite', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(SSE, {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
+    })));
+    const res = makeStreamRes();
+    const done = new Promise<void>(resolve => res.on('finish', () => resolve()));
+
+    await relayAnthropicMessages(
+      res as never,
+      'https://upstream.example/v1/messages',
+      { model: 'qwen3.8-max', stream: true },
+      'key',
+      true,
+      { responseModelOverride: 'clodex:opencode-go:qwen3.8-max[1m]' },
+    );
+    await done;
+
+    expect(res.status()).toBe(200);
+    expect(res.headers()['Content-Type']).toBe('text/event-stream');
+    const body = res.body();
+    // The echo invariant: the client sees back exactly the id it asked for.
+    expect(body).toContain('"model":"clodex:opencode-go:qwen3.8-max[1m]"');
+    expect(body).not.toContain('"model":"qwen3.8-max"');
+    // Every other line survives byte-for-byte.
+    expect(body).toContain('data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"hi"}}');
+    expect(body).toContain('event: message_stop');
+  });
+
+  it('streams through untouched without an override', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(SSE, {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
+    })));
+    const res = makeStreamRes();
+    const done = new Promise<void>(resolve => res.on('finish', () => resolve()));
+
+    await relayAnthropicMessages(
+      res as never,
+      'https://upstream.example/v1/messages',
+      { model: 'qwen3.8-max', stream: true },
+      'key',
+      true,
+      {},
+    );
+    await done;
+
+    expect(res.body()).toBe(SSE);
   });
 });


### PR DESCRIPTION
## Summary

- add the built-in OpenCode Go provider with a checked-in 17-model catalog (13 OpenAI-compatible and 4 Anthropic)
- keep runtime catalog authority checked in and offline while retaining the maintained review-time updater
- add provider setup, discovery, refresh, routing, compatibility, and catalog coverage
- pin recognizable OpenCode records to immutable package-specific credential destinations across discovery, refresh, and runtime materialization
- route models without upstream `count_tokens` support through the existing local estimator at every model-aware Anthropic HTTP ingress
- filter imported or older retained caches through the committed catalog before runtime, display, or patch exposure
- fold in the O2-activated response-model identity and JSON/SSE framing corrections

This is **OpenCode stack 2/7**. Its precursor, #99, is merged. The final O2 delta is 45 files with 4,623 insertions and 144 deletions, rebuilt as 18 focused commits rather than replayed from the historical stacked branch.

## Current-main reconciliation

The final O2 series is based directly on upstream v2.5.1 commit `0c5457b0242c43a842ea2723abf9b3094392d981`.

- v2.5.1's Claude Code 2.1.228 support, PATCH 10 / transform version 6, and pre-PR documentation gate remain intact.
- The checked-in OpenCode catalog remains the single runtime allowlist and metadata authority.
- Imported retained identities use that authority even when their stored ID, template, npm transport, or optional provider URL reflects an older setup.
- Ordinary and custom providers retain their existing endpoint, cache, pricing, and model behavior.
- Package metadata adds the provider description, keyword, and maintained update script; dependencies, lockfile, schema, and persisted configuration remain unchanged.

## Security and compatibility boundaries

- Recognizable OpenCode records are pinned before npm-specific refresh dispatch, custom-endpoint validation, or DNS lookup.
- Supported provider-ID migration retains template identity and remains pinned.
- Compatible and Anthropic packages map only to their fixed SDK-specific endpoints; missing provider URLs use the corresponding immutable package pin, while explicit mismatches and unsupported packages fail closed.
- Retained cached model IDs are projected through the committed 17-model authority before materialization, provider browse/readiness/counts, catalog display, and patch metadata.
- Explicit pricing-preservation settings remain authoritative; imported retained identities keep curated pricing when the persisted flag is absent.
- Ordinary/custom provider endpoint and unknown-model behavior is conserved.
- The generic, pre-existing class in which a hand-edited record abandons both retained identity fields while preserving another provider's credential reference is provider-agnostic and outside this O2 slice; no supported writer creates that state.
- General custom-endpoint hardening remains tracked separately in #109.

## Validation

Using Node 24.19.0 and pnpm 10.34.5 on exact `c093b897062baaf45513e43c25cbc5e4358bbad9`:

- `pnpm test` — 93 files / 1,772 tests passed
- `pnpm typecheck` — passed
- `pnpm build` — passed
- `git diff --check` — passed
- clean-tree check — passed
- retained identity, destination, discovery, cache-projection, pricing, and count-token class audits — complete
- independent refutations of the final cache projection, package-specific missing-URL behavior, entitlement-error taxonomy, and refresh-time pricing preservation — clean, including mutation/deletion proofs
- fork review — clean on exact HEAD: [zachspartofaday/clodex#46](https://github.com/zachspartofaday/clodex/pull/46#issuecomment-5267742447)

The complete gate was repeated after the exact-head clean review. No live provider request or credential mutation was made.

## Stack

#99, the mixed-protocol provider foundation, is merged. The remaining publication order is:

1. **#100 (this PR)** — base OpenCode Go provider and hardening
2. #110 — favorites curation and bounded exposure
3. #113 — unavailable versus capacity-omitted alias diagnostics
4. #101 — pinned CLI resolver contracts and deterministic catalog
5. #102 — negative-only Anthropic identity and beta boundaries
6. #103 — effort policy and validated wire-map authority
7. #104 — same-target ordered native alias preservation

Source work and fork review are complete through #104. Each successor remains draft until its precursor merges; it will then be rebased onto the resulting `main`, revalidated, and presented for maintainer review in the order above so every PR retains a focused delta.

