### PR TITLE
fix(patch): restore patching on Claude Code 2.1.228 so model aliases work again

### DIFF
--- a/.claude/docs/claude-code-internals.md
+++ b/.claude/docs/claude-code-internals.md
@@ -58,6 +58,13 @@ only behavioural gate — but the bundle already renders `model-default` as a fi
 `pH()` is the shared child-env builder, with 14 call sites. The split that matters for bridge
 isolation:
 
+**Its minified name and declarator list change release to release** — `pH()` in 2.1.221, `XH()` in
+2.1.224, `$M()` in 2.1.226, `o1()` in 2.1.228, which also hoisted the settings-colour env into its
+own binding (`r=<mod>.settingsColorEnv`) inside the opening `let`. That is why PATCH 10's anchor
+identifies the function by the landmarks inside its body — the `CLAUDE_CODE_REMOTE` ternary, the
+`INPUT_${…}` deletion tail, and the required-literal check — and tolerates declarator drift ahead of
+the ternary rather than counting bindings.
+
 - **Shell-mediated** (reachable from a `.zshenv`-style user snippet): the Bash tool, hooks, subagent
   status line, the shell snapshot/env probe.
 - **Direct binary spawns** (no shell, unreachable from any rc file): stdio MCP servers, LSP servers,

--- a/.claude/harnesses/README.md
+++ b/.claude/harnesses/README.md
@@ -26,6 +26,7 @@ Several need real Claude Code bundles. Extract them once with
 | `pr78-patch10-anchor-over-real-bundles` | PATCH 10's anchor self-identifies the child-env builder across every real bundle — match count, bound function, matched span, and that no rewritten `process.env` reference escapes the declaring function. Extracts the regex from `patch-transforms.ts` so it cannot drift. The default first move on any anchor PR. |
 | `pr78-patch10-wrong-target-mutations` | The three wrong-target classes — preceding decoy, token-bearing neighbour, nested named function — plus a `vm.Script` parse of the patched output. |
 | `pr78-patch10-execute-real-builder` | Extracts the *patched* builder out of a real bundle and **executes** it with stubs. Reading a regex replacement is not evidence the code runs. |
+| `cc228-patch10-execute-real-builder` | The same execution proof against the real 2.1.228 bundle, whose builder gained a declarator and broke the anchor. Recovers every free identifier from the builder's own text, so a name it fails to account for is a ReferenceError rather than a vacuous pass. Copy this one when a new release moves the builder again. |
 | `pr78-r3-audit-proof-publication` | What actually reaches `writeContent`, driving the real `applyLocalPatchSet` → `builtInPatchProofsChanged` → `applyPatch` chain — a publication guarantee proven without repacking 250 MB. Self-contained. |
 | `pr78-r3-audit-partial-drift` | A required literal appearing twice means migrating only one occurrence still validates. A one-occurrence fixture cannot show this. |
 

--- a/.claude/harnesses/cc228-patch10-execute-real-builder.harness.ts
+++ b/.claude/harnesses/cc228-patch10-execute-real-builder.harness.ts
@@ -118,6 +118,16 @@ const CONTRACT = JSON.stringify({
   injected: { HTTPS_PROXY: 'http://127.0.0.1:49653', NODE_EXTRA_CA_CERTS: '/home/u/.clodex/ca.pem' },
 });
 
+// Without REVIEW_BUNDLE_DIR the whole suite skips, which is the intended way to
+// run the rest of the folder. But a dir that is SET and holds no 2.1.228 bundle
+// is a mistake — skipping there reports 19 green-looking skips for a proof that
+// never ran.
+describe.runIf(BUNDLE_DIR)('bundle availability', () => {
+  it('finds a 2.1.228 bundle in REVIEW_BUNDLE_DIR', () => {
+    expect(BUNDLE, `no *2.1.228*.js in ${BUNDLE_DIR}`).toBeTruthy();
+  });
+});
+
 describe.skipIf(!pristine)('Claude Code 2.1.228 — the patched builder, executed', () => {
   it('applies every patch site, PATCH 10 included', () => {
     const out = applyClodexPatches(pristine, CONFIG);

--- a/.claude/harnesses/cc228-patch10-execute-real-builder.harness.ts
+++ b/.claude/harnesses/cc228-patch10-execute-real-builder.harness.ts
@@ -1,0 +1,207 @@
+// REVIEW HARNESS (not for merge) — Claude Code 2.1.228 PATCH 10 anchor repair.
+//
+// 2.1.228 hoisted the settings-colour env into its own declarator inside the
+// child-env builder's `let` statement, so an anchor that counted declarators
+// reported "anchor not found" and — PATCH 10 being required — `clodex patch`
+// refused to patch 2.1.228 at all.
+//
+// This drives the REAL applyClodexPatches over the REAL 2.1.228 bundle, then
+// EXTRACTS the patched builder and EXECUTES it. Reading a regex replacement is
+// not evidence the code runs. Every free identifier is bound explicitly, so a
+// name the harness failed to account for surfaces as a ReferenceError rather
+// than passing silently.
+//
+//   REVIEW_BUNDLE_DIR=<bundle dir> pnpm vitest run --config vitest.harness.config.ts \
+//     .claude/harnesses/cc228-patch10-execute-real-builder.harness.ts
+//
+// `node scripts/extract-cc-bundles.mjs` fills the bundle dir from the pristine
+// *.orig backups; a version never patched on this machine has no backup yet, so
+// extract that one straight from ~/.local/share/claude/versions/<v> (it is
+// pristine by definition) with the same tweakcc `readContent` call.
+import { describe, expect, it } from 'vitest';
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import vm from 'node:vm';
+import { applyClodexPatches } from '../../src/patch-transforms.js';
+import { NETWORK_ENV_CONTRACT_VAR } from '../../src/network-env.js';
+
+const BUNDLE_DIR = process.env['REVIEW_BUNDLE_DIR'] ?? '';
+const MARKER = '/*ccpatch:child-network-env*/';
+const CONFIG = { 'clodex:openai:gpt-5.6-sol': { alias: 'sol', display: 'GPT-5.6 Sol' } };
+
+function findBundle(): string | null {
+  if (!BUNDLE_DIR || !existsSync(BUNDLE_DIR)) return null;
+  const hit = readdirSync(BUNDLE_DIR).find(f => f.includes('2.1.228') && f.endsWith('.js'));
+  return hit ? join(BUNDLE_DIR, hit) : null;
+}
+
+const BUNDLE = findBundle();
+const pristine = BUNDLE ? readFileSync(BUNDLE, 'utf8') : '';
+const patched = pristine ? applyClodexPatches(pristine, CONFIG).content : '';
+
+function patchedBuilderSource(): string {
+  const at = patched.indexOf(MARKER);
+  expect(at, 'patch marker present').toBeGreaterThan(-1);
+  const declStart = patched.slice(0, at).lastIndexOf('function ');
+  let depth = 0;
+  const open = patched.indexOf('{', declStart);
+  for (let i = open; i < patched.length; i++) {
+    if (patched[i] === '{') depth++;
+    else if (patched[i] === '}') {
+      depth--;
+      if (depth === 0) return patched.slice(declStart, i + 1);
+    }
+  }
+  throw new Error('unbalanced');
+}
+
+/** Every free identifier the 2.1.228 builder reads, recovered from its own text. */
+function freeNames(builder: string): Record<string, string> {
+  const pick = (label: string, re: RegExp, group = 1): string => {
+    const m = builder.match(re);
+    expect(m, `could not locate ${label}`).toBeTruthy();
+    return m![group]!;
+  };
+  return {
+    injected: pick('injected-env builder', /\*\/[\s\S]*?\}let ([\w$]+)=([\w$]+)\(\),/, 2),
+    settings: pick('settings-colour env holder', /,[\w$]+=([\w$]+)\.settingsColorEnv,/),
+    remoteFlag: pick('remote flag', /=([\w$]+)\(_clodexChildEnv\.CLAUDE_CODE_REMOTE\)\?/),
+    remoteEnv: pick('remote env builder', /\(_clodexChildEnv\.CLAUDE_CODE_REMOTE\)\?([\w$]+)\(/),
+    scrubFlag: pick(
+      'credential-scrub flag',
+      /,[\w$]+=([\w$]+)\(\),[\w$]+=_clodexChildEnv\.CLAUDE_CODE_OAUTH_TOKEN/,
+    ),
+    predicateA: pick('secret predicate A', /if\(([\w$]+)\([\w$]+\)\|\|([\w$]+)\([\w$]+\)\)delete/, 1),
+    predicateB: pick('secret predicate B', /if\(([\w$]+)\([\w$]+\)\|\|([\w$]+)\([\w$]+\)\)delete/, 2),
+    denyList: pick('dynamic deny list', /,[\w$]+=([\w$]+)\(_clodexChildEnv\),/),
+    staticList: pick('static deny list', /=([\w$]+)\.some\(\(/),
+    inputList: pick(
+      'action-input deny list',
+      /for\(let [\w$]+ of ([\w$]+)\)delete [\w$]+\[[\w$]+\],delete [\w$]+\[`INPUT_/,
+    ),
+    liveEnv: pick('live env accessor', /([\w$]+)\.CLAUDE_BG_SOCKET_TOKENS_PATH/),
+  };
+}
+
+interface Scenario {
+  scrub?: boolean;
+  /** Extra keys the static deny list should strip, proving native filtering survives. */
+  staticDeny?: string[];
+}
+
+function runBuilder(env: Record<string, string>, opts: Scenario = {}): Record<string, string> {
+  const builder = patchedBuilderSource();
+  const names = freeNames(builder);
+  const bindings: Record<string, unknown> = {
+    process: { env },
+    [names['injected']!]: () => ({}),
+    [names['settings']!]: { settingsColorEnv: {} },
+    [names['remoteFlag']!]: () => false,
+    [names['remoteEnv']!]: (x: unknown) => x,
+    [names['scrubFlag']!]: () => Boolean(opts.scrub),
+    [names['predicateA']!]: () => false,
+    [names['predicateB']!]: () => false,
+    [names['denyList']!]: () => [],
+    [names['staticList']!]: opts.staticDeny ?? [],
+    [names['inputList']!]: ['ANTHROPIC_API_KEY'],
+    [names['liveEnv']!]: env,
+  };
+  const params = Object.keys(bindings);
+  const factory = new Function(...params, `return (${builder})`);
+  const fn = factory(...params.map(p => bindings[p])) as () => Record<string, string>;
+  return fn();
+}
+
+const CONTRACT = JSON.stringify({
+  version: 1,
+  original: { HTTPS_PROXY: 'http://corp-proxy:3128', NODE_EXTRA_CA_CERTS: null },
+  injected: { HTTPS_PROXY: 'http://127.0.0.1:49653', NODE_EXTRA_CA_CERTS: '/home/u/.clodex/ca.pem' },
+});
+
+describe.skipIf(!pristine)('Claude Code 2.1.228 — the patched builder, executed', () => {
+  it('applies every patch site, PATCH 10 included', () => {
+    const out = applyClodexPatches(pristine, CONFIG);
+    expect(out.results.filter(r => r.status !== 'OK')).toEqual([]);
+    expect(out.content.match(/\/\*ccpatch:child-network-env\*\//g)).toHaveLength(1);
+  });
+
+  it('produces a bundle that still parses', () => {
+    expect(() => new vm.Script(patched)).not.toThrow();
+  });
+
+  it('binds the builder that owns the settings-colour declarator', () => {
+    const builder = patchedBuilderSource();
+    expect(builder).toContain('.settingsColorEnv');
+    // No rewritten reference may escape the declaring function.
+    expect(patched.split('_clodexChildEnv').length - 1)
+      .toBe(builder.split('_clodexChildEnv').length - 1);
+  });
+
+  it('early-return branch: reverts to the external proxy and drops the CA + contract', () => {
+    const out = runBuilder({
+      PATH: '/usr/bin',
+      HTTPS_PROXY: 'http://127.0.0.1:49653',
+      NODE_EXTRA_CA_CERTS: '/home/u/.clodex/ca.pem',
+      [NETWORK_ENV_CONTRACT_VAR]: CONTRACT,
+    });
+    expect(out['HTTPS_PROXY']).toBe('http://corp-proxy:3128');
+    expect(out['NODE_EXTRA_CA_CERTS']).toBeUndefined();
+    expect(out[NETWORK_ENV_CONTRACT_VAR]).toBeUndefined();
+    expect(out['PATH']).toBe('/usr/bin');
+  });
+
+  it('full-copy branch (credential scrub) also reverts and still scrubs secrets', () => {
+    const out = runBuilder({
+      PATH: '/usr/bin',
+      ANTHROPIC_API_KEY: 'sk-secret',
+      CLAUDE_CODE_OAUTH_TOKEN: 'oauth-secret',
+      HTTPS_PROXY: 'http://127.0.0.1:49653',
+      NODE_EXTRA_CA_CERTS: '/home/u/.clodex/ca.pem',
+      [NETWORK_ENV_CONTRACT_VAR]: CONTRACT,
+    }, { scrub: true, staticDeny: ['ANTHROPIC_API_KEY'] });
+    expect(out['HTTPS_PROXY']).toBe('http://corp-proxy:3128');
+    expect(out['NODE_EXTRA_CA_CERTS']).toBeUndefined();
+    expect(out[NETWORK_ENV_CONTRACT_VAR]).toBeUndefined();
+    expect(out['ANTHROPIC_API_KEY'], 'native filtering still runs').toBeUndefined();
+    expect(out['CLAUDE_CODE_OAUTH_TOKEN'], 'credential scrub still runs').toBeUndefined();
+  });
+
+  it('does NOT revert a value some other layer changed after the injection', () => {
+    const out = runBuilder({
+      HTTPS_PROXY: 'http://settings-level:9999',
+      NODE_EXTRA_CA_CERTS: '/home/u/.clodex/ca.pem',
+      [NETWORK_ENV_CONTRACT_VAR]: CONTRACT,
+    });
+    expect(out['HTTPS_PROXY'], 'settings override stays authoritative')
+      .toBe('http://settings-level:9999');
+    expect(out['NODE_EXTRA_CA_CERTS']).toBeUndefined();
+  });
+
+  it('no contract: returns the live process.env object, byte-for-byte unchanged', () => {
+    const env = { PATH: '/usr/bin', HTTPS_PROXY: 'http://127.0.0.1:49653' };
+    const out = runBuilder(env);
+    expect(out).toBe(env);
+  });
+
+  const hostile = [
+    'not json', '[]', 'null', '{}', '{"version":2,"original":{},"injected":{}}',
+    '{"version":1,"original":null,"injected":{}}',
+    '{"version":1,"original":{"HTTPS_PROXY":1},"injected":{"HTTPS_PROXY":"x"}}',
+    '{"version":1,"original":{"HTTPS_PROXY":"a"}}',
+    '{"version":1,"injected":{"HTTPS_PROXY":"a"}}',
+    '{"version":1,"original":{"__proto__":"x"},"injected":{"__proto__":"y"}}',
+    '""', '0',
+  ];
+  for (const raw of hostile) {
+    it(`hostile contract ${JSON.stringify(raw).slice(0, 46)} never throws and never reverts`, () => {
+      const env = {
+        PATH: '/usr/bin',
+        HTTPS_PROXY: 'http://127.0.0.1:49653',
+        [NETWORK_ENV_CONTRACT_VAR]: raw,
+      };
+      const out = runBuilder(env);
+      expect(out['HTTPS_PROXY']).toBe('http://127.0.0.1:49653');
+      expect(out[NETWORK_ENV_CONTRACT_VAR], 'contract never reaches the child').toBeUndefined();
+    });
+  }
+});

--- a/src/patch-transforms.ts
+++ b/src/patch-transforms.ts
@@ -38,7 +38,7 @@ import {
  * hash of the transform inputs to force that decision to be made rather than
  * forgotten.
  */
-export const PATCH_TRANSFORMS_VERSION = 5;
+export const PATCH_TRANSFORMS_VERSION = 6;
 
 export interface PatchScriptModelEntry {
   alias?: string;
@@ -554,6 +554,13 @@ export function applyClodexPatches(source: string, config: PatchScriptModelConfi
   // revert a key only while its live value still equals the Clodex injection.
   // Settings-level overrides therefore remain authoritative, and the builder's
   // existing filtering continues against the resulting copy.
+  //
+  // The anchor tolerates extra declarators between the first `Object.keys(...)
+  // .length>0` binding and the `CLAUDE_CODE_REMOTE` ternary: Claude Code 2.1.228
+  // hoisted the settings-colour env into one (`r=<mod>.settingsColorEnv`), which
+  // a fixed declarator count would have read as a missing anchor. `[^;{}]` keeps
+  // the run inside the same `let` statement, and the literal + nested-function
+  // checks below still prove the target really is the child-env builder.
   // ---------------------------------------------------------------------------
   {
     const patchName = 'PATCH 10: child network environment';
@@ -571,7 +578,7 @@ export function applyClodexPatches(source: string, config: PatchScriptModelConfi
     ];
     applyOnce(
       patchName,
-      /(function [\w$]+\(\)\{)(let [\w$]+=[\w$]+\(\),[\w$]+=Object\.keys\([\w$]+\)\.length>0,[\w$]+=Object\.keys\([\w$]+\)\.length>0,[\w$]+=[\w$]+\(process\.env\.CLAUDE_CODE_REMOTE\)\?(?:(?!\}\s*function )[\s\S])*?for\(let [\w$]+ of [\w$]+\)delete [\w$]+\[[\w$]+\],delete [\w$]+\[`INPUT_\$\{[\w$]+\}`\];return [\w$]+)(\})/,
+      /(function [\w$]+\(\)\{)(let [\w$]+=[\w$]+\(\),[\w$]+=Object\.keys\([\w$]+\)\.length>0,[^;{}]*?[\w$]+=[\w$]+\(process\.env\.CLAUDE_CODE_REMOTE\)\?(?:(?!\}\s*function )[\s\S])*?for\(let [\w$]+ of [\w$]+\)delete [\w$]+\[[\w$]+\],delete [\w$]+\[`INPUT_\$\{[\w$]+\}`\];return [\w$]+)(\})/,
       (_match, head, body, tail) => {
         const targetIsValid = requiredBodyLiterals.every(literal => body!.includes(literal))
           && !/\bfunction\s*[\w$]*\(/.test(body!);

--- a/tests/patcher.test.ts
+++ b/tests/patcher.test.ts
@@ -1266,6 +1266,32 @@ describe('patch script identity naming', () => {
     'let e=extra(),t=Object.keys(e).length>0,c=settings.settingsColorEnv,n=Object.keys(c).length>0,',
   );
 
+  // The tolerated run is bounded to `[^;{}]` so it cannot reach out of the `let`
+  // statement it starts in. Widen it to `[\s\S]` and the anchor starts at the
+  // NEAREST preceding function whose head happens to fit, swallowing everything
+  // up to the real builder's tail — so a decoy that opens with the same two
+  // bindings must not be able to steal the match. Without this fixture the only
+  // test that reddens on that mutation is the sha256 transform-source pin, which
+  // is a tripwire, not a behavioural test.
+  const CLAUDE_FIXTURE_DECOY = CLAUDE_FIXTURE_228.replace(
+    'function childEnv(){',
+    'function zzDecoy(){let q=extra(),w=Object.keys(q).length>0,z=w?1:2;return z}'
+    + 'function childEnv(){',
+  );
+
+  it('does not let a preceding decoy with the same opening bindings steal the match', () => {
+    expect(CLAUDE_FIXTURE_DECOY, 'fixture drifted from the shape this test mutates')
+      .not.toBe(CLAUDE_FIXTURE_228);
+
+    const out = runPatchScript(config, CLAUDE_FIXTURE_DECOY);
+
+    expect(out.match(/\/\*ccpatch:child-network-env\*\//g)).toHaveLength(1);
+    expect(out).toContain('function childEnv(){/*ccpatch:child-network-env*/');
+    expect(out, 'the decoy is left exactly as it was').toContain(
+      'function zzDecoy(){let q=extra(),w=Object.keys(q).length>0,z=w?1:2;return z}',
+    );
+  });
+
   it('patches a child builder that declares extra bindings before the remote check', () => {
     expect(CLAUDE_FIXTURE_228, 'fixture drifted from the shape this test mutates')
       .not.toBe(CLAUDE_FIXTURE);

--- a/tests/patcher.test.ts
+++ b/tests/patcher.test.ts
@@ -456,8 +456,8 @@ describe('PATCH_TRANSFORMS_VERSION', () => {
       .join('\n');
     const digest = createHash('sha256').update(source).digest('hex');
     expect({ version: PATCH_TRANSFORMS_VERSION, digest }).toEqual({
-      version: 5,
-      digest: 'aa9880c15a84007512c700c6a9a0d52975fded04145bb691254e216cf131d0ad',
+      version: 6,
+      digest: 'c2abf1d2b334562c3b3b3e2158d44c9986001c0401415912ef7dd450137eab3e',
     });
   });
 });
@@ -991,12 +991,15 @@ function executeChildEnv(
     'extra',
     'flag',
     'remote',
+    // Only the 2.1.228-shaped fixture reads this; the base fixture ignores it.
+    'settings',
     `${declaration};return childEnv;`,
   )(
     { env },
     () => extraEnv,
     () => false,
     () => ({}),
+    { settingsColorEnv: {} },
   ) as () => NodeJS.ProcessEnv;
   return childEnv();
 }
@@ -1251,6 +1254,60 @@ describe('patch script identity naming', () => {
 
   it('falls through to the native default for an unconfigured identity', () => {
     expect(executeDefaultEffort(runPatchScript(config), 'unconfigured', 'medium')).toBe('medium');
+  });
+
+  // Claude Code 2.1.228 hoisted the settings-colour env into its own declarator
+  // inside the child builder's `let` statement, between the first
+  // `Object.keys(...).length>0` binding and the CLAUDE_CODE_REMOTE ternary. An
+  // anchor that counted declarators reported "anchor not found", and because
+  // PATCH 10 is required, `clodex patch` refused to patch 2.1.228 at all.
+  const CLAUDE_FIXTURE_228 = CLAUDE_FIXTURE.replace(
+    'let e=extra(),t=Object.keys(e).length>0,n=Object.keys(e).length>0,',
+    'let e=extra(),t=Object.keys(e).length>0,c=settings.settingsColorEnv,n=Object.keys(c).length>0,',
+  );
+
+  it('patches a child builder that declares extra bindings before the remote check', () => {
+    expect(CLAUDE_FIXTURE_228, 'fixture drifted from the shape this test mutates')
+      .not.toBe(CLAUDE_FIXTURE);
+
+    const result = applyClodexPatches(CLAUDE_FIXTURE_228, config);
+
+    expect(result.results.at(-1)).toEqual({
+      status: 'OK',
+      name: 'PATCH 10: child network environment',
+    });
+    expect(result.content.match(/\/\*ccpatch:child-network-env\*\//g)).toHaveLength(1);
+    expect(result.content).toContain('function childEnv(){/*ccpatch:child-network-env*/');
+    // The added declarator survives, and the body still reads the local copy.
+    expect(result.content).toContain('c=settings.settingsColorEnv');
+    expect(result.content).toContain('let v={..._clodexChildEnv,...e,...s}');
+  });
+
+  it('restores the original network environment through the extra-binding builder', () => {
+    const out = runPatchScript(config, CLAUDE_FIXTURE_228);
+    const env = executeChildEnv(out, {
+      PATH: '/usr/bin',
+      HTTPS_PROXY: 'http://127.0.0.1:3457',
+      NODE_EXTRA_CA_CERTS: '/tmp/local-ca.pem',
+      [NETWORK_ENV_CONTRACT_VAR]: JSON.stringify({
+        version: 1,
+        original: {
+          HTTPS_PROXY: 'http://corp-proxy.example:8080',
+          NODE_EXTRA_CA_CERTS: null,
+        },
+        injected: {
+          HTTPS_PROXY: 'http://127.0.0.1:3457',
+          NODE_EXTRA_CA_CERTS: '/tmp/local-ca.pem',
+        },
+      }),
+    });
+
+    expect(env).toMatchObject({
+      PATH: '/usr/bin',
+      HTTPS_PROXY: 'http://corp-proxy.example:8080',
+    });
+    expect(env['NODE_EXTRA_CA_CERTS']).toBeUndefined();
+    expect(env[NETWORK_ENV_CONTRACT_VAR]).toBeUndefined();
   });
 
   it('targets the child builder when a token-bearing function follows it', () => {


### PR DESCRIPTION
## The bug

`clodex patch` fails on Claude Code **2.1.228**:

```
FAIL  PATCH 10: child network environment  (anchor not found)
clodex patch: required patch failed: PATCH 10: child network environment
```

PATCH 10 is `required`, so the whole patch is abandoned and the binary is left unpatched — a
2.1.228 user gets no aliases, no per-model context windows, and no effort settings. Every other
patch site applies cleanly; PATCH 10 is the only casualty.

## Why

PATCH 10 finds the shared child-environment builder by anchoring on the shape of its opening `let`
statement. 2.1.228 hoisted the settings-colour env into a binding of its own, between the first
`Object.keys(...).length>0` check and the `CLAUDE_CODE_REMOTE` ternary:

```js
// 2.1.226
function $M(){let e=bht(),t=Object.keys(e).length>0,r=Object.keys(tTs).length>0,
              n=yr(process.env.CLAUDE_CODE_REMOTE)? ...

// 2.1.228
function o1(){let e=Ubt(),t=Object.keys(e).length>0,r=a6.settingsColorEnv,n=Object.keys(r).length>0,
              o=dn(process.env.CLAUDE_CODE_REMOTE)? ...
```

The anchor required exactly two `Object.keys(...).length>0` bindings, so one extra declarator was
enough to lose the function. The builder is also renamed every release or two — `pH` (2.1.221),
`XH` (2.1.224), `$M` (2.1.226), `o1` (2.1.228) — so nothing about its identity was ever in the name.

## The fix

Tolerate extra bindings ahead of the `CLAUDE_CODE_REMOTE` check instead of counting them:

```diff
-let [\w$]+=[\w$]+\(\),[\w$]+=Object\.keys\([\w$]+\)\.length>0,[\w$]+=Object\.keys\([\w$]+\)\.length>0,[\w$]+=[\w$]+\(process\.env\.CLAUDE_CODE_REMOTE\)\?
+let [\w$]+=[\w$]+\(\),[\w$]+=Object\.keys\([\w$]+\)\.length>0,[^;{}]*?[\w$]+=[\w$]+\(process\.env\.CLAUDE_CODE_REMOTE\)\?
```

`[^;{}]` keeps the run inside the same `let` statement, so it cannot wander into another statement
or function. Target identification is unchanged in strength: the required-literal check
(`{...process.env`, the credential names, `"OTEL_"`, …) and the nested-function guard still run
before a single byte is rewritten, and a failure is still loud — a required patch that fails leaves
the installed binary untouched.

`PATCH_TRANSFORMS_VERSION` 5 → 6 so already-patched installs read as `stale-config` and re-patch
instead of silently keeping the old transforms; the digest tripwire is re-pinned to match.

## Evidence

Run against the **real pristine bundles** for 2.1.221, 2.1.224, 2.1.226 and 2.1.228.

**No drift for existing installs.** On 2.1.221/224/226 the old and new anchors select a
byte-identical span at the same offset. The only behavioural difference is on 2.1.228, where the
old anchor matched nothing.

**Right target, every version.** `pr78-patch10-anchor-over-real-bundles` (which extracts the regex
straight out of `patch-transforms.ts` so it cannot drift) passes on all four: exactly one match
each, self-identified from its own body, no rewritten `process.env` reference escaping the
declaring function.

```
2.1.221: fn=pH span=1421 rewrites=23
2.1.224: fn=XH span=1421 rewrites=23
2.1.226: fn=$M span=1421 rewrites=23
2.1.228: fn=o1 span=1480 rewrites=24
```

**Wrong targets still rejected on 2.1.228.** `pr78-patch10-wrong-target-mutations`, re-pointed at
the 2.1.228 bundle, passes all three classes — a zero-arg decoy immediately before the builder does
not steal the match, removing the next function's landmark tokens does not break it, and a nested
named function in the body fails loudly and publishes nothing.

**The patched 2.1.228 builder actually runs.** New harness
`.claude/harnesses/cc228-patch10-execute-real-builder.harness.ts` patches the real bundle, checks it
still parses, then extracts the patched builder and executes it (19 assertions). It recovers every
free identifier from the builder's own text, so a name it failed to account for surfaces as a
ReferenceError rather than a vacuous pass. Both branches revert only values that still equal the
injection, a settings-level override stays authoritative, the contract variable never reaches a
child, twelve hostile contract payloads neither throw nor revert, and Claude Code's own credential
and action-input filtering still runs.

**Regression tests.** Two tests in `tests/patcher.test.ts` build the 2.1.228 declarator shape from
the existing fixture: one asserts PATCH 10 applies at the right site, the other executes the patched
builder and checks the restore. Both fail with the old anchor, with the production error
(`required patch failed: PATCH 10: child network environment`) — they are real tripwires, not
decoration.

`pnpm typecheck && pnpm test && pnpm build` all pass (1641 tests).

## Live smoke test on a real patched 2.1.228

Applied to a real install with this branch's build:

```
Patched claude 2.1.228: 3 models, 3 aliases, 3 context windows.
  OK   PATCH 1 ... PATCH 10: child network environment
clodex patch: 11 applied, 0 skipped, 0 failed
```

Both routes answer through the patched binary — `--model luna` (OpenAI via ChatGPT OAuth, proxy
mode) and `--model haiku` (Anthropic, unchanged path).

PATCH 10's own guarantee, checked from a clean shell with no external proxy — the parent runs
bridged, its Bash child inherits none of it:

```
CHILD_PROXY=NONE
CHILD_CA=NONE
PARENT=HTTPS_PROXY=http://127.0.0.1:64796
CONTRACT=absent
```

And the compare-before-revert half, checked by launching from a shell that already had an external
`HTTPS_PROXY` — the child gets the external value back, not the parent's bridge port:

```
CHILD=http://127.0.0.1:17645     <- the value that was there before clodex injected
PARENT=HTTPS_PROXY=http://127.0.0.1:64733
CONTRACT_IN_CHILD=absent
```

## Review round

An adversarial review of this branch refuted all five core claims (wrong target, escaped rewrite,
runtime behaviour, regression on older bundles, version + digest) and found one should-fix, applied
in `e89191d`:

The anchor was mutation-checked in the **revert** direction only. Widening the tolerated run from
`[^;{}]` to `[\s\S]` — the likeliest future mistake — left the sha256 transform-source pin as the
only red test, and both `patcher.md` and the pr-review skill say never to let that pin stand alone in
a mutation check. The class is load-bearing: with the run widened, a decoy function opening with the
same two bindings, placed immediately before the real builder, takes the match. The nested-function
guard still catches it, so the worst case is a refusal to patch rather than a corrupted binary — but
nothing in `tests/` reddened. There is now a fixture placing exactly that decoy ahead of the builder;
it fails on the production target-validation error when the run is widened.

Same commit fixes a harness nit: `REVIEW_BUNDLE_DIR` set but holding no 2.1.228 bundle reported 19
green-looking skips for a proof that never ran, and now fails instead. An unset dir still skips.
