### PR TITLE
docs: teach the review skill to date an author's evidence and to salvage committed probes

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -19,10 +19,18 @@ review that got something wrong.
   release, `git diff old..new` is pure noise. Use
   `git diff $(git merge-base main X)..X` for each head and then `diff -u` the two patches. This is
   how you find out a "small update" was actually a full rebuild.
-- **Read the PR body before adjudicating between an agent and the author.** A reviewer once called a
-  contributor's number an unsupported inference when the PR's own validation section stated the
-  source in as many words — the same failure shape we warn contributors about, committed by the
-  reviewer.
+- **Before alleging the author skipped work or misstated a result, read the PR body *and* the
+  comments, and tie every claim to the head it describes.** A reviewer once called a contributor's
+  number an unsupported inference when the PR's own validation section stated the source in as many
+  words — the same failure shape we warn contributors about, committed by the reviewer. Later, a
+  panel drafted a note telling an author to re-run a gate his own transplant comment had already
+  reported, with the exact numbers we had measured ourselves. After a rebase or transplant the
+  current gate result often lands in a comment while the body still describes the dead head — but a
+  comment ages the same way, so neither surface is authoritative until you match it to the head.
+  Note what did *not* save us there: four lenses, a refuter pass, and a cross-family cross-check all
+  missed it, and the cross-check actually endorsed the note and extended it. Only an explicit
+  body-versus-comment check before drafting caught it. That is why this is a named step and not a
+  thing you can expect the panel to notice.
 
 ## Build the panel
 
@@ -190,10 +198,33 @@ pushing). Keep them while the PR is open; clean up when it closes. One worktree 
 dedicated refuter worktree per lens gives every agent full mutation rights with zero contention at
 2N worktrees instead of one per agent. Create the worktrees **before** launching a workflow.
 
-**Salvage before you prune.** Verify clean → salvage any untracked harnesses → then remove. Never
+**Salvage every delta from the reviewed head before pruning, and never let a clean `git status`
+alone be the guard.** **Committed probes do not appear in `git status`** — one worktree held three
+probe commits, including the only artifact pinning an interactive warning seam, while its status
+showed nothing but the `node_modules` symlink, so an untracked-only sweep found nothing to salvage
+and said so confidently.
+
+Record the reviewed head externally *before* agents start. Never re-derive it from the worktree you
+are inspecting, which makes drift undetectable by construction, and never from the worktrees' parent
+directory — that is not a repository, so the SHA comes back empty and `git log "$X"..HEAD` silently
+degrades to a no-op that reports nothing. Then, passing `git -C "$wt"` on every command:
+
+- classify the head. Equal is clean; ahead means salvage first. Anything else — `git merge-base
+  --is-ancestor "$head" HEAD` returns non-zero — means **stop and read the reflog**, because a
+  worktree already reset or force-moved has dropped its probes from the range, from status, and from
+  the filesystem alike, and resetting again buries them further.
+- enumerate committed files with `git log --name-status "$head"..HEAD`. Plain `git log` lists
+  commits, not paths, so it cannot drive a salvage.
+- enumerate the rest with `git status --porcelain -uall`, then sweep for `zz-*` harnesses. That
+  sweep is a naming-convention backstop, not an inventory: it misses differently-named scratch,
+  anything written outside the worktree, and files a reset already removed.
+
+Confirm every copy with `diff -q`, requiring exit 0 — exit 1 means the destination differs and 2
+that it is missing, and either one blocks the prune. Only then reset a worktree you are keeping back
+to the reviewed head, or later differentials run against polluted material. Never
 delete-then-discover; a cleanup script once refused to delete precisely because four worktrees still
-held unsalvaged harnesses. And never trust a stated branch state before destructive cleanup —
-verify with a content diff, not ancestry, because a squash merge defeats ancestry checks.
+held unsalvaged harnesses. And never trust a stated branch state before destructive cleanup — verify
+with a content diff, not ancestry, because a squash merge defeats ancestry checks.
 
 ## Verdict, posting, merging
 


### PR DESCRIPTION
Two rules for our own review process, both paid for during the round-2 review of #110. No runtime
code changes — this only edits `.claude/skills/pr-review/SKILL.md`, the guide we follow when
reviewing a pull request.

## What went wrong, and what the rules now say

**1. We nearly told a contributor to redo work he had already done and reported.**

The panel reviewing #110 noticed the PR body still reported an old test count and drafted a note
telling the author to re-run his validation gate. He had already re-run it — his transplant comment
carried `94 test files / 1,809 tests`, exactly what we had measured ourselves three times. The body
was genuinely stale, but the demand was redundant, and it would have read as an accusation about his
diligence.

The existing bullet already said to read the PR body. That covers a reviewer who did not look; it
does not cover this, where the body is honest but describes a head a later rebase or transplant
killed. The bullet is now merged with the new rule, because both are the same failure class:
alleging the author skipped work without reading the evidence he supplied. The rule is to read body
*and* comments and tie each claim to the head it describes — a comment ages after a force-push
exactly as a body does, so neither is authoritative on its own.

**2. An untracked-only salvage sweep reported "nothing to salvage" for a worktree holding three
probe commits.**

Cleaning up after the review, the salvage step keyed on `git status` untracked entries. One review
worktree had committed its probes, so `git status` showed nothing but the `node_modules` symlink and
the sweep found nothing — including the only artifact pinning an interactive warning seam. A
delete-then-discover prune would have destroyed it silently.

The salvage guard now classifies the head before trusting any range, enumerates committed files with
`git log --name-status` rather than plain `git log`, names the two provenance traps that silently
degrade the range to a no-op, and requires `diff -q` exit 0 before a prune.

## What the adversarial pass changed

Three reviewers ran against the first draft before this was pushed, on the family opposite the one
that wrote it. **Four claims were refuted and are gone from the text:**

- that the existing "commit before mutation testing" rule *caused* the agent to commit its probes —
  it used `cp` for its mutations and committed artifacts separately, and the three sibling worktrees
  under an identical prompt left theirs untracked;
- that `find` was the only check that saw them — `git log --name-status` enumerates all of them, and
  the first draft's own recommended command would have found them;
- that a `zz-*` sweep is an authoritative filesystem inventory — it is a naming-convention backstop
  that misses differently-named scratch, anything outside the worktree, and files a reset removed;
- that the cross-check caught the first incident. It did not: it endorsed the bad note and extended
  it. An explicit body-versus-comment check during final drafting caught it. That correction is now
  *in* the bullet, because "four lenses and a cross-family cross-check all missed this" is the
  argument for making it a named step rather than something you expect a panel to notice.

A fourth review challenged the pre-existing "four worktrees" cleanup incident as uncorroborated;
that claim is recorded verbatim in the maintainer's session log, so the pre-existing sentence is
unchanged.

## Verification

Every command in the new salvage text was executed against all four head states in a scratch repo —
equal, ahead, behind, and sideways:

- ahead: `git log --name-status` enumerates the committed probes, `git status --porcelain -uall`
  catches the untracked one, and plain `git log` names **zero** file paths, which is why
  `--name-status` is required;
- the parent-directory trap reproduces — a SHA derived from the non-repository worktree parent comes
  back empty and `git log ""..HEAD` reports 0 commits with exit 0;
- behind and sideways both classify as stop-and-read-the-reflog; the range alone is empty when
  behind, which is exactly when it would have looked clean;
- `diff -q` returns 1 for a differing destination and 2 for a missing one, as the text now states.

`pnpm typecheck && pnpm test && pnpm build` pass on the branch: 94 files / 1,797 tests, identical to
`main`, as expected for a docs-only change. Run with an isolated `CLODEX_HOME`,
`CLAUDE_CODE_ENTRYPOINT=cli`, and a dead ambient proxy (`HTTPS_PROXY=http://127.0.0.1:9`).

No open PR touches this file; the three drafts under `.claude/` all edit
`.claude/docs/registry-and-server.md`. `.agents` is a symlink to `.claude`, verified still resolving
to the edited file.
