### PR TITLE
test(patch): check the Claude Code binary handling on every platform, not just this Mac

### DIFF
--- a/.claude/docs/patcher.md
+++ b/.claude/docs/patcher.md
@@ -127,6 +127,24 @@ tweakcc's own repack reads back as an ordinary module name.
 - `scripts/extract-cc-bundles.mjs` needs the same shim to read a 2.1.229-or-later bundle. It shims a
   **scratch copy**; the `.orig` backups are the only pristine bytes on the machine and nothing may write to
   them.
+- **`scripts/probe-patch-mechanism.mjs` is how you check this on a platform you are not running.**
+  The refusal above shipped because every check we had ran on Mach-O, where the ELF behaviour it
+  turned on cannot occur. The probe drives the same shim → `readContent` → repack → restore cycle
+  `applyPatches` runs, against a Claude Code build for any platform, **without executing it** — so
+  a linux-arm64 or win32-x64 binary can be checked from macOS, and it calls the exported functions
+  rather than a copy so it cannot drift.
+
+  ```bash
+  node scripts/probe-patch-mechanism.mjs <claude-binary> --label linux-x64 --expect-version 2.1.233
+  ```
+
+  It checks that the binary parses, that the seeded candidate is byte-identical to the release
+  (what the content-addressed pristine backup depends on), that the restore leaves no stand-in
+  behind, that a repacked Mach-O still verifies under `codesign`, and that the published bytes read
+  back carrying what was written. It does **not** exercise the patch sites, and it cannot tell you
+  the patched binary runs — only a host or containerised `clodex patch` does that. `clodex patch`
+  resolves the version by executing the binary (`getClaudeVersionForBinary`), which is exactly why
+  a foreign binary can go through the probe and not through the real command.
 
 ## Patcher invariants
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,13 @@ poisoned/corrupt-backup refusals, `--restore`, and the manifest without touching
 
 Interactive launch flow and real-provider behavior are verified manually.
 
+**Nothing automated touches a real Claude Code binary, so nothing automated can see a break that is
+specific to one executable format.** That is not hypothetical: `clodex patch` was broken on every
+ELF build of Claude Code across two releases while macOS stayed green. Before changing
+`src/bun-entry-module.ts` or anything else in the read/repack/restore path, run
+`scripts/probe-patch-mechanism.mjs` against a build for each format — Mach-O, ELF and PE. It needs
+no Linux or Windows host, because it never executes the binary. See `.claude/docs/patcher.md`.
+
 **`claude -p` end-to-end tests are manual only — NEVER add them to the automated suite.**
 
 ## Key constraints

--- a/scripts/probe-patch-mechanism.mjs
+++ b/scripts/probe-patch-mechanism.mjs
@@ -108,6 +108,13 @@ const { tryDetectInstallation, readContent, writeContent } = await import('tweak
 // binary that somehow escapes cleanup.
 const PROBE_MARKER = '/*clodex-probe-patch-mechanism*/';
 
+// ...and enough of it to make the bundle bigger. tweakcc only extends the Mach-O segment when the
+// repacked bundle exceeds the section it came from, and an identity repack SHRINKS it by ~61 bytes,
+// so a token-sized marker leaves that branch — page rounding, segment extension, re-signing a
+// binary whose segment actually moved — untested, while every real patch takes it. The patch sites
+// add kilobytes; so does this.
+const PROBE_PADDING = `\n/*${'clodex-probe-padding'.repeat(4096)}*/\n`;
+
 const checks = [];
 const info = { label, binary, checks: [] };
 let failed = 0;
@@ -146,10 +153,13 @@ function containerFormat(file) {
     if (head.toString('latin1') === '\x7fELF') return 'elf';
     if (head.toString('latin1', 0, 2) === 'MZ') return 'pe';
     const magic = head.readUInt32BE(0);
-    // 32/64-bit Mach-O in either endianness, plus the fat wrapper.
-    if ([0xfeedface, 0xfeedfacf, 0xcefaedfe, 0xcffaedfe, 0xcafebabe, 0xbebafeca].includes(magic)) {
-      return 'macho';
-    }
+    // Kept in step with isMachO in src/bun-entry-module.ts: thin 32/64 in both byte orders, plus
+    // both fat wrappers. A magic this list misses is reported as unknown, which silently skips the
+    // signature check on a binary the patcher does re-sign.
+    const MACH_O_MAGIC = [
+      0xfeedface, 0xfeedfacf, 0xcefaedfe, 0xcffaedfe, 0xcafebabe, 0xcafebabf, 0xbebafeca,
+    ];
+    if (MACH_O_MAGIC.includes(magic)) return 'macho';
     return `unknown(0x${magic.toString(16)})`;
   } finally {
     closeSync(fd);
@@ -189,6 +199,20 @@ try {
   info.format = containerFormat(binary);
   info.pristineSize = statSync(binary).size;
   note(`${label}: ${info.format}, ${info.pristineSize} bytes`);
+
+  // --label is otherwise pure decoration, so probing one binary eight times under eight platform
+  // names would report eight greens and look like full coverage. The magic is the file's own
+  // testimony; where the label claims a platform, the two must agree. (Arch cannot be checked this
+  // way — nothing here reads e_machine/cputype — so linux-x64 vs linux-arm64 stays unverified.)
+  const EXPECTED_FORMAT = { darwin: 'macho', linux: 'elf', win32: 'pe' };
+  const claimed = EXPECTED_FORMAT[label.split('-')[0]];
+  if (claimed) {
+    record(
+      'label-matches-format',
+      claimed === info.format,
+      `${label} should be ${claimed}, the bytes say ${info.format}`,
+    );
+  }
 
   copyFileSync(binary, scratch);
   const pristineSha = await sha256(scratch);
@@ -247,7 +271,7 @@ try {
   // ---- 3. repack, then put the real entry-module name back ----------------------------------
   const repackStarted = Date.now();
   const writeShim = shimEntryModuleName(scratch);
-  await writeContent(installation, `${source}\n${PROBE_MARKER}\n`);
+  await writeContent(installation, `${source}\n${PROBE_MARKER}${PROBE_PADDING}`);
   let restoreError = null;
   if (writeShim) {
     try {
@@ -259,7 +283,16 @@ try {
   info.repackMs = Date.now() - repackStarted;
   info.publishedSize = statSync(scratch).size;
   info.growth = Number((info.publishedSize / info.pristineSize).toFixed(3));
-  note(`repacked to ${info.publishedSize} bytes (${info.growth}x)`);
+  // The ratio rounds to 1.000 on Mach-O and PE, where the repack assigns in place, so the signed
+  // delta is what shows whether the bundle actually grew — and growing is the point of the padding
+  // above, since that is what makes tweakcc extend the segment.
+  info.sizeDelta = info.publishedSize - info.pristineSize;
+  note(`repacked to ${info.publishedSize} bytes (${info.growth}x, ${info.sizeDelta >= 0 ? '+' : ''}${info.sizeDelta})`);
+  record(
+    'repack-grew',
+    info.sizeDelta > 0,
+    `${info.sizeDelta >= 0 ? '+' : ''}${info.sizeDelta} bytes — a repack that did not grow leaves the segment-extension path untested`,
+  );
   record(
     'restore-entry-name',
     restoreError === null,
@@ -283,6 +316,12 @@ try {
   // The probe never runs the binary, so a Mach-O whose signature the repack invalidated would
   // otherwise sail through here and only be caught on the one platform that executes it. codesign
   // reads any Mach-O, so this covers darwin-x64 from an arm64 host too.
+  if (info.format === 'macho' && process.platform !== 'darwin') {
+    // Saying nothing here would make a Linux run of this probe indistinguishable from a macOS one
+    // that verified the signature.
+    info.notChecked = [...(info.notChecked ?? []), 'signature-valid'];
+    note('signature-valid was NOT checked: codesign needs a macOS host');
+  }
   if (info.format === 'macho' && process.platform === 'darwin') {
     let signatureError = null;
     try {
@@ -357,6 +396,11 @@ try {
   info.reasons = info.checks.filter((c) => !c.ok).map((c) => `${c.name}: ${c.detail}`);
   if (opts.keep) {
     info.scratch = scratch;
+  } else if (opts.scratch) {
+    // A caller-supplied --scratch may be a directory with other things in it, so only what this
+    // run created comes out. A blanket rmSync here would delete the caller's contents too.
+    rmSync(scratch, { force: true });
+    rmSync(path.join(scratchDir, 'tweakcc'), { recursive: true, force: true });
   } else {
     rmSync(scratchDir, { recursive: true, force: true });
   }

--- a/scripts/probe-patch-mechanism.mjs
+++ b/scripts/probe-patch-mechanism.mjs
@@ -44,6 +44,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import {
   inspectEntryModule,
+  listBunModuleNames,
   restoreEntryModuleName,
   shimEntryModuleName,
 } from '../src/bun-entry-module.ts';
@@ -66,13 +67,24 @@ if (args.length === 0 || args.includes('-h') || args.includes('--help')) {
 
 const opts = { json: false, keep: false, label: '', scratch: '', expectVersion: '' };
 const positionals = [];
+// A missing value must be an error, not a silent one. `--label --json` used to name the binary
+// "--json" AND turn JSON output off, and a trailing `--expect-version` left the version
+// unvalidated — so a mistyped command reported PASS for a release it never checked.
+const value = (flag, i) => {
+  const next = args[i];
+  if (next === undefined || next.startsWith('-') || next === '') {
+    console.error(`${flag} needs a value. Try --help.`);
+    process.exit(1);
+  }
+  return next;
+};
 for (let i = 0; i < args.length; i++) {
   const arg = args[i];
   if (arg === '--json') opts.json = true;
   else if (arg === '--keep') opts.keep = true;
-  else if (arg === '--label') opts.label = args[++i] ?? '';
-  else if (arg === '--expect-version') opts.expectVersion = args[++i] ?? '';
-  else if (arg === '--scratch') opts.scratch = args[++i] ?? '';
+  else if (arg === '--label') opts.label = value(arg, ++i);
+  else if (arg === '--expect-version') opts.expectVersion = value(arg, ++i);
+  else if (arg === '--scratch') opts.scratch = value(arg, ++i);
   else if (arg.startsWith('-')) {
     console.error(`Unrecognized option: ${arg}. Try --help.`);
     process.exit(1);
@@ -93,9 +105,13 @@ const label = opts.label || path.basename(path.dirname(binary));
 // tweakcc keeps its own backups and config beside whatever this points at. The probe must never
 // write into a real ~/.tweakcc, so it is redirected into the scratch dir unless the caller has
 // already chosen somewhere — and before tweakcc is imported, in case it reads the variable then.
-let scratchDir = opts.scratch ? path.resolve(opts.scratch) : '';
-if (scratchDir) mkdirSync(scratchDir, { recursive: true });
-else scratchDir = mkdtempSync(path.join(tmpdir(), 'clodex-probe-'));
+// Always a private subdirectory, even under a caller-supplied --scratch. Writing `claude` and
+// `tweakcc/` straight into the given directory clobbered anything already named that, deleted it
+// on the way out, made two concurrent probes fight over the same files, and — when the binary
+// under test lived in the directory handed to --scratch — deleted the input itself.
+const scratchRoot = opts.scratch ? path.resolve(opts.scratch) : tmpdir();
+mkdirSync(scratchRoot, { recursive: true });
+const scratchDir = mkdtempSync(path.join(scratchRoot, 'clodex-probe-'));
 if (!process.env['TWEAKCC_CONFIG_DIR']) {
   const dir = path.join(scratchDir, 'tweakcc');
   mkdirSync(dir, { recursive: true });
@@ -114,6 +130,15 @@ const PROBE_MARKER = '/*clodex-probe-patch-mechanism*/';
 // binary whose segment actually moved — untested, while every real patch takes it. The patch sites
 // add kilobytes; so does this.
 const PROBE_PADDING = `\n/*${'clodex-probe-padding'.repeat(4096)}*/\n`;
+
+// Default signal handling does not unwind through the `finally` that cleans up, so an interrupted
+// run would strand a scratch tree of up to ~770 MB.
+for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
+  process.on(signal, () => {
+    if (!opts.keep) rmSync(scratchDir, { recursive: true, force: true });
+    process.exit(130);
+  });
+}
 
 const checks = [];
 const info = { label, binary, checks: [] };
@@ -198,14 +223,23 @@ let exitCode = 1;
 try {
   info.format = containerFormat(binary);
   info.pristineSize = statSync(binary).size;
+  info.pristineMode = statSync(binary).mode & 0o777;
   note(`${label}: ${info.format}, ${info.pristineSize} bytes`);
 
   // --label is otherwise pure decoration, so probing one binary eight times under eight platform
   // names would report eight greens and look like full coverage. The magic is the file's own
   // testimony; where the label claims a platform, the two must agree. (Arch cannot be checked this
   // way — nothing here reads e_machine/cputype — so linux-x64 vs linux-arm64 stays unverified.)
-  const EXPECTED_FORMAT = { darwin: 'macho', linux: 'elf', win32: 'pe' };
-  const claimed = EXPECTED_FORMAT[label.split('-')[0]];
+  // Keyed on the whole published platform name, not its first component: --label is documented as
+  // free text, and treating any "linux-…" as a platform claim would fail a PE artifact somebody
+  // labelled "linux-reference".
+  const EXPECTED_FORMAT = {
+    'darwin-arm64': 'macho', 'darwin-x64': 'macho',
+    'linux-arm64': 'elf', 'linux-x64': 'elf',
+    'linux-arm64-musl': 'elf', 'linux-x64-musl': 'elf',
+    'win32-arm64': 'pe', 'win32-x64': 'pe',
+  };
+  const claimed = EXPECTED_FORMAT[label];
   if (claimed) {
     record(
       'label-matches-format',
@@ -230,6 +264,7 @@ try {
   // The shim is undone immediately so the seeded copy is byte-identical to the source: clodex
   // publishes these bytes as the pristine backup under a content address, so a shim left in place
   // (or a stray re-sign) would poison a backup that is supposed to be Claude Code's own bytes.
+  const pristineModules = listBunModuleNames(scratch) ?? [];
   const readShim = shimEntryModuleName(scratch);
   info.shimUsed = readShim !== null;
   info.entryModuleName = readShim?.original ?? null;
@@ -270,8 +305,9 @@ try {
 
   // ---- 3. repack, then put the real entry-module name back ----------------------------------
   const repackStarted = Date.now();
+  const written = `${source}\n${PROBE_MARKER}${PROBE_PADDING}`;
   const writeShim = shimEntryModuleName(scratch);
-  await writeContent(installation, `${source}\n${PROBE_MARKER}${PROBE_PADDING}`);
+  await writeContent(installation, written);
   let restoreError = null;
   if (writeShim) {
     try {
@@ -296,7 +332,10 @@ try {
   record(
     'restore-entry-name',
     restoreError === null,
-    restoreError ?? 'the real entry-module name went back on after the repack',
+    restoreError
+      ?? (writeShim
+        ? 'the real entry-module name went back on after the repack'
+        : 'no shim was needed, so there was no entry-module name to put back'),
   );
 
   // ---- 4. is the binary that WOULD be published actually sound? -----------------------------
@@ -309,7 +348,7 @@ try {
       info.standInSurvivors === 0,
       info.standInSurvivors === 0
         ? `no ${writeShim.marker} left in the published bytes`
-        : `${info.standInSurvivors} copy/copies of ${writeShim.marker} survived — Claude Code would fail to resolve its sibling native modules`,
+        : `${info.standInSurvivors} copy/copies of ${writeShim.marker} survived; if any of them is a module name, Claude Code fails to resolve its sibling native modules`,
     );
   }
 
@@ -332,7 +371,28 @@ try {
     record(
       'signature-valid',
       signatureError === null,
-      signatureError ?? 'the repacked Mach-O still carries a valid signature, so it can be executed',
+      // Not "so it can be executed": a signed Mach-O with mode 0644 verifies and still will not
+      // run. The executable bit is checked separately, below.
+      signatureError ?? 'the Mach-O signature verifies after the repack and the name restore',
+    );
+  }
+
+  // Every check around this one can be green on a file that will not start: the patcher renames
+  // the candidate over the live install, and a repack that stopped preserving the mode would ship
+  // an unrunnable Claude Code with a perfectly valid signature. The question is whether the repack
+  // CHANGED the mode, not whether the file is executable — a Windows build unpacked from its npm
+  // tarball is 0644 and correctly so.
+  // ELF and Mach-O only: the execute bit is what the kernel consults for those, whereas a PE is
+  // launched by Windows on its extension and tweakcc's PE path legitimately writes 0644 — asserting
+  // it there would fail every Windows build for a property nothing depends on.
+  if (info.format === 'elf' || info.format === 'macho') {
+    const publishedMode = statSync(scratch).mode & 0o777;
+    record(
+      'mode-preserved',
+      publishedMode === info.pristineMode,
+      publishedMode === info.pristineMode
+        ? `mode ${publishedMode.toString(8)}, unchanged by the repack`
+        : `mode went from ${info.pristineMode.toString(8)} to ${publishedMode.toString(8)} — the published binary would not start`,
     );
   }
 
@@ -359,13 +419,25 @@ try {
   try {
     const verifyInstallation = await tryDetectInstallation({ path: scratch });
     const republished = verifyInstallation ? await readContent(verifyInstallation) : '';
+    // Exact equality, not "the marker is in there". Checking only for the marker passed a mutation
+    // that dropped the first byte of Claude Code's entry JavaScript: a repack that flips, drops,
+    // duplicates or re-encodes source bytes while carrying the marker through is precisely the
+    // silent corruption this is here to catch, and it would ship a broken install reporting OK.
+    let mismatch = '';
+    if (!republished) mismatch = 'the published binary yields no JavaScript at all';
+    else if (republished.length !== written.length) {
+      mismatch = `read back ${republished.length} bytes, wrote ${written.length}`;
+    } else if (republished !== written) {
+      let at = 0;
+      while (at < written.length && written[at] === republished[at]) at++;
+      mismatch = `the bytes differ from what was written, first at offset ${at}`;
+    }
     record(
       'published-content',
-      republished.includes(PROBE_MARKER),
-      republished
-        ? `${republished.length} bytes read back${republished.includes(PROBE_MARKER) ? ', carrying the probe marker' : ' but WITHOUT the probe marker — the repack did not land'}`
-        : 'the published binary yields no JavaScript — a patched install would be unreadable and unpatchable',
+      mismatch === '',
+      mismatch || `${republished.length} bytes read back, byte-for-byte what was written`,
     );
+
   } finally {
     // Undoing the verification shim is housekeeping, not a check: leaving it on would hand an
     // investigator a binary that cannot run and a symptom the probe invented. When it fails for
@@ -382,6 +454,25 @@ try {
     }
   }
 
+  // Taken here, on the bytes that would actually be published — after the verification shim is
+  // undone. Read while that shim is on, the entry module still carries the stand-in name and this
+  // reports a change that is the probe's own doing.
+  //
+  // A repack can rebuild a perfectly valid module table and still lose or reorder a sibling — an
+  // image or audio helper, say. The entry module reads, the signature verifies, every check above
+  // is green, and the feature that needed the missing module fails in front of a user.
+  const publishedModules = listBunModuleNames(scratch) ?? [];
+  const lost = pristineModules.filter((n) => !publishedModules.includes(n));
+  const gained = publishedModules.filter((n) => !pristineModules.includes(n));
+  info.moduleCount = { pristine: pristineModules.length, published: publishedModules.length };
+  record(
+    'modules-intact',
+    lost.length === 0 && gained.length === 0 && pristineModules.length === publishedModules.length,
+    lost.length === 0 && gained.length === 0
+      ? `all ${publishedModules.length} modules survived the repack`
+      : `the repack changed the module list — lost [${lost.slice(0, 5).join(', ')}], gained [${gained.slice(0, 5).join(', ')}]`,
+  );
+
   exitCode = failed === 0 ? 0 : 1;
 } catch (err) {
   const detail = err instanceof Error ? err.message : String(err);
@@ -394,16 +485,10 @@ try {
   info.failed = failed;
   info.verdict = failed === 0 ? 'pass' : 'fail';
   info.reasons = info.checks.filter((c) => !c.ok).map((c) => `${c.name}: ${c.detail}`);
-  if (opts.keep) {
-    info.scratch = scratch;
-  } else if (opts.scratch) {
-    // A caller-supplied --scratch may be a directory with other things in it, so only what this
-    // run created comes out. A blanket rmSync here would delete the caller's contents too.
-    rmSync(scratch, { force: true });
-    rmSync(path.join(scratchDir, 'tweakcc'), { recursive: true, force: true });
-  } else {
-    rmSync(scratchDir, { recursive: true, force: true });
-  }
+  // scratchDir is always one this run made, so removing it wholesale takes nothing that was not
+  // put there by this run.
+  if (opts.keep) info.scratch = scratch;
+  else rmSync(scratchDir, { recursive: true, force: true });
   if (opts.json) process.stdout.write(`${JSON.stringify(info)}\n`);
   else console.log(`${info.verdict.toUpperCase()} ${label} — ${checks.length} checks in ${Math.round(info.durationMs / 1000)}s`);
 }

--- a/scripts/probe-patch-mechanism.mjs
+++ b/scripts/probe-patch-mechanism.mjs
@@ -1,0 +1,349 @@
+#!/usr/bin/env node
+// Does `clodex patch`'s binary handling survive a round trip on a Claude Code build for ANOTHER
+// platform?
+//
+// The patch sites themselves match against extracted JavaScript, which is near-identical on every
+// platform — one platform covers them. Everything around the JavaScript is not: the entry-module
+// shim, tweakcc's read, the repack, the restore and the Mach-O re-sign all depend on the container
+// format, and that is the half that has broken. Every ELF build of Claude Code from 2.1.229 onward
+// was unpatchable across two clodex releases while macOS stayed green, because nothing tested an
+// ELF binary.
+//
+// This probe closes that gap without a Linux host: it never EXECUTES the binary, it only
+// manipulates its bytes, so a linux-arm64 or win32-x64 binary can be probed from macOS. (Running it
+// is what `clodex patch` itself needs — it resolves the version by executing the binary — which is
+// why full-patch coverage for Linux needs a container and this does not.)
+//
+//   node scripts/probe-patch-mechanism.mjs <claude-binary> [options]
+//
+//     --json             emit one JSON object on stdout and nothing else
+//     --label NAME       how this binary is named in the output (default: its parent dir name)
+//     --expect-version V fail unless the binary is that Claude Code release
+//     --scratch DIR      where the ~300 MB working copy goes (default: a fresh tmpdir)
+//     --keep             leave the scratch copy behind for inspection
+//
+// Exit status is 0 only when every check passed, so a shell caller can branch on that alone.
+//
+// Must run from inside this repo so `tweakcc` resolves from node_modules. Needs Node >= 22.18 (or
+// `--experimental-strip-types`) for the .ts import below; .nvmrc pins 24.
+
+import {
+  closeSync,
+  copyFileSync,
+  createReadStream,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { createHash } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  inspectEntryModule,
+  restoreEntryModuleName,
+  shimEntryModuleName,
+} from '../src/bun-entry-module.ts';
+
+const args = process.argv.slice(2);
+if (args.length === 0 || args.includes('-h') || args.includes('--help')) {
+  console.log(
+    'Usage: node scripts/probe-patch-mechanism.mjs <claude-binary> [options]\n\n' +
+      '  --json              emit one JSON object on stdout and nothing else\n' +
+      '  --label NAME        how this binary is named in the output\n' +
+      '  --expect-version V  fail unless the binary is that Claude Code release\n' +
+      '  --scratch DIR       where the ~300 MB working copy goes\n' +
+      '  --keep              leave the scratch copy behind\n\n' +
+      'Exercises the shim/read/repack/restore cycle `clodex patch` runs, without executing the\n' +
+      'binary — so a build for any platform can be probed from any host. Exits 0 only if every\n' +
+      'check passed.',
+  );
+  process.exit(0);
+}
+
+const opts = { json: false, keep: false, label: '', scratch: '', expectVersion: '' };
+const positionals = [];
+for (let i = 0; i < args.length; i++) {
+  const arg = args[i];
+  if (arg === '--json') opts.json = true;
+  else if (arg === '--keep') opts.keep = true;
+  else if (arg === '--label') opts.label = args[++i] ?? '';
+  else if (arg === '--expect-version') opts.expectVersion = args[++i] ?? '';
+  else if (arg === '--scratch') opts.scratch = args[++i] ?? '';
+  else if (arg.startsWith('-')) {
+    console.error(`Unrecognized option: ${arg}. Try --help.`);
+    process.exit(1);
+  } else positionals.push(arg);
+}
+if (positionals.length !== 1) {
+  console.error(`Expected exactly one binary path, got ${positionals.length}. Try --help.`);
+  process.exit(1);
+}
+
+const binary = path.resolve(positionals[0]);
+if (!statSync(binary, { throwIfNoEntry: false })?.isFile()) {
+  console.error(`Not a file: ${binary}`);
+  process.exit(1);
+}
+const label = opts.label || path.basename(path.dirname(binary));
+
+// tweakcc keeps its own backups and config beside whatever this points at. The probe must never
+// write into a real ~/.tweakcc, so it is redirected into the scratch dir unless the caller has
+// already chosen somewhere — and before tweakcc is imported, in case it reads the variable then.
+let scratchDir = opts.scratch ? path.resolve(opts.scratch) : '';
+if (scratchDir) mkdirSync(scratchDir, { recursive: true });
+else scratchDir = mkdtempSync(path.join(tmpdir(), 'clodex-probe-'));
+if (!process.env['TWEAKCC_CONFIG_DIR']) {
+  const dir = path.join(scratchDir, 'tweakcc');
+  mkdirSync(dir, { recursive: true });
+  process.env['TWEAKCC_CONFIG_DIR'] = dir;
+}
+
+const { tryDetectInstallation, readContent, writeContent } = await import('tweakcc');
+
+// What the probe writes into the bundle. Long enough not to occur by chance, and identifiable in a
+// binary that somehow escapes cleanup.
+const PROBE_MARKER = '/*clodex-probe-patch-mechanism*/';
+
+const checks = [];
+const info = { label, binary, checks: [] };
+let failed = 0;
+
+// name    stable identifier a caller can branch on
+// ok      did it hold
+// detail  what was actually observed — the thing worth reading in a Slack alert
+function record(name, ok, detail) {
+  checks.push(name);
+  info.checks.push({ name, ok, detail });
+  if (!ok) failed++;
+  if (!opts.json) console.log(`${ok ? 'OK  ' : 'FAIL'} ${name}${detail ? ` — ${detail}` : ''}`);
+}
+
+function note(message) {
+  if (!opts.json) console.log(`     ${message}`);
+}
+
+function sha256(file) {
+  return new Promise((resolve, reject) => {
+    const hash = createHash('sha256');
+    createReadStream(file)
+      .on('error', reject)
+      .on('data', (chunk) => hash.update(chunk))
+      .on('end', () => resolve(hash.digest('hex')));
+  });
+}
+
+// Which container the binary is, read from its own magic rather than from the package name — the
+// name is a label, the magic is the thing that decides which code path tweakcc takes.
+function containerFormat(file) {
+  const fd = openSync(file, 'r');
+  try {
+    const head = Buffer.alloc(4);
+    readSync(fd, head, 0, 4, 0);
+    if (head.toString('latin1') === '\x7fELF') return 'elf';
+    if (head.toString('latin1', 0, 2) === 'MZ') return 'pe';
+    const magic = head.readUInt32BE(0);
+    // 32/64-bit Mach-O in either endianness, plus the fat wrapper.
+    if ([0xfeedface, 0xfeedfacf, 0xcefaedfe, 0xcffaedfe, 0xcafebabe, 0xbebafeca].includes(magic)) {
+      return 'macho';
+    }
+    return `unknown(0x${magic.toString(16)})`;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+// Every byte occurrence of `needle`, module name or not. Streaming, because these binaries are
+// ~300 MB and a match can straddle any read boundary.
+function countOccurrences(file, needle) {
+  const fd = openSync(file, 'r');
+  try {
+    const size = statSync(file).size;
+    const pattern = Buffer.from(needle);
+    const chunkBytes = 8 * 1024 * 1024;
+    let carry = Buffer.alloc(0);
+    let found = 0;
+    for (let position = 0; position < size; ) {
+      const length = Math.min(chunkBytes, size - position);
+      const buf = Buffer.alloc(length);
+      readSync(fd, buf, 0, length, position);
+      const window = carry.length > 0 ? Buffer.concat([carry, buf]) : buf;
+      for (let at = window.indexOf(pattern); at >= 0; at = window.indexOf(pattern, at + 1)) found++;
+      carry = Buffer.from(window.subarray(Math.max(0, window.length - (pattern.length - 1))));
+      position += length;
+    }
+    return found;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+const started = Date.now();
+const scratch = path.join(scratchDir, 'claude');
+let exitCode = 1;
+
+try {
+  info.format = containerFormat(binary);
+  info.pristineSize = statSync(binary).size;
+  note(`${label}: ${info.format}, ${info.pristineSize} bytes`);
+
+  copyFileSync(binary, scratch);
+  const pristineSha = await sha256(scratch);
+
+  // ---- 1. can the pristine binary be read at all? -------------------------------------------
+  info.entryState = inspectEntryModule(scratch);
+  record(
+    'pristine-parses',
+    info.entryState !== 'unparseable',
+    `entry module is ${info.entryState}`,
+  );
+  if (info.entryState === 'unparseable') throw new Error('nothing further can be probed');
+
+  // ---- 2. seed the candidate, exactly as patcher.ts does ------------------------------------
+  // The shim is undone immediately so the seeded copy is byte-identical to the source: clodex
+  // publishes these bytes as the pristine backup under a content address, so a shim left in place
+  // (or a stray re-sign) would poison a backup that is supposed to be Claude Code's own bytes.
+  const readShim = shimEntryModuleName(scratch);
+  info.shimUsed = readShim !== null;
+  info.entryModuleName = readShim?.original ?? null;
+  const installation = await tryDetectInstallation({ path: scratch });
+  record(
+    'tweakcc-detects',
+    Boolean(installation),
+    installation
+      ? `version ${installation.version}, kind ${installation.kind}`
+      : 'tryDetectInstallation returned nothing',
+  );
+  if (!installation) throw new Error('nothing further can be probed');
+  info.detectedVersion = installation.version ?? null;
+
+  // The probe never runs the binary, so this is the only confirmation that the bytes under test
+  // are the release they were asked for — worth having before a mismatch is reported as the
+  // release being broken.
+  if (opts.expectVersion) {
+    record(
+      'expected-version',
+      info.detectedVersion === opts.expectVersion,
+      `binary is ${info.detectedVersion}, expected ${opts.expectVersion}`,
+    );
+  }
+
+  const source = await readContent(installation);
+  record('read-content', Boolean(source) && source.length > 1_000_000, `${source ? source.length : 0} bytes of JavaScript`);
+  if (!source) throw new Error('nothing further can be probed');
+  info.sourceBytes = source.length;
+  info.readMs = Date.now() - started;
+
+  if (readShim) restoreEntryModuleName(scratch, readShim, { resign: false });
+  record(
+    'seed-round-trip',
+    (await sha256(scratch)) === pristineSha,
+    'the copy the pristine backup is taken from is byte-identical to the release',
+  );
+
+  // ---- 3. repack, then put the real entry-module name back ----------------------------------
+  const repackStarted = Date.now();
+  const writeShim = shimEntryModuleName(scratch);
+  await writeContent(installation, `${source}\n${PROBE_MARKER}\n`);
+  let restoreError = null;
+  if (writeShim) {
+    try {
+      restoreEntryModuleName(scratch, writeShim, { resign: true });
+    } catch (err) {
+      restoreError = err instanceof Error ? err.message : String(err);
+    }
+  }
+  info.repackMs = Date.now() - repackStarted;
+  info.publishedSize = statSync(scratch).size;
+  info.growth = Number((info.publishedSize / info.pristineSize).toFixed(3));
+  note(`repacked to ${info.publishedSize} bytes (${info.growth}x)`);
+  record(
+    'restore-entry-name',
+    restoreError === null,
+    restoreError ?? 'the real entry-module name went back on after the repack',
+  );
+
+  // ---- 4. is the binary that WOULD be published actually sound? -----------------------------
+  // Reading OK from the steps above is not evidence of that: the checks below are on the bytes
+  // that would be renamed over the live install.
+  if (writeShim) {
+    info.standInSurvivors = countOccurrences(scratch, writeShim.marker);
+    record(
+      'no-stand-in',
+      info.standInSurvivors === 0,
+      info.standInSurvivors === 0
+        ? `no ${writeShim.marker} left in the published bytes`
+        : `${info.standInSurvivors} copy/copies of ${writeShim.marker} survived — Claude Code would fail to resolve its sibling native modules`,
+    );
+  }
+
+  const publishedState = inspectEntryModule(scratch);
+  record(
+    'published-parses',
+    publishedState === info.entryState,
+    publishedState === info.entryState
+      ? `entry module is ${publishedState}, as it was before`
+      : `entry module went from ${info.entryState} to ${publishedState}`,
+  );
+
+  // The published binary carries Claude Code's own module name, so it has to be shimmed again to
+  // be readable — and unshimmed again afterwards, or this leaves behind a binary that cannot run
+  // and reports a failure that is the probe's own doing.
+  const verifyShim = shimEntryModuleName(scratch);
+  record(
+    'entry-name-restored',
+    !writeShim || verifyShim?.original === writeShim.original,
+    verifyShim
+      ? `published entry module is named ${JSON.stringify(verifyShim.original)}`
+      : 'published binary needs no shim (its entry module is already one tweakcc recognizes)',
+  );
+  try {
+    const verifyInstallation = await tryDetectInstallation({ path: scratch });
+    const republished = verifyInstallation ? await readContent(verifyInstallation) : '';
+    record(
+      'published-content',
+      republished.includes(PROBE_MARKER),
+      republished
+        ? `${republished.length} bytes read back${republished.includes(PROBE_MARKER) ? ', carrying the probe marker' : ' but WITHOUT the probe marker — the repack did not land'}`
+        : 'the published binary yields no JavaScript — a patched install would be unreadable and unpatchable',
+    );
+  } finally {
+    // Undoing the verification shim is housekeeping, not a check: leaving it on would hand an
+    // investigator a binary that cannot run and a symptom the probe invented. When it fails for
+    // the same reason `restore-entry-name` already reported, saying so twice only pads the alert.
+    try {
+      if (verifyShim) restoreEntryModuleName(scratch, verifyShim, { resign: true });
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      if (info.checks.every((c) => c.name !== 'restore-entry-name' || c.ok)) {
+        record('cleanup-restore', false, detail);
+      } else {
+        note(`cleanup restore also failed: ${detail}`);
+      }
+    }
+  }
+
+  exitCode = failed === 0 ? 0 : 1;
+} catch (err) {
+  const detail = err instanceof Error ? err.message : String(err);
+  if (detail !== 'nothing further can be probed') {
+    record('probe-completed', false, detail);
+  }
+  exitCode = 1;
+} finally {
+  info.durationMs = Date.now() - started;
+  info.failed = failed;
+  info.verdict = failed === 0 ? 'pass' : 'fail';
+  info.reasons = info.checks.filter((c) => !c.ok).map((c) => `${c.name}: ${c.detail}`);
+  if (opts.keep) {
+    info.scratch = scratch;
+  } else {
+    rmSync(scratchDir, { recursive: true, force: true });
+  }
+  if (opts.json) process.stdout.write(`${JSON.stringify(info)}\n`);
+  else console.log(`${info.verdict.toUpperCase()} ${label} — ${checks.length} checks in ${Math.round(info.durationMs / 1000)}s`);
+}
+
+process.exit(exitCode);

--- a/scripts/probe-patch-mechanism.mjs
+++ b/scripts/probe-patch-mechanism.mjs
@@ -39,6 +39,7 @@ import {
   statSync,
 } from 'node:fs';
 import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import {
@@ -276,6 +277,23 @@ try {
       info.standInSurvivors === 0
         ? `no ${writeShim.marker} left in the published bytes`
         : `${info.standInSurvivors} copy/copies of ${writeShim.marker} survived — Claude Code would fail to resolve its sibling native modules`,
+    );
+  }
+
+  // The probe never runs the binary, so a Mach-O whose signature the repack invalidated would
+  // otherwise sail through here and only be caught on the one platform that executes it. codesign
+  // reads any Mach-O, so this covers darwin-x64 from an arm64 host too.
+  if (info.format === 'macho' && process.platform === 'darwin') {
+    let signatureError = null;
+    try {
+      execFileSync('codesign', ['--verify', '--strict', scratch], { stdio: 'pipe' });
+    } catch (err) {
+      signatureError = (err.stderr?.toString() || err.message || String(err)).trim().split('\n')[0];
+    }
+    record(
+      'signature-valid',
+      signatureError === null,
+      signatureError ?? 'the repacked Mach-O still carries a valid signature, so it can be executed',
     );
   }
 

--- a/src/bun-entry-module.ts
+++ b/src/bun-entry-module.ts
@@ -287,6 +287,26 @@ export function inspectEntryModule(path: string): EntryModuleState {
 }
 
 /**
+ * Every module name in the blob, in blob order, or null when the blob cannot be
+ * read. Opens read-only, so it is safe on a pristine backup.
+ *
+ * Nothing in the patch path uses this: it exists so a caller can compare the
+ * module inventory before and after a repack. `inspectEntryModule` collapses the
+ * whole table to three states, which cannot see a repack that rebuilds a valid
+ * table while dropping or reordering a NON-entry sibling — the entry module still
+ * reads, the signature still verifies, and the native feature that needed the lost
+ * module fails later, in front of a user. See scripts/probe-patch-mechanism.mjs.
+ */
+export function listBunModuleNames(path: string): string[] | null {
+  const fd = openSync(path, 'r');
+  try {
+    return readBunModuleNames(fd, statSync(path).size)?.names ?? null;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/**
  * Give an unpatchable Claude Code binary a module name tweakcc recognizes, so it
  * can read and repack it. Returns null — no write — when the binary already has a
  * recognizable module (every release before 2.1.229, so nothing drifts for


### PR DESCRIPTION
`clodex patch` was broken on every Linux build of Claude Code for two releases, and nothing in this
repo could have caught it. Reading and repacking the binary depends on its executable format, and
the only thing exercising that path ran on macOS, where the bug cannot happen. It took an outside
contributor to report it.

This adds `scripts/probe-patch-mechanism.mjs`: a script that runs the same read/repack/restore cycle
the patcher runs, against a Claude Code build for **any** platform, from whatever machine you are
on. It never executes the binary, so a linux-arm64 or win32-x64 build can be checked from macOS.
Nothing that ships imports it and no runtime behaviour changes.

```
node scripts/probe-patch-mechanism.mjs <claude-binary> --label linux-x64 --expect-version 2.1.233
```

## Why the probe can exist at all

`clodex patch` resolves the version by *executing* the binary (`getClaudeVersionForBinary`), so a
foreign binary cannot go through the real command on the host. But everything the ELF break touched
— the entry-module shim, tweakcc's read, the repack, the restore, the Mach-O re-sign — is pure file
manipulation. The probe drives exactly that, calling the real exported helpers from
`src/bun-entry-module.ts` rather than a copy.

Scope, stated plainly: it does **not** exercise the 11 patch sites and cannot tell you the patched
binary runs. Only a host or containerised `clodex patch` does that. It also cannot verify
architecture — nothing here reads `e_machine`/`cputype`, so linux-x64 vs linux-arm64 is unverified.

## What it checks

`label-matches-format`, `pristine-parses`, `tweakcc-detects`, `expected-version`, `read-content`,
`seed-round-trip`, `repack-grew`, `restore-entry-name`, `no-stand-in`, `signature-valid` (Mach-O on
a macOS host), `mode-preserved` (ELF/Mach-O), `published-parses`, `entry-name-restored`,
`published-content`, `modules-intact`.

Two are worth calling out because they were added after review found the first versions insufficient:

- **`published-content` compares the published bundle byte-for-byte** against what was written.
  Checking only that the marker survived passed a mutation that deleted the first byte of Claude
  Code's entry JavaScript.
- **`modules-intact`** compares the module inventory before and after. A repack can rebuild a valid
  module table while losing a non-entry sibling: the entry module still reads, the signature still
  verifies, and the feature that needed the missing module fails later, in front of a user. This is
  what `listBunModuleNames` was added for — a read-only accessor, unused by the patch path, because
  `inspectEntryModule` collapses the whole table to three states and cannot see this.

## Evidence

All against the real published Claude Code 2.1.233 packages for all eight platforms.

**It passes where it should.** 8/8 green on this branch: darwin-arm64, darwin-x64 (Mach-O),
linux-x64, linux-arm64, linux-x64-musl, linux-arm64-musl (ELF), win32-x64, win32-arm64 (PE).

**It fails where it should.** Run against `abe4e24`, the commit before the Linux fix, exactly the
four ELF builds go red with the defect that actually shipped:

```
restore-entry-name: the entry-module stand-in /clodex--/claude survived restoration
no-stand-in: 1 copy/copies of /clodex--/claude survived
```

darwin and win32 stay green there, matching the real incident.

**Mutations, to show the checks discriminate** rather than merely being numerous. Each was applied
in a throwaway worktree and reverted:

| mutation | expected red | result |
| --- | --- | --- |
| `restoreEveryStandIn` made a no-op | `no-stand-in`, `entry-name-restored` | as expected |
| seed restore re-signs | `seed-round-trip` | as expected |
| `writeContent` skipped | `published-content` | as expected |
| Mach-O re-sign dropped | `signature-valid` | as expected |
| repack drops one source byte | `published-content` | as expected |
| wrong `--expect-version` | `expected-version` | as expected |
| not a Claude Code binary | `pristine-parses` | as expected |

One mutation deliberately produced no red: writing the stand-in back instead of the real name in
`restoreEntryModuleName`. That is genuinely a no-op — `restoreEveryStandIn` re-scans and overwrites
every stand-in module name one statement later. Verified by reading the function, not assumed.

`tweakcc-detects`, `read-content` and `published-parses` have no dedicated mutation; with tweakcc
4.3.0 those paths throw rather than return falsy, so the failure surfaces as the catch-all
`probe-completed`. The verdict is still red, but the specific check name is not what fires.

## Payload size is load-bearing

The first version appended a 32-byte marker. An identity repack *shrinks* a Mach-O bundle by ~61
bytes, so the delta stayed negative and tweakcc never took its `extendSegment` branch — page
rounding, segment extension, and re-signing a binary whose segment actually moved were all
untested, while every real patch takes that path. The payload is now ~84 KB and `repack-grew`
asserts the published binary is larger. Measured on darwin-arm64 2.1.233: 306,981,408 → 307,062,192
bytes, and `signature-valid` still passes after the segment moves.

## What I could not verify

- **Architecture.** As above — a linux-x64 build probed under the label `linux-arm64` would pass.
- **PE signatures.** tweakcc's PE path never re-signs, so there is nothing to assert; adding a check
  would claim a property production does not maintain.
- **Non-macOS hosts.** `signature-valid` needs `codesign`. Rather than silently omitting it, the
  probe records it in `notChecked` and says so.
- **`.orig` backups and real installs** were never touched: every run works on a scratch copy.

## Verification

`pnpm typecheck && pnpm test && pnpm build` all clean — 1802 tests, 94 files, run with an isolated
`CLODEX_HOME` and `CLAUDE_CODE_ENTRYPOINT` unset. Node 24.14.1.

The change is additive: one new script, one new read-only export, docs. No shipped code path calls
either, so there is no launch or provider surface to smoke test.

## Reviewed

An adversarial panel ran over this before the first push and returned REQUEST CHANGES; the
byte-for-byte comparison, the module inventory, the argument validation, the `--scratch` ownership
fix and several overstated detail strings are all its findings. It was re-run after those changes.

## Not in scope

Issue #129 (deleting the entry-module shim once tweakcc 4.3.3 is pinned). The probe is written to
survive it: the shim-specific checks are conditional on a shim having been needed, and the durable
assertions — the published bundle round-trips, the modules survive, the binary is still executable
and signed — do not mention the shim at all.
