### PR TITLE
test(canary): catch a Claude Code release that breaks patching on Windows or Linux ARM

### DIFF
--- a/.claude/docs/patcher.md
+++ b/.claude/docs/patcher.md
@@ -141,10 +141,26 @@ tweakcc's own repack reads back as an ordinary module name.
   It checks that the binary parses, that the seeded candidate is byte-identical to the release
   (what the content-addressed pristine backup depends on), that the restore leaves no stand-in
   behind, that a repacked Mach-O still verifies under `codesign`, and that the published bytes read
-  back carrying what was written. It does **not** exercise the patch sites, and it cannot tell you
-  the patched binary runs — only a host or containerised `clodex patch` does that. `clodex patch`
-  resolves the version by executing the binary (`getClaudeVersionForBinary`), which is exactly why
-  a foreign binary can go through the probe and not through the real command.
+  back carrying what was written.
+
+  **It also applies every patch site to that build's own bundle** (`scripts/probe-patch-sites.mjs`,
+  which calls the real `applyClodexPatches` with a synthetic config that activates all of them),
+  fails on any `FAIL`, `SKIP`, missing or duplicated site, and repacks **what the transforms
+  produced** rather than the pristine bytes — so the byte-for-byte readback also proves clodex's
+  own emitted patch survives the PE/ELF/Mach-O round trip. Anchors were assumed platform-independent
+  until Claude Code 2.1.238, where `PATCH 5: model picker options` matched five builds and missed
+  `linux-arm64`, `linux-arm64-musl` and `win32-arm64`.
+
+  Two things it still cannot tell you: **that the patched binary runs**, and **that an anchor bound
+  to the function it was aimed at** rather than a lookalike that also emits valid JavaScript. Only a
+  host or containerised `clodex patch` answers the first. `clodex patch` resolves the version by
+  executing the binary (`getClaudeVersionForBinary`), which is exactly why a foreign binary can go
+  through the probe and not through the real command.
+
+  `tests/probe-patch-sites.test.ts` pins the probe's synthetic config and its expected-site list
+  against the real transform set — so a new or renamed `PATCH` site reddens `pnpm test` rather than
+  failing five platforms in the hourly canary. Revisit it whenever you bump
+  `PATCH_TRANSFORMS_VERSION`.
 
 ## Patcher invariants
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,11 @@ ELF build of Claude Code across two releases while macOS stayed green. Before ch
 `scripts/probe-patch-mechanism.mjs` against a build for each format — Mach-O, ELF and PE. It needs
 no Linux or Windows host, because it never executes the binary. See `.claude/docs/patcher.md`.
 
+**Patch anchors are not platform-independent either.** Claude Code 2.1.238 minified one helper's
+parameter differently on its arm64 builds, so `PATCH 5: model picker options` matched five builds
+and missed `linux-arm64`, `linux-arm64-musl` and `win32-arm64`. The probe now applies every patch
+site to each build's own bundle; run it per format when you touch `src/patch-transforms.ts` too.
+
 **`claude -p` end-to-end tests are manual only — NEVER add them to the automated suite.**
 
 ## Key constraints

--- a/canary/README.md
+++ b/canary/README.md
@@ -20,6 +20,41 @@ State lives outside the repo: `~/.local/state/clodex-patch-canary/` (triage reco
 one log per run) and `~/.cache/clodex-patch-canary/` (a private clone hard-reset to `origin/main`
 each run, plus sandboxes — removed on success, kept on failure for the investigation).
 
+## The three legs, and what each one actually proves
+
+Only two of the eight published builds can go through the real `clodex patch`: `clodex patch`
+resolves the version by **executing** the binary, so a foreign build needs either this Mac's own
+architecture or a native-architecture container. The other five get the probe,
+`scripts/probe-patch-mechanism.mjs`, which works on any build from any host because it never
+executes anything.
+
+| Leg | Patch anchors checked | Binary repacked | Patched binary started |
+| --- | --- | --- | --- |
+| `host` — the real command on this Mac | yes | yes | **yes** |
+| `container` — the real command in a Linux container | yes | yes | **yes** |
+| `probe` — `probe-patch-mechanism.mjs` | yes | yes | no |
+
+A probe **does** now prove: every clodex patch site matched an anchor in that specific build's
+bundle exactly once; no site was ambiguous, missing or silently skipped; the transforms threw
+nothing; and the bundle they produced survived the PE/ELF/Mach-O read-repack-restore round trip
+byte for byte, still carrying clodex's own `ccpatch:` markers.
+
+A probe **does not** prove:
+
+- **that the patched binary runs.** Nothing here starts it, so a repack that produces a PE
+  Windows refuses to load, or an ELF the kernel rejects, would still pass. Only the `host` and
+  `container` legs answer that, and only for macOS-arm64 and Linux-arm64.
+- **that an anchor bound to the right code.** A regex that matches a lookalike function still
+  emits valid JavaScript and reports `OK`. The probe checks that a site *applied*, never that it
+  applied to the thing it was aimed at.
+
+That distinction is why a probe leg's coverage line reads "native execution not checked" and why
+the Slack alert never calls a probe pass "`clodex patch` applies cleanly". Before this existed a
+probe exercised **zero** patch sites, and Claude Code 2.1.238 shipped with the `PATCH 5: model
+picker options` anchor no longer matching its `linux-arm64`, `linux-arm64-musl` and `win32-arm64`
+builds. The two Linux builds have container images and were reported as failures. `win32-arm64`
+has none, so it was a probe — and it was reported as a clean pass.
+
 ## Install
 
 ```bash
@@ -50,3 +85,24 @@ The selftest drives the real functions against fixtures and stand-ins, so it nee
 touches no real install. It mocks the `claude` binary, which means it cannot see bugs in how the
 canary invokes the *real* CLI — the argv tests exist because one such bug (a prompt silently
 swallowed by the variadic `--add-dir`) shipped and cost a day of coverage.
+
+The probe has automated coverage on both sides of the repo boundary:
+
+```bash
+pnpm vitest run tests/probe-patch-sites.test.ts   # the patch-site half, against a bundle fixture
+./canary/clodex-patch-canary-selftest.sh          # the verdict half, against captured probe.json
+```
+
+`tests/probe-patch-sites.test.ts` is also what stops the probe from paging you over a *clodex*
+change: it pins the probe's synthetic config and its list of expected patch sites against the real
+transform set, so adding or renaming a `PATCH` site reddens `pnpm test` instead of failing five
+platforms at 03:00. Bump `PATCH_TRANSFORMS_VERSION` and that file is the one that tells you the
+probe needs updating too.
+
+Neither of those touches a real Claude Code binary, so neither can see a break specific to one
+executable format. For that, run the probe by hand against a build of each — it needs no Linux or
+Windows host:
+
+```bash
+node scripts/probe-patch-mechanism.mjs /path/to/claude.exe --label win32-arm64
+```

--- a/canary/clodex-patch-canary-platforms.sh
+++ b/canary/clodex-patch-canary-platforms.sh
@@ -9,9 +9,13 @@
 # WHY THIS EXISTS
 # `clodex patch` does two separable things, and they fail for different reasons:
 #
-#   the patch sites  match anchors in the extracted JavaScript, which is near-identical on every
-#                    platform (26,599,210 bytes on darwin vs 26,596,328 on linux for 2.1.233).
-#                    One platform genuinely covers them.
+#   the patch sites  match anchors in the extracted JavaScript. This was assumed to be
+#                    near-identical on every platform (26,599,210 bytes on darwin vs 26,596,328 on
+#                    linux for 2.1.233), so that one platform covered them all. 2.1.238 disproved
+#                    it: `PATCH 5: model picker options` matched on darwin-arm64, darwin-x64,
+#                    linux-x64, linux-x64-musl and win32-x64 and NOT on linux-arm64,
+#                    linux-arm64-musl or win32-arm64. Every build's anchors are now checked
+#                    against that build's own bundle.
 #   the container    the entry-module shim, tweakcc's read, the repack, the restore and the
 #                    Mach-O re-sign all depend on the executable format — and that is the half
 #                    that broke. Every ELF build of Claude Code from 2.1.229 on was unpatchable
@@ -21,15 +25,18 @@
 # So every published platform is now tested, by the strongest means available for it:
 #
 #   host       the real `clodex patch` on this Mac — the authoritative "is it safe for me to
-#              update" answer, and the only leg that exercises all 11 patch sites end to end.
+#              update" answer, and the only leg that patches AND then starts the binary here.
 #   container  the real `clodex patch` inside a native-architecture Linux container. `clodex
 #              patch` resolves the version by EXECUTING the binary, so a foreign binary cannot go
 #              through the real command on the host — a container is the only way to run the whole
 #              thing against ELF.
-#   probe      scripts/probe-patch-mechanism.mjs from the clodex checkout under test: the same
-#              shim/read/repack/restore cycle the patcher runs, driven directly against the
-#              binary's bytes. It never executes the binary, so it works from macOS against every
+#   probe      scripts/probe-patch-mechanism.mjs from the clodex checkout under test: it applies
+#              every clodex patch site to the bundle it extracts from THAT build, repacks what
+#              those transforms produced, and runs the same shim/read/repack/restore cycle the
+#              patcher runs. It never executes the binary, so it works from macOS against every
 #              format, and it is the only coverage win32 and linux-x64 can have cheaply.
+#              What it cannot show: that the patched binary starts, and that an anchor bound to
+#              the function it was meant to bind to rather than a lookalike that also parses.
 #
 # A leg that cannot RUN (no Docker, a platform package that has not published yet, a container
 # that could not install its dependencies) is an `error`, never a `fail`. Only evidence that the
@@ -430,7 +437,7 @@ run_leg_container() { # run_leg_container <platform> <version>
   return 0
 }
 
-# ---- probe: the mechanism only, no execution ---------------------------------------------------
+# ---- probe: the bundle patch and the binary handling, without execution ------------------------
 
 # The most informative line of a failed probe's stderr. `tail -3` of a Node crash is the tail of
 # its stack trace — "}", blank, "Node.js v24.14.1" — which is exactly the useless thing a Slack
@@ -471,6 +478,15 @@ run_leg_probe() { # run_leg_probe <platform> <version>
   set -e
   rm -rf "$WORK/$platform/probe-scratch"
 
+  evaluate_probe_leg "$platform" "$json" "$rc" "$WORK/$platform/probe.stderr"
+  return 0
+}
+
+# Turn a captured probe.json into a verdict. Split out from the leg above — like evaluate_report —
+# so the self-test can drive it against hand-written results without downloading a 300 MB binary.
+evaluate_probe_leg() { # evaluate_probe_leg <platform> <probe.json> <exit-code> <stderr-file>
+  local platform="$1" json="$2" rc="$3" stderr="$4" failed_sites
+
   # Both halves matter: `jq -e .` alone accepts any valid JSON, and the `.checks[]` extraction
   # below then dies with "Cannot iterate over null" — under errexit that kills the whole canary
   # before any verdict is recorded, so one schema change would leave releases untriaged.
@@ -479,15 +495,35 @@ run_leg_probe() { # run_leg_probe <platform> <version>
     # No JSON at all means the probe itself did not run (a missing script on an older origin/main,
     # a Node too old for the .ts import). That is the canary's problem, not the release's.
     LEG_STATUS=error
-    LEG_REASONS="- the $platform mechanism probe produced no usable result (exit $rc): $(probe_error_summary "$WORK/$platform/probe.stderr")
+    LEG_REASONS="- the $platform probe produced no usable result (exit $rc): $(probe_error_summary "$stderr")
+"
+    return 0
+  fi
+
+  # A probe that reports no patch sites is the OLD probe — the one that checked executable-format
+  # handling only and reported a clean pass on win32-arm64 while `PATCH 5: model picker options`
+  # had stopped matching there. Its verdict says nothing about the anchors, so it may not be
+  # recorded as if it did. An `error`, not a `fail`: the clodex build under test is behind, the
+  # release is not implicated — and an error is already enough to withhold the green tick.
+  if ! jq -e '(.patchSites | type) == "array" and (.patchSites | length) > 0' \
+       "$json" >/dev/null 2>&1; then
+    LEG_STATUS=error
+    LEG_REASONS="- the $platform probe reported no patch-site results, so only this build's executable format was checked and its patch anchors were not — the clodex build under test (${MAIN_SHA:-unknown} on $CANARY_BRANCH) predates per-build patch-site checking
 "
     return 0
   fi
 
   LEG_DETAIL="$(jq -c '{format, entryState, shimUsed, pristineSize, publishedSize, growth,
-                        detectedVersion, sourceBytes, durationMs}' "$json")"
-  LEG_SITES="$(jq -c '[.checks[] | {key: .name, value: (if .ok then "OK" else "FAIL" end)}]
-                      | from_entries' "$json")"
+                        detectedVersion, sourceBytes, durationMs, patchSites: (.patchSiteSummary // null)}' "$json")"
+  # Both sets of names, in one map, because both are checks that must keep holding: the mechanism
+  # checks are what the baseline comparison has always watched, and the patch sites are what this
+  # leg could not see at all before. The two name spaces do not overlap.
+  # `// []` even though the guard above already refused a result without patchSites: reached with
+  # a null here, `.patchSites[]` dies with "Cannot iterate over null" and errexit takes the whole
+  # canary down before ANY platform's verdict is recorded — one schema change, every release left
+  # untriaged. The guard decides the verdict; this keeps a regression in the guard survivable.
+  LEG_SITES="$(jq -c '([.checks[] | {key: .name, value: (if .ok then "OK" else "FAIL" end)}] | from_entries)
+                      + ([(.patchSites // [])[] | {key: .name, value: .status}] | from_entries)' "$json")"
   if [ "$(jq -r '.verdict' "$json")" = "pass" ]; then
     LEG_STATUS=pass
   else
@@ -495,7 +531,8 @@ run_leg_probe() { # run_leg_probe <platform> <version>
     LEG_REASONS="$(jq -r '(.reasons // []) | map("- " + .) | join("\n")' "$json")
 "
   fi
-  log "$platform probe: $(jq -r '.verdict' "$json") ($(jq -r '(.durationMs/1000|floor)' "$json")s, $(jq -r '.format' "$json"))"
+  failed_sites="$(jq -r '[(.patchSites // [])[] | select(.status == "FAIL") | .name] | join("; ")' "$json")"
+  log "$platform probe: $(jq -r '.verdict' "$json") ($(jq -r '(.durationMs/1000|floor)' "$json")s, $(jq -r '.format' "$json"), $(jq -r '.patchSiteSummary.applied // 0') patch sites applied${failed_sites:+, FAILED: $failed_sites})"
   return 0
 }
 
@@ -626,7 +663,7 @@ matrix_downgrade_notes() {
   jq -r -s --arg why "$why" '
     map(select(.downgraded == true) | .platform) as $d
     | if ($d | length) == 0 then ""
-      else "- \($why), so \($d | join(" and ")) got the binary-handling probe instead of a full `clodex patch` in a container. NO patch site was exercised on Linux this run."
+      else "- \($why), so \($d | join(" and ")) got the bundle-patch + binary-handling probe instead of a full `clodex patch` in a container. The patch sites were checked against those builds bundles, but NO patched Linux binary was started this run."
       end' "$MATRIX"
 }
 
@@ -641,8 +678,9 @@ matrix_coverage_line() {
              elif .mode == "host" then "full patch, this Mac"
              elif .mode == "container" then "full patch in \(.detail.image // "a container")"
              elif .mode == "probe" and .downgraded then
-               "binary handling ONLY — no container, so no patch site ran here"
-             elif .mode == "probe" then "binary handling"
+               "bundle patch + binary handling — no container, so the patched binary was never started here"
+             elif .mode == "probe" then
+               "bundle patch + binary handling; native execution not checked"
              else "not tested" end;
     map("\(sym) *\(.platform)* — \(how)") | join("\n")' "$MATRIX"
 }
@@ -654,7 +692,7 @@ matrix_coverage_brief() {
     def sym: if .status == "fail" then ":x:" else ":grey_question:" end;
     def how: if .mode == "host" then "full patch, this Mac"
              elif .mode == "container" then "full patch in \(.detail.image // "a container")"
-             elif .mode == "probe" then "binary handling"
+             elif .mode == "probe" then "bundle patch + binary handling"
              else "not tested" end;
     (map(select(.status != "pass")) | map("\(sym) *\(.platform)* — \(how)")) as $bad
     | (map(select(.status == "pass") | .platform)) as $good

--- a/canary/clodex-patch-canary-selftest.sh
+++ b/canary/clodex-patch-canary-selftest.sh
@@ -401,12 +401,130 @@ case "$FULL" in
   *":warning: *linux-arm64*"*) pass=$((pass + 1)); printf 'ok   %s\n' "a downgraded leg is not shown as a clean tick" ;;
   *) fail=$((fail + 1)); printf 'FAIL a downgraded leg is not shown as a clean tick — got:\n%s\n' "$FULL" ;;
 esac
+# win32 has no container image, so its probe is the strongest leg it can have and keeps its tick.
+# But the tick alone used to be the whole assertion, and that is what let win32-arm64 be reported
+# clean on 2.1.238 while `PATCH 5: model picker options` no longer matched there. A probe now
+# exercises the patch sites, so the tick is earned — and the line must still say what was NOT
+# established, or the tick means more than it should.
 case "$FULL" in
   *":white_check_mark: *win32-x64*"*) pass=$((pass + 1)); printf 'ok   %s\n' "a probe-by-design leg still shows a clean tick" ;;
   *) fail=$((fail + 1)); printf 'FAIL a probe-by-design leg lost its tick — got:\n%s\n' "$FULL" ;;
 esac
+case "$FULL" in
+  *"win32-x64* — bundle patch + binary handling; native execution not checked"*)
+    pass=$((pass + 1)); printf 'ok   %s\n' "a probe-by-design leg discloses that nothing was executed" ;;
+  *) fail=$((fail + 1)); printf 'FAIL a probe-by-design leg discloses that nothing was executed — got:\n%s\n' "$FULL" ;;
+esac
+case "$(matrix_downgrade_notes)" in
+  *"NO patched Linux binary was started"*)
+    pass=$((pass + 1)); printf 'ok   %s\n' "a downgraded leg says what it did and did not cover" ;;
+  *) fail=$((fail + 1)); printf 'FAIL a downgraded leg says what it did and did not cover — got: %s\n' "$(matrix_downgrade_notes)" ;;
+esac
 matrix_check "--no-container is not reported as Docker being down" "0" \
   "$(opt_container=0 matrix_downgrade_notes | grep -c 'Docker was not available')"
+
+# 19b. The probe's verdict, driven through the real evaluate_probe_leg against hand-written
+#      results — the leg itself needs a 300 MB binary, this does not.
+#
+#      This is the blind spot that let Claude Code 2.1.238 through. win32-arm64 has no container
+#      image, so it is always a probe; the probe exercised zero patch sites; `PATCH 5: model
+#      picker options` had stopped matching on that build; and the canary reported win32-arm64 as
+#      a clean pass while reporting the same break on the two Linux builds that DO have images.
+MECHANISM_CHECKS='[{"name":"pristine-parses","ok":true,"detail":"entry module is needs-shim"},
+                   {"name":"read-content","ok":true,"detail":"28147627 bytes of JavaScript"},
+                   {"name":"published-content","ok":true,"detail":"byte-for-byte"}]'
+
+# write_probe_json <file> <verdict> <patch-sites-json> [reasons-json] [extra-check-json]
+write_probe_json() {
+  jq -n --argjson checks "$MECHANISM_CHECKS" --arg verdict "$2" --argjson sites "$3" \
+        --argjson reasons "${4:-[]}" --argjson extra "${5:-null}" \
+    '{label: "win32-arm64", format: "pe", entryState: "needs-shim", shimUsed: true,
+      pristineSize: 322051744, publishedSize: 322133550, growth: 1, detectedVersion: "2.1.238",
+      sourceBytes: 28147627, durationMs: 33016, verdict: $verdict, reasons: $reasons,
+      checks: ($checks + (if $extra == null then [] else [$extra] end)),
+      patchSites: $sites,
+      patchSiteSummary: {applied: ($sites | map(select(.status == "OK")) | length),
+                         skipped: ($sites | map(select(.status == "SKIP")) | length),
+                         failed:  ($sites | map(select(.status == "FAIL")) | length),
+                         total: ($sites | length)}}' > "$1"
+}
+
+ALL_SITES_OK='[{"name":"PATCH 1: Agent tool model enum","status":"OK"},
+               {"name":"PATCH 5: model picker options","status":"OK"},
+               {"name":"PATCH 10: child network environment","status":"OK"}]'
+PATCH5_MISSING='[{"name":"PATCH 1: Agent tool model enum","status":"OK"},
+                 {"name":"PATCH 5: model picker options","status":"FAIL","extra":"anchor not found"},
+                 {"name":"PATCH 10: child network environment","status":"OK"}]'
+
+: > "$TMP/probe.stderr"
+leg_reset
+write_probe_json "$TMP/probe-ok.json" pass "$ALL_SITES_OK"
+evaluate_probe_leg win32-arm64 "$TMP/probe-ok.json" 0 "$TMP/probe.stderr" >/dev/null
+matrix_check "a clean probe passes" "pass" "$LEG_STATUS"
+matrix_check "a clean probe reports no reasons" "" "$LEG_REASONS"
+# Both name spaces, in one map: losing the mechanism checks here would silently retire the
+# regression detection that has watched them since the ELF break.
+matrix_check "a probe records its patch sites alongside its mechanism checks" "OK OK" \
+  "$(printf '%s' "$LEG_SITES" | jq -r '."PATCH 5: model picker options" + " " + ."published-content"')"
+matrix_check "a probe records how many patch sites applied" "3" \
+  "$(printf '%s' "$LEG_DETAIL" | jq -r '.patchSites.applied')"
+
+leg_reset
+write_probe_json "$TMP/probe-p5.json" fail "$PATCH5_MISSING" \
+  '["patch sites FAILED: PATCH 5: model picker options"]' \
+  '{"name":"patch-sites-apply","ok":false,"detail":"patch sites FAILED: PATCH 5: model picker options"}'
+evaluate_probe_leg win32-arm64 "$TMP/probe-p5.json" 1 "$TMP/probe.stderr" >/dev/null
+matrix_check "a probe that loses PATCH 5 FAILS" "fail" "$LEG_STATUS"
+matrix_check "a probe names the patch site it lost" \
+  "- patch sites FAILED: PATCH 5: model picker options" "$(printf '%s' "$LEG_REASONS" | head -1)"
+matrix_check "a failing patch site is recorded as FAIL, not as a missing key" "FAIL" \
+  "$(printf '%s' "$LEG_SITES" | jq -r '."PATCH 5: model picker options"')"
+
+# The old probe: mechanism checks, verdict pass, no patch sites at all. Recording that as a pass
+# is precisely the report that made 2.1.238 look safe on Windows, so it may not be one.
+leg_reset
+jq -n --argjson checks "$MECHANISM_CHECKS" \
+  '{label: "win32-arm64", format: "pe", durationMs: 1, verdict: "pass", reasons: [], checks: $checks}' \
+  > "$TMP/probe-old.json"
+evaluate_probe_leg win32-arm64 "$TMP/probe-old.json" 0 "$TMP/probe.stderr" >/dev/null
+matrix_check "a probe with no patch-site results is never a pass" "error" "$LEG_STATUS"
+case "$LEG_REASONS" in
+  *"patch anchors were not"*) pass=$((pass + 1)); printf 'ok   %s\n' "a probe with no patch-site results says why it is not a verdict" ;;
+  *) fail=$((fail + 1)); printf 'FAIL a probe with no patch-site results says why — got: %s\n' "$LEG_REASONS" ;;
+esac
+
+# 19c. The whole incident, end to end at the matrix level: 2.1.238 lost PATCH 5 on the two arm64
+#      Linux builds AND on win32-arm64. All three must fail, as one grouped cause, and the run
+#      must not earn the green tick.
+write_matrix \
+  "darwin-arm64:host:pass" "darwin-x64:probe:pass" "linux-x64:probe:pass" \
+  "linux-arm64:container:fail:patch sites FAILED: PATCH 5: model picker options" \
+  "linux-x64-musl:probe:pass" \
+  "linux-arm64-musl:container:fail:patch sites FAILED: PATCH 5: model picker options" \
+  "win32-x64:probe:pass" \
+  "win32-arm64:probe:fail:patch sites FAILED: PATCH 5: model picker options"
+matrix_check "2.1.238: win32-arm64 fails with the Linux builds instead of passing beside them" \
+  "linux-arm64 linux-arm64-musl win32-arm64" "$(matrix_platforms fail)"
+matrix_check "2.1.238: one anchor on three builds is one alert line" "1" \
+  "$(matrix_reason_groups | grep -c '^- ')"
+case "$(matrix_reason_groups)" in
+  *"[linux-arm64, linux-arm64-musl, win32-arm64]"*)
+    pass=$((pass + 1)); printf 'ok   %s\n' "2.1.238: the grouped line names all three builds" ;;
+  *) fail=$((fail + 1)); printf 'FAIL 2.1.238 grouped line — got: %s\n' "$(matrix_reason_groups)" ;;
+esac
+# The gate the main flow actually branches on. `coverage_is_complete` is deliberately NOT it: it
+# asks "was every platform tested", and a leg that failed was tested — it is the non-empty reason
+# list that sends the run down the alert path instead of the "safe to update" one.
+if [ -n "$(matrix_reason_groups)" ]; then
+  pass=$((pass + 1)); printf 'ok   %s\n' "2.1.238: a lost patch anchor sends the run down the alert path"
+else
+  fail=$((fail + 1)); printf 'FAIL 2.1.238 produced no reasons, so it would have been announced as safe\n'
+fi
+# And the quieter half of the same failure: a platform recorded as clean becomes next release's
+# baseline, so win32-arm64 passing here would ALSO have taught the canary that a bundle missing
+# PATCH 5 is what win32-arm64 is supposed to look like.
+matrix_check "2.1.238: a build that lost a patch anchor sets no baseline" "" \
+  "$(jq -s -r 'map(select(.status == "pass") | .platform) | map(select(. == "win32-arm64")) | join("")' "$MATRIX")"
 
 # 20. The state machine. These filters decide whether a release is ever retested and whether
 #     regression detection keeps working, so they are driven through the real state_update.

--- a/canary/clodex-patch-canary.sh
+++ b/canary/clodex-patch-canary.sh
@@ -9,7 +9,7 @@
 #   3. syncs a private clone of clodex to a freshly fetched origin/main and builds it
 #   4. downloads that release for EVERY published platform into a throwaway sandbox and tests each
 #      one — the real `clodex patch` on this Mac, the real `clodex patch` in a Linux container for
-#      arm64 glibc and musl, and the binary-handling probe for the rest. See
+#      arm64 glibc and musl, and a bundle-patch + binary-handling probe for the rest. See
 #      clodex-patch-canary-platforms.sh for why, and for what each leg proves.
 #   5. if any platform's patch mechanism is broken, launches ONE background Claude session to
 #      investigate all of them, fix, and open a PR — and pings Slack at the start
@@ -24,7 +24,7 @@
 #   --retriage VER      forget VER's recorded verdict, then run
 #   --force             ignore the already-triaged record and the in-flight deferral
 #   --platforms LIST    comma-separated platforms to test instead of all of them
-#   --no-container      never use Docker; test Linux with the probe only
+#   --no-container      never use Docker; test Linux with the probe only (no binary is started)
 #   --no-launch         report a failure but do not start the background Claude session
 #   --no-slack          never post to Slack
 #   --keep-work         keep the sandbox even when the run passes
@@ -593,7 +593,7 @@ write_repro_script() {
     printf '#   %s/repro.sh linux-arm64 <your-worktree>  # the same leg against your fix\n' "$WORK"
     printf '#\n'
     printf '# The leg matches the platform: the host runs the real `clodex patch`; linux-arm64 and\n'
-    printf '# linux-arm64-musl run it inside a container; the rest run the binary-handling probe,\n'
+    printf '# linux-arm64-musl run it inside a container; the rest run the bundle-patch probe,\n'
     printf '# scripts/probe-patch-mechanism.mjs. Your worktree does NOT need to be built first —\n'
     printf '# the host leg builds it if dist is missing and the container legs always rebuild.\n'
     printf '#\n'
@@ -614,7 +614,7 @@ ENTRY="$(jq -s -c --arg p "$PLATFORM" 'map(select(.platform == $p)) | last // em
   exit 1
 }
 # The leg this platform actually got. MODE=container overrides it: if the canary ran without
-# Docker, the recorded leg is a probe, and a probe pass does NOT verify a patch-site fix.
+# Docker, the recorded leg is a probe, and a probe never starts the binary it patched.
 MODE="${MODE:-$(printf '%s' "$ENTRY" | jq -r '.mode')}"
 TARBALL="$(printf '%s' "$ENTRY" | jq -r '.tarball')"
 MEMBER=claude
@@ -747,9 +747,11 @@ scope:
   container  the real \`clodex patch\` inside a native-arch Linux container. \`clodex patch\`
              resolves the version by EXECUTING the binary, so a foreign binary can only go through
              the real command this way.
-  probe      scripts/probe-patch-mechanism.mjs — the same shim/read/repack/restore cycle
-             src/patcher.ts runs, driven against the binary's bytes without executing it. It
-             covers EXECUTABLE-FORMAT handling ONLY, not the patch sites.
+  probe      scripts/probe-patch-mechanism.mjs — it applies every clodex patch site to the
+             bundle extracted from that build, repacks the result, and runs the same
+             shim/read/repack/restore cycle src/patcher.ts runs, all without executing the
+             binary. It covers the anchors AND the executable format; it never starts the
+             patched binary.
 A failure confined to one executable format (ELF, Mach-O, PE) points at src/bun-entry-module.ts or
 tweakcc's repack, not at the patch anchors. A failure on every platform at once points at the
 anchors in src/patch-transforms.ts. If instead the reasons say a check that passed on an earlier
@@ -757,8 +759,10 @@ release now SKIPs, the release is patchable and an ANCHOR DRIFTED: diff the two 
 scripts/extract-cc-bundles.mjs (last clean release: $BASE_VERSION) before touching anything.
 
 Two limits on what a green leg proves, so you do not report a fix as verified when it is not:
-- A leg recorded as \`probe\` exercises ZERO patch sites. If a platform above says [probe] and your
-  fix touches patch sites, a pass there verifies nothing — re-run it as
+- A leg recorded as \`probe\` never STARTS the binary it patched. It proves the anchors matched and
+  the repack round-tripped; it cannot prove the patched binary runs, and it cannot tell an anchor
+  that bound to the wrong function from one that bound to the right one. Where that distinction
+  decides your fix, re-run the leg as
   \`MODE=container $WORK/repro.sh <platform> <your-worktree>\`, and if Docker is unavailable, say so
   in your concluding Slack rather than calling it verified.
 - No leg ever EXECUTES an x64 ELF binary; x64 coverage is bytes-only by design. Check x64
@@ -1334,11 +1338,11 @@ $UNTESTED_COUNT build(s) could not be tested at all this run — they are marked
     # judged on has a hole in it, and a hole reported as a clean pass is the original incident.
     PASS_HEAD=":warning: *Claude Code $VERSION — nothing broke, but this is not a full all-clear.*"
   fi
-  # Only mention the byte-level tier when something is actually in it. "0 got the byte-level check
-  # only" next to five untested builds reads as a contradiction.
+  # Only mention the bundle-level tier when something is actually in it. "0 got the bundle-level
+  # check only" next to five untested builds reads as a contradiction.
   PROBE_LINE=""
   [ "$PROBE_COUNT" -eq 0 ] || PROBE_LINE="
-$PROBE_COUNT got the byte-level check only — enough to catch a repack or format break, not enough to say the patch sites still land there."
+$PROBE_COUNT got the bundle-level check only: every clodex patch site applied to their own bundle and the repack round-tripped, but no patched binary was started there."
   slack "$PASS_HEAD
 The real \`clodex patch\` ran on $FULL_COUNT of $TOTAL_COUNT builds ($FULL_LEGS): $HOST_LINE.$PROBE_LINE$UNTESTED_LINE
 Tested against clodex origin/main \`${MAIN_SHA:0:8}\` (not the published $(node -p "require('$REPO_DIR/package.json').version" 2>/dev/null || echo release)), so this is a verdict on main.

--- a/scripts/probe-patch-mechanism.mjs
+++ b/scripts/probe-patch-mechanism.mjs
@@ -1,18 +1,26 @@
 #!/usr/bin/env node
-// Does `clodex patch`'s binary handling survive a round trip on a Claude Code build for ANOTHER
-// platform?
+// Would `clodex patch` work on a Claude Code build for ANOTHER platform?
 //
-// The patch sites themselves match against extracted JavaScript, which is near-identical on every
-// platform — one platform covers them. Everything around the JavaScript is not: the entry-module
-// shim, tweakcc's read, the repack, the restore and the Mach-O re-sign all depend on the container
-// format, and that is the half that has broken. Every ELF build of Claude Code from 2.1.229 onward
-// was unpatchable across two clodex releases while macOS stayed green, because nothing tested an
-// ELF binary.
+// Two separable halves, and this answers both without ever EXECUTING the binary — which is what
+// lets a linux-arm64 or win32-x64 build be checked from macOS. (Running it is what `clodex patch`
+// itself needs, since it resolves the version by executing the binary; that is why full-patch
+// coverage for Linux needs a container and this does not.)
 //
-// This probe closes that gap without a Linux host: it never EXECUTES the binary, it only
-// manipulates its bytes, so a linux-arm64 or win32-x64 binary can be probed from macOS. (Running it
-// is what `clodex patch` itself needs — it resolves the version by executing the binary — which is
-// why full-patch coverage for Linux needs a container and this does not.)
+//   the container   the entry-module shim, tweakcc's read, the repack, the restore and the Mach-O
+//                   re-sign all depend on the executable format. Every ELF build of Claude Code
+//                   from 2.1.229 onward was unpatchable across two clodex releases while macOS
+//                   stayed green, because nothing tested an ELF binary.
+//   the patch sites the anchors clodex matches in the extracted JavaScript. These were long
+//                   assumed to be platform-independent — "one platform covers them all". 2.1.238
+//                   proved otherwise: `PATCH 5: model picker options` matched on five builds and
+//                   not on linux-arm64, linux-arm64-musl or win32-arm64. So this probe now applies
+//                   the real transforms to the real bundle it extracted from THIS build, and
+//                   repacks what they produced rather than the pristine bytes.
+//
+// What it still does NOT establish, and must never be reported as if it did: the patched binary is
+// never started, so nothing here says a PE runs on Windows or an ELF runs on Linux. And an anchor
+// that binds to the WRONG function while still emitting valid JavaScript passes every check below.
+// Only the host and container legs of the canary run the patched binary.
 //
 //   node scripts/probe-patch-mechanism.mjs <claude-binary> [options]
 //
@@ -31,6 +39,7 @@ import {
   closeSync,
   copyFileSync,
   createReadStream,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   openSync,
@@ -40,6 +49,7 @@ import {
 } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
+import { registerHooks } from 'node:module';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import {
@@ -48,6 +58,25 @@ import {
   restoreEntryModuleName,
   shimEntryModuleName,
 } from '../src/bun-entry-module.ts';
+
+// `src/` spells its own imports the TypeScript way — `./model-aliases.js` for a file that is
+// really `./model-aliases.ts`. tsup and vitest both understand that; bare `node` does not, and
+// resolves it to a file that does not exist. bun-entry-module.ts happens to import nothing
+// relative, which is why the static import above works; patch-transforms.ts does, so it is loaded
+// dynamically BELOW this hook — a static import would be resolved before this line ever runs.
+// Guarded on the sibling .ts actually existing, so a real .js file is never redirected.
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier.startsWith('.') && specifier.endsWith('.js') && context.parentURL) {
+      const candidate = new URL(`${specifier.slice(0, -3)}.ts`, context.parentURL);
+      if (candidate.protocol === 'file:' && existsSync(candidate)) {
+        return nextResolve(candidate.href, context);
+      }
+    }
+    return nextResolve(specifier, context);
+  },
+});
+const { checkPatchSites } = await import('./probe-patch-sites.mjs');
 
 const args = process.argv.slice(2);
 if (args.length === 0 || args.includes('-h') || args.includes('--help')) {
@@ -58,9 +87,10 @@ if (args.length === 0 || args.includes('-h') || args.includes('--help')) {
       '  --expect-version V  fail unless the binary is that Claude Code release\n' +
       '  --scratch DIR       where the ~300 MB working copy goes\n' +
       '  --keep              leave the scratch copy behind\n\n' +
-      'Exercises the shim/read/repack/restore cycle `clodex patch` runs, without executing the\n' +
-      'binary — so a build for any platform can be probed from any host. Exits 0 only if every\n' +
-      'check passed.',
+      'Applies every clodex patch site to this build\'s own bundle and runs the shim/read/repack/\n' +
+      'restore cycle `clodex patch` runs — without executing the binary, so a build for any\n' +
+      'platform can be probed from any host. It does NOT start the patched binary. Exits 0 only\n' +
+      'if every check passed.',
   );
   process.exit(0);
 }
@@ -144,12 +174,16 @@ const checks = [];
 const info = { label, binary, checks: [] };
 let failed = 0;
 
-// name    stable identifier a caller can branch on
-// ok      did it hold
-// detail  what was actually observed — the thing worth reading in a Slack alert
-function record(name, ok, detail) {
+// name     stable identifier a caller can branch on
+// ok       did it hold
+// detail   what was actually observed — the thing worth reading in a Slack alert
+// reasons  how a failure should be phrased in the canary's alert, when `name: detail` is the
+//          wrong shape. The patch-site check needs this: it can hold several distinct findings,
+//          and its main one has to read exactly as the host and container legs word it so that
+//          one anchor broken on four builds collapses to a single line instead of four.
+function record(name, ok, detail, reasons) {
   checks.push(name);
-  info.checks.push({ name, ok, detail });
+  info.checks.push({ name, ok, detail, ...(reasons ? { reasons } : {}) });
   if (!ok) failed++;
   if (!opts.json) console.log(`${ok ? 'OK  ' : 'FAIL'} ${name}${detail ? ` — ${detail}` : ''}`);
 }
@@ -303,9 +337,33 @@ try {
     'the copy the pristine backup is taken from is byte-identical to the release',
   );
 
-  // ---- 3. repack, then put the real entry-module name back ----------------------------------
+  // ---- 3. do clodex's patch sites still land in THIS build's bundle? ------------------------
+  // The half that used to be taken on faith. Every anchor is matched against the JavaScript that
+  // came out of this specific binary, with a synthetic config that turns on every site — so a
+  // build whose picker, resolver or context anchor drifted is caught here even when no host of
+  // that platform exists to run the real command.
+  const patchStarted = Date.now();
+  const patch = checkPatchSites(source);
+  info.patchSites = patch.sites;
+  info.patchSiteSummary = patch.summary;
+  info.patchMs = Date.now() - patchStarted;
+  record(
+    'patch-sites-apply',
+    patch.failures.length === 0,
+    patch.failures.length === 0
+      ? `all ${patch.summary.total} patch sites applied to this build's own bundle`
+      : patch.failures.join(' | '),
+    patch.failures,
+  );
+
+  // ---- 4. repack, then put the real entry-module name back ----------------------------------
+  // What goes back in is the PATCHED bundle, not the pristine one: repacking bytes nobody patched
+  // would leave the thing users actually receive — clodex's emitted patch, kilobytes of it,
+  // surviving a PE/ELF/Mach-O round trip — unproven by the byte-for-byte readback below. When the
+  // patch aborted there is nothing patched to write, so the pristine source stands in and the
+  // container half is still measured; `patch-sites-apply` above has already reported the abort.
   const repackStarted = Date.now();
-  const written = `${source}\n${PROBE_MARKER}${PROBE_PADDING}`;
+  const written = `${patch.patchedSource ?? source}\n${PROBE_MARKER}${PROBE_PADDING}`;
   const writeShim = shimEntryModuleName(scratch);
   await writeContent(installation, written);
   let restoreError = null;
@@ -338,7 +396,7 @@ try {
         : 'no shim was needed, so there was no entry-module name to put back'),
   );
 
-  // ---- 4. is the binary that WOULD be published actually sound? -----------------------------
+  // ---- 5. is the binary that WOULD be published actually sound? -----------------------------
   // Reading OK from the steps above is not evidence of that: the checks below are on the bytes
   // that would be renamed over the live install.
   if (writeShim) {
@@ -438,6 +496,31 @@ try {
       mismatch || `${republished.length} bytes read back, byte-for-byte what was written`,
     );
 
+    // `published-content` compares the readback against what this probe CHOSE to write, so it is
+    // silent about whether that was the patched bundle or the pristine one — repack the wrong
+    // string and it stays green. This is the independent half: the bytes that would be published
+    // must carry the markers clodex's own transforms emitted, which is the same evidence the host
+    // and container legs take from the real patched binary.
+    //
+    // Read off the patched bundle rather than hard-coded, so a new marker is covered the day it
+    // is added and a renamed one does not fail here for a reason that has nothing to do with the
+    // release.
+    const emitted = [...new Set(patch.patchedSource?.match(/ccpatch:[a-zA-Z0-9_-]+/g) ?? [])];
+    info.patchMarkers = emitted;
+    if (emitted.length === 0) {
+      // Only reachable when the patch aborted; `patch-sites-apply` has already said so.
+      info.notChecked = [...(info.notChecked ?? []), 'published-carries-patch'];
+      note('published-carries-patch was NOT checked: the patch produced no bundle to look for');
+    } else {
+      const absent = emitted.filter((marker) => !republished.includes(marker));
+      record(
+        'published-carries-patch',
+        absent.length === 0,
+        absent.length === 0
+          ? `the published bytes carry all ${emitted.length} clodex patch markers (${emitted.join(', ')})`
+          : `the published bytes are missing ${absent.join(', ')} — what was repacked is not what the patch produced`,
+      );
+    }
   } finally {
     // Undoing the verification shim is housekeeping, not a check: leaving it on would hand an
     // investigator a binary that cannot run and a symptom the probe invented. When it fails for
@@ -484,7 +567,9 @@ try {
   info.durationMs = Date.now() - started;
   info.failed = failed;
   info.verdict = failed === 0 ? 'pass' : 'fail';
-  info.reasons = info.checks.filter((c) => !c.ok).map((c) => `${c.name}: ${c.detail}`);
+  info.reasons = info.checks
+    .filter((c) => !c.ok)
+    .flatMap((c) => c.reasons ?? [`${c.name}: ${c.detail}`]);
   // scratchDir is always one this run made, so removing it wholesale takes nothing that was not
   // put there by this run.
   if (opts.keep) info.scratch = scratch;

--- a/scripts/probe-patch-sites.mjs
+++ b/scripts/probe-patch-sites.mjs
@@ -1,0 +1,151 @@
+// The patch-site half of scripts/probe-patch-mechanism.mjs.
+//
+// WHY THIS EXISTS
+// The probe used to check the CONTAINER only — shim, read, repack, restore — on the theory that
+// the extracted JavaScript is near-identical on every platform, so one platform's `clodex patch`
+// covers the anchors for all of them. Claude Code 2.1.238 disproved that: `PATCH 5: model picker
+// options` matched on darwin-arm64, darwin-x64, linux-x64, linux-x64-musl and win32-x64, and did
+// NOT match on linux-arm64, linux-arm64-musl or win32-arm64. The two Linux builds have containers
+// and reported `fail`; win32-arm64 has no image, so it was a probe — and a probe exercised zero
+// patch sites, so it reported a clean `pass` on a build clodex could not correctly patch.
+//
+// So the probe now applies the REAL transforms to the REAL bundle it just extracted. That needs
+// no host of the target platform and no execution: the anchors are matched against a string.
+//
+// It is kept in its own module so `tests/probe-patch-sites.test.ts` can pin the expectations below
+// against the actual transform set. Without that pin, adding or renaming a PATCH site would make
+// every probe leg fail at 03:00 as if Claude Code had broken; with it, `pnpm test` reddens first.
+
+import { applyClodexPatches, PatchApplyError } from '../src/patch-transforms.ts';
+
+/**
+ * One synthetic model that turns on every conditional patch site.
+ *
+ * Deliberately NOT the operator's real favorites: the probe must ask the same question of every
+ * release regardless of whose machine it runs on, and half these sites are skipped entirely by a
+ * config that omits `alias`, `context`, `display` or `effort`. `effort` lists all five native
+ * levels because PATCH 8b and 8c are gated on `xhigh` and `max` being declared.
+ *
+ * The alias is long and unlovely on purpose — it has to be a name no Claude Code build already
+ * contains, or PATCH 1/3/5 would report SKIP ("already patched") against a pristine bundle.
+ */
+export const PROBE_PATCH_CONFIG = Object.freeze({
+  'clodex:probe:mechanism-canary': {
+    alias: 'clodexprobecanary',
+    context: 272000,
+    display: 'clodex probe (synthetic model, not a real one)',
+    effort: { levels: ['low', 'medium', 'high', 'xhigh', 'max'], defaultLevel: 'high' },
+  },
+});
+
+/**
+ * Every site PROBE_PATCH_CONFIG is expected to exercise, in the order applyClodexPatches runs them.
+ *
+ * A name that stops appearing is as serious as one that fails: a site nobody attempts is a site
+ * nobody is watching. `tests/probe-patch-sites.test.ts` keeps this honest, and bumping
+ * PATCH_TRANSFORMS_VERSION is the moment to revisit it.
+ */
+export const EXPECTED_PATCH_SITES = Object.freeze([
+  'PATCH 1: Agent tool model enum',
+  'PATCH 3: known-alias validator list',
+  'PATCH 6: alias resolver switch',
+  'PATCH 5: model picker options',
+  'PATCH 4: Agent tool model description',
+  'PATCH 7: per-model context window',
+  'PATCH 8a: effort capability',
+  'PATCH 8b: xhigh effort capability',
+  'PATCH 8c: max effort capability',
+  'PATCH 9: default effort',
+  'PATCH 10: child network environment',
+]);
+
+const joinNames = (names) => names.join('; ');
+
+/**
+ * Apply every clodex patch site to one build's extracted bundle.
+ *
+ * @param {string} source the JavaScript tweakcc read out of the binary
+ * @returns {{
+ *   patchedSource: string | null,   the patched bundle, or null if the patch aborted
+ *   sites: {name: string, status: string, extra?: string}[],
+ *   failures: string[],             one ready-to-read reason per finding, empty when clean
+ *   summary: {applied: number, skipped: number, failed: number, total: number},
+ * }}
+ */
+export function checkPatchSites(source) {
+  const sites = [];
+  const failures = [];
+  let patchedSource = null;
+  let aborted = '';
+
+  try {
+    const outcome = applyClodexPatches(source, PROBE_PATCH_CONFIG);
+    patchedSource = outcome.content;
+    sites.push(...outcome.results);
+  } catch (err) {
+    aborted = err instanceof Error ? err.message : String(err);
+    // A required site that fails throws, and the sites decided before it are on the error. They
+    // are the most useful thing in the alert, so they are kept rather than discarded.
+    if (err instanceof PatchApplyError) sites.push(...err.results);
+    failures.push(`clodex patch aborted on this build's bundle: ${aborted}`);
+  }
+
+  const byStatus = (status) => sites.filter((s) => s.status === status).map((s) => s.name);
+  const failed = sites.filter((s) => s.status === 'FAIL');
+  const skipped = byStatus('SKIP');
+
+  // Phrased exactly as the host and container legs phrase it, so one anchor that broke on four
+  // builds collapses to a single line in the Slack alert instead of one line per leg.
+  if (failed.length > 0) {
+    failures.push(`patch sites FAILED: ${joinNames(failed.map((s) => s.name))}`);
+  }
+
+  // A SKIP means "already patched" or "nothing configured". Against a pristine release bundle
+  // with the config above, neither is possible — so a SKIP is an anchor that matched something it
+  // should not have, or a config that quietly stopped activating that site.
+  if (skipped.length > 0) {
+    failures.push(
+      `patch sites did nothing on this build's bundle (reported SKIP against pristine bytes): ${joinNames(skipped)}`,
+    );
+  }
+
+  const seen = new Set();
+  const duplicates = [];
+  for (const site of sites) {
+    if (seen.has(site.name)) duplicates.push(site.name);
+    seen.add(site.name);
+  }
+  if (duplicates.length > 0) {
+    failures.push(`the same patch site was reported twice: ${joinNames([...new Set(duplicates)])}`);
+  }
+
+  const unexpected = [...seen].filter((name) => !EXPECTED_PATCH_SITES.includes(name));
+  if (unexpected.length > 0) {
+    failures.push(
+      `the probe does not know these patch sites, so nothing vouches for them — clodex's transform set changed, the release did not: ${joinNames(unexpected)}`,
+    );
+  }
+
+  // Only meaningful when the run got all the way through. After an abort the remaining sites are
+  // missing BECAUSE of the abort, and listing them would bury the one line that says why.
+  if (!aborted) {
+    const missing = EXPECTED_PATCH_SITES.filter((name) => !seen.has(name));
+    if (missing.length > 0) {
+      failures.push(
+        `these patch sites were never attempted, so this build is unchecked for them — clodex's transform set or the probe's synthetic config changed, the release did not: ${joinNames(missing)}`,
+      );
+    }
+  }
+
+  return {
+    patchedSource,
+    sites,
+    failures,
+    summary: {
+      applied: byStatus('OK').length,
+      skipped: skipped.length,
+      failed: failed.length,
+      total: sites.length,
+    },
+  };
+}

--- a/tests/fixtures/claude-bundle.ts
+++ b/tests/fixtures/claude-bundle.ts
@@ -1,0 +1,33 @@
+// Minified stand-ins for the Claude Code bundle, carrying every anchor the patch transforms key
+// on so they can be executed end to end.
+//
+// Shared rather than private to one test file: tests/probe-patch-sites.test.ts pins the canary
+// probe's synthetic config and its list of expected patch sites against these same anchors, which
+// is what stops a new or renamed PATCH site from reaching the hourly canary as a mystery failure
+// on every platform at once.
+
+export const CLAUDE_CORE_FIXTURE = [
+  '.enum(["sonnet","opus","haiku","fable"]).optional().describe(`Optional model override for this agent. Defaults to inherit.`)',
+  'var KNOWN=["sonnet","opus","haiku","fable","opusplan"];',
+  'function rz(x){switch(x){case"best":{return "opus"}default:return null}}',
+  'function opts(e,t,r){let n=cur(),o=(n==="opus")?[n,r]:[r];for(let i of o)Dlh(e,i,t);return e}',
+  'function RS(e,t){let r=FAc();if(r!==void 0)return r;if(EHi(e,t))return Dve;return $Ac(e,t)}',
+  'function cwdOf(){let p=process.env.PWD;return p}',
+  'function childEnv(){let e=extra(),t=Object.keys(e).length>0,n=Object.keys(e).length>0,s=flag(process.env.CLAUDE_CODE_REMOTE)?remote():{};let o=[process.env.CLAUDE_CODE_OAUTH_TOKEN,process.env.CLAUDE_CODE_SUBSCRIPTION_TYPE,process.env.CLAUDE_BG_PTY_AUTH,"OTEL_",process.env.CLAUDE_CODE_OTEL_DIAG_STDERR],u=["CLAUDE_CODE_OAUTH_TOKEN"];if(!t&&!n&&!o[0])return process.env;let v={...process.env,...e,...s};for(let k of u)delete v[k],delete v[`INPUT_${k}`];return v}function mcpAllow(){let e=process.env.CLAUDE_CODE_MCP_ALLOWLIST_ENV;return e}',
+].join('\n');
+
+export const CLAUDE_FIXTURE = [
+  CLAUDE_CORE_FIXTURE,
+  'function OI(e){if(SNr(e))return!1;let t=Ede(e,"effort");if(t!==void 0)return t;return!1}',
+  'function I_e(e){if(SNr(e))return!1;let t=Ede(e,"xhigh_effort");if(t!==void 0)return t;return!1}',
+  'function eqe(e){if(SNr(e))return!1;let t=Ede(e,"max_effort");if(t!==void 0)return t;return!1}',
+  'function ait(e){return ww(lo(e))?.default_effort??"high"}',
+].join('\n');
+
+export const CLAUDE_PROXY_EFFORT_FIXTURE = [
+  CLAUDE_CORE_FIXTURE,
+  'function OI(e){if(SNr(e))return!1;let t=Ede(e,"effort");if(t!==void 0)return t;return proxyMode(e)}',
+  'function I_e(e){if(SNr(e))return!1;let t=Ede(e,"xhigh_effort");if(t!==void 0)return t;return proxyMode(e)}',
+  'function eqe(e){if(SNr(e))return!1;let t=Ede(e,"max_effort");if(t!==void 0)return t;return proxyMode(e)}',
+  'function ait(e){return ww(lo(e))?.default_effort??"high"}',
+].join('\n');

--- a/tests/patcher.test.ts
+++ b/tests/patcher.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { tweakccRecognizesModuleName } from '../src/bun-entry-module.js';
 import {
+  CLAUDE_CORE_FIXTURE,
+  CLAUDE_FIXTURE,
+  CLAUDE_PROXY_EFFORT_FIXTURE,
+} from './fixtures/claude-bundle.js';
+import {
   buildFakeNativeClaude,
   MACHO_MAGIC,
   parseBunBlob,
@@ -762,17 +767,6 @@ describe('summarizePatchResults', () => {
   });
 });
 
-// A minified stand-in for the Claude Code bundle carrying every anchor the
-// patch transforms key on, so they can be executed end to end.
-const CLAUDE_CORE_FIXTURE = [
-  '.enum(["sonnet","opus","haiku","fable"]).optional().describe(`Optional model override for this agent. Defaults to inherit.`)',
-  'var KNOWN=["sonnet","opus","haiku","fable","opusplan"];',
-  'function rz(x){switch(x){case"best":{return "opus"}default:return null}}',
-  'function opts(e,t,r){let n=cur(),o=(n==="opus")?[n,r]:[r];for(let i of o)Dlh(e,i,t);return e}',
-  'function RS(e,t){let r=FAc();if(r!==void 0)return r;if(EHi(e,t))return Dve;return $Ac(e,t)}',
-  'function cwdOf(){let p=process.env.PWD;return p}',
-  'function childEnv(){let e=extra(),t=Object.keys(e).length>0,n=Object.keys(e).length>0,s=flag(process.env.CLAUDE_CODE_REMOTE)?remote():{};let o=[process.env.CLAUDE_CODE_OAUTH_TOKEN,process.env.CLAUDE_CODE_SUBSCRIPTION_TYPE,process.env.CLAUDE_BG_PTY_AUTH,"OTEL_",process.env.CLAUDE_CODE_OTEL_DIAG_STDERR],u=["CLAUDE_CODE_OAUTH_TOKEN"];if(!t&&!n&&!o[0])return process.env;let v={...process.env,...e,...s};for(let k of u)delete v[k],delete v[`INPUT_${k}`];return v}function mcpAllow(){let e=process.env.CLAUDE_CODE_MCP_ALLOWLIST_ENV;return e}',
-].join('\n');
 
 const digestOf = (text: string) => createHash('sha256').update(text).digest('hex');
 
@@ -1188,21 +1182,6 @@ describe('applyPatch', () => {
   });
 });
 
-const CLAUDE_FIXTURE = [
-  CLAUDE_CORE_FIXTURE,
-  'function OI(e){if(SNr(e))return!1;let t=Ede(e,"effort");if(t!==void 0)return t;return!1}',
-  'function I_e(e){if(SNr(e))return!1;let t=Ede(e,"xhigh_effort");if(t!==void 0)return t;return!1}',
-  'function eqe(e){if(SNr(e))return!1;let t=Ede(e,"max_effort");if(t!==void 0)return t;return!1}',
-  'function ait(e){return ww(lo(e))?.default_effort??"high"}',
-].join('\n');
-
-const CLAUDE_PROXY_EFFORT_FIXTURE = [
-  CLAUDE_CORE_FIXTURE,
-  'function OI(e){if(SNr(e))return!1;let t=Ede(e,"effort");if(t!==void 0)return t;return proxyMode(e)}',
-  'function I_e(e){if(SNr(e))return!1;let t=Ede(e,"xhigh_effort");if(t!==void 0)return t;return proxyMode(e)}',
-  'function eqe(e){if(SNr(e))return!1;let t=Ede(e,"max_effort");if(t!==void 0)return t;return proxyMode(e)}',
-  'function ait(e){return ww(lo(e))?.default_effort??"high"}',
-].join('\n');
 
 function runPatchScript(config: Parameters<typeof applyClodexPatches>[1], source = CLAUDE_FIXTURE): string {
   return applyClodexPatches(source, config).content;

--- a/tests/probe-patch-sites.test.ts
+++ b/tests/probe-patch-sites.test.ts
@@ -1,0 +1,127 @@
+// The patch-site half of the release canary's probe (scripts/probe-patch-sites.mjs).
+//
+// The canary runs that probe against a real Claude Code build for every platform that has no
+// container image — win32-x64, win32-arm64, linux-x64, linux-x64-musl, darwin-x64. It used to
+// check executable-format handling only, so it reported win32-arm64 as a clean pass on Claude
+// Code 2.1.238 while `PATCH 5: model picker options` no longer matched that build's bundle at
+// all. It now applies the real transforms, which means two new ways for it to be wrong:
+//
+//   - it stops noticing a broken anchor, and the blind spot is back;
+//   - it starts failing on a clodex change rather than a Claude Code change, and pages a human at
+//     03:00 for every platform at once.
+//
+// Both are caught here instead of in production. Bump PATCH_TRANSFORMS_VERSION and this file
+// reddens until the probe's expectations are brought along with the transform set.
+
+import { describe, it, expect } from 'vitest';
+import {
+  checkPatchSites,
+  EXPECTED_PATCH_SITES,
+  PROBE_PATCH_CONFIG,
+} from '../scripts/probe-patch-sites.mjs';
+import { applyClodexPatches } from '../src/patch-transforms.js';
+import { CLAUDE_FIXTURE } from './fixtures/claude-bundle.js';
+
+describe('the canary probe against a healthy bundle', () => {
+  it('exercises every patch site the transform set has, and no other', () => {
+    const { sites, failures } = checkPatchSites(CLAUDE_FIXTURE);
+
+    // Exact list, in order. A site the probe does not know about is a site nothing vouches for on
+    // five of the eight published builds, and a name drifting is as invisible as a name removed.
+    expect(sites.map((s) => s.name)).toEqual([...EXPECTED_PATCH_SITES]);
+    expect(failures).toEqual([]);
+  });
+
+  it('leaves nothing SKIPped, because a skip means a site did no work', () => {
+    const { sites, summary } = checkPatchSites(CLAUDE_FIXTURE);
+
+    expect(sites.every((s) => s.status === 'OK')).toBe(true);
+    expect(summary).toEqual({
+      applied: EXPECTED_PATCH_SITES.length,
+      skipped: 0,
+      failed: 0,
+      total: EXPECTED_PATCH_SITES.length,
+    });
+  });
+
+  it('returns the patched bundle, which is what the probe repacks into the binary', () => {
+    const { patchedSource } = checkPatchSites(CLAUDE_FIXTURE);
+
+    // Repacking pristine bytes would leave the thing users actually receive — clodex's emitted
+    // patch surviving a PE/ELF/Mach-O round trip — unproven by the probe's byte-for-byte readback.
+    expect(patchedSource).not.toBeNull();
+    expect(patchedSource!.length).toBeGreaterThan(CLAUDE_FIXTURE.length);
+    expect(patchedSource).toContain('clodexprobecanary');
+  });
+
+  it('agrees with applyClodexPatches called directly, so it adds no interpretation of its own', () => {
+    const direct = applyClodexPatches(CLAUDE_FIXTURE, PROBE_PATCH_CONFIG);
+
+    expect(checkPatchSites(CLAUDE_FIXTURE).patchedSource).toBe(direct.content);
+  });
+});
+
+describe('the canary probe against a bundle whose anchors drifted', () => {
+  // The real Claude Code 2.1.238 regression, reproduced. Its linux-arm64, linux-arm64-musl and
+  // win32-arm64 builds minified the picker helper's second parameter from `r` to `n`, and the
+  // PATCH 5 anchor spells `r` literally — so the anchor matched on the other five builds and not
+  // on those three. Renaming the same identifier in the fixture reproduces exactly that shape.
+  const PICKER_ANCHOR = 'function opts(e,t,r){let n=cur(),o=(n==="opus")?[n,r]:[r];for(let i of o)Dlh(e,i,t);return e}';
+  const PICKER_DRIFTED = 'function opts(e,t,q){let n=cur(),o=(n==="opus")?[n,q]:[q];for(let i of o)Dlh(e,i,t);return e}';
+
+  it('fails when the model-picker anchor no longer matches — the 2.1.238 win32-arm64 break', () => {
+    expect(CLAUDE_FIXTURE, 'fixture drifted from the shape this test mutates')
+      .toContain(PICKER_ANCHOR);
+    const drifted = CLAUDE_FIXTURE.replace(PICKER_ANCHOR, PICKER_DRIFTED);
+
+    const { sites, failures } = checkPatchSites(drifted);
+
+    expect(sites.find((s) => s.name === 'PATCH 5: model picker options')?.status).toBe('FAIL');
+    // Worded exactly as the host and container legs word it, so one anchor broken on three builds
+    // collapses to a single line in the alert rather than one line per build.
+    expect(failures).toContain('patch sites FAILED: PATCH 5: model picker options');
+  });
+
+  it('still returns a patched bundle when an OPTIONAL site fails, so the repack is measured too', () => {
+    const drifted = CLAUDE_FIXTURE.replace(PICKER_ANCHOR, PICKER_DRIFTED);
+
+    // PATCH 5 is not `required`, so applyClodexPatches publishes anyway. The probe must report the
+    // miss AND go on to exercise the executable-format half against the bytes it produced.
+    expect(checkPatchSites(drifted).patchedSource).not.toBeNull();
+  });
+
+  it('reports the abort, and no patched bundle, when a REQUIRED site fails', () => {
+    const drifted = CLAUDE_FIXTURE.replace(
+      '.enum(["sonnet","opus","haiku","fable"])',
+      '.enum(["sonnet","opus","haiku","fable"]) /* moved */',
+    );
+
+    const { patchedSource, failures } = checkPatchSites(drifted);
+
+    // applyClodexPatches throws on a required miss, so there are no patched bytes to repack. The
+    // probe must still say so rather than quietly repacking pristine ones and calling that a pass.
+    expect(patchedSource).toBeNull();
+    expect(failures[0]).toContain("clodex patch aborted on this build's bundle");
+    // The sites after the abort are unattempted BECAUSE of it. Listing them as findings of their
+    // own would bury the single line that says why.
+    expect(failures.join('\n')).not.toContain('were never attempted');
+  });
+
+  it('refuses a bundle that already carries a clodex patch, and names all three symptoms', () => {
+    // Release bytes are pristine, so this cannot come from Claude Code — it is the probe pointed
+    // at something it should not be, or a config that stopped activating a site. It exercises the
+    // three name-level rules at once: a SKIP, the `(refresh)` variants the probe does not expect,
+    // and the plain names that then go unattempted.
+    const alreadyPatched = applyClodexPatches(CLAUDE_FIXTURE, PROBE_PATCH_CONFIG).content;
+
+    const { failures, summary } = checkPatchSites(alreadyPatched);
+
+    expect(summary.skipped).toBe(EXPECTED_PATCH_SITES.length);
+    // Ordered: the cause first, its consequences after. An operator reads line one.
+    expect(failures[0]).toContain('reported SKIP against pristine bytes');
+    expect(failures[1]).toContain('the probe does not know these patch sites');
+    expect(failures[2]).toContain('were never attempted');
+    // And the wording sends the reader at clodex, not at a night of diffing Claude Code bundles.
+    expect(failures[2]).toContain("clodex's transform set");
+  });
+});


### PR DESCRIPTION
The automated canary that tests each new Claude Code release against `clodex patch` reported a
release as **passing on Windows when patching was in fact broken there**. This makes it report the
truth.

## What went wrong

The canary tests every published platform, but only some legs can run the real `clodex patch`: one
on this Mac, and Linux ARM inside a container. The rest run a *probe* — the same read/repack/restore
cycle driven against the binary's bytes without executing it. A probe covers executable-format
handling and **exercises no patch sites at all**, yet its verdict was mapped straight to a platform
`pass`.

Windows has no container image available, so it is always a probe. When Claude Code 2.1.238 broke
`PATCH 5: model picker options`, the canary reported `fail` for the two Linux ARM legs and **`pass`
for `win32-arm64`**, which was equally broken. The recorded result shows 13 mechanism checks and no
patch-site results at all.

## What changed

The probe now applies the real patch transforms to the bundle it just extracted, so a platform with
no host and no container still verifies that every patch site matches. It fails on any site that
fails, is skipped against pristine bytes, or is missing, duplicated or unrecognised.

The probe also repacks the *patched* bundle rather than the pristine one, so the existing
byte-for-byte readback additionally proves the emitted patch survives the PE/ELF/Mach-O round trip.
A new `published-carries-patch` check asserts the readback carries the markers the transforms
emitted — the previous check compared the readback against whatever the probe chose to write, so it
could not notice the wrong string being repacked.

A probe result carrying no patch sites is now an `error` rather than a verdict, since that shape is
the old behaviour and recording it as `pass` is the bug being fixed.

## Verified against the real binaries

Against the published 2.1.238 builds, using the anchor as it stands on `main`:

| Build | Format | Result |
| --- | --- | --- |
| `win32-arm64` | PE | **FAIL** — `PATCH 5: model picker options` |
| `linux-arm64` | ELF | **FAIL**, matching its container leg |
| `win32-x64` | PE | pass, 11/11 sites |
| `darwin-arm64` | Mach-O | pass, 11/11, signature valid |

Across 31 extracted bundles the check fires on exactly the three builds the incident affected, with
no false positives from 2.1.214 onward.

15 mutations were run against the new code and every one turned a test red. Two of them exposed real
defects that are fixed here, including one that would have aborted a canary run before any
platform's verdict was recorded. The self-test goes from 85 to 101 assertions; none were weakened.
`tests/probe-patch-sites.test.ts` pins the probe's expected-site list against the real transform set,
so adding or renaming a patch site fails the test suite rather than five platforms at 3am.

One existing assertion — that a probe-by-design platform still shows a clean tick — was changed
deliberately rather than deleted: Windows has no stronger leg available, so it keeps its tick, but
the coverage line must now say that native execution was not checked.

## What this does not cover

A probe still does not prove the patched binary runs; nothing starts it, so a repack producing a PE
that Windows refuses to load would pass. Only the host and container legs answer that, and only for
macOS ARM64 and Linux ARM64.

A probe also cannot tell an anchor that bound to the intended function from one that bound to a
lookalike and still emitted valid JavaScript. `OK` means a site applied, never that it applied to
what it was aimed at. Nothing in the canary covers that today.

`.claude/docs/patcher.md` previously stated that the probe does not exercise patch sites, which is no
longer true; it and `canary/README.md` are updated to describe both the new coverage and the limits
above.
