### PR TITLE
fix(patch): restore patching on Claude Code 2.1.231 so aliases and effort settings work again

### DIFF
--- a/.claude/docs/claude-code-internals.md
+++ b/.claude/docs/claude-code-internals.md
@@ -34,6 +34,36 @@ Then **enumerate every branch of the function yourself.** Shipped bugs have come
 gates that happened to be visible, and from grepping one syntactic form of a comparison — grep the
 *value*, then trace every hit.
 
+## The entry module's name is not stable (renamed in 2.1.231)
+
+The bundle lives in a Bun data blob as one module among ~15, and tweakcc finds it **by name**:
+`/claude`, `claude`, `/claude.exe`, `claude.exe`, `/src/entrypoints/cli.js`, `src/entrypoints/cli.js`.
+
+| Version | Entry module |
+| --- | --- |
+| 2.1.224, 2.1.226, 2.1.228 | `/$bunfs/root/src/entrypoints/cli.js` |
+| 2.1.231 | `/$bunfs/root/cli` |
+
+(Those are the versions actually inspected; 2.1.229 and 2.1.230 were never available here.)
+
+2.1.231 matches none of them, so `readContent` threw and every patch failed with
+"Failed to extract JavaScript from native installation" — which reads like the `node-gyp-build`
+packaging fault described in `patcher.md` and is not it. tweakcc 4.3.2, the latest release, still
+carries the old list. `src/bun-entry-module.ts` works around it; see `patcher.md`.
+
+Two things that are easy to assume wrongly about the blob:
+
+- **The entry module also carries ~190 MB of Bun bytecode** (`// @bun @bytecode @bun-cjs`), and
+  repacking preserves it verbatim. It does **not** win over the patched source — a canary injected
+  into the JS prints at startup on a repacked 2.1.231 (verified twice on macOS arm64 — once by
+  hand and once through clodex's own local-patches feature, both printing the canary on stderr
+  ahead of `--version`). Bytecode has been present since at least 2.1.226, so this was never the
+  thing standing between clodex and a working patch.
+- The blob's own 32-byte offsets record where it starts, and it ends with a fixed `---- Bun! ----`
+  trailer, so it can be located by scanning back from EOF with no Mach-O/ELF/PE parsing at all.
+  `entryPointId` names the entry module directly and survives renames; the *name* is only how
+  tweakcc happens to look it up.
+
 ## Unknown-model context-window enforcement (verified 2.1.223+)
 
 Enforcement hangs off a single gate: `KJe(e,t)` returns `Q9(e,t).source !== "auto"`. `Q9` returns

--- a/.claude/docs/patcher.md
+++ b/.claude/docs/patcher.md
@@ -1,10 +1,10 @@
 <!-- Read when changing src/patcher.ts, patch-transforms.ts, patch-backup.ts, local-patches.ts,
-     built-in-patch-proofs.ts, or anything about `clodex patch`. -->
+     built-in-patch-proofs.ts, bun-entry-module.ts, or anything about `clodex patch`. -->
 
 # Patcher
 
 `src/patcher.ts` + `src/patch-transforms.ts` + `src/built-in-patch-proofs.ts` +
-`src/local-patches.ts` + `src/patch-backup.ts`.
+`src/local-patches.ts` + `src/patch-backup.ts` + `src/bun-entry-module.ts`.
 
 `clodex patch` uses tweakcc's programmatic API — an exact-pinned, declared runtime dependency
 (externalized in `tsup.config.ts`; it brings `node-lief` for native repacking and `ink`/`react` for
@@ -12,7 +12,9 @@ its picker, which is why `patcher.ts` loads it via lazy `import()`). **Never `np
 network.** Flow: `tryDetectInstallation({ path })` → `readContent` → `applyClodexPatches(source,
 config)` (in-process pure function applying built-in PATCH 1–10 sites) → optional
 `applyLocalPatches` transaction with built-in postcondition verification → `writeContent` (repacks
-the native binary). Both layers return per-site OK/SKIP/FAIL results shown by `--trace`.
+the native binary). Both layers return per-site OK/SKIP/FAIL results shown by `--trace`. Since
+2.1.231, the reads and the repack are each wrapped in the entry-module shim below, without which
+tweakcc cannot find the bundle at all.
 
 tweakcc ships no `.d.ts` despite its `types` field — `src/tweakcc.d.ts` declares the verified API
 surface; re-verify when bumping the pin. `node-gyp-build` is a deliberate direct dependency even
@@ -20,7 +22,9 @@ though no clodex source imports it: a node-lief release demoted it to a devDepen
 `require`-ing it at runtime (reported against 1.3.1; the lockfile currently resolves 1.3.0), so
 fresh installs resolved a node-lief throwing
 `Cannot find module 'node-gyp-build'` — which tweakcc's lazy loader swallows into a null and clodex
-surfaces as the misleading "Failed to extract JavaScript from native installation". Declaring it
+surfaces as the misleading "Failed to extract JavaScript from native installation" (the same message
+a module-name mismatch produces, so read the entry-module section below before chasing this one).
+Declaring it
 ourselves guarantees it lands somewhere node-lief's `require` can resolve — that is the invariant to
 check any alternative fix against, which matters because this repo uses pnpm's strict non-hoisted
 layout with exact pins. Keep it even after node-lief fixes the packaging.
@@ -28,6 +32,61 @@ layout with exact pins. Keep it even after node-lief fixes the packaging.
 The built-ins bake favorites + aliases into the binary: model validation, `/model` listing, alias
 resolution, context windows via a `/*ccpatch:ctx*/`-marked map, per-model effort
 capabilities/defaults, and child-command network isolation.
+
+## The entry-module shim (`bun-entry-module.ts`)
+
+tweakcc finds the module holding the bundle **by name**, and Claude Code 2.1.231 renamed it from
+`/$bunfs/root/src/entrypoints/cli.js` to `/$bunfs/root/cli`, which none of tweakcc's six accepted
+names match — so `readContent` threw and 2.1.231 could not be patched at all.
+The upstream list is unchanged as of tweakcc 4.3.2; `.claude/docs/claude-code-internals.md` has the
+bundle-side detail. **Delete this shim once tweakcc identifies the module by `entryPointId`.**
+
+The name is used for identification only, so `shimEntryModuleName` swaps it for a stand-in of
+**identical byte length** (`/clodex--/claude` for a 16-byte original) that tweakcc does recognize,
+and `restoreEntryModuleName` puts the real name back. Equal length is the whole safety argument: no
+offset, length, or size field in the blob changes, so the edit is a pure byte overwrite that
+tweakcc's own repack reads back as an ordinary module name.
+
+- **The shim must never survive into a published binary.** Claude Code's other modules
+  (`image-processor.node`, `audio-capture.node`, …) live at `/$bunfs/root/*` and resolve against the
+  entry module's own directory, so shipping the stand-in name would break them. It is applied twice —
+  around `readContent`, and again around `writeContent`, which re-parses the candidate — and undone
+  after each.
+- **`restoreEntryModuleName`'s `resign` flag is load-bearing, and `false` is not the safe default.**
+  Re-signing is *required* after a repack, because the write invalidates the ad-hoc signature and an
+  unsigned Mach-O will not run. It is *forbidden* on the read path, because `codesign` replaces
+  Claude Code's own signature: the seeded candidate stops being byte-identical to the install it came
+  from, and the bootstrap path publishes exactly those bytes as the content-addressed pristine
+  backup. In development this produced a backup whose content hash did not match the hash in its
+  own name; it never shipped, and only an end-to-end run caught it, because a synthetic non-Mach-O
+  fixture never reaches `codesign`. The candidate is now re-hashed against `plan.pristineSha256`
+  immediately before it is published as a backup, so drifted bytes fail loudly instead.
+- **Only rename when tweakcc would otherwise find nothing.** If any module name already matches, the
+  shim is a no-op — a second match could hand tweakcc a different module than it picks today, and
+  every release before 2.1.231 must keep behaving exactly as it did. This is also what makes the
+  two selectors agree: tweakcc *reads* the first name-matching module but *rewrites every* one,
+  while the shim renames the entry module specifically. Refusing to fire when a match already
+  exists guarantees exactly one match, so all three always mean the same module.
+- Locating the name parses the Bun blob directly (scan back from EOF for the trailer, recover the
+  blob start from its own `byteCount`) rather than the executable container, so it needs no
+  `node-lief`. **Verified on Mach-O only** — ELF and PE are inferred from tweakcc's own reader.
+  Every derived offset is bounds-checked and every name must be printable and NUL-terminated: a
+  misparse returns null — leaving tweakcc's own error — instead of overwriting sixteen bytes at a
+  guessed offset.
+- **More than one trailer can be in the file, so the scan validates rather than trusting position.**
+  Repacking is not size-neutral (an identity repack of 2.1.231 *shrinks* the blob by 61 bytes) and
+  the replacement section content is written over the old, so the previous blob's trailer survives at
+  a **higher** offset. Real binaries also carry a decoy `---- Bun! ----` around 55 MB — Bun's runtime
+  ships the literal in `__TEXT`. Candidates are therefore tried from EOF backwards and the first one
+  that validates wins. `TAIL_SCAN_BYTES` is a cost bound with a hard floor: the last trailer sits
+  683–802 KB from EOF on real binaries, and a window below that silently disables the shim.
+- **Restoration is proven, not assumed.** After writing the real name back, the whole file is scanned
+  for the stand-in. Locating the blob is a search, so "I wrote the name where I found the marker" is
+  weaker than it sounds — it is also true of a write into a stale copy while the live blob stays
+  shimmed. The scan is what actually holds the never-publish-the-stand-in rule up.
+- `scripts/extract-cc-bundles.mjs` needs the same shim to read a 2.1.231 bundle. It shims a **scratch
+  copy**; the `.orig` backups are the only pristine bytes on the machine and nothing may write to
+  them.
 
 ## Patcher invariants
 

--- a/scripts/extract-cc-bundles.mjs
+++ b/scripts/extract-cc-bundles.mjs
@@ -4,7 +4,8 @@
 // The bundle is compressed inside the native binary, so raw byte greps do not work — this is the
 // only way to read what the client actually does. See .claude/docs/claude-code-internals.md.
 //
-// Must run from inside this repo so `tweakcc` resolves from node_modules.
+// Must run from inside this repo so `tweakcc` resolves from node_modules. Needs Node >= 22.18
+// (or `--experimental-strip-types`) for the .ts import below; .nvmrc pins 24.
 //
 //   node scripts/extract-cc-bundles.mjs [outDir]
 //
@@ -16,9 +17,19 @@
 // harnesses will find them.
 
 import { tryDetectInstallation, readContent } from 'tweakcc';
-import { readdirSync, writeFileSync, existsSync, mkdirSync, statSync } from 'node:fs';
+import {
+  readdirSync,
+  writeFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  statSync,
+  copyFileSync,
+  rmSync,
+} from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import path from 'node:path';
+import { inspectEntryModule, shimEntryModuleName } from '../src/bun-entry-module.ts';
 
 const args = process.argv.slice(2);
 if (args.includes('-h') || args.includes('--help')) {
@@ -85,8 +96,26 @@ for (const f of files) {
     }
     console.log(`re-extracting ${f}: cached file is only ${size} bytes`);
   }
+  // Claude Code 2.1.231 renamed the module tweakcc looks for. The rename that makes it
+  // readable again is a write, so it happens on a scratch copy — these backups are the only
+  // pristine bytes on the machine and nothing here may touch them.
+  let readFrom = path.join(srcDir, f);
+  let scratchDir;
   try {
-    const inst = await tryDetectInstallation({ path: path.join(srcDir, f) });
+    const state = inspectEntryModule(readFrom);
+    if (state === 'unparseable') {
+      // Distinguishing this from a name mismatch matters: tweakcc reports the same
+      // "Failed to extract JavaScript" for both, and for the unrelated node-gyp-build fault.
+      console.log(`NOTE ${f} has no readable Bun module list — extraction below is unshimmed`);
+    }
+    if (state === 'needs-shim') {
+      scratchDir = mkdtempSync(path.join(tmpdir(), 'cc-bundle-'));
+      const scratch = path.join(scratchDir, f);
+      copyFileSync(readFrom, scratch);
+      shimEntryModuleName(scratch);
+      readFrom = scratch;
+    }
+    const inst = await tryDetectInstallation({ path: readFrom });
     if (!inst) throw new Error('tweakcc did not recognize the binary');
     const src = await readContent(inst);
     if (!src) throw new Error('readContent returned nothing');
@@ -103,6 +132,8 @@ for (const f of files) {
   } catch (e) {
     console.log('FAIL', f, String(e).slice(0, 200));
     failed++;
+  } finally {
+    if (scratchDir) rmSync(scratchDir, { recursive: true, force: true });
   }
 }
 

--- a/src/bun-entry-module.ts
+++ b/src/bun-entry-module.ts
@@ -1,0 +1,336 @@
+// Makes a Claude Code native binary's entry module discoverable by tweakcc.
+//
+// tweakcc finds the module holding Claude Code's JavaScript by NAME — it accepts
+// `/claude`, `claude`, `/claude.exe`, `claude.exe`, `/src/entrypoints/cli.js` and
+// `src/entrypoints/cli.js`. Claude Code 2.1.231 renamed its entry module from
+// `/$bunfs/root/src/entrypoints/cli.js` to `/$bunfs/root/cli`, which matches none
+// of them, so `readContent` throws and `clodex patch` fails with
+// "Failed to extract JavaScript from native installation".
+//
+// The name is used for identification only — nothing at runtime resolves modules
+// through it except Bun's own `$bunfs` paths — so this module swaps it for a
+// stand-in of IDENTICAL byte length that tweakcc does recognize, and puts the real
+// name back before the patched candidate is published. Equal length is what keeps
+// the edit safe: no offset, length, or size field in the Bun blob changes, so the
+// swap is a pure byte overwrite that any later parse (including tweakcc's own
+// repack) sees as an ordinary module name.
+//
+// The name still has to be right in the published binary: the OTHER modules live at
+// `/$bunfs/root/*` and are resolved relative to the entry module's directory, so
+// shipping a renamed entry would break the native image, audio, and URL helpers.
+//
+// Locating the name deliberately does NOT parse Mach-O/ELF/PE: the Bun blob ends with a fixed
+// trailer and its own header records where the blob starts, so scanning back from EOF finds it
+// with no dependency on node-lief. Verified on Mach-O; ELF and PE are inferred from tweakcc's
+// own reader and untested — in both, a parse that does not validate returns null and leaves
+// tweakcc to report its usual failure, so the cost of being wrong there is a refusal to patch.
+//
+// See .claude/docs/patcher.md and .claude/docs/claude-code-internals.md.
+
+import { closeSync, openSync, readSync, statSync, writeSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+/** Terminates the Bun data blob in every container format Bun emits. */
+const BUN_TRAILER = Buffer.from('\n---- Bun! ----\n');
+
+/** `{ byteCount: u64, modulesPtr: u32/u32, entryPointId: u32, compileExecArgvPtr: u32/u32, flags: u32 }`. */
+const BUN_OFFSETS_BYTES = 32;
+
+/**
+ * How far back from EOF the trailer is searched for. This is a cost bound, not a correctness one —
+ * scanning further only costs time, because every candidate is validated — but it IS a floor: a
+ * window smaller than the distance from the last trailer to EOF finds nothing and silently disables
+ * the shim. Measured on the real binaries, that distance is 683–802 KB, almost all of it code
+ * signature, so this leaves ~20x headroom.
+ */
+const TAIL_SCAN_BYTES = 16 * 1024 * 1024;
+
+/** Bun's module struct grew from 36 to 52 bytes; both are still in the wild. */
+const MODULE_STRUCT_BYTES_CURRENT = 52;
+const MODULE_STRUCT_BYTES_LEGACY = 36;
+
+/** A module path far longer than this is a misparse, not a name. */
+const MAX_MODULE_NAME_BYTES = 4096;
+
+/** The shortest name that can be swapped in: `/claude`. */
+const MIN_SHIMMABLE_NAME_BYTES = 7;
+
+export interface EntryModuleShim {
+  /** Absolute file offset of the entry module's name bytes. */
+  offset: number;
+  /** The name Claude Code actually ships, restored before the binary is published. */
+  original: string;
+  /** The identical-length stand-in tweakcc recognizes. */
+  marker: string;
+}
+
+/**
+ * tweakcc's own test for "this is the module holding Claude Code's JS", mirrored
+ * exactly. A name this accepts needs no shim; a binary where NO module name is
+ * accepted is one tweakcc cannot read or repack.
+ */
+export function tweakccRecognizesModuleName(name: string): boolean {
+  return name.endsWith('/claude')
+    || name === 'claude'
+    || name.endsWith('/claude.exe')
+    || name === 'claude.exe'
+    || name.endsWith('/src/entrypoints/cli.js')
+    || name === 'src/entrypoints/cli.js';
+}
+
+/**
+ * A recognizable stand-in of exactly `byteLength` bytes, or null when no such name
+ * exists (any name shorter than `/claude`). The `clodex` infix makes a stand-in
+ * that somehow escaped restoration identifiable on sight.
+ */
+export function entryModuleShimName(byteLength: number): string | null {
+  if (byteLength < MIN_SHIMMABLE_NAME_BYTES) return null;
+  const padding = byteLength - MIN_SHIMMABLE_NAME_BYTES;
+  return '/clodex'.padEnd(padding, '-').slice(0, padding) + '/claude';
+}
+
+interface BunModuleNames {
+  /** Every module name in the blob, in blob order. */
+  names: string[];
+  /** Index of the module Bun starts at. */
+  entryPointId: number;
+  /** Absolute file offset of each name's bytes, parallel to `names`. */
+  offsets: number[];
+}
+
+function readAt(fd: number, length: number, position: number): Buffer | null {
+  if (length <= 0 || position < 0) return null;
+  const buffer = Buffer.alloc(length);
+  const read = readSync(fd, buffer, 0, length, position);
+  return read === length ? buffer : null;
+}
+
+/**
+ * Read every module name out of the Bun blob embedded in `path`, or null when the
+ * blob cannot be located and validated. Every derived offset is bounds-checked
+ * against the blob's own recorded size, so a misparse yields null rather than a
+ * plausible-looking wrong answer.
+ */
+function readBunModuleNames(fd: number, fileSize: number): BunModuleNames | null {
+  const tailLength = Math.min(fileSize, TAIL_SCAN_BYTES);
+  const tail = readAt(fd, tailLength, fileSize - tailLength);
+  if (!tail) return null;
+  const tailAt = fileSize - tailLength;
+
+  // A repack can leave the PREVIOUS blob's trailer behind at a HIGHER offset than the new one: the
+  // replacement section content is written over the old content, and when it is shorter the old
+  // tail survives inside the segment. (On a real 2.1.231 an identity repack shrinks the blob by 61
+  // bytes, so this is reachable whenever the patched bundle grows by less than that.) Taking only
+  // the last trailer would parse a stale offsets struct against the new blob, so try each candidate
+  // from EOF backwards and keep the first that validates.
+  for (let searchFrom = tail.length - 1; searchFrom >= 0;) {
+    const trailerInTail = tail.lastIndexOf(BUN_TRAILER, searchFrom);
+    if (trailerInTail < 0) return null;
+    const parsed = parseBunModuleNamesAt(fd, tailAt + trailerInTail - BUN_OFFSETS_BYTES);
+    if (parsed) return parsed;
+    searchFrom = trailerInTail - 1;
+  }
+  return null;
+}
+
+/**
+ * Parse the module list whose 32-byte offsets struct sits at `offsetsAt`, or null if anything about
+ * it fails to validate. Never throws: a corrupt file must degrade to "no shim", leaving tweakcc to
+ * report its own extraction failure.
+ */
+function parseBunModuleNamesAt(fd: number, offsetsAt: number): BunModuleNames | null {
+  try {
+    return parseBunModuleNamesAtUnchecked(fd, offsetsAt);
+  } catch {
+    return null;
+  }
+}
+
+function parseBunModuleNamesAtUnchecked(fd: number, offsetsAt: number): BunModuleNames | null {
+  const offsets = readAt(fd, BUN_OFFSETS_BYTES, offsetsAt);
+  if (!offsets) return null;
+  const byteCount = offsets.readBigUInt64LE(0);
+  const modulesOffset = offsets.readUInt32LE(8);
+  const modulesLength = offsets.readUInt32LE(12);
+  const entryPointId = offsets.readUInt32LE(16);
+
+  // `byteCount` is where the blob records its own offsets struct, which is how the
+  // blob's start is recovered without knowing anything about the container.
+  if (byteCount <= 0n || byteCount > BigInt(offsetsAt)) return null;
+  const blobAt = offsetsAt - Number(byteCount);
+  if (modulesLength <= 0 || BigInt(modulesOffset) + BigInt(modulesLength) > byteCount) return null;
+
+  // Bun's own ambiguity rule: divisible by both (or neither) means the current format.
+  const structBytes = modulesLength % MODULE_STRUCT_BYTES_LEGACY === 0
+      && modulesLength % MODULE_STRUCT_BYTES_CURRENT !== 0
+    ? MODULE_STRUCT_BYTES_LEGACY
+    : MODULE_STRUCT_BYTES_CURRENT;
+  const moduleCount = Math.floor(modulesLength / structBytes);
+  if (moduleCount <= 0 || entryPointId >= moduleCount) return null;
+
+  const modules = readAt(fd, moduleCount * structBytes, blobAt + modulesOffset);
+  if (!modules) return null;
+
+  const names: string[] = [];
+  const nameOffsets: number[] = [];
+  for (let index = 0; index < moduleCount; index++) {
+    const nameOffset = modules.readUInt32LE(index * structBytes);
+    const nameLength = modules.readUInt32LE(index * structBytes + 4);
+    if (nameLength <= 0 || nameLength > MAX_MODULE_NAME_BYTES) return null;
+    if (BigInt(nameOffset) + BigInt(nameLength) > byteCount) return null;
+    // Bun NUL-terminates every string in the blob; its absence means this is not a
+    // string table and the struct size or entry point was misread.
+    const bytes = readAt(fd, nameLength + 1, blobAt + nameOffset);
+    if (!bytes || bytes[nameLength] !== 0) return null;
+    const name = bytes.subarray(0, nameLength).toString('utf8');
+    if (!/^[\x20-\x7e]+$/.test(name)) return null;
+    names.push(name);
+    nameOffsets.push(blobAt + nameOffset);
+  }
+  return { names, entryPointId, offsets: nameOffsets };
+}
+
+/**
+ * Prove the stand-in is gone from the ENTIRE file, not merely from wherever the parse just looked.
+ * Locating the blob is a search, and a repack can leave a stale trailer behind, so "I wrote the
+ * real name back where I found the marker" is a weaker statement than it appears — it would also
+ * be true of a write into a dead copy of the blob while the live one stayed shimmed. Publishing
+ * that binary is the one outcome this module exists to prevent, and it costs one sequential read
+ * to rule out.
+ */
+function assertShimGone(fd: number, fileSize: number, marker: string): void {
+  const needle = Buffer.from(marker);
+  const chunkBytes = 8 * 1024 * 1024;
+  let carry = Buffer.alloc(0);
+  for (let position = 0; position < fileSize;) {
+    const length = Math.min(chunkBytes, fileSize - position);
+    const chunk = readAt(fd, length, position);
+    if (!chunk) throw new Error('could not re-read the candidate to verify the entry-module name');
+    const window = carry.length > 0 ? Buffer.concat([carry, chunk]) : chunk;
+    if (window.includes(needle)) {
+      throw new Error(`the entry-module stand-in ${marker} survived restoration`);
+    }
+    // Keep the last needle-1 bytes so a marker straddling two chunks is still seen.
+    carry = Buffer.from(window.subarray(Math.max(0, window.length - (needle.length - 1))));
+    position += length;
+  }
+}
+
+/** Overwrite a module name in place, refusing to continue on a short write. */
+function writeNameBytes(fd: number, name: string, offset: number): void {
+  const bytes = Buffer.from(name);
+  const written = writeSync(fd, bytes, 0, bytes.length, offset);
+  if (written !== bytes.length) {
+    throw new Error(`wrote ${written} of ${bytes.length} entry-module name bytes at ${offset}`);
+  }
+}
+
+function isMachO(fd: number): boolean {
+  const magic = readAt(fd, 4, 0);
+  if (!magic) return false;
+  const value = magic.readUInt32BE(0);
+  return value === 0xfeedface // 32-bit, big-endian magic
+    || value === 0xfeedfacf // 64-bit
+    || value === 0xcefaedfe // 32-bit, byte-swapped
+    || value === 0xcffaedfe // 64-bit, byte-swapped
+    || value === 0xcafebabe // universal ("fat")
+    || value === 0xcafebabf; // universal, 64-bit
+}
+
+/**
+ * - `discoverable` — tweakcc can already find the bundle; no shim, no change.
+ * - `needs-shim` — the module list is readable and nothing in it matches.
+ * - `unparseable` — no Bun module list could be read at all.
+ *
+ * The last two both mean "do nothing" to a caller, but they are very different
+ * diagnoses, and collapsing them costs a bisect: tweakcc reports the same
+ * "Failed to extract JavaScript" for a name it cannot match, a blob it cannot
+ * read, and the unrelated `node-gyp-build` packaging fault. Opens read-only, so
+ * it is safe to ask about a pristine backup.
+ */
+export type EntryModuleState = 'discoverable' | 'needs-shim' | 'unparseable';
+
+export function inspectEntryModule(path: string): EntryModuleState {
+  const fd = openSync(path, 'r');
+  try {
+    const parsed = readBunModuleNames(fd, statSync(path).size);
+    if (parsed === null) return 'unparseable';
+    return parsed.names.some(tweakccRecognizesModuleName) ? 'discoverable' : 'needs-shim';
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/**
+ * Give an unpatchable Claude Code binary a module name tweakcc recognizes, so it
+ * can read and repack it. Returns null — no write — when the binary already has a
+ * recognizable module (every release before 2.1.231, so nothing drifts for
+ * existing installs) or when no shim is possible, in which case tweakcc reports its
+ * own extraction failure as before.
+ *
+ * `path` must be a private copy: this WRITES to it.
+ */
+export function shimEntryModuleName(path: string): EntryModuleShim | null {
+  const fd = openSync(path, 'r+');
+  try {
+    const parsed = readBunModuleNames(fd, statSync(path).size);
+    if (!parsed) return null;
+    // Only rename when tweakcc would otherwise find nothing. If it can already
+    // reach a module, renaming would add a second candidate and could hand it a
+    // different one than it picks today.
+    if (parsed.names.some(tweakccRecognizesModuleName)) return null;
+
+    const original = parsed.names[parsed.entryPointId]!;
+    const offset = parsed.offsets[parsed.entryPointId]!;
+    const marker = entryModuleShimName(Buffer.byteLength(original));
+    if (marker === null) return null;
+
+    writeNameBytes(fd, marker, offset);
+    return { offset, original, marker };
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/**
+ * Put Claude Code's real entry-module name back. Call this on the repacked
+ * candidate BEFORE it is published — a binary shipped under the stand-in name
+ * would fail to resolve its sibling native modules.
+ *
+ * The name is re-located rather than written at `shim.offset`, because repacking
+ * rebuilds the blob and moves it.
+ *
+ * `resign` re-applies an ad-hoc Mach-O signature, which the write invalidates.
+ * Pass it after a repack, where the binary would otherwise be unrunnable — and
+ * failing here (candidate discarded, install untouched) beats publishing a binary
+ * that will not start. Pass `false` when the restore returns a file to bytes that
+ * were already validly signed, because re-signing REPLACES Claude Code's own
+ * signature and the result is no longer byte-identical to the pristine install —
+ * which would silently corrupt a content-addressed pristine backup taken from it.
+ */
+export function restoreEntryModuleName(
+  path: string,
+  shim: EntryModuleShim,
+  { resign }: { resign: boolean },
+): void {
+  const fd = openSync(path, 'r+');
+  let machO: boolean;
+  try {
+    const parsed = readBunModuleNames(fd, statSync(path).size);
+    const offset = parsed?.offsets[parsed.entryPointId];
+    if (!parsed || offset === undefined || parsed.names[parsed.entryPointId] !== shim.marker) {
+      throw new Error(
+        `expected the entry module of ${path} to be named ${shim.marker}, found `
+        + `${parsed ? JSON.stringify(parsed.names[parsed.entryPointId]) : 'no readable Bun module list'}`,
+      );
+    }
+    writeNameBytes(fd, shim.original, offset);
+    assertShimGone(fd, statSync(path).size, shim.marker);
+    machO = resign && isMachO(fd);
+  } finally {
+    closeSync(fd);
+  }
+  if (machO && process.platform === 'darwin') {
+    execFileSync('codesign', ['-s', '-', '-f', path], { stdio: 'ignore' });
+  }
+}

--- a/src/patcher.ts
+++ b/src/patcher.ts
@@ -53,6 +53,7 @@ import {
 import { loadRegistry } from './registry/io.js';
 import { findModelsDevModel } from './registry/models-dev.js';
 import { findClaudeBinary, getClaudeVersionForBinary } from './launch.js';
+import { restoreEntryModuleName, shimEntryModuleName } from './bun-entry-module.js';
 import {
   backupDir,
   collectPristineFacts,
@@ -627,8 +628,17 @@ export async function applyPatch(
     const candidatePath = join(candidateDir, basename(binaryPath));
     const seedCandidate = async (from: string): Promise<{ installation: Installation; source: string }> => {
       copyFileSync(from, candidatePath);
+      // Claude Code 2.1.231 renamed the module tweakcc looks for; the shim is a
+      // same-length rename that only has to be in place while tweakcc reads. It
+      // is undone immediately so the seeded candidate stays byte-identical to
+      // `from` — the snapshot path publishes these exact bytes as the pristine
+      // backup under a content address, so re-signing here (which would swap
+      // Claude Code's signature for an ad-hoc one) must not happen.
+      const shim = shimEntryModuleName(candidatePath);
       const installation = await tryDetectInstallation({ path: candidatePath });
-      return { installation, source: await readContent(installation) };
+      const source = await readContent(installation);
+      if (shim) restoreEntryModuleName(candidatePath, shim, { resign: false });
+      return { installation, source };
     };
 
     const facts: PristineFacts = collectPristineFacts({
@@ -697,6 +707,18 @@ export async function applyPatch(
       // Written unconditionally: this branch is only reached when no VALID backup
       // holds these bytes, so an existing file at this content address is a
       // corrupt one being replaced by the bytes its name asserts.
+      //
+      // The candidate has been read from and written to by now (the entry-module shim, at least),
+      // so prove it still IS those bytes rather than assuming it. `plan.pristineSha256` is the
+      // live binary's hash and the name this is about to be filed under, so a mismatch would mean
+      // publishing a backup that lies about its own contents — which only a much later run would
+      // notice, as a backup nobody can trust.
+      if (sha256File(candidatePath) !== plan.pristineSha256) {
+        throw new Error(
+          `the patch candidate no longer matches the pristine bytes it was seeded from; refusing `
+          + `to publish it as ${plan.backupPath}`,
+        );
+      }
       publishBackupFile(candidatePath, plan.backupPath);
     }
 
@@ -767,7 +789,13 @@ export async function applyPatch(
       local = discardLocalPatchOutcome(builtIn.content, local.results);
     }
     results = [...results, ...local.results];
+    // Repacking reads the module list back off the candidate, so the shim has to
+    // be in place again — and undone again before the candidate is published,
+    // because Claude Code's sibling native modules resolve against the entry
+    // module's own path.
+    const writeShim = shimEntryModuleName(candidatePath);
     await writeContent(loaded.installation, local.content);
+    if (writeShim) restoreEntryModuleName(candidatePath, writeShim, { resign: true });
     patchedSize = statSync(candidatePath).size;
     patchedSha256 = sha256File(candidatePath);
     renameSync(candidatePath, binaryPath);

--- a/tests/bun-blob-fixture.ts
+++ b/tests/bun-blob-fixture.ts
@@ -1,0 +1,163 @@
+// A synthetic Bun data blob, laid out exactly as Bun (and tweakcc's repack) writes it:
+// NUL-terminated strings, then the module structs, then the exec-argv string, then the 32-byte
+// offsets struct, then the trailer.
+//
+// Not a *.test.ts, so vitest's `include: ['tests/**/*.test.ts']` never collects it as a suite.
+//
+// Verified against the real layout: the module names, entry-point id, struct size and header form
+// this produces match what a real Claude Code 2.1.231 binary carries.
+
+export const BUN_TRAILER = Buffer.from('\n---- Bun! ----\n');
+
+/** An arm64 Mach-O binary starts with these four bytes. */
+export const MACHO_MAGIC = Buffer.from([0xcf, 0xfa, 0xed, 0xfe]);
+
+export interface BunModuleFixture {
+  name: string;
+  /** The module's payload. Only the entry module's is ever read as the bundle. */
+  contents?: string;
+}
+
+export interface BunBlobOptions {
+  entryPointId?: number;
+  structBytes?: 52 | 36;
+  /** Corrupt the entry name's recorded length, to exercise the parser's guards. */
+  entryNameLengthDelta?: number;
+  /** Point the entry name outside the blob, to exercise the bounds guard. */
+  entryNameOutOfBounds?: boolean;
+}
+
+export function buildBunBlob(
+  modules: BunModuleFixture[],
+  {
+    entryPointId = 0,
+    structBytes = 52,
+    entryNameLengthDelta = 0,
+    entryNameOutOfBounds = false,
+  }: BunBlobOptions = {},
+): Buffer {
+  const stringsPerModule = structBytes === 52 ? 6 : 4;
+  const strings: Buffer[] = [];
+  for (const module of modules) {
+    strings.push(Buffer.from(module.name));
+    strings.push(Buffer.from(module.contents ?? ''));
+    // sourcemap, bytecode (+ moduleInfo, bytecodeOriginPath) — empty here.
+    for (let field = 2; field < stringsPerModule; field++) strings.push(Buffer.alloc(0));
+  }
+
+  const pointers: { offset: number; length: number }[] = [];
+  let cursor = 0;
+  for (const value of strings) {
+    pointers.push({ offset: cursor, length: value.length });
+    cursor += value.length + 1;
+  }
+  const modulesOffset = cursor;
+  const modulesLength = modules.length * structBytes;
+  cursor += modulesLength;
+  const argvOffset = cursor;
+  cursor += 1;
+  const offsetsOffset = cursor;
+  cursor += 32;
+  const trailerOffset = cursor;
+  cursor += BUN_TRAILER.length;
+
+  const blob = Buffer.alloc(cursor);
+  strings.forEach((value, index) => {
+    value.copy(blob, pointers[index]!.offset);
+    blob[pointers[index]!.offset + value.length] = 0;
+  });
+  for (let module = 0; module < modules.length; module++) {
+    let at = modulesOffset + module * structBytes;
+    for (let field = 0; field < stringsPerModule; field++) {
+      const pointer = pointers[module * stringsPerModule + field]!;
+      const isEntryName = field === 0 && module === entryPointId;
+      // `cursor` is the whole blob, so this points at the first byte past it.
+      blob.writeUInt32LE(isEntryName && entryNameOutOfBounds ? cursor : pointer.offset, at);
+      blob.writeUInt32LE(pointer.length + (isEntryName ? entryNameLengthDelta : 0), at + 4);
+      at += 8;
+    }
+    blob.writeUInt8(1, at); // encoding
+    blob.writeUInt8(1, at + 1); // loader
+    blob.writeUInt8(2, at + 2); // moduleFormat
+    blob.writeUInt8(0, at + 3); // side
+  }
+  let at = offsetsOffset;
+  blob.writeBigUInt64LE(BigInt(offsetsOffset), at);
+  at += 8;
+  blob.writeUInt32LE(modulesOffset, at);
+  blob.writeUInt32LE(modulesLength, at + 4);
+  at += 8;
+  blob.writeUInt32LE(entryPointId, at);
+  at += 4;
+  blob.writeUInt32LE(argvOffset, at);
+  blob.writeUInt32LE(0, at + 4);
+  at += 8;
+  blob.writeUInt32LE(0, at); // flags
+  BUN_TRAILER.copy(blob, trailerOffset);
+  return blob;
+}
+
+export interface ParsedBunBlob {
+  names: string[];
+  contents: string[];
+  entryPointId: number;
+}
+
+/**
+ * Read a blob back. Used by the tweakcc stand-in to answer `readContent`/`writeContent` the way
+ * tweakcc does — by module name — so a test that removes the shim sees tweakcc's real failure.
+ */
+export function parseBunBlob(binary: Buffer): ParsedBunBlob {
+  const trailerAt = binary.lastIndexOf(BUN_TRAILER);
+  if (trailerAt < 0) throw new Error('no Bun trailer in fixture');
+  const offsetsAt = trailerAt - 32;
+  const blobAt = offsetsAt - Number(binary.readBigUInt64LE(offsetsAt));
+  const modulesOffset = binary.readUInt32LE(offsetsAt + 8);
+  const modulesLength = binary.readUInt32LE(offsetsAt + 12);
+  const entryPointId = binary.readUInt32LE(offsetsAt + 16);
+  const structBytes = modulesLength % 36 === 0 && modulesLength % 52 !== 0 ? 36 : 52;
+
+  const names: string[] = [];
+  const contents: string[] = [];
+  for (let module = 0; module < modulesLength / structBytes; module++) {
+    const at = blobAt + modulesOffset + module * structBytes;
+    const read = (field: number) => {
+      const offset = binary.readUInt32LE(at + field * 8);
+      const length = binary.readUInt32LE(at + field * 8 + 4);
+      return binary.subarray(blobAt + offset, blobAt + offset + length).toString('utf8');
+    };
+    names.push(read(0));
+    contents.push(read(1));
+  }
+  return { names, contents, entryPointId };
+}
+
+/**
+ * A stand-in for a native Claude Code install: a shell script that answers `--version` (the patcher
+ * probes the real binary this way) followed by the blob. `sh` exits before reaching the blob bytes.
+ */
+export function buildFakeNativeClaude(
+  version: string,
+  modules: BunModuleFixture[],
+  options: BunBlobOptions = {},
+): Buffer {
+  const script = `#!/bin/sh\nif [ "$1" = "--version" ]; then echo "${version} (Claude Code)"; exit 0; fi\nexit 1\n`;
+  return Buffer.concat([Buffer.from(script), buildBunBlob(modules, options)]);
+}
+
+/** Rebuild a fake install around new module contents, the way a repack does. */
+export function rebuildFakeNativeClaude(
+  binary: Buffer,
+  version: string,
+  contentsByIndex: (index: number, previous: string) => string,
+): Buffer {
+  const parsed = parseBunBlob(binary);
+  return buildFakeNativeClaude(
+    version,
+    parsed.names.map((name, index) => ({
+      name,
+      contents: contentsByIndex(index, parsed.contents[index]!),
+    })),
+    { entryPointId: parsed.entryPointId },
+  );
+}

--- a/tests/bun-entry-module.test.ts
+++ b/tests/bun-entry-module.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  inspectEntryModule,
+  entryModuleShimName,
+  restoreEntryModuleName,
+  shimEntryModuleName,
+  tweakccRecognizesModuleName,
+} from '../src/bun-entry-module.js';
+import {
+  buildBunBlob,
+  BUN_TRAILER,
+  MACHO_MAGIC,
+  type BunBlobOptions,
+} from './bun-blob-fixture.js';
+
+vi.mock('node:child_process', () => ({ execFileSync: vi.fn() }));
+
+/**
+ * The blob wrapped in a container: leading bytes standing in for the executable headers and
+ * sections ahead of it, trailing bytes for a code signature.
+ */
+function buildBinary(names: string[], options: BunBlobOptions = {}): Buffer {
+  return Buffer.concat([
+    Buffer.from('not-a-real-executable-header'.repeat(8)),
+    buildBunBlob(names.map(name => ({ name })), options),
+    // Deliberately opens with sixteen printable, NUL-terminated bytes: a pointer that escapes the
+    // blob must be rejected for being out of bounds, not because whatever it landed on happened to
+    // look wrong.
+    Buffer.concat([
+      Buffer.from('pretend-code-sig'),
+      Buffer.from([0]),
+      Buffer.from('nature'.repeat(16)),
+    ]),
+  ]);
+}
+
+const CURRENT_NAMES = [
+  '/$bunfs/root/cli',
+  '/$bunfs/root/image-processor.js',
+  '/$bunfs/root/mermaid.min.js',
+];
+const PRE_231_NAMES = [
+  '/$bunfs/root/src/entrypoints/cli.js',
+  '/$bunfs/root/image-processor.js',
+  '/$bunfs/root/mermaid.min.js',
+];
+
+describe('bun entry module shim', () => {
+  let dir: string;
+  let binary: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'bun-entry-'));
+    binary = join(dir, 'claude');
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  const write = (bytes: Buffer) => {
+    writeFileSync(binary, bytes);
+    return bytes;
+  };
+
+  it('leaves a binary tweakcc can already read untouched', () => {
+    const before = write(buildBinary(PRE_231_NAMES));
+
+    expect(inspectEntryModule(binary)).toBe('discoverable');
+    expect(shimEntryModuleName(binary)).toBeNull();
+    expect(readFileSync(binary).equals(before)).toBe(true);
+  });
+
+  it('makes the renamed 2.1.231 entry module discoverable', () => {
+    write(buildBinary(CURRENT_NAMES));
+    expect(inspectEntryModule(binary)).toBe('needs-shim');
+
+    const shim = shimEntryModuleName(binary);
+
+    expect(shim?.original).toBe('/$bunfs/root/cli');
+    expect(tweakccRecognizesModuleName(shim!.marker)).toBe(true);
+    expect(inspectEntryModule(binary)).toBe('discoverable');
+  });
+
+  it('changes nothing but the name bytes, and puts them back exactly', () => {
+    const before = write(buildBinary(CURRENT_NAMES));
+
+    const shim = shimEntryModuleName(binary)!;
+    const shimmed = readFileSync(binary);
+
+    expect(shimmed.length).toBe(before.length);
+    const differing = [...shimmed].flatMap((byte, index) => byte === before[index] ? [] : [index]);
+    expect(differing.length).toBeGreaterThan(0);
+    expect(Math.min(...differing)).toBeGreaterThanOrEqual(shim.offset);
+    expect(Math.max(...differing)).toBeLessThan(shim.offset + Buffer.byteLength(shim.original));
+
+    restoreEntryModuleName(binary, shim, { resign: false });
+    expect(readFileSync(binary).equals(before)).toBe(true);
+  });
+
+  it('shims the entry module rather than the first one', () => {
+    const names = ['/$bunfs/root/mermaid.min.js', '/$bunfs/root/helper.js', '/$bunfs/root/cli'];
+    const before = write(buildBinary(names, { entryPointId: 2 }));
+
+    const shim = shimEntryModuleName(binary)!;
+
+    expect(shim.original).toBe('/$bunfs/root/cli');
+    const after = readFileSync(binary);
+    expect(after.indexOf('/$bunfs/root/mermaid.min.js')).toBe(before.indexOf('/$bunfs/root/mermaid.min.js'));
+    expect(after.indexOf('/$bunfs/root/helper.js')).toBe(before.indexOf('/$bunfs/root/helper.js'));
+  });
+
+  it('reads the legacy 36-byte module struct', () => {
+    write(buildBinary(CURRENT_NAMES, { structBytes: 36 }));
+
+    expect(shimEntryModuleName(binary)?.original).toBe('/$bunfs/root/cli');
+    expect(inspectEntryModule(binary)).toBe('discoverable');
+  });
+
+  it('declines to shim a name too short to hold a recognizable one', () => {
+    // `/claude` is seven bytes; nothing shorter can be swapped in place.
+    const before = write(buildBinary(['cli', '/$bunfs/root/helper.js']));
+
+    expect(shimEntryModuleName(binary)).toBeNull();
+    expect(readFileSync(binary).equals(before)).toBe(true);
+  });
+
+  it('declines to shim a name that is not where the module list says it ends', () => {
+    // A name field one byte short of its NUL means this parse disagrees with the
+    // real layout — renaming on that basis would overwrite the wrong span.
+    const before = write(buildBinary(CURRENT_NAMES, { entryNameLengthDelta: -1 }));
+
+    expect(shimEntryModuleName(binary)).toBeNull();
+    expect(inspectEntryModule(binary)).toBe('unparseable');
+    expect(readFileSync(binary).equals(before)).toBe(true);
+  });
+
+  it('declines to shim a name pointing outside the blob', () => {
+    const before = write(buildBinary(CURRENT_NAMES, { entryNameOutOfBounds: true }));
+
+    expect(shimEntryModuleName(binary)).toBeNull();
+    expect(readFileSync(binary).equals(before)).toBe(true);
+  });
+
+  /**
+   * The real container is nothing like a tight wrapper: on 2.1.231 the blob's trailer sits
+   * ~800 KB from EOF behind a ~590 KB code signature, and the file carries a decoy
+   * `---- Bun! ----` at ~55 MB (Bun's runtime ships the literal in __TEXT). A fixture that hugs
+   * the blob passes with a scan window far too small to work, or one so wide it finds the decoy.
+   */
+  describe('inside a realistic container', () => {
+    const blobOf = (names: string[]) => buildBunBlob(names.map(name => ({ name })));
+
+    it('finds a blob buried under a code signature far larger than a page', () => {
+      write(Buffer.concat([blobOf(CURRENT_NAMES), Buffer.alloc(1_500_000, 0x41)]));
+
+      expect(shimEntryModuleName(binary)?.original).toBe('/$bunfs/root/cli');
+    });
+
+    it('is not fooled by a decoy trailer ahead of the blob', () => {
+      write(Buffer.concat([
+        Buffer.from('runtime strings: '),
+        BUN_TRAILER,
+        Buffer.alloc(4096, 0x42),
+        blobOf(CURRENT_NAMES),
+        Buffer.alloc(2048, 0x43),
+      ]));
+
+      expect(shimEntryModuleName(binary)?.original).toBe('/$bunfs/root/cli');
+    });
+
+    it('skips a stale trailer a shrinking repack left behind after the live blob', () => {
+      // Verified against the real binary: an identity repack of 2.1.231 shrinks the blob by 61
+      // bytes and the previous offsets struct + trailer survive at a HIGHER file offset.
+      const blob = blobOf(CURRENT_NAMES);
+      const staleTail = blob.subarray(blob.length - (32 + BUN_TRAILER.length));
+      write(Buffer.concat([blob, Buffer.from('LEFT!'), staleTail, Buffer.alloc(1024, 0x44)]));
+
+      expect(shimEntryModuleName(binary)?.original).toBe('/$bunfs/root/cli');
+    });
+  });
+
+  describe('refuses a module list that does not validate', () => {
+    const corrupted = (mutate: (blob: Buffer, offsetsAt: number) => void) => {
+      const blob = buildBunBlob(CURRENT_NAMES.map(name => ({ name })));
+      mutate(blob, blob.length - (32 + BUN_TRAILER.length));
+      return write(Buffer.concat([blob, Buffer.alloc(64, 0x45)]));
+    };
+
+    it('when a name carries a byte no module path would', () => {
+      // A control byte where a path should be means these offsets are being read as
+      // something they are not — the same signal as a missing NUL, one step earlier.
+      const before = write(buildBinary(['/$bunfs/root/cli', '/$bunfs/root/helper.js']));
+
+      expect(shimEntryModuleName(binary)).toBeNull();
+      expect(readFileSync(binary).equals(before)).toBe(true);
+    });
+
+    it('when the entry point is not one of the modules', () => {
+      const before = corrupted((blob, offsetsAt) => blob.writeUInt32LE(3, offsetsAt + 16));
+
+      expect(shimEntryModuleName(binary)).toBeNull();
+      expect(readFileSync(binary).equals(before)).toBe(true);
+    });
+
+    it('when the module table overruns the blob', () => {
+      const before = corrupted((blob, offsetsAt) => blob.writeUInt32LE(0xffff, offsetsAt + 12));
+
+      expect(shimEntryModuleName(binary)).toBeNull();
+      expect(readFileSync(binary).equals(before)).toBe(true);
+    });
+
+    it('when the module table is empty', () => {
+      const before = corrupted((blob, offsetsAt) => blob.writeUInt32LE(0, offsetsAt + 12));
+
+      expect(shimEntryModuleName(binary)).toBeNull();
+      expect(readFileSync(binary).equals(before)).toBe(true);
+    });
+
+    it('when the blob claims to start before the file does', () => {
+      const before = corrupted((blob, offsetsAt) => blob.writeBigUInt64LE(1n << 40n, offsetsAt));
+
+      expect(shimEntryModuleName(binary)).toBeNull();
+      expect(readFileSync(binary).equals(before)).toBe(true);
+    });
+  });
+
+  it('declines to shim when no module list can be found', () => {
+    const before = write(Buffer.from('this is not a bun binary at all'.repeat(100)));
+
+    expect(shimEntryModuleName(binary)).toBeNull();
+    // Nothing a shim can fix — tweakcc reports its own extraction failure.
+    expect(inspectEntryModule(binary)).toBe('unparseable');
+    expect(readFileSync(binary).equals(before)).toBe(true);
+  });
+
+  it('does not shim when tweakcc can already reach some other module', () => {
+    // Two matches would let tweakcc pick a module other than the entry point.
+    const before = write(buildBinary(['/$bunfs/root/cli', '/$bunfs/root/claude']));
+
+    expect(inspectEntryModule(binary)).toBe('discoverable');
+    expect(shimEntryModuleName(binary)).toBeNull();
+    expect(readFileSync(binary).equals(before)).toBe(true);
+  });
+
+  it('restores the name where the repack moved it, not where it was shimmed', () => {
+    // A repack rebuilds the blob, so the name almost never comes back at the same offset. Writing
+    // at the remembered offset would corrupt whatever now lives there and leave the stand-in in
+    // place. Growing an earlier module reproduces the shift.
+    const modules = [
+      { name: '/$bunfs/root/mermaid.min.js', contents: 'small' },
+      { name: '/$bunfs/root/cli', contents: 'bundle' },
+    ];
+    write(Buffer.concat([buildBunBlob(modules, { entryPointId: 1 }), Buffer.alloc(64, 0x46)]));
+    const shim = shimEntryModuleName(binary)!;
+    const moved = buildBunBlob(
+      [{ ...modules[0]!, contents: 'much larger contents than before' }, {
+        name: shim.marker,
+        contents: 'bundle',
+      }],
+      { entryPointId: 1 },
+    );
+    writeFileSync(binary, Buffer.concat([moved, Buffer.alloc(64, 0x46)]));
+
+    restoreEntryModuleName(binary, shim, { resign: false });
+
+    expect(inspectEntryModule(binary)).toBe('needs-shim');
+    expect(readFileSync(binary).includes(shim.marker)).toBe(false);
+    expect(shimEntryModuleName(binary)?.original).toBe('/$bunfs/root/cli');
+  });
+
+  it('refuses to publish a file where the stand-in survived elsewhere', () => {
+    // The parse finds one blob; the guarantee is about the whole file. A stale copy of the blob
+    // left behind by a repack is exactly how the stand-in could outlive its own restoration.
+    const blob = buildBunBlob(CURRENT_NAMES.map(name => ({ name })));
+    write(Buffer.concat([blob, Buffer.alloc(32, 0x47)]));
+    const shim = shimEntryModuleName(binary)!;
+    const shimmed = readFileSync(binary);
+    writeFileSync(binary, Buffer.concat([shimmed, Buffer.from(shim.marker)]));
+
+    expect(() => restoreEntryModuleName(binary, shim, { resign: false }))
+      .toThrow(/survived restoration/);
+  });
+
+  it('refuses to restore over a name that is not the shim it wrote', () => {
+    write(buildBinary(CURRENT_NAMES));
+    const shim = shimEntryModuleName(binary)!;
+    restoreEntryModuleName(binary, shim, { resign: false });
+
+    expect(() => restoreEntryModuleName(binary, shim, { resign: false }))
+      .toThrow(/expected the entry module/);
+  });
+
+  describe('Mach-O signatures', () => {
+    let platform: PropertyDescriptor;
+
+    beforeEach(() => {
+      platform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+      Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+      vi.mocked(execFileSync).mockClear();
+      // A Bun blob is located by scanning back from EOF, so the Mach-O magic can
+      // simply lead the same synthetic container.
+      writeFileSync(binary, Buffer.concat([MACHO_MAGIC, buildBinary(CURRENT_NAMES)]));
+    });
+    afterEach(() => Object.defineProperty(process, 'platform', platform));
+
+    it('re-signs after a repack, which leaves the binary otherwise unrunnable', () => {
+      const shim = shimEntryModuleName(binary)!;
+
+      restoreEntryModuleName(binary, shim, { resign: true });
+
+      expect(vi.mocked(execFileSync)).toHaveBeenCalledWith(
+        'codesign',
+        ['-s', '-', '-f', binary],
+        expect.anything(),
+      );
+    });
+
+    it('leaves the signature alone when the restore reproduces the original bytes', () => {
+      // Re-signing here would swap Claude Code's own signature for an ad-hoc one,
+      // so bytes taken as a pristine backup would not match the install they came
+      // from — nor the content address they are filed under.
+      const before = readFileSync(binary);
+      const shim = shimEntryModuleName(binary)!;
+
+      restoreEntryModuleName(binary, shim, { resign: false });
+
+      expect(vi.mocked(execFileSync)).not.toHaveBeenCalled();
+      expect(readFileSync(binary).equals(before)).toBe(true);
+    });
+  });
+
+  it('builds a recognizable name at any length that admits one', () => {
+    for (let length = 7; length <= 64; length++) {
+      const name = entryModuleShimName(length);
+      expect(Buffer.byteLength(name!)).toBe(length);
+      expect(tweakccRecognizesModuleName(name!)).toBe(true);
+    }
+    expect(entryModuleShimName(6)).toBeNull();
+  });
+});

--- a/tests/patcher.test.ts
+++ b/tests/patcher.test.ts
@@ -1,4 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { tweakccRecognizesModuleName } from '../src/bun-entry-module.js';
+import {
+  buildFakeNativeClaude,
+  MACHO_MAGIC,
+  parseBunBlob,
+  rebuildFakeNativeClaude,
+} from './bun-blob-fixture.js';
+import { execFileSync } from 'node:child_process';
 import * as p from '@clack/prompts';
 import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
@@ -54,6 +62,10 @@ const tweakccMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('tweakcc', () => tweakccMocks);
+
+// The entry-module shim re-signs a Mach-O candidate after repacking it; nothing here should ever
+// shell out for real, and asserting on the call is how the resign decision gets discriminated.
+vi.mock('node:child_process', () => ({ execFileSync: vi.fn() }));
 
 describe('buildPatchModelConfig', () => {
   const favorites = [
@@ -948,6 +960,118 @@ describe('applyPatch', () => {
         backupPath: pristinePath,
       });
     } finally {
+      if (previousAppHome === undefined) delete process.env.CLODEX_HOME;
+      else process.env.CLODEX_HOME = previousAppHome;
+      if (previousTweakccHome === undefined) delete process.env.TWEAKCC_CONFIG_DIR;
+      else process.env.TWEAKCC_CONFIG_DIR = previousTweakccHome;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  /**
+   * Claude Code 2.1.231 renamed the module tweakcc identifies the bundle by, so extraction and
+   * repacking both stopped finding it. The stand-in below reproduces that: it resolves the module
+   * BY NAME, exactly as tweakcc does, and — also exactly as tweakcc does — repacks the original
+   * contents rather than erroring when no name matches.
+   *
+   * Without this, the shim is unpinned: removing both calls from `applyPatch` leaves every other
+   * patcher test green, because they all hand `readContent` a fixture instead of a binary.
+   */
+  it('patches a binary whose entry module tweakcc cannot name, and publishes the real name', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'clodex-entry-module-'));
+    const binaryPath = join(dir, 'claude');
+    const tweakccHome = join(dir, 'tweakcc-home');
+    const previousAppHome = process.env.CLODEX_HOME;
+    const previousTweakccHome = process.env.TWEAKCC_CONFIG_DIR;
+    const RENAMED_ENTRY = '/$bunfs/root/cli';
+    const pristine = Buffer.concat([MACHO_MAGIC, buildFakeNativeClaude('test-version', [
+      { name: RENAMED_ENTRY, contents: CLAUDE_FIXTURE },
+      { name: '/$bunfs/root/image-processor.js', contents: 'native helper' },
+    ])]);
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+    vi.mocked(execFileSync).mockClear();
+    mkdirSync(tweakccHome, { recursive: true });
+    writeFileSync(binaryPath, pristine, { mode: 0o755 });
+    process.env.CLODEX_HOME = dir;
+    process.env.TWEAKCC_CONFIG_DIR = tweakccHome;
+
+    tweakccMocks.tryDetectInstallation.mockReset();
+    tweakccMocks.readContent.mockReset();
+    tweakccMocks.writeContent.mockReset();
+    tweakccMocks.tryDetectInstallation.mockImplementation(
+      async ({ path }: { path: string }) => ({ path, version: 'test-version', kind: 'native' }),
+    );
+    tweakccMocks.readContent.mockImplementation(async ({ path }: { path: string }) => {
+      const parsed = parseBunBlob(readFileSync(path));
+      const index = parsed.names.findIndex(tweakccRecognizesModuleName);
+      if (index < 0) {
+        throw new Error(`Failed to extract JavaScript from native installation: ${path}`);
+      }
+      return parsed.contents[index]!;
+    });
+    tweakccMocks.writeContent.mockImplementation(
+      async ({ path }: { path: string }, content: string) => {
+        const parsed = parseBunBlob(readFileSync(path));
+        const target = parsed.names.findIndex(tweakccRecognizesModuleName);
+        writeFileSync(
+          path,
+          Buffer.concat([MACHO_MAGIC, rebuildFakeNativeClaude(
+            readFileSync(path),
+            'test-version',
+            (index, previous) => (index === target ? content : previous),
+          )]),
+          { mode: 0o755 },
+        );
+      },
+    );
+
+    try {
+      const outcome = await applyPatch(
+        binaryPath,
+        'test-version',
+        {
+          config: {
+            'clodex:test:extended': {
+              alias: 'extended',
+              effort: {
+                levels: ['low', 'medium', 'high', 'xhigh', 'max'],
+                defaultLevel: 'high',
+              },
+            },
+          },
+          unknownWindows: [],
+        },
+        'desired-config-hash',
+        { trace: false, manifest: null },
+      );
+
+      expect(outcome.ok).toBe(true);
+      const published = parseBunBlob(readFileSync(binaryPath));
+      // The published binary must carry Claude Code's own module name: its sibling native modules
+      // resolve against the entry module's directory.
+      expect(published.names[published.entryPointId]).toBe(RENAMED_ENTRY);
+      expect(published.names.some(name => name.includes('clodex'))).toBe(false);
+      // ...and the bundle inside it must actually be the patched one, which pins the shim around
+      // the repack: without it the stand-in silently republishes the original contents.
+      expect(published.contents[published.entryPointId]).toContain('/*ccpatch:');
+      expect(published.contents[published.entryPointId]).not.toBe(CLAUDE_FIXTURE);
+      // The untouched sibling survives the round trip.
+      expect(published.contents[1]).toBe('native helper');
+
+      // The pristine backup is the install's own bytes, not a shimmed or re-signed variant.
+      const backup = readFileSync(join(tweakccHome, 'native-binary.backup'));
+      expect(backup.equals(pristine)).toBe(true);
+      const manifest = JSON.parse(readFileSync(getPatchManifestPath(), 'utf8')) as PatchManifest;
+      expect(readFileSync(manifest.backupPath).equals(pristine)).toBe(true);
+      expect(manifest.pristineSha256).toBe(createHash('sha256').update(pristine).digest('hex'));
+
+      // Exactly one re-sign, for the repack. Signing after the read would have replaced Claude
+      // Code's own signature and made the bytes above stop matching the install they came from.
+      const signings = vi.mocked(execFileSync).mock.calls.filter(([command]) => command === 'codesign');
+      expect(signings).toHaveLength(1);
+    } finally {
+      Object.defineProperty(process, 'platform', platform);
       if (previousAppHome === undefined) delete process.env.CLODEX_HOME;
       else process.env.CLODEX_HOME = previousAppHome;
       if (previousTweakccHome === undefined) delete process.env.TWEAKCC_CONFIG_DIR;


### PR DESCRIPTION
`clodex patch` stopped working the moment Claude Code 2.1.231 arrived. Every attempt failed with
`Failed to extract JavaScript from native installation`, which left anyone on 2.1.231 with no model
aliases, no per-model context windows (so auto-compaction misfires and long sessions die with
"Prompt is too long"), and no effort settings — with no way forward except staying on an older
Claude Code. This restores patching on 2.1.231.

## The failure

Claude Code renamed the module that holds its JavaScript bundle:

| Claude Code | Entry module |
| --- | --- |
| 2.1.224 / 2.1.226 / 2.1.228 | `/$bunfs/root/src/entrypoints/cli.js` |
| **2.1.231** | **`/$bunfs/root/cli`** |

tweakcc locates that module **by name**, accepting exactly six: `/claude`, `claude`,
`/claude.exe`, `claude.exe`, `/src/entrypoints/cli.js`, `src/entrypoints/cli.js`. The new name
matches none, so `readContent` throws and `applyPatch` aborts before it writes anything.
(Those are the versions actually inspected — 2.1.229 and 2.1.230 were never available here.)

Fully reachable: it is every `clodex patch` on the current Claude Code release, on any platform.
The install is left untouched, so the symptom is a hard failure rather than a broken binary.

Two things this is **not**. It is not the `node-gyp-build` packaging fault that produces the same
message (`.claude/docs/patcher.md`) — the binary parses fine: `__BUN`/`__bun` located, u64 header,
15 modules, offsets sane. And it is not fixed by bumping the pin: tweakcc **4.3.2**, the latest
release and the target of #45, carries a byte-identical predicate. Reported upstream as
[Piebald-AI/tweakcc#945](https://github.com/Piebald-AI/tweakcc/issues/945), where the durable fix is
to select the module by `entryPointId`; this is the third time a rename has broken extraction
(tweakcc #583/#584/#585), so the shim here is deliberately easy to delete once upstream lands.

## The change

`src/bun-entry-module.ts` swaps the entry module's name for a stand-in of **identical byte length**
that tweakcc recognizes (`/clodex--/claude` for a 16-byte original), and restores the real name
afterwards. Equal length is the entire safety argument: no offset, length, or size field in the Bun
blob changes, so the edit is a pure byte overwrite that tweakcc's own repack reads back as an
ordinary module name. It is applied around `readContent` and again around `writeContent` (which
re-parses the candidate), and undone after each.

The name must be correct in the published binary — Claude Code's sibling native modules
(`image-processor.node`, `audio-capture.node`, …) resolve against the entry module's directory, so
shipping the stand-in would break them.

Locating the blob does not parse Mach-O/ELF/PE at all: the blob ends in a fixed trailer and records
where it starts, so scanning back from EOF finds it with no `node-lief` dependency. Every derived
offset is bounds-checked, and names must be printable and NUL-terminated; a misparse returns null
and leaves tweakcc's own error rather than overwriting bytes at a guessed offset. The shim is also a
no-op when any module name already matches, so every release before 2.1.231 behaves exactly as it
did — and that is what keeps tweakcc's two selectors honest, since it reads the *first* matching
module but rewrites *every* one, so there must only ever be one.

`scripts/extract-cc-bundles.mjs` needs the same fix to read a 2.1.231 bundle. It shims a **scratch
copy** — the `.orig` backups are the only pristine bytes on the machine.

**Deliberately not done:** no vendored extract/repack (that would fork ~200 lines of platform binary
surgery testable on one OS), and no tweakcc bump — 4.3.2 does not fix this.

## Three defects found while verifying, all fixed and pinned

**A corrupt pristine backup.** The first end-to-end run "succeeded" and filed a backup whose content
hashed to `adde33a6…` under a name asserting `ba790279…`. Restoring the name re-signed the binary,
replacing Claude Code's signature, so the candidate was no longer byte-identical to the install
whose bytes were about to be published as pristine. Re-signing is *required* after a repack (an
unsigned Mach-O will not run) and *forbidden* on the read path — now an explicit `resign` flag.
The candidate is additionally re-hashed against `plan.pristineSha256` — the hash the backup's own
name asserts — immediately before it is published, so the whole class fails loudly instead of
silently, on every seeding path rather than only the shimmed one. Reintroducing the bug aborts with
no backup written and the install untouched.

**A stale trailer after a repack**, found by review and then reproduced directly on the real
binary: an identity repack of 2.1.231 shrinks the blob by exactly 61 bytes
(`byteCount 228071183 → 228071122`), and the previous trailer survives at a **higher** file offset
(`293918519`) than the live one (`293918458`). Taking the last trailer parses a dead offsets struct
and fails. The scan now walks candidates from EOF backwards and keeps the first that validates —
which also makes it immune to the decoy `---- Bun! ----` that every real binary carries around
55 MB (Bun ships the literal in `__TEXT`). Not reachable through the built-ins today, which grow the
bundle far past the cliff, but reachable via a net-shrinking local patch or any change to Bun's
repack slack. Impact was failure only: the throw precedes `renameSync`.

**Nothing re-checked the published bytes.** `restoreEntryModuleName` verified it found *a* blob whose
entry name was the stand-in — which, with a stale trailer now proven real, could be satisfied by the
wrong blob while the live one stayed shimmed. Restoration now scans the entire file to prove the
stand-in is gone, so the never-publish-the-stand-in rule is enforced rather than inferred.

## Evidence

Real `clodex patch` against the real 2.1.231, sandboxed (`CLODEX_HOME`, `TWEAKCC_CONFIG_DIR`,
`TWEAKCC_CC_INSTALLATION_PATH` all temp dirs; the live install was never a target):

- **11/11** built-in sites applied, plus a local patch
- the published binary **executes the patched bundle** — a canary planted through clodex's own
  local-patches feature prints at startup. This matters because the entry module also carries
  ~190 MB of Bun bytecode that the repack preserves verbatim; the bytecode does **not** win
- entry module restored to `/$bunfs/root/cli`, no stand-in anywhere in the file, signature valid
- pristine backup byte-identical to the install and matching its content address
- no regression pre-2.1.231: 2.1.228 patches 11/11 with the shim a no-op

Product smoke test on that patched binary via `CLODEX_CLAUDE_PATH`, default proxy mode — Anthropic
passthrough `--model haiku` → `HAIKU-OK`; translated legs `--model luna` → `MODEL-OK` and
`--model sol` → `SOL-OK`. The aliases resolving is itself proof the patch is live in the binary.

`scripts/extract-cc-bundles.mjs` extracts the 2.1.231 bundle (25,410,680 bytes), leaves the `.orig`
backup byte-identical, and leaks no temp directories.

**Tests.** Before the new integration test, deleting *both* shim calls from `applyPatch` left all
155 patcher tests green — every other test hands `readContent` a fixture instead of a binary. The
new test drives `applyPatch` against a synthetic native binary through a tweakcc stand-in that
resolves the module by name and, exactly like tweakcc, silently repacks the original contents when
nothing matches. Deleting either call site, or both, now reddens it. A reviewer's independent mutation audit then found 15 more mutations that
survived a green suite; the fixtures hugged the blob (113 trailing bytes where the real container
has ~800 KB), so a scan window far too small to work still passed. Now caught: a scan window below
the real trailer distance, a decoy or stale trailer, the entry-point index ignored, the
"already discoverable" guard removed, a non-length-preserving stand-in, the marker check or
NUL-terminator or printable-name or entry-point-bound checks dropped, restoring at the remembered
offset instead of re-locating, the whole-file stand-in scan removed, and — via a Mach-O fixture and
a mocked `codesign` — the `resign` flag flipped in either direction.

Environment: macOS 15 / arm64, Node 24.14.1, pnpm 10.34.5, tweakcc 4.3.0 (current pin).
`pnpm typecheck && pnpm test && pnpm build` all clean, and green again under
`CLODEX_HOME=$(mktemp -d)`.

## Reviewed

Three independent adversarial reviews (byte-level parsing, patcher integration, tests and docs).
Two ran their own sandboxed end-to-end `clodex patch` against real 2.1.231 and confirmed the backup,
signature, published name, `--restore` round trip, and no regression on 2.1.228. Their findings are
the three defects and the mutation gaps above, plus a batch of smaller corrections applied here: the
`readContent` "returns null" claim was wrong (it throws — `src/tweakcc.d.ts` declares
`Promise<string>` two files away), the container-format and affected-version claims were scoped to
what was actually observed, `entryModuleIsDiscoverable` was collapsing "unparseable" into
"already fine" and is now three-valued so the diagnosis survives, the round-trip guard moved to the
publish site, and short writes now fail loudly.

## What I could not verify

- **macOS/Mach-O only.** ELF and PE were reasoned about against tweakcc's own repack code, not run.
  The predicate is format-independent so 2.1.231 should be affected identically everywhere, but I
  have no Linux or Windows 2.1.231 install.
- **Fat Mach-O:** node-lief reads the first slice while the EOF scan finds the last. Claude Code
  ships thin arm64; if that changed, the result is tweakcc's own extraction error, not corruption.
- **An ELF binary carrying both a `.bun` section and a legacy overlay** would diverge from tweakcc's
  preference. I could not produce that state and do not know that it exists.
- A **stand-in shorter than `/claude`** (7 bytes) is impossible; a future name under 7 bytes returns
  null and restores today's failure rather than a wrong rename.
- **No 36-byte-struct binary exists to test against** — all real binaries use the 52-byte struct, so
  the legacy path is fixture-only evidence.
- **Two bounds checks are redundant** with the short-read and string-validation guards: dropping
  either leaves behavior unchanged, so no test reddens for them. They are kept as cheap defence in
  depth, not because a test demands them.

## Failure and rollback

Every failure path leaves the install untouched: both restores precede the single `renameSync` that
publishes, the candidate lives in a `.clodex-patch-*` temp dir removed in a `finally`, and
`patchedSize`/`patchedSha256` are computed after the restore and re-sign. A kill between shim and
restore leaves only an orphan temp directory. `clodex patch --restore` is unaffected — it copies the
verified backup straight over the binary and never calls tweakcc.

## Land order

Independent of #45 (tweakcc 4.3.2); that bump neither fixes nor breaks this, and this PR does not
touch `package.json`. #45 is already stale against `main` — its diff targets the old `CLAUDE.md`
patcher section, which has since moved to `.claude/docs/patcher.md`, the file this PR edits.
