### PR TITLE
fix(transport): clarify usage-limit semantics

### DIFF
--- a/src/oauth/responses-websocket.ts
+++ b/src/oauth/responses-websocket.ts
@@ -12,7 +12,12 @@ import type { FetchFunction } from '@ai-sdk/provider-utils';
 import type { RawData, WebSocket as WsWebSocket } from 'ws';
 import { CODEX_RESPONSES_WEBSOCKETS_BETA } from '../constants.js';
 import { outboundWsProxyAgent } from '../outbound-proxy.js';
-import { anthropicErrorType, clampRetryAfterSeconds, frameStatusCode } from '../upstream-error.js';
+import {
+  anthropicErrorType,
+  clampRetryAfterSeconds,
+  frameStatusCode,
+  MAX_RETRY_AFTER_SECONDS,
+} from '../upstream-error.js';
 import { sanitizeToolInput } from '../tool-input-sanitize.js';
 
 const RESPONSES_LITE_HEADER = 'x-openai-internal-codex-responses-lite';
@@ -874,8 +879,9 @@ function responseErrorMessage(event: unknown): string | undefined {
 }
 
 function boundedDiagnosticIdentifier(value: unknown): string | undefined {
-  if (typeof value !== 'string') return undefined;
-  const normalized = value.trim();
+  const identifier = typeof value === 'number' && Number.isFinite(value) ? String(value) : value;
+  if (typeof identifier !== 'string') return undefined;
+  const normalized = identifier.trim();
   return normalized && /^[a-zA-Z0-9_.:/-]+$/.test(normalized)
     ? normalized.slice(0, 128)
     : undefined;
@@ -1640,21 +1646,24 @@ function handleSocketMessage(entry: ConnectionEntry, data: RawData): void {
   }
 
   if (errorStatus !== undefined) {
+    const usageLimited = [responseErrorType(event), errorCode].some(value => (
+      typeof value === 'string' && value.toLowerCase().includes('usage_limit')
+    ));
+    // A generic 5xx field is only a fallback when a structured plan-limit class
+    // is present. Otherwise it masks the more specific 429 signal carried by the
+    // same frame. Explicit deterministic 4xx statuses remain authoritative.
+    const statusCode = usageLimited && errorStatus >= 500 ? 429 : errorStatus;
     // The AI SDK strips unknown frame fields, so a backoff hint survives only
     // baked into the message text — same reason the connection-limit branch
-    // above spells it out. Clamped, so a hostile hint cannot park a client past
-    // the 120s no-event stream abort.
-    // Only when upstream actually gave one. `clampRetryAfterSeconds` supplies a
-    // 5s DEFAULT for a missing hint, so clamping unconditionally would have
-    // every 429 assert a backoff upstream never stated — and that value becomes
-    // a real `retry-after` header downstream. Worse on a plan-level limit,
-    // where the reason says hours: a prose-only "retry after 1800s" would get
-    // "; retry after 5s" appended, and the client reads the first match.
-    const statedRetryAfter = errorStatus === 429 ? responseRetryAfterSeconds(event) : undefined;
-    const retryAfterSeconds = statedRetryAfter === undefined
-      ? undefined
-      : clampRetryAfterSeconds(statedRetryAfter);
-    const reason = responseErrorMessage(event) ?? `OpenAI rejected the request (HTTP ${errorStatus})`;
+    // above spells it out. Only forward a value upstream actually gave. An
+    // oversized ordinary rate-limit hint is capped, but omitting an oversized
+    // plan-limit hint is more honest than claiming the 60s cap is its reset time.
+    const statedRetryAfter = statusCode === 429 ? responseRetryAfterSeconds(event) : undefined;
+    const retryAfterSeconds = statedRetryAfter !== undefined
+      && (!usageLimited || statedRetryAfter <= MAX_RETRY_AFTER_SECONDS)
+      ? clampRetryAfterSeconds(statedRetryAfter)
+      : undefined;
+    const reason = responseErrorMessage(event) ?? `OpenAI rejected the request (HTTP ${statusCode})`;
     failContext(
       entry,
       ctx,
@@ -1669,10 +1678,10 @@ function handleSocketMessage(entry: ConnectionEntry, data: RawData): void {
         // file's diagnostics. The connection-limit branch can pass its code raw
         // only because it has just been compared `===` to a known constant.
         errorCode: boundedDiagnosticIdentifier(errorCode),
-        mappedStatusCode: errorStatus,
+        mappedStatusCode: statusCode,
         ...(retryAfterSeconds !== undefined ? { retryAfterSeconds } : {}),
       },
-      errorStatus,
+      statusCode,
       retryAfterSeconds,
     );
     return;
@@ -1720,19 +1729,20 @@ function handleSocketMessage(entry: ConnectionEntry, data: RawData): void {
     // `code: '401'` matches no rule, lands on the 500 default, and gets
     // rewritten as a retryable 502.
     const numericOrNamed = typeof details.errorCode === 'string' ? details.errorCode : undefined;
-    const classified = numericOrNamed !== undefined || discriminator
-      ? frameStatusCode(numericOrNamed, discriminator)
-      : 500;
+    const classified = frameStatusCode(numericOrNamed, discriminator);
     const statusCode = classified !== 500
       ? classified
       : settledReason ? 400 : 502;
     const usageLimited = statusCode === 429;
+    const planLimited = discriminator.includes('usage_limit');
     // Only when upstream stated one, and only baked into the TEXT: the AI SDK's
     // chunk schema is a closed zod object that strips `retry_after_seconds`, so
     // a hint carried only in the frame field never reaches the client. This is
     // the same reason the status-carrying branch above spells it out.
-    const retryAfterSeconds = usageLimited && responseRetryAfterSeconds(event) !== undefined
-      ? clampRetryAfterSeconds(responseRetryAfterSeconds(event))
+    const statedRetryAfter = usageLimited ? responseRetryAfterSeconds(event) : undefined;
+    const retryAfterSeconds = statedRetryAfter !== undefined
+      && (!planLimited || statedRetryAfter <= MAX_RETRY_AFTER_SECONDS)
+      ? clampRetryAfterSeconds(statedRetryAfter)
       : undefined;
     // The BOUNDED summary is the message, upstream's prose is not used at all.
     // A `response.failed` body can echo request content or backend detail, and

--- a/src/oauth/responses-websocket.ts
+++ b/src/oauth/responses-websocket.ts
@@ -831,6 +831,13 @@ function responseErrorType(event: unknown): string | undefined {
   return typeof responseError?.type === 'string' ? responseError.type : undefined;
 }
 
+/** Preserve a plan-limit class through failContext's existing structured `error.type` channel. */
+function responsePlanLimitType(event: unknown): string | undefined {
+  return [responseErrorType(event), responseErrorCode(event)].find(value => (
+    typeof value === 'string' && value.toLowerCase().includes('usage_limit')
+  ));
+}
+
 function responseRetryAfterSeconds(event: unknown): number | undefined {
   if (!event || typeof event !== 'object') return undefined;
   const record = event as JsonObject;
@@ -1309,6 +1316,7 @@ function failContext(
   diagnosticDetails: Record<string, unknown>,
   statusCode?: number,
   retryAfterSeconds?: number,
+  planLimitType?: string,
 ): void {
   if (ctx.closed || entry.current !== ctx) return;
   entry.debug(`fail: ${message}`);
@@ -1321,7 +1329,8 @@ function failContext(
     type: 'error',
     sequence_number: ctx.frameCount,
     error: {
-      type: statusCode === undefined ? 'transport_error' : anthropicErrorType(statusCode),
+      type: planLimitType
+        ?? (statusCode === undefined ? 'transport_error' : anthropicErrorType(statusCode)),
       code: statusCode === undefined ? 'websocket_transport_error' : String(statusCode),
       message,
       param: null,
@@ -1646,9 +1655,8 @@ function handleSocketMessage(entry: ConnectionEntry, data: RawData): void {
   }
 
   if (errorStatus !== undefined) {
-    const usageLimited = [responseErrorType(event), errorCode].some(value => (
-      typeof value === 'string' && value.toLowerCase().includes('usage_limit')
-    ));
+    const planLimitType = responsePlanLimitType(event);
+    const usageLimited = planLimitType !== undefined;
     // A generic 5xx field is only a fallback when a structured plan-limit class
     // is present. Otherwise it masks the more specific 429 signal carried by the
     // same frame. Explicit deterministic 4xx statuses remain authoritative.
@@ -1683,6 +1691,7 @@ function handleSocketMessage(entry: ConnectionEntry, data: RawData): void {
       },
       statusCode,
       retryAfterSeconds,
+      planLimitType,
     );
     return;
   }
@@ -1734,7 +1743,8 @@ function handleSocketMessage(entry: ConnectionEntry, data: RawData): void {
       ? classified
       : settledReason ? 400 : 502;
     const usageLimited = statusCode === 429;
-    const planLimited = discriminator.includes('usage_limit');
+    const planLimitType = responsePlanLimitType(event);
+    const planLimited = planLimitType !== undefined;
     // Only when upstream stated one, and only baked into the TEXT: the AI SDK's
     // chunk schema is a closed zod object that strips `retry_after_seconds`, so
     // a hint carried only in the frame field never reaches the client. This is
@@ -1772,6 +1782,7 @@ function handleSocketMessage(entry: ConnectionEntry, data: RawData): void {
       },
       statusCode,
       retryAfterSeconds,
+      planLimitType,
     );
     return;
   }

--- a/src/oauth/responses-websocket.ts
+++ b/src/oauth/responses-websocket.ts
@@ -1329,6 +1329,8 @@ function failContext(
     type: 'error',
     sequence_number: ctx.frameCount,
     error: {
+      // Synthetic `type` preserves plan identity while `code` preserves
+      // authoritative HTTP status.
       type: planLimitType
         ?? (statusCode === undefined ? 'transport_error' : anthropicErrorType(statusCode)),
       code: statusCode === undefined ? 'websocket_transport_error' : String(statusCode),
@@ -1668,6 +1670,7 @@ function handleSocketMessage(entry: ConnectionEntry, data: RawData): void {
     // plan-limit hint is more honest than claiming the 60s cap is its reset time.
     const statedRetryAfter = statusCode === 429 ? responseRetryAfterSeconds(event) : undefined;
     const retryAfterSeconds = statedRetryAfter !== undefined
+      && statedRetryAfter >= 0
       && (!usageLimited || statedRetryAfter <= MAX_RETRY_AFTER_SECONDS)
       ? clampRetryAfterSeconds(statedRetryAfter)
       : undefined;
@@ -1751,6 +1754,7 @@ function handleSocketMessage(entry: ConnectionEntry, data: RawData): void {
     // the same reason the status-carrying branch above spells it out.
     const statedRetryAfter = usageLimited ? responseRetryAfterSeconds(event) : undefined;
     const retryAfterSeconds = statedRetryAfter !== undefined
+      && statedRetryAfter >= 0
       && (!planLimited || statedRetryAfter <= MAX_RETRY_AFTER_SECONDS)
       ? clampRetryAfterSeconds(statedRetryAfter)
       : undefined;

--- a/src/upstream-error.ts
+++ b/src/upstream-error.ts
@@ -49,13 +49,31 @@ function retryAfterFromText(message: unknown): number | undefined {
   return match ? Number(match[1]) : undefined;
 }
 
+/**
+ * Structured `error` payload carried by an APICallError — the parsed `data`
+ * the SDK populated, or, when it only serialized the body, the `error` object
+ * inside the parsed `responseBody` JSON. Data wins over the serialized body so
+ * both consumers below read one consistent payload; malformed or non-object
+ * shapes safely yield undefined and never throw.
+ */
+function structuredErrorPayload(inner: InstanceType<typeof APICallError>): Record<string, unknown> | undefined {
+  const fromData = asRecord(asRecord(inner.data)?.error);
+  if (fromData !== undefined) return fromData;
+  if (typeof inner.responseBody !== 'string') return undefined;
+  try {
+    return asRecord(asRecord(JSON.parse(inner.responseBody))?.error);
+  } catch {
+    return undefined;
+  }
+}
+
 function numericRetryAfterSeconds(inner: InstanceType<typeof APICallError>): number | undefined {
-  const data = inner.data as { error?: { retry_after_seconds?: unknown; message?: unknown } } | undefined;
-  const fromBody = data?.error?.retry_after_seconds;
+  const error = structuredErrorPayload(inner);
+  const fromBody = error?.retry_after_seconds;
   if (typeof fromBody === 'number' && Number.isFinite(fromBody) && fromBody >= 0) return fromBody;
   const fromHeader = inner.responseHeaders?.['retry-after'];
   if (typeof fromHeader === 'string' && /^\d+$/.test(fromHeader.trim())) return Number(fromHeader.trim());
-  for (const message of [data?.error?.message, inner.message]) {
+  for (const message of [error?.message, inner.message]) {
     const fromText = retryAfterFromText(message);
     if (fromText !== undefined) return fromText;
   }
@@ -63,7 +81,7 @@ function numericRetryAfterSeconds(inner: InstanceType<typeof APICallError>): num
 }
 
 function apiErrorIsPlanUsageLimit(inner: InstanceType<typeof APICallError>): boolean {
-  const error = (inner.data as { error?: { type?: unknown; code?: unknown } } | undefined)?.error;
+  const error = structuredErrorPayload(inner);
   return [error?.type, error?.code].some(value => (
     typeof value === 'string' && value.toLowerCase().includes('usage_limit')
   ));

--- a/src/upstream-error.ts
+++ b/src/upstream-error.ts
@@ -24,9 +24,9 @@ export interface SdkUpstreamErrorDetails {
 /** Default downstream backoff hint when the upstream throttle gives none. */
 export const DEFAULT_RETRY_AFTER_SECONDS = 5;
 /**
- * Upper bound for any retry-after hint clodex produces or forwards. Keeps the
- * AI SDK's bounded backoff (default maxRetries=2) and downstream clients well
- * clear of clodex's 120s no-event stream abort.
+ * Upper bound for retry-after hints clodex produces or forwards. Ordinary
+ * throttle hints clamp here; a plan-level reset above the bound is omitted
+ * rather than misreported as this cap.
  */
 export const MAX_RETRY_AFTER_SECONDS = 60;
 
@@ -60,6 +60,13 @@ function numericRetryAfterSeconds(inner: InstanceType<typeof APICallError>): num
     if (fromText !== undefined) return fromText;
   }
   return undefined;
+}
+
+function apiErrorIsPlanUsageLimit(inner: InstanceType<typeof APICallError>): boolean {
+  const error = (inner.data as { error?: { type?: unknown; code?: unknown } } | undefined)?.error;
+  return [error?.type, error?.code].some(value => (
+    typeof value === 'string' && value.toLowerCase().includes('usage_limit')
+  ));
 }
 
 // ── Provider stream error frames ────────────────────────────────────────────
@@ -132,11 +139,11 @@ function errorCodeValue(record: Record<string, unknown>): string | undefined {
 /**
  * Real HTTP status behind a frame.
  *
- * Deliberately mirrors `@ai-sdk/openai`'s own `getStatusCode`: substring
- * discriminators rather than an exact-match table, and 500 when nothing
- * matches. That keeps a mid-stream frame classified IDENTICALLY to the same
- * frame arriving pre-output (which the SDK maps itself), and it degrades
- * gracefully as OpenAI adds codes instead of silently falling out of date.
+ * Mirrors `@ai-sdk/openai`'s own `getStatusCode`: substring discriminators
+ * rather than an exact-match table, and 500 when nothing matches. clodex adds
+ * the plan-level `usage_limit` term because the OAuth Responses transport uses
+ * it for a real rate-limit condition. Apart from that documented extension,
+ * matching the SDK prevents a pre/post-output classification split.
  *
  * Always returning a status also matters for correctness, not just tidiness:
  * an undefined result would send the recovered message on to the prose
@@ -155,10 +162,10 @@ export function frameStatusCode(code: string | undefined, discriminator: string)
   // before any auth check and so reports 400 here exactly as it does in the
   // SDK. Diverging would reintroduce the pre/post-output split this avoids,
   // and an auth failure cannot reach a mid-stream frame anyway.
-  // `usage_limit` alongside the quota/rate classes: an exhausted plan is a real
-  // 429, and without it the discriminator falls through to the 500 default —
-  // which `frameIsRetryable` treats as transient, so the client spends its whole
-  // retry budget re-asking a question upstream has already answered.
+  // `usage_limit` belongs alongside the quota/rate classes: it surfaces an
+  // exhausted plan as 429/rate_limit_error and lets downstream receive an
+  // honest backoff hint when the stated reset fits the bounded hint policy.
+  // Both 429 and the 500 fallback are retryable; this mapping saves no attempts.
   if (/insufficient_quota|rate_limit|usage_limit/.test(discriminator)) return 429;
   if (discriminator.includes('authentication')) return 401;
   if (discriminator.includes('permission')) return 403;
@@ -250,6 +257,10 @@ export function providerErrorFrame(err: unknown): ProviderErrorFrame | undefined
         ? payload.retry_after_seconds
         : retryAfterFromText(message))
     : undefined;
+  const retryAfterSeconds = rawRetryAfter !== undefined
+    && (!discriminator.includes('usage_limit') || rawRetryAfter <= MAX_RETRY_AFTER_SECONDS)
+    ? clampRetryAfterSeconds(rawRetryAfter)
+    : undefined;
 
   let serialized: string;
   try {
@@ -263,7 +274,7 @@ export function providerErrorFrame(err: unknown): ProviderErrorFrame | undefined
     message,
     statusCode,
     contextLengthExceeded: frameIsContextLengthExceeded(discriminator, message),
-    ...(rawRetryAfter !== undefined ? { retryAfterSeconds: clampRetryAfterSeconds(rawRetryAfter) } : {}),
+    ...(retryAfterSeconds !== undefined ? { retryAfterSeconds } : {}),
     ...(code === 'websocket_transport_error' ? { transportCode: 'websocket_transport_error' as const } : {}),
     serialized,
   };
@@ -313,9 +324,10 @@ export function sdkUpstreamErrorDetails(err: unknown): SdkUpstreamErrorDetails |
   }
 
   const rawRetryAfter = inner.statusCode === 429 ? numericRetryAfterSeconds(inner) : undefined;
-  const retryAfterSeconds = rawRetryAfter === undefined
-    ? undefined
-    : clampRetryAfterSeconds(rawRetryAfter);
+  const retryAfterSeconds = rawRetryAfter !== undefined
+    && (!apiErrorIsPlanUsageLimit(inner) || rawRetryAfter <= MAX_RETRY_AFTER_SECONDS)
+    ? clampRetryAfterSeconds(rawRetryAfter)
+    : undefined;
   const transportCode = boundedTransportCode(inner.data);
 
   return {

--- a/tests/responses-websocket.test.ts
+++ b/tests/responses-websocket.test.ts
@@ -1037,6 +1037,9 @@ describe('createResponsesWebSocketFetch', () => {
     // The AI SDK strips unknown frame fields, so the hint only survives baked
     // into the message — which is how the consumer recovers it.
     expect(body).toContain('retry after 45s');
+    expect(await readErrorFrame(new Response(body))).toMatchObject({
+      error: { retry_after_seconds: 45 },
+    });
     expect(await classifyThroughSdk(body)).toMatchObject({
       statusCode: 429,
       isRetryable: true,
@@ -1227,10 +1230,12 @@ describe('createResponsesWebSocketFetch', () => {
     ['content_filter', { type: 'response.incomplete', response: { id: 'r', status: 'incomplete', incomplete_details: { reason: 'content_filter' } } }],
     ['max_output_tokens', { type: 'response.incomplete', response: { id: 'r', status: 'incomplete', incomplete_details: { reason: 'max_output_tokens' } } }],
     ['invalid_request_error', { type: 'response.failed', response: { id: 'r', status: 'failed', error: { type: 'invalid_request_error', message: 'bad' } } }],
-  ])('does not make a deterministic %s outcome retryable', async (_label, frame) => {
-    const verdict = await classifyThroughSdk(await failWith(frame));
+  ])('does not make a deterministic %s outcome retryable', async (label, frame) => {
+    const body = await failWith(frame);
+    const verdict = await classifyThroughSdk(body);
     expect(verdict).toMatchObject({ statusCode: 400 });
     expect(verdict?.isRetryable).toBe(false);
+    expect(body).toContain(label);
   });
 
   it('preserves a context-limit failure as 400 so auto-compaction still fires', async () => {
@@ -1279,7 +1284,28 @@ describe('createResponsesWebSocketFetch', () => {
     }
   });
 
-  it('carries an output-less usage-limit backoff in the message text', async () => {
+  it('normalizes a finite numeric code in diagnostics and classification', async () => {
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
+      onDiagnostic: event => diagnostics.push(event),
+    });
+    const res = await wsFetch('https://x', { method: 'POST', headers: {}, body: '{}' });
+    const socket = lastSocket();
+    socket.emit('open');
+    socket.emit('message', Buffer.from(JSON.stringify({
+      type: 'response.failed',
+      response: { id: 'r', status: 'failed', error: { code: 429, message: 'limited' } },
+    })));
+
+    const body = await readAll(res);
+    expect(await classifyThroughSdk(body)).toMatchObject({ statusCode: 429, isRetryable: true });
+    expect(diagnostics).toContainEqual(expect.objectContaining({
+      source: 'empty_failure_terminal',
+      errorCode: '429',
+    }));
+  });
+
+  it('carries a bounded output-less rate-limit backoff in the message text', async () => {
     // The AI SDK's chunk schema is a closed zod object that strips
     // `retry_after_seconds`, so a hint carried only in the frame field never
     // reaches the client — it has to be baked into the prose.
@@ -1288,13 +1314,30 @@ describe('createResponsesWebSocketFetch', () => {
       response: {
         id: 'r',
         status: 'failed',
-        error: { type: 'usage_limit_reached', message: 'weekly limit reached', retry_after_seconds: 1800 },
+        error: { type: 'rate_limit_exceeded', message: 'burst limit reached', retry_after_seconds: 1800 },
       },
     });
-    // Clamped to MAX_RETRY_AFTER_SECONDS: a hint of hours must not park the
-    // client past the 120s no-event stream abort.
+    // Ordinary rate-limit hints remain capped to keep clients within the
+    // transport's bounded retry window.
     expect(body).toContain('retry after 60s');
     expect(await classifyThroughSdk(body)).toMatchObject({ statusCode: 429, retryAfterSeconds: 60 });
+  });
+
+  it('omits an oversized plan-limit hint instead of claiming the 60s cap is the reset time', async () => {
+    const body = await failWith({
+      type: 'response.failed',
+      response: {
+        id: 'r',
+        status: 'failed',
+        error: { type: 'usage_limit_reached', message: 'weekly limit reached', retry_after_seconds: 21_600 },
+      },
+    });
+    const frame = await readErrorFrame(new Response(body));
+    expect(frame.error.type).toBe('rate_limit_error');
+    expect(frame.error.code).toBe('429');
+    expect(frame.error.retry_after_seconds).toBeUndefined();
+    expect(frame.error.message).not.toContain('retry after');
+    expect(await classifyThroughSdk(body)).toMatchObject({ statusCode: 429, isRetryable: true });
   });
 
   it('asserts no backoff upstream never stated', async () => {
@@ -1352,9 +1395,29 @@ describe('createResponsesWebSocketFetch', () => {
       },
     })));
 
-    // An exhausted account is not a server fault: 502 would spend the client's
-    // whole retry budget re-asking a question upstream has already answered.
-    expect(await classifyThroughSdk(await readAll(res))).toMatchObject({ statusCode: 429 });
+    // The mapping gives downstream the real rate-limit class. It does not save
+    // SDK attempts: both 429 and generic 5xx failures are retryable.
+    expect(await classifyThroughSdk(await readAll(res))).toMatchObject({
+      statusCode: 429,
+      isRetryable: true,
+    });
+  });
+
+  it('lets a specific usage-limit identifier outrank a generic HTTP failure status', async () => {
+    const body = await failWith({
+      type: 'error',
+      status: 500,
+      error: {
+        type: 'usage_limit_reached',
+        code: 'server_error',
+        message: 'private plan-limit explanation',
+      },
+    });
+    const frame = await readErrorFrame(new Response(body));
+    expect(frame.error.type).toBe('rate_limit_error');
+    expect(frame.error.code).toBe('429');
+    expect(frame.error.message).toBe('private plan-limit explanation');
+    expect(await classifyThroughSdk(body)).toMatchObject({ statusCode: 429, isRetryable: true });
   });
 
   it('keeps a content-free fingerprint of what upstream actually said', async () => {
@@ -1386,7 +1449,8 @@ describe('createResponsesWebSocketFetch', () => {
     expect(record!.upstreamMessageBytes).toBe(29);
     expect(record!.upstreamMessageHash).toMatch(/^[a-f0-9]{16}$/);
     // ...alongside, not instead of, the fingerprint of what the client was told.
-    expect(record!.errorMessageBytes).not.toBe(29);
+    const expectedSummary = 'OpenAI ended the response with no output (server_error)';
+    expect(record!.errorMessageBytes).toBe(Buffer.byteLength(expectedSummary));
     expect(JSON.stringify(record)).not.toContain('sensitive backend explanation');
   });
 
@@ -3353,11 +3417,14 @@ describe('createResponsesWebSocketFetch', () => {
     }));
   });
 
-  it('still logs a retried rejection, which no error_frame record covers', async () => {
-    // The retry frame carries a 400, so the rejection branch would claim it if
-    // the willRetry arm of the diagnostic gate were dropped — and because the
-    // retry returns before that branch, the failure would then be logged
-    // NOWHERE. This pins the arm that prevents it.
+  it.each([
+    ['status-bearing', 400],
+    ['status-less', undefined],
+  ])('still logs a retried %s rejection, which no error_frame record covers', async (_label, status) => {
+    // The rejection branch would claim the status-bearing frame if the
+    // willRetry arm of the diagnostic gate were dropped, while the status-less
+    // frame would miss both records. Because retry returns before either branch,
+    // both would then be logged NOWHERE. These rows pin the arm that prevents it.
     const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
     const input = [{ role: 'user', content: [{ type: 'input_text', text: 'one' }] }];
     const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
@@ -3382,7 +3449,8 @@ describe('createResponsesWebSocketFetch', () => {
       ])),
     });
     firstSocket.emit('message', Buffer.from(JSON.stringify({
-      type: 'error', status: 400,
+      type: 'error',
+      ...(status === undefined ? {} : { status }),
       error: { code: 'previous_response_not_found', message: 'gone' },
     })));
     const replacement = lastSocket();

--- a/tests/responses-websocket.test.ts
+++ b/tests/responses-websocket.test.ts
@@ -1098,6 +1098,33 @@ describe('createResponsesWebSocketFetch', () => {
     expect(verdict?.retryAfterSeconds).toBeUndefined();
   });
 
+  it('keeps an authoritative 403 alongside the plan-limit identity it names', async () => {
+    // Unlike the generic 5xx fallback, a deterministic 4xx status stays the
+    // mapped status: the synthetic `type` still names the plan class, while
+    // `code` carries the 403 the SDK classifies as non-retryable.
+    const wsFetch = createResponsesWebSocketFetch(WS_URL);
+    const res = await wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload([])),
+    });
+    const socket = lastSocket();
+    socket.emit('open');
+    socket.emit('message', Buffer.from(JSON.stringify({
+      type: 'error',
+      error: { type: 'usage_limit_reached', message: 'plan limit; not authorized' },
+      status: 403,
+    })));
+
+    const body = await readAll(res);
+    const frame = await readErrorFrame(new Response(body));
+    expect(frame.error.type).toBe('usage_limit_reached');
+    expect(frame.error.code).toBe('403');
+    expect(frame.error.retry_after_seconds).toBeUndefined();
+    expect(frame.error.message).not.toContain('retry after');
+    const verdict = await classifyThroughSdk(body);
+    expect(verdict).toMatchObject({ statusCode: 403, isRetryable: false });
+    expect(verdict?.retryAfterSeconds).toBeUndefined();
+  });
+
   it('states no backoff hint on a 429 when upstream gave none', async () => {
     const wsFetch = createResponsesWebSocketFetch(WS_URL);
     const res = await wsFetch('https://x', {
@@ -1118,6 +1145,62 @@ describe('createResponsesWebSocketFetch', () => {
     // send the client back long before the limit resets.
     expect(body).not.toContain('retry after');
     expect(await classifyThroughSdk(body)).toMatchObject({ statusCode: 429 });
+  });
+
+  it('does not fabricate a five-second hint from a negative in-band backoff', async () => {
+    // clampRetryAfterSeconds turns a negative value into the 5s default, which
+    // would invent a hint upstream never gave; the gate rejects it instead.
+    const wsFetch = createResponsesWebSocketFetch(WS_URL);
+    const res = await wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload([])),
+    });
+    const socket = lastSocket();
+    socket.emit('open');
+    socket.emit('message', Buffer.from(JSON.stringify({
+      type: 'error',
+      error: { type: 'rate_limit_error', message: 'slow down', retry_after_seconds: -5 },
+      status: 429,
+    })));
+
+    const body = await readAll(res);
+    expect(body).not.toContain('retry after');
+    const verdict = await classifyThroughSdk(body);
+    expect(verdict).toMatchObject({ statusCode: 429, isRetryable: true });
+    expect(verdict?.retryAfterSeconds).toBeUndefined();
+  });
+
+  it.each([
+    ['a fractional plan-limit hint', {
+      type: 'error',
+      error: { type: 'usage_limit_reached', message: 'plan limit', retry_after_seconds: 60.4 },
+      status: 429,
+    }, undefined],
+    ['a fractional ordinary hint', {
+      type: 'error',
+      error: { type: 'rate_limit_error', message: 'burst limit', retry_after_seconds: 60.4 },
+      status: 429,
+    }, 60],
+  ] as const)('pins the raw 60.4 policy for %s', async (_label, frame, expectedHint) => {
+    const wsFetch = createResponsesWebSocketFetch(WS_URL);
+    const res = await wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload([])),
+    });
+    const socket = lastSocket();
+    socket.emit('open');
+    socket.emit('message', Buffer.from(JSON.stringify(frame)));
+
+    const body = await readAll(res);
+    const wire = await readErrorFrame(new Response(body));
+    expect(wire.error.code).toBe('429');
+    if (expectedHint === undefined) {
+      // Raw 60.4 is above the plan-limit cap, so the hint is omitted whole.
+      expect(wire.error.retry_after_seconds).toBeUndefined();
+      expect(wire.error.message).not.toContain('retry after');
+    } else {
+      // Ordinary rate-limit hints round, then clamp, to the transport bound.
+      expect(wire.error.retry_after_seconds).toBe(expectedHint);
+      expect(wire.error.message).toContain('retry after 60s');
+    }
   });
 
   it('reads a status nested under error, not only the top-level one', async () => {
@@ -1373,6 +1456,27 @@ describe('createResponsesWebSocketFetch', () => {
     expect(verdict?.retryAfterSeconds).toBeUndefined();
   });
 
+  it('preserves plan identity from a code-only usage-limit terminal', async () => {
+    // No `type` at all: the plan class travels in `code`, and the synthetic
+    // frame still names it in `type` while `code` carries the mapped 429.
+    const body = await failWith({
+      type: 'response.failed',
+      response: {
+        id: 'r',
+        status: 'failed',
+        error: { code: 'usage_limit_reached', message: 'plan limit reached', retry_after_seconds: 21_600 },
+      },
+    });
+    const frame = await readErrorFrame(new Response(body));
+    expect(frame.error.type).toBe('usage_limit_reached');
+    expect(frame.error.code).toBe('429');
+    expect(frame.error.retry_after_seconds).toBeUndefined();
+    expect(frame.error.message).not.toContain('retry after');
+    const verdict = await classifyThroughSdk(body);
+    expect(verdict).toMatchObject({ statusCode: 429, isRetryable: true });
+    expect(verdict?.retryAfterSeconds).toBeUndefined();
+  });
+
   it('asserts no backoff upstream never stated', async () => {
     const body = await failWith({
       type: 'response.failed',
@@ -1380,6 +1484,51 @@ describe('createResponsesWebSocketFetch', () => {
     });
     expect(body).not.toContain('retry after');
     expect(await classifyThroughSdk(body)).toMatchObject({ statusCode: 429 });
+  });
+
+  it('does not fabricate a five-second hint from a negative output-less backoff', async () => {
+    const body = await failWith({
+      type: 'response.failed',
+      response: {
+        id: 'r',
+        status: 'failed',
+        error: { type: 'rate_limit_exceeded', message: 'burst limit reached', retry_after_seconds: -5 },
+      },
+    });
+    expect(body).not.toContain('retry after');
+    const verdict = await classifyThroughSdk(body);
+    expect(verdict).toMatchObject({ statusCode: 429, isRetryable: true });
+    expect(verdict?.retryAfterSeconds).toBeUndefined();
+  });
+
+  it.each([
+    ['a fractional plan-limit hint', {
+      type: 'response.failed',
+      response: {
+        id: 'r',
+        status: 'failed',
+        error: { type: 'usage_limit_reached', message: 'plan limit reached', retry_after_seconds: 60.4 },
+      },
+    }, undefined],
+    ['a fractional ordinary hint', {
+      type: 'response.failed',
+      response: {
+        id: 'r',
+        status: 'failed',
+        error: { type: 'rate_limit_exceeded', message: 'burst limit reached', retry_after_seconds: 60.4 },
+      },
+    }, 60],
+  ] as const)('pins the raw 60.4 policy for %s', async (_label, frame, expectedHint) => {
+    const body = await failWith(frame);
+    if (expectedHint === undefined) {
+      // Raw 60.4 is above the plan-limit cap, so the hint is omitted whole.
+      expect(body).not.toContain('retry after');
+      expect(await classifyThroughSdk(body)).toMatchObject({ statusCode: 429 });
+    } else {
+      // Ordinary rate-limit hints round, then clamp, to the transport bound.
+      expect(body).toContain('retry after 60s');
+      expect(await classifyThroughSdk(body)).toMatchObject({ statusCode: 429, retryAfterSeconds: 60 });
+    }
   });
 
   it('never carries upstream failure prose to the log OR the client', async () => {

--- a/tests/responses-websocket.test.ts
+++ b/tests/responses-websocket.test.ts
@@ -1071,6 +1071,33 @@ describe('createResponsesWebSocketFetch', () => {
     expect(await readAll(res)).toContain('retry after 60s');
   });
 
+  it('does not reinterpret an oversized status-bearing plan reset after SDK classification', async () => {
+    const wsFetch = createResponsesWebSocketFetch(WS_URL);
+    const res = await wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload([])),
+    });
+    const socket = lastSocket();
+    socket.emit('open');
+    socket.emit('message', Buffer.from(JSON.stringify({
+      type: 'error',
+      error: {
+        type: 'usage_limit_reached',
+        message: 'Usage limit reached; retry after 21600s',
+        retry_after_seconds: 21_600,
+      },
+      status: 429,
+    })));
+
+    const body = await readAll(res);
+    const frame = await readErrorFrame(new Response(body));
+    expect(frame.error.type).toBe('usage_limit_reached');
+    expect(frame.error.code).toBe('429');
+    expect(frame.error.retry_after_seconds).toBeUndefined();
+    const verdict = await classifyThroughSdk(body);
+    expect(verdict).toMatchObject({ statusCode: 429, isRetryable: true });
+    expect(verdict?.retryAfterSeconds).toBeUndefined();
+  });
+
   it('states no backoff hint on a 429 when upstream gave none', async () => {
     const wsFetch = createResponsesWebSocketFetch(WS_URL);
     const res = await wsFetch('https://x', {
@@ -1329,15 +1356,21 @@ describe('createResponsesWebSocketFetch', () => {
       response: {
         id: 'r',
         status: 'failed',
-        error: { type: 'usage_limit_reached', message: 'weekly limit reached', retry_after_seconds: 21_600 },
+        error: {
+          type: 'usage_limit_reached',
+          message: 'weekly limit reached; retry after 21600s',
+          retry_after_seconds: 21_600,
+        },
       },
     });
     const frame = await readErrorFrame(new Response(body));
-    expect(frame.error.type).toBe('rate_limit_error');
+    expect(frame.error.type).toBe('usage_limit_reached');
     expect(frame.error.code).toBe('429');
     expect(frame.error.retry_after_seconds).toBeUndefined();
     expect(frame.error.message).not.toContain('retry after');
-    expect(await classifyThroughSdk(body)).toMatchObject({ statusCode: 429, isRetryable: true });
+    const verdict = await classifyThroughSdk(body);
+    expect(verdict).toMatchObject({ statusCode: 429, isRetryable: true });
+    expect(verdict?.retryAfterSeconds).toBeUndefined();
   });
 
   it('asserts no backoff upstream never stated', async () => {
@@ -1414,7 +1447,7 @@ describe('createResponsesWebSocketFetch', () => {
       },
     });
     const frame = await readErrorFrame(new Response(body));
-    expect(frame.error.type).toBe('rate_limit_error');
+    expect(frame.error.type).toBe('usage_limit_reached');
     expect(frame.error.code).toBe('429');
     expect(frame.error.message).toBe('private plan-limit explanation');
     expect(await classifyThroughSdk(body)).toMatchObject({ statusCode: 429, isRetryable: true });

--- a/tests/upstream-error.test.ts
+++ b/tests/upstream-error.test.ts
@@ -107,6 +107,36 @@ describe('sdkUpstreamErrorDetails retry-after extraction', () => {
     expect(details).toMatchObject({ statusCode: 429, isRetryable: true });
     expect(details?.retryAfterSeconds).toBeUndefined();
   });
+
+  it('detects a usage limit whose discriminator survives only in the serialized body', () => {
+    // The SDK may serialize the error body into responseBody without also
+    // populating `data`; the usage-limit signal then lives only in that JSON,
+    // so the classifier must read the same structured payload both consumers
+    // use. Misread, the oversized retry-after below would be clamped to 60s
+    // instead of omitted.
+    const details = sdkUpstreamErrorDetails(apiCallError({
+      statusCode: 429,
+      responseBody: JSON.stringify({
+        error: {
+          type: 'usage_limit_reached',
+          code: 'usage_limit_reached',
+          message: 'Weekly usage limit reached',
+        },
+      }),
+      responseHeaders: { 'retry-after': '21600' },
+    }));
+    expect(details).toMatchObject({ statusCode: 429, isRetryable: true });
+    expect(details?.retryAfterSeconds).toBeUndefined();
+  });
+
+  it('treats a malformed serialized body as absent instead of crashing the classifier', () => {
+    const details = sdkUpstreamErrorDetails(apiCallError({
+      statusCode: 429,
+      responseBody: 'not json {',
+      responseHeaders: { 'retry-after': '3600' },
+    }));
+    expect(details).toMatchObject({ statusCode: 429, isRetryable: true, retryAfterSeconds: 60 });
+  });
 });
 
 describe('usage-limit classification', () => {

--- a/tests/upstream-error.test.ts
+++ b/tests/upstream-error.test.ts
@@ -108,12 +108,31 @@ describe('sdkUpstreamErrorDetails retry-after extraction', () => {
     expect(details?.retryAfterSeconds).toBeUndefined();
   });
 
+  it('omits the capped hint for a code-only plan-limit signal with no type discriminator', () => {
+    // `apiErrorIsPlanUsageLimit` accepts either the `type` or the `code`, so
+    // the code alone must be enough to trigger the omission — the plan-limit
+    // signal survives without any `type` on the payload.
+    const details = sdkUpstreamErrorDetails(apiCallError({
+      statusCode: 429,
+      data: {
+        error: {
+          code: 'usage_limit_reached',
+          message: 'Weekly usage limit reached',
+          retry_after_seconds: 21_600,
+        },
+      },
+    }));
+    expect(details).toMatchObject({ statusCode: 429, isRetryable: true });
+    expect(details?.retryAfterSeconds).toBeUndefined();
+  });
+
   it('detects a usage limit whose discriminator survives only in the serialized body', () => {
-    // The SDK may serialize the error body into responseBody without also
-    // populating `data`; the usage-limit signal then lives only in that JSON,
-    // so the classifier must read the same structured payload both consumers
-    // use. Misread, the oversized retry-after below would be clamped to 60s
-    // instead of omitted.
+    // The responseBody fallback exists for malformed or non-conforming bodies:
+    // the SDK's JSON error handler populates `data` for any schema-valid body,
+    // whose error schema requires the message. When the usage-limit signal does
+    // survive only in the serialized body, the classifier must still read the
+    // same structured payload both consumers use. Misread, the oversized
+    // retry-after below would be clamped to 60s instead of omitted.
     const details = sdkUpstreamErrorDetails(apiCallError({
       statusCode: 429,
       responseBody: JSON.stringify({
@@ -127,6 +146,25 @@ describe('sdkUpstreamErrorDetails retry-after extraction', () => {
     }));
     expect(details).toMatchObject({ statusCode: 429, isRetryable: true });
     expect(details?.retryAfterSeconds).toBeUndefined();
+  });
+
+  it('lets a parsed body retry hint win over a conflicting retry-after header', () => {
+    // numericRetryAfterSeconds reads the parsed body before the header, so the
+    // body's in-bounds plan-limit hint is kept (the exemption only omits hints
+    // above the cap) while the capped header is never consulted.
+    const details = sdkUpstreamErrorDetails(apiCallError({
+      statusCode: 429,
+      responseBody: JSON.stringify({
+        error: {
+          type: 'usage_limit_reached',
+          code: 'usage_limit_reached',
+          message: 'Weekly usage limit reached',
+          retry_after_seconds: 30,
+        },
+      }),
+      responseHeaders: { 'retry-after': '21600' },
+    }));
+    expect(details).toMatchObject({ statusCode: 429, isRetryable: true, retryAfterSeconds: 30 });
   });
 
   it('treats a malformed serialized body as absent instead of crashing the classifier', () => {
@@ -157,6 +195,29 @@ describe('usage-limit classification', () => {
       attemptCount: 1,
     });
     expect(anthropicErrorType(details!.statusCode!)).toBe('rate_limit_error');
+  });
+
+  it('omits the backoff hint for a raw usage-limit frame even when its prose carries one', () => {
+    // The plan-limit exemption applies on the frame path too: an oversized
+    // reset stated only in message prose is omitted, never clamped.
+    const details = sdkUpstreamErrorDetails({
+      type: 'usage_limit_reached',
+      code: 'usage_limit_reached',
+      message: 'Weekly usage limit reached; retry after 3600s',
+    });
+    expect(details).toMatchObject({ statusCode: 429, isRetryable: true });
+    expect(details?.retryAfterSeconds).toBeUndefined();
+  });
+
+  it('clamps the same oversized prose hint on an ordinary rate-limit frame', () => {
+    // The control: an equivalent plain rate limit with the same oversized hint
+    // is an ordinary throttle and still clamps to 60s.
+    const details = sdkUpstreamErrorDetails({
+      type: 'rate_limit_exceeded',
+      code: 'rate_limit_exceeded',
+      message: 'Rate limit reached; retry after 3600s',
+    });
+    expect(details).toMatchObject({ statusCode: 429, isRetryable: true, retryAfterSeconds: 60 });
   });
 });
 

--- a/tests/upstream-error.test.ts
+++ b/tests/upstream-error.test.ts
@@ -4,6 +4,7 @@ import {
   anthropicErrorType,
   clampRetryAfterSeconds,
   formatUpstreamError,
+  frameStatusCode,
   isContextLengthExceededError,
   sdkUpstreamErrorDetails,
   upstreamHttpStatus,
@@ -89,6 +90,43 @@ describe('sdkUpstreamErrorDetails retry-after extraction', () => {
     }));
     expect(details?.statusCode).toBe(500);
     expect(details?.retryAfterSeconds).toBeUndefined();
+  });
+
+  it('omits a misleading capped HTTP backoff for a plan-level usage limit', () => {
+    const details = sdkUpstreamErrorDetails(apiCallError({
+      statusCode: 429,
+      data: {
+        error: {
+          type: 'usage_limit_reached',
+          code: 'usage_limit_reached',
+          message: 'Weekly usage limit reached',
+          retry_after_seconds: 21_600,
+        },
+      },
+    }));
+    expect(details).toMatchObject({ statusCode: 429, isRetryable: true });
+    expect(details?.retryAfterSeconds).toBeUndefined();
+  });
+});
+
+describe('usage-limit classification', () => {
+  it('maps the clodex-specific usage-limit signal to retryable 429 semantics', () => {
+    expect(frameStatusCode(undefined, 'usage_limit_reached')).toBe(429);
+    expect(frameStatusCode(undefined, 'server_error usage_limit_reached')).toBe(429);
+
+    const details = sdkUpstreamErrorDetails({
+      type: 'usage_limit_reached',
+      code: 'usage_limit_reached',
+      message: 'Weekly usage limit reached',
+      retry_after_seconds: 30,
+    });
+    expect(details).toMatchObject({
+      statusCode: 429,
+      isRetryable: true,
+      retryAfterSeconds: 30,
+      attemptCount: 1,
+    });
+    expect(anthropicErrorType(details!.statusCode!)).toBe('rate_limit_error');
   });
 });
 


### PR DESCRIPTION
Follow-up to #96.

## Summary

- correct the durable mechanism narrative: mapping `usage_limit` does not save retry attempts because both 429 and 5xx remain retryable
- retain the ordinary 60-second retry-after cap while omitting oversized plan-level reset claims rather than falsely reporting 60 seconds
- let structured `usage_limit` override generic 5xx classification while preserving explicit deterministic 4xx authority
- normalize finite numeric WebSocket diagnostic identifiers to bounded strings
- pin HTTP and WebSocket status/retry/header/body/log/summary behavior, including output-less terminal summaries and both forms of `previous_response_not_found`
- remove one proven redundant fallback without broadening unverified classifier rules

`resets_in_seconds` remains unchanged because no captured provider frame verifies that shape. No speculative chunk-discriminator rule was introduced.

For the current bundled client, omitting the misleading `retry-after: 60` leaves the configured retry count unchanged but restores its normal exponential spacing—about 1.125–1.5 seconds total for the default two retries instead of 120 seconds.

## Review provenance

This branch is based directly on current upstream v2.4.0 (`ad907a54`). Its complete diff remains exactly four files: `src/upstream-error.ts`, `src/oauth/responses-websocket.ts`, and their two direct test files.

The original fork review found the same plan-limit discriminator-loss family at two representation boundaries. The required whole-family exhaustion audit mechanically enumerated every `usage_limit` / `rate_limit_error` occurrence, retry field/prose parser, all six WebSocket synthetic-error construction routes, status-bearing/status-less terminal paths, and `data` / serialized-`responseBody` parser. The mechanically bounded class was exhausted with no unresolved members; the complete upstream-error file and targeted WebSocket transition logic were judgment-checked.

The maintainer review's four independently removable classifier branches and applicable optional edges were resolved fork-first in [zachspartofaday/clodex#44](https://github.com/zachspartofaday/clodex/pull/44). Exact source head `746c0c5115fc5f464f5086f3b052df91dd583512` received a clean serialized Codex result; the validated fork merge advanced this upstream PR to `76462b7f7ee3fe103a39c41c91846ca795354512`.

## Validation

Node 24.19.0 / pnpm 10.34.5 with ambient `CLODEX_*` and proxy variables removed:

- focused upstream-error/WebSocket suite: 2 files / 169 tests passed
- `pnpm typecheck`: passed
- `pnpm test`: 85 files / 1,391 tests passed
- `pnpm build`: passed
- `git diff --check ad907a5436a13cc807e988ad5b4dff0437483d36..HEAD`: passed

Targeted falsifiers confirmed the new tests fail if either non-negative retry-hint gate is removed. No existing assertion was weakened.

## Safety

- synthetic fixtures only; no live provider traffic, credential mutation, or raw-log publication
- no WebSocket continuation restructuring, post-output replay, or parallel classifier/redaction path
- no dependency, package, lock, release, registry/auth, generated-catalog, or committed `dist/` changes
