### PR TITLE
docs: make the pre-PR bar a gate that closes before the first push

### DIFF
--- a/.claude/skills/pr-verification/SKILL.md
+++ b/.claude/skills/pr-verification/SKILL.md
@@ -9,6 +9,18 @@ Your change will be held to a higher bar than "the suite is green." Across ~100 
 PRs, three failures dominate — in this order. They are what most review rounds are spent on, and
 every one of them is cheaper to catch now than after a reviewer finds it.
 
+**This file is a gate, not a checklist to run alongside the PR.** Nothing is pushed and no PR is
+opened until every item below has been done and your local adversarial review has reported and its
+findings are resolved. Running the review in parallel with `git push` looks like free wall-clock and
+is not: a finding that lands after the branch is public costs a force-push or a second PR, it can
+reach a reviewer or a merge first, and it arrives already framed as follow-up — which is how a
+should-fix becomes a won't-fix. "Quick PR" is a reason to keep the change small, never a reason to
+open it before the gate closes.
+
+A review that reports "nothing to fix" still has to report *before* the push. The point is not that
+findings are likely; it is that the branch going public is the irreversible step, and the review is
+what tells you whether it should.
+
 ## 1. Tests must discriminate. Green is not evidence.
 
 The single most common defect. Tests pass; the behavior they claim to pin is absent, unreachable,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ restructuring.
 
 | Load this | When |
 | --- | --- |
-| `.claude/skills/pr-verification/SKILL.md` | Preparing a change: the bar it must clear before you open the PR. |
+| `.claude/skills/pr-verification/SKILL.md` | **Before the first `git push` of any change** — the gate it must clear, and why pushing before your review reports costs more than it saves. Load it when you start preparing the change, not when you are about to open the PR. |
 | `.claude/skills/pr-review/SKILL.md` | Reviewing someone else's PR: panels, proof techniques, verdicts, merging. |
 | `.claude/docs/claude-code-internals.md` | Before asserting how Claude Code itself behaves, or re-deriving it. |
 | `.claude/docs/patcher.md` | Changing `clodex patch`, patch transforms, or backups. |


### PR DESCRIPTION
## What this changes

Two documentation edits, no code. Both come out of a concrete process failure on #118.

**`pr-verification` becomes a gate with an explicit ordering rule.** The skill is titled "Before you
open a PR" and describes the bar thoroughly, but it never says *when* the bar closes relative to
pushing. That gap let "run the adversarial review in parallel with `git push`, and fix anything it
finds in a follow-up commit" look like a free wall-clock win. It isn't. The branch going public is
the irreversible step: a finding that lands after it costs a force-push or a second PR, it can reach
a reviewer or a merge first, and it arrives already framed as follow-up work — which is how a
should-fix becomes a won't-fix.

**The `CLAUDE.md` trigger moves from "preparing a change" to the first `git push`.** This is the more
important of the two. On #118 the deeper failure was not misreading the skill — it was never opening
it, which also meant skipping the launch-path smoke test the skill mandates and writing a PR caveat
claiming a credential gap that did not exist. A trigger keyed to an activity with no sharp edge
("preparing a change") is easy to slip past when the request sounds urgent. One keyed to a specific
irreversible command is not.

## Why it is worth writing down

The rationalisation that produced the failure is a plausible-sounding one that will recur: treating
the review as insurance rather than as a gate, and reading "quick PR" as permission to parallelise.
The added text names that reasoning and answers it, rather than only restating the rule — "quick PR"
is a reason to keep the change small, never a reason to open it before the gate closes.

It also states that a review reporting "nothing to fix" still has to report before the push. The
point is not that findings are likely; it is that the review is what tells you whether the
irreversible step should happen.

## Scope

Markdown only — no code, tests, or transforms touched, so `PATCH_TRANSFORMS_VERSION` and the digest
pin are unaffected. Wording checked against `pr-review`, which governs reviewing an already-open PR
and does not conflict: one skill is the pre-push gate, the other is what happens once a PR exists.

Independent of #118 and touches no file that PR touches, so the two merge in either order.
