### PR TITLE
fix(env): bypass the proxy for the loopback gateway in endpoint mode

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -60,6 +60,100 @@ export function applyClaudeCodeThirdPartyCompat(env: NodeJS.ProcessEnv): void {
   env['CLAUDE_CODE_SIMPLE_SYSTEM_PROMPT'] = '0';
 }
 
+/** Loopback spellings the child must reach directly even behind a proxy. */
+const LOOPBACK_NO_PROXY_ENTRIES = ['localhost', '127.0.0.1', '::1'] as const;
+
+/** Hostname of a base URL, with IPv6 brackets stripped; '' when unparseable. */
+function gatewayHostname(gatewayUrl: string): string {
+  try {
+    return new URL(gatewayUrl).hostname.replace(/^\[|\]$/g, '').toLowerCase();
+  } catch {
+    return '';
+  }
+}
+
+/** Loopback per RFC 5735/4291: `localhost`, all of 127.0.0.0/8, and `::1`. */
+function isLoopbackHost(host: string): boolean {
+  if (host === 'localhost' || host.endsWith('.localhost')) return true;
+  if (host === '::1' || host === '0:0:0:0:0:0:0:1') return true;
+  const v4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (!v4) return false;
+  const octets = v4.slice(1).map(Number);
+  if (octets.some(o => o > 255)) return false;
+  return octets[0] === 127;
+}
+
+/**
+ * The NO_PROXY value the child actually consults. Claude Code reads
+ * `no_proxy || NO_PROXY`, so a non-empty lowercase value wins OUTRIGHT and the
+ * uppercase one is never seen. Unioning the two would hand back proxy-free
+ * routing for hosts the user had bypassed in only the losing variable.
+ */
+function effectiveNoProxyValue(env: NodeJS.ProcessEnv): string {
+  return env['no_proxy'] || env['NO_PROXY'] || '';
+}
+
+function normalizedNoProxyEntries(env: NodeJS.ProcessEnv): string[] {
+  return effectiveNoProxyValue(env)
+    .split(',')
+    .map(value => value.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Endpoint mode points the child at a local gateway but deliberately leaves the
+ * user's HTTP(S)_PROXY in place — Claude Code still needs it for its OWN outbound
+ * traffic (WebFetch, MCP servers, telemetry). Claude Code honours NO_PROXY but has
+ * no implicit loopback bypass, so without this it asks the corporate proxy to fetch
+ * the loopback gateway and a proxy that refuses returns a bodyless 503 (issue #95,
+ * confirmed fixed by the reporter with a manual `no_proxy`).
+ *
+ * Deliberately additive: entries already present are preserved, and the child's
+ * proxy is left usable for everything that is not the gateway. This is why we do
+ * NOT simply delete the proxy vars the way the wrapper's endpoint branch does.
+ */
+export function addGatewayNoProxyBypass(env: NodeJS.ProcessEnv, gatewayUrl: string): void {
+  const hasProxy = Boolean(
+    env['HTTPS_PROXY']?.trim() || env['https_proxy']?.trim()
+    || env['HTTP_PROXY']?.trim() || env['http_proxy']?.trim(),
+  );
+  // Nothing to bypass without a proxy — do not add noise to a clean env.
+  if (!hasProxy) return;
+
+  // ONLY loopback gateways. `buildChildEnv` is also called with a REMOTE
+  // Anthropic-passthrough baseUrl (`cli.ts`, the modelFormat === 'anthropic'
+  // branch), and that host must keep using the proxy — bypassing it there would
+  // point the child straight at a host the proxy may be the only route to.
+  const host = gatewayHostname(gatewayUrl);
+  if (!isLoopbackHost(host)) return;
+
+  // `*` bypasses everything ONLY as the entire value — Claude Code's matcher
+  // tests `value === "*"` before splitting, and a `*` appearing as one entry in
+  // a list matches nothing. Bailing on a list-member `*` would make this a
+  // silent no-op and reproduce #95 for anyone with e.g. `NO_PROXY=internal,*`.
+  if (effectiveNoProxyValue(env) === '*') return;
+  const existing = normalizedNoProxyEntries(env);
+
+  // The gateway's OWN address has to be in the list: NO_PROXY matches host by
+  // host, so the canonical spellings do not cover a gateway bound elsewhere in
+  // 127.0.0.0/8 (all of which is loopback). Without this, `http://127.1.2.3:…`
+  // is recognised as local and still routed to the proxy — the original bug.
+  const additions: string[] = [...LOOPBACK_NO_PROXY_ENTRIES, host];
+  const seen = new Set(existing.map(entry => entry.toLowerCase()));
+  const merged = [...existing];
+  for (const entry of additions) {
+    const key = entry.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(entry);
+  }
+
+  const value = merged.join(',');
+  // Claude Code reads `no_proxy` before `NO_PROXY`; set both so neither wins stale.
+  env['NO_PROXY'] = value;
+  env['no_proxy'] = value;
+}
+
 export function buildChildEnv(
   baseUrl: string,
   model: string,
@@ -76,6 +170,7 @@ export function buildChildEnv(
     ? `http://127.0.0.1:${proxyPort}`
     : baseUrl;
   env['ANTHROPIC_API_KEY'] = apiKey;
+  addGatewayNoProxyBypass(env, env['ANTHROPIC_BASE_URL']);
   const bareModel = stripOneMContextSuffix(model);
   env['ANTHROPIC_MODEL'] = claudeCodeClientModelId(model, contextWindow);
   // Claude Code defaults to 200K for non-api.anthropic.com base URLs; override with

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, afterEach, beforeEach } from 'vitest';
 import {
   detectConflicts,
+  addGatewayNoProxyBypass,
   buildChildEnv,
   buildHttpProxyChildEnv,
   classifyKeyringError,
@@ -285,5 +286,255 @@ describe('child-env builders never mutate clodex process.env', () => {
     expect(process.env['HTTPS_PROXY']).toBe(before['HTTPS_PROXY']);
     expect(process.env['HTTP_PROXY']).toBe(before['HTTP_PROXY']);
     expect(process.env['ANTHROPIC_BASE_URL']).toBe(before['ANTHROPIC_BASE_URL']);
+  });
+});
+
+// Issue #95: endpoint mode leaves the user's HTTP(S)_PROXY in the child env while
+// pointing ANTHROPIC_BASE_URL at a loopback gateway. Claude Code honours NO_PROXY
+// but has no implicit loopback bypass, so the child asked the corporate proxy to
+// fetch 127.0.0.1 and a refusing proxy answered with a bodyless 503.
+describe('addGatewayNoProxyBypass', () => {
+  const GATEWAY = 'http://127.0.0.1:17645';
+
+  it('does nothing when no proxy is configured', () => {
+    const env: NodeJS.ProcessEnv = {};
+    addGatewayNoProxyBypass(env, GATEWAY);
+    expect(env['NO_PROXY']).toBeUndefined();
+    expect(env['no_proxy']).toBeUndefined();
+  });
+
+  it('bypasses every loopback spelling when a proxy is configured', () => {
+    const env: NodeJS.ProcessEnv = { HTTP_PROXY: 'http://corp:3128' };
+    addGatewayNoProxyBypass(env, GATEWAY);
+    const entries = env['NO_PROXY']!.split(',');
+    expect(entries).toContain('localhost');
+    expect(entries).toContain('127.0.0.1');
+    expect(entries).toContain('::1');
+  });
+
+  it('sets both casings, because Claude Code reads no_proxy first', () => {
+    const env: NodeJS.ProcessEnv = { HTTPS_PROXY: 'http://corp:3128' };
+    addGatewayNoProxyBypass(env, GATEWAY);
+    expect(env['no_proxy']).toBe(env['NO_PROXY']);
+    expect(env['no_proxy']).toBeTruthy();
+  });
+
+  it('is triggered by any of the four proxy spellings', () => {
+    for (const name of ['HTTP_PROXY', 'HTTPS_PROXY', 'http_proxy', 'https_proxy']) {
+      const env: NodeJS.ProcessEnv = { [name]: 'http://corp:3128' };
+      addGatewayNoProxyBypass(env, GATEWAY);
+      expect(env['NO_PROXY'], `expected ${name} to trigger the bypass`).toContain('127.0.0.1');
+    }
+  });
+
+  it('preserves the user existing NO_PROXY entries', () => {
+    const env: NodeJS.ProcessEnv = { HTTP_PROXY: 'http://corp:3128', NO_PROXY: 'internal.corp,.example.com' };
+    addGatewayNoProxyBypass(env, GATEWAY);
+    const entries = env['NO_PROXY']!.split(',');
+    expect(entries).toContain('internal.corp');
+    expect(entries).toContain('.example.com');
+    expect(entries).toContain('127.0.0.1');
+  });
+
+  it('does not duplicate an entry the user already had, case-insensitively', () => {
+    const env: NodeJS.ProcessEnv = { HTTP_PROXY: 'http://corp:3128', NO_PROXY: 'LocalHost,127.0.0.1' };
+    addGatewayNoProxyBypass(env, GATEWAY);
+    const entries = env['NO_PROXY']!.split(',');
+    expect(entries.filter(e => e.toLowerCase() === 'localhost')).toHaveLength(1);
+    expect(entries.filter(e => e === '127.0.0.1')).toHaveLength(1);
+  });
+
+  it('leaves a wildcard NO_PROXY untouched rather than narrowing it', () => {
+    const env: NodeJS.ProcessEnv = { HTTP_PROXY: 'http://corp:3128', NO_PROXY: '*' };
+    addGatewayNoProxyBypass(env, GATEWAY);
+    expect(env['NO_PROXY']).toBe('*');
+  });
+
+  // Claude Code's matcher tests `value === "*"` BEFORE splitting, so a `*` that is
+  // merely one entry in a list bypasses nothing. Treating it as bypass-everything
+  // would make this a silent no-op and reproduce #95 for that user.
+  it('still bypasses when * is only one entry in a list', () => {
+    const env: NodeJS.ProcessEnv = { HTTP_PROXY: 'http://corp:3128', NO_PROXY: 'internal.corp,*' };
+    addGatewayNoProxyBypass(env, GATEWAY);
+    const entries = env['NO_PROXY']!.split(',');
+    expect(entries).toContain('127.0.0.1');
+    expect(entries).toContain('internal.corp');
+  });
+
+  // Claude Code reads `no_proxy || NO_PROXY`: a non-empty lowercase value wins
+  // outright, so the uppercase one must not be merged back in.
+  it('follows lowercase precedence instead of unioning divergent casings', () => {
+    const env: NodeJS.ProcessEnv = {
+      HTTP_PROXY: 'http://corp:3128',
+      no_proxy: 'lower.internal',
+      NO_PROXY: 'upper.internal',
+    };
+    addGatewayNoProxyBypass(env, GATEWAY);
+    const entries = env['no_proxy']!.split(',');
+    expect(entries).toContain('lower.internal');
+    expect(entries).not.toContain('upper.internal');
+    expect(env['NO_PROXY']).toBe(env['no_proxy']);
+  });
+
+  it('falls through to NO_PROXY when no_proxy is set but empty', () => {
+    const env: NodeJS.ProcessEnv = {
+      HTTP_PROXY: 'http://corp:3128',
+      no_proxy: '',
+      NO_PROXY: 'upper.internal',
+    };
+    addGatewayNoProxyBypass(env, GATEWAY);
+    expect(env['NO_PROXY']!.split(',')).toContain('upper.internal');
+  });
+
+  // The dangerous direction: buildChildEnv is ALSO called with a remote
+  // Anthropic-passthrough baseUrl. Bypassing the proxy for a remote host could
+  // point the child at a host the proxy is the only route to.
+  it('does NOT touch NO_PROXY for a remote gateway', () => {
+    const env: NodeJS.ProcessEnv = { HTTP_PROXY: 'http://corp:3128' };
+    addGatewayNoProxyBypass(env, 'https://api.anthropic.com');
+    expect(env['NO_PROXY']).toBeUndefined();
+    expect(env['no_proxy']).toBeUndefined();
+  });
+
+  it('does NOT bypass a non-loopback LAN gateway', () => {
+    const env: NodeJS.ProcessEnv = { HTTP_PROXY: 'http://corp:3128' };
+    addGatewayNoProxyBypass(env, 'http://gateway.lan:17645');
+    expect(env['NO_PROXY']).toBeUndefined();
+  });
+
+  // NO_PROXY matches host-by-host, so classifying an address as loopback is
+  // worthless unless that exact address lands in the list.
+  it('emits the gateway address itself across the whole 127.0.0.0/8 range', () => {
+    for (const host of ['127.0.0.1', '127.0.0.53', '127.1.2.3']) {
+      const env: NodeJS.ProcessEnv = { HTTP_PROXY: 'http://corp:3128' };
+      addGatewayNoProxyBypass(env, `http://${host}:17645`);
+      expect(env['NO_PROXY']!.split(','), `expected ${host} to be bypassed`).toContain(host);
+    }
+  });
+
+  it('does not repeat the gateway address when it is already a canonical entry', () => {
+    const env: NodeJS.ProcessEnv = { HTTP_PROXY: 'http://corp:3128' };
+    addGatewayNoProxyBypass(env, 'http://127.0.0.1:17645');
+    const entries = env['NO_PROXY']!.split(',');
+    expect(entries.filter(e => e === '127.0.0.1')).toHaveLength(1);
+  });
+
+  // Regression guard: reading only the uppercase variable silently discards a
+  // user who set just `no_proxy`, sending their internal hosts to the proxy.
+  it('preserves entries the user set in lowercase no_proxy only', () => {
+    const env: NodeJS.ProcessEnv = { HTTP_PROXY: 'http://corp:3128', no_proxy: 'git.internal' };
+    addGatewayNoProxyBypass(env, GATEWAY);
+    expect(env['NO_PROXY']!.split(',')).toContain('git.internal');
+    expect(env['no_proxy']!.split(',')).toContain('git.internal');
+  });
+
+  it('honours a wildcard set only in lowercase no_proxy', () => {
+    const env: NodeJS.ProcessEnv = { HTTP_PROXY: 'http://corp:3128', no_proxy: '*' };
+    addGatewayNoProxyBypass(env, GATEWAY);
+    expect(env['no_proxy']).toBe('*');
+    expect(env['NO_PROXY']).toBeUndefined();
+  });
+
+  it('treats RFC 6761 .localhost names as loopback', () => {
+    const env: NodeJS.ProcessEnv = { HTTP_PROXY: 'http://corp:3128' };
+    addGatewayNoProxyBypass(env, 'http://gateway.localhost:17645');
+    expect(env['NO_PROXY']!.split(',')).toContain('gateway.localhost');
+  });
+
+  it('recognises a bracketed IPv6 loopback gateway', () => {
+    const env: NodeJS.ProcessEnv = { HTTP_PROXY: 'http://corp:3128' };
+    addGatewayNoProxyBypass(env, 'http://[::1]:17645');
+    const entries = env['NO_PROXY']!.split(',');
+    expect(entries).toContain('::1');
+    expect(entries.some(e => e.includes('['))).toBe(false);
+  });
+
+  it('does NOT bypass a non-loopback IPv6 gateway', () => {
+    const env: NodeJS.ProcessEnv = { HTTP_PROXY: 'http://corp:3128' };
+    addGatewayNoProxyBypass(env, 'http://[fd00::1]:17645');
+    expect(env['NO_PROXY']).toBeUndefined();
+  });
+
+  it('does nothing when the gateway URL is malformed', () => {
+    const env: NodeJS.ProcessEnv = { HTTP_PROXY: 'http://corp:3128' };
+    addGatewayNoProxyBypass(env, 'not a url');
+    expect(env['NO_PROXY']).toBeUndefined();
+  });
+});
+
+describe('buildChildEnv proxy bypass (issue #95)', () => {
+  const PROXY_NAMES = ['HTTP_PROXY', 'HTTPS_PROXY', 'http_proxy', 'https_proxy', 'NO_PROXY', 'no_proxy'];
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const name of PROXY_NAMES) {
+      saved[name] = process.env[name];
+      delete process.env[name];
+    }
+  });
+
+  afterEach(() => {
+    for (const name of PROXY_NAMES) {
+      if (saved[name] === undefined) delete process.env[name];
+      else process.env[name] = saved[name];
+    }
+  });
+
+  it('bypasses the loopback gateway the child was pointed at', () => {
+    process.env['HTTP_PROXY'] = 'http://corp:3128';
+    const env = buildChildEnv(UPSTREAM_URL, 'claude-sonnet-4-6', 'my-key', 17645);
+    expect(env['ANTHROPIC_BASE_URL']).toBe('http://127.0.0.1:17645');
+    expect(env['NO_PROXY']!.split(',')).toContain('127.0.0.1');
+    expect(env['no_proxy']).toBe(env['NO_PROXY']);
+  });
+
+  it('keeps the proxy itself in the child env — the child still needs it', () => {
+    process.env['HTTP_PROXY'] = 'http://corp:3128';
+    const env = buildChildEnv(UPSTREAM_URL, 'claude-sonnet-4-6', 'my-key', 17645);
+    expect(env['HTTP_PROXY']).toBe('http://corp:3128');
+  });
+
+  it('adds nothing when the user has no proxy configured', () => {
+    const env = buildChildEnv(UPSTREAM_URL, 'claude-sonnet-4-6', 'my-key', 17645);
+    expect(env['NO_PROXY']).toBeUndefined();
+    expect(env['no_proxy']).toBeUndefined();
+  });
+
+  it('never mutates the parent process env', () => {
+    process.env['HTTP_PROXY'] = 'http://corp:3128';
+    const before = { ...process.env };
+    buildChildEnv(UPSTREAM_URL, 'claude-sonnet-4-6', 'my-key', 17645);
+    expect({ ...process.env }).toEqual(before);
+    expect(process.env['NO_PROXY']).toBeUndefined();
+  });
+});
+
+describe('buildChildEnv remote passthrough keeps the proxy (issue #95 regression guard)', () => {
+  const PROXY_NAMES = ['HTTP_PROXY', 'HTTPS_PROXY', 'http_proxy', 'https_proxy', 'NO_PROXY', 'no_proxy'];
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const name of PROXY_NAMES) {
+      saved[name] = process.env[name];
+      delete process.env[name];
+    }
+  });
+
+  afterEach(() => {
+    for (const name of PROXY_NAMES) {
+      if (saved[name] === undefined) delete process.env[name];
+      else process.env[name] = saved[name];
+    }
+  });
+
+  // An Anthropic-format passthrough model launches with a REMOTE baseUrl and no
+  // local proxy port. That host must keep going through the user's proxy.
+  it('leaves NO_PROXY alone when the child points at a remote baseUrl', () => {
+    process.env['HTTPS_PROXY'] = 'http://corp:3128';
+    const env = buildChildEnv('https://api.example.com', 'claude-sonnet-4-6', 'my-key');
+    expect(env['ANTHROPIC_BASE_URL']).toBe('https://api.example.com');
+    expect(env['NO_PROXY']).toBeUndefined();
+    expect(env['no_proxy']).toBeUndefined();
+    expect(env['HTTPS_PROXY']).toBe('http://corp:3128');
   });
 });


### PR DESCRIPTION
## Summary

Endpoint mode launches Claude Code with `ANTHROPIC_BASE_URL` pointed at a local gateway, but `buildChildEnv` passes the user's `HTTP_PROXY`/`HTTPS_PROXY` straight through — `CONFLICTING_ENV_VARS` contains no proxy variables. Claude Code honours `NO_PROXY` but has no implicit loopback bypass, so it asked the corporate proxy to fetch `127.0.0.1` and a proxy that refuses answered with a bodyless 503.

This appends the loopback spellings, plus the gateway's own address, to the child's `NO_PROXY`/`no_proxy` whenever a proxy is configured.

Reported in #95, where the reporter confirmed a manual `no_proxy` resolved it.

## Why not just delete the proxy variables

The wrapper's endpoint branch (`computeWrapperEnv`) does exactly that, but it is the blunter option: the child still needs the proxy for its **own** outbound traffic — WebFetch, MCP servers, telemetry. On a network where direct egress is blocked, stripping the proxy trades one broken thing for another. This change is additive instead: existing entries are preserved and the proxy stays usable for everything that is not the gateway.

(The resulting inconsistency between the two launch paths is pre-existing and left alone here.)

## Behaviour is keyed to Claude Code's actual matcher, not to intuition

Three details were taken from the matcher in the 2.1.226 bundle rather than assumed:

- It reads `no_proxy || NO_PROXY`, so a non-empty **lowercase** value wins outright. The two casings are therefore *not* unioned — unioning would silently un-proxy hosts the user had bypassed in only the losing variable. Both casings are written to the same resolved value so neither can win stale.
- It treats `*` as bypass-everything **only when that is the entire value**; a `*` appearing as one entry in a list matches nothing. So `NO_PROXY=internal.corp,*` must not suppress this fix — an earlier revision of this change got that wrong and would have silently no-opped for those users.
- Its host comparison treats `localhost` and every `127.0.0.0/8` address as equivalent, so the explicit gateway entry is not needed *for Claude Code*. It is kept for exact-matching consumers such as `proxy-from-env`.

## Scope: loopback only

`buildChildEnv` is also called with a **remote** Anthropic-passthrough `baseUrl`. Bypassing the proxy for that host would point the child straight at a server the proxy may be the only route to, so the bypass only applies when the gateway is loopback. There is a regression test for this.

## Validation

- `pnpm test` — 85 files / 1370 tests passed
- `pnpm typecheck`, `pnpm build` — passed
- Mutation-tested: removing the call site, no-oping the helper, dropping the lowercase write, weakening the loopback predicate, dropping the wildcard guard, dropping dedupe, dropping the existing-entry preservation, dropping the proxy-presence guard, and reverting each of the two matcher-semantics fixes above are all caught by full-file runs.
- Tests manipulate real proxy environment variables, so they save and restore what they touch and pass both in a clean shell and one that already has `HTTPS_PROXY`/`NO_PROXY` set.

No credentials, prompts, or provider payloads are involved.
