### PR TITLE
fix(patch): keep your own local patch text intact when clodex patches Claude Code

### DIFF
--- a/.claude/docs/claude-code-internals.md
+++ b/.claude/docs/claude-code-internals.md
@@ -34,7 +34,7 @@ Then **enumerate every branch of the function yourself.** Shipped bugs have come
 gates that happened to be visible, and from grepping one syntactic form of a comparison — grep the
 *value*, then trace every hit.
 
-## The entry module's name is not stable (renamed in 2.1.231)
+## The entry module's name is not stable (renamed in 2.1.229)
 
 The bundle lives in a Bun data blob as one module among ~15, and tweakcc finds it **by name**:
 `/claude`, `claude`, `/claude.exe`, `claude.exe`, `/src/entrypoints/cli.js`, `src/entrypoints/cli.js`.
@@ -42,14 +42,17 @@ The bundle lives in a Bun data blob as one module among ~15, and tweakcc finds i
 | Version | Entry module |
 | --- | --- |
 | 2.1.224, 2.1.226, 2.1.228 | `/$bunfs/root/src/entrypoints/cli.js` |
-| 2.1.231 | `/$bunfs/root/cli` |
+| 2.1.229, 2.1.231–2.1.234 | `/$bunfs/root/cli` |
 
-(Those are the versions actually inspected; 2.1.229 and 2.1.230 were never available here.)
+(2.1.228 is the last release clodex's pinned tweakcc 4.3.0 — and clodex's own mirrored copy of its
+name list — can discover, and 2.1.230 was never published for any platform package, so 2.1.229 is
+where the rename actually landed. Confirmed on linux-x64 and darwin-arm64.)
 
-2.1.231 matches none of them, so `readContent` threw and every patch failed with
+2.1.229 and later match none of them, so `readContent` threw and every patch failed with
 "Failed to extract JavaScript from native installation" — which reads like the `node-gyp-build`
-packaging fault described in `patcher.md` and is not it. tweakcc 4.3.2, the latest release, still
-carries the old list. `src/bun-entry-module.ts` works around it; see `patcher.md`.
+packaging fault described in `patcher.md` and is not it. tweakcc carried the old list through
+4.3.2; **4.3.3** added `/cli`, but clodex mirrors the list itself and is still pinned to 4.3.0, so
+`src/bun-entry-module.ts` works around it; see `patcher.md`.
 
 Two things that are easy to assume wrongly about the blob:
 

--- a/.claude/docs/patcher.md
+++ b/.claude/docs/patcher.md
@@ -122,7 +122,8 @@ tweakcc's own repack reads back as an ordinary module name.
   before a NUL is still rewritten — reproduced against a real repack. Proving an occurrence is a
   module name means parsing the stale table it belongs to, which is not worth adding to a module
   that disappears entirely once tweakcc recognizes `/cli` and the rename goes away. Deleting the
-  shim closes this by construction; until then it is a known, opt-in-only limitation.
+  shim closes this by construction; until then it is a known, opt-in-only limitation — tracked in
+  issue #129, which also records the one behaviour the deletion must not silently drop.
 - `scripts/extract-cc-bundles.mjs` needs the same shim to read a 2.1.229-or-later bundle. It shims a
   **scratch copy**; the `.orig` backups are the only pristine bytes on the machine and nothing may write to
   them.

--- a/.claude/docs/patcher.md
+++ b/.claude/docs/patcher.md
@@ -13,7 +13,7 @@ network.** Flow: `tryDetectInstallation({ path })` → `readContent` → `applyC
 config)` (in-process pure function applying built-in PATCH 1–10 sites) → optional
 `applyLocalPatches` transaction with built-in postcondition verification → `writeContent` (repacks
 the native binary). Both layers return per-site OK/SKIP/FAIL results shown by `--trace`. Since
-2.1.231, the reads and the repack are each wrapped in the entry-module shim below, without which
+2.1.229, the reads and the repack are each wrapped in the entry-module shim below, without which
 tweakcc cannot find the bundle at all.
 
 tweakcc ships no `.d.ts` despite its `types` field — `src/tweakcc.d.ts` declares the verified API
@@ -67,7 +67,7 @@ tweakcc's own repack reads back as an ordinary module name.
   immediately before it is published as a backup, so drifted bytes fail loudly instead.
 - **Only rename when tweakcc would otherwise find nothing.** If any module name already matches, the
   shim is a no-op — a second match could hand tweakcc a different module than it picks today, and
-  every release before 2.1.231 must keep behaving exactly as it did. This is also what makes the
+  every release before 2.1.229 must keep behaving exactly as it did. This is also what makes the
   two selectors agree: tweakcc *reads* the first name-matching module but *rewrites every* one,
   while the shim renames the entry module specifically. Refusing to fire when a match already
   exists guarantees exactly one match, so all three always mean the same module.
@@ -88,9 +88,13 @@ tweakcc's own repack reads back as an ordinary module name.
 - **Restoration is swept, not assumed.** Locating the blob is a search, so "I wrote the name where I
   found the marker" is weaker than it sounds — it is also true of a write into a stale copy while the
   live blob stays shimmed. So after the parse-directed write the whole file is scanned and the real
-  name goes back over **every** remaining copy, then a second scan proves none is left. That is what
-  holds the never-publish-the-stand-in rule up, and it does not depend on the parse having picked the
-  live blob: the stale-copy case gets the real name too.
+  name goes back over **every remaining copy that is a module name**, then a second scan proves none
+  is left. That is what holds the never-publish-the-stand-in rule up, and it does not depend on the
+  parse having picked the live blob: the stale-copy case gets the real name too.
+  Read that rule precisely: it is *never publish a binary that resolves its entry module to the
+  stand-in*, not *never let those sixteen bytes appear anywhere*. Inert copies may legitimately
+  remain — a local patch is allowed to contain the literal — and they are harmless because Bun's
+  parser only accepts a NUL-terminated name.
   Refusing to publish on any surviving copy — the earlier behaviour — could not distinguish that
   case from a benign one, and **every ELF build produces the benign one on every patch**. tweakcc
   branches on container format, and only the ELF-with-a-`.bun`-section path *relocates* the section
@@ -105,15 +109,22 @@ tweakcc's own repack reads back as an ordinary module name.
   That predates the shim — 2.1.228, which needs no shim at all, balloons identically — and it does
   not compound, because the candidate is reseeded from pristine bytes on every run. Do not add a
   size sanity bound: at 2.37x today, any plausible cap would recreate the refusal this replaced.
-  Rewriting is sound only while every copy is one the shim wrote, so `shimEntryModuleName` declines a
-  binary that already carries the marker. That guard cannot see a copy that arrives *after* it runs:
-  a local patch emitting the stand-in literal lands in the file at `writeContent` and is then
-  rewritten with the real name, silently. Reachable only by deliberately emitting clodex's own
-  sentinel from an opt-in local patch, but it is a fail-closed behaviour this trades away — narrow
-  both the sweep and the guard to occurrences followed by a NUL (Bun terminates every blob string;
-  a JS literal is followed by a quote).
-- `scripts/extract-cc-bundles.mjs` needs the same shim to read a 2.1.229-or-later bundle. It shims a **scratch
-  copy**; the `.orig` backups are the only pristine bytes on the machine and nothing may write to
+  Rewriting is sound only while every rewritten copy is one the shim wrote, so `isModuleNameAt`
+  requires a trailing NUL and `shimEntryModuleName` declines a binary whose blob already carries a
+  marker *as a module name*. Without that test the sweep reached content the guard could never have
+  seen, because a local patch's output only lands in the file at `writeContent`, long after the
+  guard ran — a patch emitting the stand-in literal had it rewritten to the real name in the
+  published binary while `clodex patch` reported success. Both halves need the same predicate:
+  narrowing only the sweep would leave the literal in place and then trip the guard on the next run,
+  making the binary unreadable.
+  **The NUL test narrows this case; it does not eliminate it.** Bun NUL-terminates every string
+  field in the blob, not only module names, so a local patch that emits the stand-in immediately
+  before a NUL is still rewritten — reproduced against a real repack. Proving an occurrence is a
+  module name means parsing the stale table it belongs to, which is not worth adding to a module
+  that disappears entirely once tweakcc recognizes `/cli` and the rename goes away. Deleting the
+  shim closes this by construction; until then it is a known, opt-in-only limitation.
+- `scripts/extract-cc-bundles.mjs` needs the same shim to read a 2.1.229-or-later bundle. It shims a
+  **scratch copy**; the `.orig` backups are the only pristine bytes on the machine and nothing may write to
   them.
 
 ## Patcher invariants

--- a/scripts/extract-cc-bundles.mjs
+++ b/scripts/extract-cc-bundles.mjs
@@ -96,7 +96,7 @@ for (const f of files) {
     }
     console.log(`re-extracting ${f}: cached file is only ${size} bytes`);
   }
-  // Claude Code 2.1.231 renamed the module tweakcc looks for. The rename that makes it
+  // Claude Code 2.1.229 renamed the module tweakcc looks for. The rename that makes it
   // readable again is a write, so it happens on a scratch copy — these backups are the only
   // pristine bytes on the machine and nothing here may touch them.
   let readFrom = path.join(srcDir, f);

--- a/src/bun-entry-module.ts
+++ b/src/bun-entry-module.ts
@@ -2,7 +2,7 @@
 //
 // tweakcc finds the module holding Claude Code's JavaScript by NAME — it accepts
 // `/claude`, `claude`, `/claude.exe`, `claude.exe`, `/src/entrypoints/cli.js` and
-// `src/entrypoints/cli.js`. Claude Code 2.1.231 renamed its entry module from
+// `src/entrypoints/cli.js`. Claude Code 2.1.229 renamed its entry module from
 // `/$bunfs/root/src/entrypoints/cli.js` to `/$bunfs/root/cli`, which matches none
 // of them, so `readContent` throws and `clodex patch` fails with
 // "Failed to extract JavaScript from native installation".
@@ -220,12 +220,25 @@ function findStandIn(fd: number, fileSize: number, marker: string): number[] {
  * rewriting fixes both. See `.claude/docs/patcher.md`.
  */
 function restoreEveryStandIn(fd: number, fileSize: number, shim: EntryModuleShim): void {
-  const found = findStandIn(fd, fileSize, shim.marker);
+  const moduleNameCopies = (): number[] => findStandIn(fd, fileSize, shim.marker)
+    .filter(offset => isModuleNameAt(fd, offset, shim.marker));
+  const found = moduleNameCopies();
   for (const offset of found) writeNameBytes(fd, shim.original, offset);
   // Only re-scan if something was rewritten: a first pass that found nothing has already proved it.
-  if (found.length > 0 && findStandIn(fd, fileSize, shim.marker).length > 0) {
+  if (found.length > 0 && moduleNameCopies().length > 0) {
     throw new Error(`the entry-module stand-in ${shim.marker} survived restoration`);
   }
+}
+
+/**
+ * Bun NUL-terminates every string in its blob (which is why `readBunModuleNames` rejects a table
+ * whose name is not), so a copy of the stand-in that is NOT followed by a NUL cannot be a module
+ * name. It is unrelated content — most plausibly a string literal in the patched JavaScript — and
+ * rewriting it would silently change the published bundle.
+ */
+function isModuleNameAt(fd: number, offset: number, marker: string): boolean {
+  const after = readAt(fd, 1, offset + Buffer.byteLength(marker));
+  return after !== null && after[0] === 0;
 }
 
 /** Overwrite a module name in place, refusing to continue on a short write. */
@@ -276,7 +289,7 @@ export function inspectEntryModule(path: string): EntryModuleState {
 /**
  * Give an unpatchable Claude Code binary a module name tweakcc recognizes, so it
  * can read and repack it. Returns null — no write — when the binary already has a
- * recognizable module (every release before 2.1.231, so nothing drifts for
+ * recognizable module (every release before 2.1.229, so nothing drifts for
  * existing installs) or when no shim is possible, in which case tweakcc reports its
  * own extraction failure as before.
  *
@@ -296,8 +309,15 @@ export function shimEntryModuleName(path: string): EntryModuleShim | null {
     const offset = parsed.offsets[parsed.entryPointId]!;
     const marker = entryModuleShimName(Buffer.byteLength(original));
     if (marker === null) return null;
-    // Rewriting every copy on restore is only sound while every copy is one this module wrote.
-    if (findStandIn(fd, statSync(path).size, marker).length > 0) return null;
+    // Rewriting every module-name copy on restore is only sound while every one of them is a copy
+    // this module wrote, so decline a binary whose blob already carries one. A NON-module-name
+    // occurrence (an ordinary string in the bundle) is left alone by the restore sweep, so it is
+    // not a reason to refuse — and refusing on it would make a binary whose patched JavaScript
+    // happens to contain the stand-in impossible to read or re-patch.
+    if (findStandIn(fd, statSync(path).size, marker)
+      .some(offset => isModuleNameAt(fd, offset, marker))) {
+      return null;
+    }
 
     writeNameBytes(fd, marker, offset);
     return { offset, original, marker };

--- a/src/patcher.ts
+++ b/src/patcher.ts
@@ -640,7 +640,7 @@ export async function applyPatch(
     const candidatePath = join(candidateDir, basename(binaryPath));
     const seedCandidate = async (from: string): Promise<{ installation: Installation; source: string }> => {
       copyFileSync(from, candidatePath);
-      // Claude Code 2.1.231 renamed the module tweakcc looks for; the shim is a
+      // Claude Code 2.1.229 renamed the module tweakcc looks for; the shim is a
       // same-length rename that only has to be in place while tweakcc reads. It
       // is undone immediately so the seeded candidate stays byte-identical to
       // `from` — the snapshot path publishes these exact bytes as the pristine

--- a/tests/bun-entry-module.test.ts
+++ b/tests/bun-entry-module.test.ts
@@ -43,7 +43,7 @@ const CURRENT_NAMES = [
   '/$bunfs/root/image-processor.js',
   '/$bunfs/root/mermaid.min.js',
 ];
-const PRE_231_NAMES = [
+const PRE_RENAME_NAMES = [
   '/$bunfs/root/src/entrypoints/cli.js',
   '/$bunfs/root/image-processor.js',
   '/$bunfs/root/mermaid.min.js',
@@ -65,14 +65,14 @@ describe('bun entry module shim', () => {
   };
 
   it('leaves a binary tweakcc can already read untouched', () => {
-    const before = write(buildBinary(PRE_231_NAMES));
+    const before = write(buildBinary(PRE_RENAME_NAMES));
 
     expect(inspectEntryModule(binary)).toBe('discoverable');
     expect(shimEntryModuleName(binary)).toBeNull();
     expect(readFileSync(binary).equals(before)).toBe(true);
   });
 
-  it('makes the renamed 2.1.231 entry module discoverable', () => {
+  it('makes the renamed 2.1.229-and-later entry module discoverable', () => {
     write(buildBinary(CURRENT_NAMES));
     expect(inspectEntryModule(binary)).toBe('needs-shim');
 
@@ -280,13 +280,13 @@ describe('bun entry module shim', () => {
     write(Buffer.concat([blob, Buffer.alloc(32, 0x47)]));
     const shim = shimEntryModuleName(binary)!;
     const shimmed = readFileSync(binary);
-    writeFileSync(binary, Buffer.concat([shimmed, Buffer.from(shim.marker)]));
+    writeFileSync(binary, Buffer.concat([shimmed, Buffer.from(shim.marker), Buffer.alloc(1)]));
 
     restoreEntryModuleName(binary, shim, { resign: false });
 
     const restored = readFileSync(binary);
     expect(restored.includes(shim.marker)).toBe(false);
-    expect(restored.subarray(restored.length - shim.original.length).toString())
+    expect(restored.subarray(restored.length - 1 - shim.original.length, restored.length - 1).toString())
       .toBe(shim.original);
     expect(shimEntryModuleName(binary)?.original).toBe('/$bunfs/root/cli');
   });
@@ -324,8 +324,8 @@ describe('bun entry module shim', () => {
     const beyondTail = 1024 * 1024;
     // Spans the boundary between the first and second read, where the carry arithmetic applies.
     const acrossBoundary = chunkBytes - 8;
-    repacked.write(shim.marker, beyondTail, 'latin1');
-    repacked.write(shim.marker, acrossBoundary, 'latin1');
+    repacked.write(`${shim.marker}\0`, beyondTail, 'latin1');
+    repacked.write(`${shim.marker}\0`, acrossBoundary, 'latin1');
     writeFileSync(binary, repacked);
 
     restoreEntryModuleName(binary, shim, { resign: false });
@@ -337,12 +337,55 @@ describe('bun entry module shim', () => {
     }
   });
 
+  it('leaves a stand-in that is not a module name alone', () => {
+    // The sweep rewrites by byte match, so without a type check it would also rewrite an ordinary
+    // string in the patched bundle. A local patch emitting the stand-in literal is the reachable
+    // shape: it arrives at writeContent, AFTER the shim guard has already run, and silently
+    // becoming `/$bunfs/root/cli` would change the published JavaScript.
+    const blob = buildBunBlob(CURRENT_NAMES.map(name => ({ name })));
+    write(Buffer.concat([blob, Buffer.alloc(32, 0x47)]));
+    const shim = shimEntryModuleName(binary)!;
+    const shimmed = readFileSync(binary);
+    // Quote-delimited, exactly as a JS string literal lands — no NUL terminator. The orphan beside
+    // it is the competitor: the sweep must rewrite that one in the same pass it leaves this one
+    // alone, so neither a no-op sweep nor an indiscriminate one can pass.
+    const literal = Buffer.from(`x="${shim.marker}";`);
+    const orphan = Buffer.from(`${shim.marker}\0`);
+    writeFileSync(binary, Buffer.concat([shimmed, literal, orphan]));
+
+    restoreEntryModuleName(binary, shim, { resign: false });
+
+    const restored = readFileSync(binary);
+    const orphanAt = shimmed.length + literal.length;
+    expect(restored.subarray(orphanAt, orphanAt + orphan.length).toString())
+      .toBe(`${shim.original}\0`);
+    expect(restored.subarray(shimmed.length, shimmed.length + literal.length).toString())
+      .toBe(`x="${shim.marker}";`);
+  });
+
+  it('still shims a binary whose bundle merely mentions the stand-in', () => {
+    // The mirror of the guard: a non-module-name occurrence must not make the binary unpatchable.
+    // Narrowing only the sweep and not the guard would strand exactly this binary.
+    const marker = entryModuleShimName('/$bunfs/root/cli'.length)!;
+    const blob = buildBunBlob(CURRENT_NAMES.map(name => ({ name })));
+    write(Buffer.concat([blob, Buffer.from(`x="${marker}";`)]));
+
+    expect(shimEntryModuleName(binary)?.original).toBe('/$bunfs/root/cli');
+  });
+
   it('declines to shim a binary that already carries the stand-in bytes', () => {
     // Restoration rewrites every copy of the marker, which is only sound while every copy is one
     // the shim wrote. Anything else is left to tweakcc's own extraction failure.
     const marker = entryModuleShimName('/$bunfs/root/cli'.length)!;
     const blob = buildBunBlob(CURRENT_NAMES.map(name => ({ name })));
-    write(Buffer.concat([blob, Buffer.from(marker)]));
+    // The bundle literal comes FIRST, so a guard that only inspects the earliest occurrence would
+    // see a non-module-name and wrongly agree to shim.
+    write(Buffer.concat([
+      blob,
+      Buffer.from(`x="${marker}";`),
+      Buffer.from(marker),
+      Buffer.alloc(1),
+    ]));
 
     expect(shimEntryModuleName(binary)).toBeNull();
     expect(readFileSync(binary).includes(marker)).toBe(true);

--- a/tests/patcher.test.ts
+++ b/tests/patcher.test.ts
@@ -1076,7 +1076,7 @@ describe('applyPatch', () => {
   });
 
   /**
-   * Claude Code 2.1.231 renamed the module tweakcc identifies the bundle by, so extraction and
+   * Claude Code 2.1.229 renamed the module tweakcc identifies the bundle by, so extraction and
    * repacking both stopped finding it. The stand-in below reproduces that: it resolves the module
    * BY NAME, exactly as tweakcc does, and — also exactly as tweakcc does — repacks the original
    * contents rather than erroring when no name matches.


### PR DESCRIPTION
Follow-up to #126, from reviewing it. Two things: a real defect that review turned up in the sweep
#126 introduced, and the version correction #126's author inherited from our own docs.

**User-visible failure.** With local patches enabled, a patch whose emitted JavaScript contains
clodex's internal stand-in `/clodex--/claude` had that string silently rewritten to
`/$bunfs/root/cli` in the published binary, while `clodex patch` reported success. The user's own
patch text changed and nothing said so.

**Root cause.** Restoring the entry-module name swept the whole candidate and rewrote *every* byte
range matching the stand-in, with no test that a range was actually a module name. The pre-shim
guard cannot catch this: a local patch's output only enters the file at `writeContent`, long after
the guard ran.

**Reachability.** Adversarial-only — `--enable-local-patches` is opt-in, the file is a fixed path,
and the trigger is clodex's own private sentinel, which appears nowhere in `src/`. No released
binary is suspect. It is fixed because restoration should not guess what it is rewriting, not
because anyone is hitting it.

**Change.** An occurrence counts only when the next byte is NUL — every string in a Bun blob is
NUL-terminated (`readBunModuleNames` already depends on it) and a JavaScript string literal is
followed by a quote. Applied to **both** the sweep and the guard: narrowing only the sweep leaves
the literal in the file, which then trips the guard and makes the binary unreadable on the next
patch.

**Deliberately left out.** Proving an occurrence really is a module name — which needs the stale
table parsed — is *not* done, so this narrows the case rather than eliminating it: a patch emitting
the stand-in immediately before a NUL is still rewritten (reproduced against a real repack). That
logic would go into a module which disappears entirely once the tweakcc pin reaches 4.3.3 and the
rename goes away, closing this by construction. Recorded as a known limitation in `patcher.md` and
tracked with the migration.

**Discriminating tests and mutations.** Two new tests, each with a competing decoy in its fixture so
neither a lazy nor an indiscriminate implementation passes. Six mutations, each run over the full
file (never `-t`):

| mutation | result |
| --- | --- |
| revert sweep narrowing only | new sweep test, alone |
| revert guard narrowing only | new guard test, alone |
| `isModuleNameAt` always true | both new tests |
| `isModuleNameAt` always false | 4 restoration/guard tests (proves it does not over-reject) |
| guard inspects only the first occurrence | decline test |
| sweep is a no-op | 4 tests incl. the new sweep test |

The last two were green before the decoys were added, and are the reason they exist.

**Runtime evidence.** Real `clodex patch` against a real Claude Code 2.1.233 install, macOS arm64,
Node 24.14.1, tweakcc 4.3.0, with a local patch emitting the sentinel plus a one-byte-different
control string:

| | patch result | user's literal in the published binary |
| --- | --- | --- |
| `main` (24c86d3) | `12 applied, 0 failed`, exit 0 | rewritten to `/$bunfs/root/cli` |
| this branch | `12 applied, 0 failed`, exit 0 | intact |

The control survived in both, so the rewrite was specific to the stand-in. No regression: clean
darwin-arm64 patch is `11 applied, 0 skipped, 0 failed`, binary runs, `codesign --verify` valid,
zero stand-ins; full linux-arm64 patch in a native arm64 container is `11 applied, 0 failed` and the
binary runs. Every live and orphan copy across linux-x64, linux-arm64, linux-x64-musl and
darwin-arm64 is NUL-terminated under both tweakcc 4.3.0 and 4.3.3, so the predicate is not keyed to
one repack implementation.

**The version correction.** The entry-module rename landed in **2.1.229**, not 2.1.231: 2.1.228 is
the last release our pinned tweakcc can discover, 2.1.229 already carries `/$bunfs/root/cli` on
linux-x64 and darwin-arm64, and 2.1.230 was never published for any platform package. Our comments,
both docs and the 2.5.2 changelog all said 2.1.231, and #126's author inherited it from us. Three
remaining 2.1.231 references are measurements taken on that version and are left alone. Also drops a
stale claim that tweakcc 4.3.2 was the latest release.

**Not verified.** Windows and darwin-x64 were not exercised through a real `clodex patch` (no
runtime available); both were checked through the tweakcc read/repack path and neither produces a
surviving stand-in at all. Whether any future repack can emit a module name without a NUL.

**Failure and rollback.** Unchanged. Restoration still throws on a surviving module-name copy, the
candidate is discarded before the install is touched, and `--restore` still returns pristine bytes.

Gates: `pnpm typecheck`, `pnpm test` (1802 passed, 94 files), `pnpm build`, commitlint over both
commits. Note `CLAUDE_CODE_ENTRYPOINT` must be unset when running the suite locally or one unrelated
proxy test fails spuriously — that is pre-existing on `main`.
