### PR TITLE
docs: teach the review skill to question a hunk's rationale, not just its comment

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -66,6 +66,7 @@ break the parser; build prompts with `[...].join('\n')`.
 | "This is/isn't reachable in practice" | Mine the diagnostics ledgers for rate and reachability. |
 | "This terminal output is safe" | Drive real Claude Code under `tmux` and read the actual bytes. |
 | "Nothing consumes X" | Grep the **value**, not one comparison spelling, and trace every hit. |
+| "This hunk is required by the feature" | Revert it and run the full suite. Only its own tests red, none of the feature's, is strong evidence it is severable — then trace the consumers to be sure. |
 
 **Mining the ledgers.** `~/.clodex/logs/sessions/*websocket-diagnostics*.jsonl` is a large corpus of
 real traffic and it has settled more disputes than any other technique. Gotchas: files exceed Node's
@@ -136,6 +137,21 @@ Bundle-dependent harnesses need `node scripts/extract-cc-bundles.mjs` run once, 
   that did survive.
 - **A wrong claim in our own code comment or docs propagates into contributor PRs.** This has
   happened twice. When an author's description is wrong, check whether they got it from us first.
+- **Aim at the decision, not just the comment.** A *circular* justification — one citing as an
+  external given the behavior its own hunk creates — still needs correcting, but it is also a tell
+  that the real rationale went unstated. Ask why the hunk exists before you file the wording. We
+  filed a blocking ask because a comment said the Anthropic passthrough "already" refused to echo on
+  a fallback when the same hunk is what made it refuse; the better question was why the change was
+  there at all. Reverting both halves left **1716/1719** green — only that change's own three
+  tests red, every feature test passing — so it was severable from the PR's stated purpose, and
+  the commit message turned out to carry the rationale the comment lacked. That converted one
+  blocking ask into a prose fix plus a scope note.
+- **When the ask turns on a vendor fact nobody here has observed, ask for the fact before
+  prescribing the code.** For a community-supported provider we cannot exercise, a synthetic
+  response body shows a risk, not a reachable defect, and narrowing a predicate around it can make
+  the code worse — a panel proposed exactly that against an auth response no reviewer had seen.
+  Frame it as "tell us the real response, **or** make this change," and say plainly that we could
+  not verify it.
 - **Verify "blocked by X" justifications by executing them.** A structural claim that sounds
   obviously true is exactly the kind that ships into a review and gets cited for years.
 - **Don't let "not a regression versus `main`" excuse shipping a broken guarantee.**


### PR DESCRIPTION
## What this changes

Three additions to `.claude/skills/pr-review/SKILL.md` — two calibration rules and one proof
technique. No code, no behavior change; this is the review methodology that lives next to the code
it describes.

## Why

All three were paid for by the #100 review, and specifically by getting something wrong in the draft
of it.

That draft filed a blocking ask because a comment said the Anthropic passthrough "already" refused
to echo the requested id on a default-route fallback — when the same hunk is what makes it refuse.
The maintainer's pushback was the better question: post-merge the comment becomes true, so why
complain about the wording instead of asking why the change was made at all?

Following that thread produced a measurement the review had not taken. Reverting both halves of the
change left **1716/1719** green, with only that change's own three tests red and every OpenCode Go
test passing — so it was severable from the PR's stated purpose, and the commit message turned out
to carry a rationale the comment lacked. The ask became "put the real reason in the comment" plus a
scope note, and the blocking count dropped from three to two.

Generalized, that is two rules and a technique:

- A circular justification still needs correcting, but it is a **tell** that the real rationale went
  unstated. Ask why the hunk exists before filing the wording.
- `"This hunk is required by the feature"` now has an entry in the proof table: revert it and run the
  full suite.
- Separately: when an ask turns on a vendor fact nobody here has observed — the case for any
  community-supported provider we hold no account for — ask for the fact before prescribing a code
  change. A synthetic response body shows a risk, not a reachable defect, and narrowing a predicate
  around one can make the code worse.

## Verification

The text was put through an adversarial pass from a different model family before this branch was
pushed, per the gate in `.claude/skills/pr-verification/SKILL.md`, and it **refuted four of its own
claims**:

- "a response body nobody had ever seen" overstated the evidence — only that no reviewer here had
  observed it. Corrected.
- "comments read circular precisely when the author had no independent reason to state" is
  **disproved by the very incident it cites**: the commit message did carry an independent rationale.
  Removed.
- "the author usually settles it in one request" generalized from a single case. Removed.
- The proof-table row claimed a revert *proves* severability; a green feature suite is strong
  evidence, not proof, since the feature's own tests may be thin. Softened, with a follow-up step to
  trace consumers.

That pass also independently re-ran the revert in a scratch worktree and confirmed 1716/1719 with
exactly the three named tests red and no OpenCode Go test failing.

Concurrency: no open PR touches this file; its last change was #117.