### PR TITLE
fix(patch): restore your models in Claude Code 2.1.238's /model picker on ARM64 Linux and Windows

### DIFF
--- a/.claude/docs/patcher.md
+++ b/.claude/docs/patcher.md
@@ -164,6 +164,48 @@ tweakcc's own repack reads back as an ordinary module name.
 
 ## Patcher invariants
 
+- **The eight published builds of one Claude Code version are eight different bundles, and a
+  minified identifier is not stable across them.** 2.1.238 named the `/model` picker's builder
+  `(e,t,r){let n=…}` on five of the eight published builds but `(e,t,n){let r=…}` on linux-arm64,
+  linux-arm64-musl and win32-arm64, so PATCH 5's anchor — which spelled `r` out — matched five
+  builds and silently dropped every picker entry on the other three. Tie repeated names together
+  with back-references instead of spelling them out, and when the replacement has to name a
+  variable, capture it from the match rather than assuming the name. **Wildcarding alone is not
+  enough**: an anchor made of pure structure (ternary → loop → call) identifies nothing, and a
+  review demonstrated a same-shaped neighbour being patched, with status `OK`, once the real site
+  drifted out of the match. Keep a semantic discriminator that only the intended site can satisfy —
+  for PATCH 5 that is the builder's own `"opus"`/`"sonnet"` comparison — and **count the
+  discriminator across the whole bundle, not just the anchor**. "Matched once" means one candidate
+  survived, not that it was the right one: a second review built a twin carrying its own
+  opus/sonnet selection, moved the real picker out of the match by turning `for(` into `for (`, and
+  PATCH 5 injected into the twin and reported success. Because the anchor begins with the counted
+  expression, at most one site in the bundle can match it. Read that guarantee precisely — it
+  holds **only while the real site keeps spelling the discriminator the way the count spells it**.
+  Were
+  the picker respelt upstream to the equivalent `(x==="sonnet"||x==="opus")` while something else
+  adopted the counted spelling, the survivor would be the wrong function again; if only the
+  spelling drifts, the count goes to zero and PATCH 5 fails loud, which is the safe direction.
+  Note also that both regexes are **lexical, not syntax-aware**: they match inside block comments
+  and template literals (executed — one match each), so "occurs once" is a claim about bytes, not
+  about executable code. **An identity oracle must be derived from content, never position** — an
+  oracle that took "the function following the built-in option factory" blessed that same twin,
+  because the twin was inserted into exactly that gap. Note what the replacement does and does not
+  prove: it validates the appender the builder loops through, so a different caller of the genuine
+  appender would inherit that evidence; it rejects the realistic impostor, which brings its own.
+  Verify with the real-bundle
+  harness over **every platform's** bundle (`scripts/extract-cc-bundles.mjs` reads a foreign binary
+  fine), not just this Mac's: the canary's probe legs exercise zero patch sites, so win32-arm64
+  recorded a `pass` for the release this broke.
+- **Calibrate a patch-anchor weakness by corpus reachability and by which direction it fails, not
+  by whether an attack can be constructed** — one always can, against every site we ship.
+  PATCH 5's surviving hole needs upstream to make two coordinated changes at once (respell its own
+  discriminator *and* introduce the counted spelling elsewhere, in a function that also matches the
+  full anchor shape); it has zero instances across every bundle we hold, and it was accepted rather
+  than defended. The reason is the incident itself: **this outage was caused by an over-specific
+  anchor**, and every discriminator added is one more thing a benign upstream rename can break for
+  real users. Weigh added specificity against that, prefer anchors that fail loud over anchors that
+  fail silent, and let the canary — which now runs the real patch sites on Linux and the host —
+  catch the loud ones.
 - **The alias IS the model identity in the binary.** For any favorite with an alias, the short name
   (`sol`) — never the canonical `clodex:<provider>:<model>` id — is what lands in the Agent-tool zod
   enum (PATCH 1), the known-alias validator list (PATCH 3), the `/model` picker value (PATCH 5), and

--- a/.claude/harnesses/README.md
+++ b/.claude/harnesses/README.md
@@ -19,10 +19,11 @@ one into `tests/` only after you have run it and confirmed it actually asserts s
 Several need real Claude Code bundles. Extract them once with
 `node scripts/extract-cc-bundles.mjs` and point `REVIEW_BUNDLE_DIR` at the output.
 
-## Patcher / PATCH 10
+## Patcher / PATCH 5 and PATCH 10
 
 | Harness | Claim it settles |
 | --- | --- |
+| `cc238-patch5-anchor-over-real-bundles` | PATCH 5's /model picker anchor binds one builder per bundle **at the sole model selection**, identified from the builder's own content rather than from what it sits next to, pushes into the array that builder returns, and the patched builder **executes** and yields the entries. Per bundle it also runs the strongest wrong-target attack — a twin carrying its own opus/sonnet selection while the real picker drifts by one space — and re-runs the pre-2.1.238 anchor to assert the exact set of builds it missed. Copy this one when a release moves the picker; the position-derived oracle it replaced blessed the twin. |
 | `pr78-patch10-anchor-over-real-bundles` | PATCH 10's anchor self-identifies the child-env builder across every real bundle — match count, bound function, matched span, and that no rewritten `process.env` reference escapes the declaring function. Extracts the regex from `patch-transforms.ts` so it cannot drift. The default first move on any anchor PR. |
 | `pr78-patch10-wrong-target-mutations` | The three wrong-target classes — preceding decoy, token-bearing neighbour, nested named function — plus a `vm.Script` parse of the patched output. |
 | `pr78-patch10-execute-real-builder` | Extracts the *patched* builder out of a real bundle and **executes** it with stubs. Reading a regex replacement is not evidence the code runs. |

--- a/.claude/harnesses/cc238-patch5-anchor-over-real-bundles.harness.ts
+++ b/.claude/harnesses/cc238-patch5-anchor-over-real-bundles.harness.ts
@@ -1,0 +1,256 @@
+// REVIEW HARNESS (not for merge) — Claude Code 2.1.238, PATCH 5 target identification.
+//
+// 2.1.238's per-platform builds gave the /model picker's choke-point function different minified
+// identifiers (`(e,t,r){let n=…}` on five of the eight published builds, `(e,t,n){let r=…}` on
+// linux-arm64, linux-arm64-musl and win32-arm64), and the old anchor spelled `r`/`e`/`t` out. This
+// drives the REAL applyClodexPatches over every pristine bundle on this machine and measures:
+//   - the whole-bundle count of the model selection PATCH 5 keys on, and that the anchor binds at
+//     exactly that offset (the property that makes counting it meaningful)
+//   - anchor match count and matched span
+//   - that the bound function loops through Claude Code's own option appender — the helper named
+//     in its loop must splice into the options list and build entries from the real
+//     `{value:"sonnet"…}` / `{value:"opusplan"…}` factories. That is evidence from content rather
+//     than from position, which the oracle it replaced was not: that one took "the function
+//     following the built-in option factory" and blessed a competitor inserted into the gap. It is
+//     NOT proof that the bound function is the picker — the evidence belongs to the appender, so
+//     any other caller of the genuine appender would inherit it. What it does reject is the
+//     realistic impostor, which brings its own appender.
+//   - that the array pushed into is the one that function RETURNS
+//   - that the patched function, EXECUTED with stubs, yields the custom entries
+//   - idempotency: a second pass over the patched source changes nothing
+// plus two adversarial passes over the same real bundles:
+//   - the OLD anchor, asserted to miss EXACTLY linux-arm64, linux-arm64-musl and win32-arm64
+//   - the strongest wrong-target attack: a competitor carrying its OWN opus/sonnet selection and
+//     the exact surrounding shape, with the real picker moved out of the match by one space. The
+//     anchor alone binds that competitor; PATCH 5 must refuse instead.
+//
+// Needs real bundles — `node scripts/extract-cc-bundles.mjs /tmp/cc-bundles` — and, like every
+// harness here, a config of its own because vitest.config.ts only collects tests/:
+//
+//   printf "export default { test: { include: ['.claude/harnesses/**/*.harness.ts'], testTimeout: 300000 } };\n" \
+//     > /tmp/harness.vitest.config.ts
+//   REVIEW_BUNDLE_DIR=/tmp/cc-bundles npx vitest run --root . --config /tmp/harness.vitest.config.ts \
+//     .claude/harnesses/cc238-patch5-anchor-over-real-bundles.harness.ts
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { applyClodexPatches } from '../../src/patch-transforms.js';
+
+const BUNDLE_DIR = process.env['REVIEW_BUNDLE_DIR'] ?? '';
+
+/** The anchor as it stood before this fix — kept verbatim as the regression proof. */
+const OLD_ANCHOR = /(\?\[[\w$]+,r\]:\[r\];for\(let [\w$]+ of [\w$]+\)[\w$]+\(e,[\w$]+,t\);)/;
+
+/** The 2.1.238 builds whose picker the old anchor could not find. */
+const EXPECTED_OLD_MISSES = ['linux-arm64@2.1.238', 'linux-arm64-musl@2.1.238', 'win32-arm64@2.1.238'];
+
+/** Every build published for 2.1.238. A corpus missing any of them is not a comprehensive run. */
+const REQUIRED_238 = [
+  'darwin-arm64', 'darwin-x64', 'linux-arm64', 'linux-arm64-musl',
+  'linux-x64', 'linux-x64-musl', 'win32-arm64', 'win32-x64',
+].map(p => `${p}@2.1.238`);
+
+const CONFIG = {
+  'clodex:openai-oauth:gpt-5.6-sol': { alias: 'sol', context: 272_000, display: 'GPT-5.6 Sol (OpenAI (ChatGPT))' },
+  'clodex:openai-oauth:gpt-5.6-luna': { alias: 'luna', display: 'GPT-5.6 Luna (OpenAI (ChatGPT))' },
+};
+
+function bundles(): string[] {
+  if (!BUNDLE_DIR || !existsSync(BUNDLE_DIR)) return [];
+  return readdirSync(BUNDLE_DIR).filter(f => f.endsWith('.js')).sort();
+}
+
+/**
+ * `<platform>@<version>` for a per-platform extraction, in either filename order, else null for a
+ * host-only historical bundle. Extractions of the same release under two names are byte-identical
+ * duplicates, so platform claims are asserted on this label, not on the filename.
+ */
+function label(file: string): string | null {
+  const version = /(\d+\.\d+\.\d+)/.exec(file)?.[1];
+  const platform = /(darwin|linux|win32)-(arm64|x64)(-musl)?/.exec(file)?.[0];
+  return version && platform ? `${platform}@${version}` : null;
+}
+
+/** Both PATCH 5 regexes, read out of the production source so they cannot drift from it. */
+function liveRegexes(): { anchor: string; selection: string } {
+  const src = readFileSync(join(import.meta.dirname, '..', '..', 'src', 'patch-transforms.ts'), 'utf8');
+  const selection = /const modelSelections = \[\.\.\.js\.matchAll\((\/(?:[^\n]|\\\/)+?\/)g\)\]/.exec(src);
+  expect(selection, 'extracted the model-selection regex literal').toBeTruthy();
+  const at = src.indexOf('applyOnce(\n        pickerSite,');
+  expect(at, 'PATCH 5 applyOnce present').toBeGreaterThan(-1);
+  const anchor = src.slice(at).match(/\n\s*(\/(?:[^\n]|\\\/)+?\/),\n/);
+  expect(anchor, 'extracted the PATCH 5 anchor literal').toBeTruthy();
+  return { anchor: anchor![1]!.slice(1, -1), selection: selection![1]!.slice(1, -1) };
+}
+
+/** The enclosing `function NAME(...){...}` containing a byte offset. */
+function enclosingFunction(src: string, at: number): { name: string; text: string } {
+  const start = src.lastIndexOf('function ', at);
+  const name = /^function ([\w$]+)\(/.exec(src.slice(start))?.[1];
+  expect(name, 'sits inside a named function').toBeTruthy();
+  const open = src.indexOf('{', src.indexOf(')', start));
+  let depth = 0;
+  for (let i = open; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}' && --depth === 0) return { name: name!, text: src.slice(start, i + 1) };
+  }
+  throw new Error('unbalanced');
+}
+
+function functionText(src: string, name: string): string | null {
+  const at = src.indexOf(`function ${name}(`);
+  return at < 0 ? null : enclosingFunction(src, at + 9).text;
+}
+
+/**
+ * Assert from CONTENT that `builder` loops through Claude Code's own option appender: the helper it
+ * names must insert into the options list and assemble entries from the built-in option factories.
+ * Nothing here reads position, so a function merely inserted NEXT TO the picker cannot borrow its
+ * identity — which the position-derived oracle this replaced allowed.
+ *
+ * Read the guarantee precisely: the evidence belongs to the appender, not to `builder`, so a
+ * different function that calls the SAME appender would satisfy this too. It rejects a competitor
+ * that brings its own appender; it is not a proof of picker-ness on its own.
+ */
+function assertIsPickerBuilder(source: string, builder: { name: string; text: string }): void {
+  const appender = /for\(let ([\w$]+) of [\w$]+\)([\w$]+)\(/.exec(builder.text)?.[2];
+  expect(appender, `${builder.name} loops through an appender`).toBeTruthy();
+  const body = functionText(source, appender!);
+  expect(body, `${appender} is a declared function`).toBeTruthy();
+  expect(body!.includes('.splice('), `${appender} inserts into the options list`).toBe(true);
+  const factories = [...new Set([...body!.matchAll(/([\w$]+)\(/g)].map(m => m[1]!))]
+    .filter(n => n !== appender)
+    .filter(n => /\{value:"(opus|sonnet|opusplan)"/.test(functionText(source, n) ?? ''));
+  expect(factories.length, `${appender} builds Claude Code's own model options`).toBeGreaterThan(0);
+}
+
+describe('Claude Code 2.1.238 — PATCH 5 anchor over real pristine bundles', () => {
+  const files = bundles();
+
+  it('has every published 2.1.238 build, plus history', () => {
+    expect(files.length, `set REVIEW_BUNDLE_DIR; found ${files.length}`).toBeGreaterThan(5);
+    const present = new Set(files.map(label).filter(Boolean) as string[]);
+    expect([...REQUIRED_238].filter(id => !present.has(id)), 'missing 2.1.238 builds').toEqual([]);
+    expect(files.filter(f => label(f) === null).length, 'historical bundles').toBeGreaterThan(5);
+  });
+
+  it('counting the model selection can only mean what PATCH 5 relies on', () => {
+    const { anchor, selection } = liveRegexes();
+    // The anchor BEGINS with the counted selection. That is the whole argument for "exactly one
+    // selection ⇒ the anchor cannot bind anywhere else".
+    expect(anchor.startsWith(selection), `anchor ${anchor} must start with ${selection}`).toBe(true);
+  });
+
+  it('the OLD anchor missed exactly the three builds this fix is for', () => {
+    const misses = new Set<string>();
+    const unlabelled: string[] = [];
+    for (const file of files) {
+      const source = readFileSync(join(BUNDLE_DIR, file), 'utf8');
+      if ([...source.matchAll(new RegExp(OLD_ANCHOR.source, 'g'))].length === 1) continue;
+      const id = label(file);
+      if (id) misses.add(id);
+      else unlabelled.push(file);
+    }
+    // Both directions: no unexpected miss, and every claimed miss really is one.
+    expect(unlabelled, 'a historical host bundle must not miss').toEqual([]);
+    expect([...misses].sort()).toEqual([...EXPECTED_OLD_MISSES].sort());
+  });
+
+  for (const file of files) {
+    it(`${file}: binds the one picker builder and pushes into the array it returns`, () => {
+      const source = readFileSync(join(BUNDLE_DIR, file), 'utf8');
+      const { anchor, selection } = liveRegexes();
+
+      // 1. the selection is unique, the anchor matches once, and it binds THERE
+      const selections = [...source.matchAll(new RegExp(selection, 'g'))];
+      expect(selections.length, 'model selections in bundle').toBe(1);
+      const all = [...source.matchAll(new RegExp(anchor, 'g'))];
+      expect(all.length, 'anchor matches').toBe(1);
+      expect(all[0]!.index, 'anchor binds at the model selection').toBe(selections[0]!.index);
+      expect(all[0]![0]!.length, 'matched span').toBeLessThan(200);
+
+      // 2. the patch reports OK and injects exactly once
+      const out = applyClodexPatches(source, CONFIG);
+      expect(out.results.find(r => r.name.startsWith('PATCH 5'))?.status).toBe('OK');
+      const injections = [...out.content.matchAll(/\{value:"sol",label:"Sol"/g)];
+      expect(injections.length, 'exactly one injection').toBe(1);
+
+      // 3. the bound function is the picker on its own content, and the array it pushes into is
+      //    the one that function returns
+      const fn = enclosingFunction(out.content, injections[0]!.index!);
+      assertIsPickerBuilder(out.content, fn);
+      const pushVar = /\)\)([\w$]+)\.push\(_o\)/.exec(fn.text)?.[1];
+      const returnVar = /return ([\w$]+)\}$/.exec(fn.text)?.[1];
+      expect(pushVar, 'push target captured from the build').toBeTruthy();
+      expect(pushVar, 'pushes into the array the builder returns').toBe(returnVar);
+
+      // 4. EXECUTE the patched builder. Every free identifier is stubbed from the function's own
+      //    text, so an unaccounted name is a ReferenceError rather than a vacuous pass.
+      const free = [...new Set([...fn.text.matchAll(/([\w$]+)\(/g)].map(m => m[1]!))]
+        .filter(n => n !== fn.name && n !== 'function' && n !== 'for' && n !== 'if');
+      const build = Function(...free, `${fn.text};return ${fn.name};`)(
+        ...free.map(() => (...args: unknown[]) => {
+          if (args.length === 3) {
+            (args[0] as { value: string }[]).push({ value: String(args[1]) });
+            return undefined;
+          }
+          return 'opus';
+        }),
+      ) as (options: { value: string }[], a: unknown, b: unknown) => { value: string }[];
+
+      const result = build([{ value: null as unknown as string }], 'ctx', 'opus');
+      const values = result.map(o => o.value);
+      expect(values, 'both aliases reach the picker').toEqual(expect.arrayContaining(['sol', 'luna']));
+      expect(values.filter(v => v === 'sol'), 'the dedupe guard holds').toHaveLength(1);
+      expect(build(result, 'ctx', 'opus').filter(o => o.value === 'sol'), 'second pass adds nothing')
+        .toHaveLength(1);
+
+      // 5. idempotent: re-patching the patched source is a SKIP, not a FAIL
+      const again = applyClodexPatches(out.content, CONFIG);
+      expect(again.results.find(r => r.name.startsWith('PATCH 5'))?.status).toBe('SKIP');
+      expect(again.content).toBe(out.content);
+
+      // eslint-disable-next-line no-console
+      console.log(`${file}: fn=${fn.name} options=${pushVar} span=${all[0]![0]!.length}`);
+    });
+
+    it(`${file}: refuses a model-selecting twin when the picker drifts out of the match`, () => {
+      const source = readFileSync(join(BUNDLE_DIR, file), 'utf8');
+      const { anchor } = liveRegexes();
+      const match = [...source.matchAll(new RegExp(anchor, 'g'))][0]!;
+
+      // The strongest competitor: exact surrounding shape AND its own opus/sonnet selection,
+      // inserted immediately before the real builder, whose loop is then put cosmetically out of
+      // reach. This is the composition that patched the impostor and reported OK.
+      const twin = 'function zzTwin(a,b,c){let d=zzCur(),f=(d==="opus"||d==="sonnet")&&d!==c?[d,c]:[c];'
+        + 'for(let g of f)zzAppend(a,g,b);return a}';
+      const declStart = source.lastIndexOf('function ', match.index!);
+      const drifted = source.slice(0, declStart)
+        + twin
+        + source.slice(declStart, match.index!)
+        + match[0]!.replace('for(let', 'for (let')
+        + source.slice(match.index! + match[0]!.length);
+
+      // Sanity: the anchor ALONE now binds the twin — the attack is live, not hypothetical.
+      const bound = [...drifted.matchAll(new RegExp(anchor, 'g'))];
+      expect(bound.length, 'the anchor alone finds one site').toBe(1);
+      expect(enclosingFunction(drifted, bound[0]!.index!).name, 'and it is the twin').toBe('zzTwin');
+      // And the identity oracle used above must REJECT the twin, which brings its own appender.
+      // The earlier, position-derived oracle blessed it, because the twin sits where it looked.
+      expect(() => assertIsPickerBuilder(drifted, enclosingFunction(drifted, bound[0]!.index!)),
+        'the content oracle rejects the twin').toThrow();
+
+      // Production must refuse rather than patch it.
+      const out = applyClodexPatches(drifted, CONFIG);
+      expect(out.results.find(r => r.name.startsWith('PATCH 5'))).toEqual({
+        status: 'FAIL',
+        name: 'PATCH 5: model picker options',
+        extra: 'model selection appears 2 times (expected 1)',
+      });
+      expect(out.content, 'nothing was injected').not.toContain('{value:"sol",label:"Sol"');
+      expect(out.content, 'the twin is left exactly as it was').toContain(twin);
+      expect(out.content, 'the drifted picker is left exactly as it was')
+        .toContain(match[0]!.replace('for(let', 'for (let'));
+    });
+  }
+});

--- a/src/patch-transforms.ts
+++ b/src/patch-transforms.ts
@@ -38,7 +38,7 @@ import {
  * hash of the transform inputs to force that decision to be made rather than
  * forgotten.
  */
-export const PATCH_TRANSFORMS_VERSION = 6;
+export const PATCH_TRANSFORMS_VERSION = 7;
 
 export interface PatchScriptModelEntry {
   alias?: string;
@@ -348,6 +348,52 @@ export function applyClodexPatches(source: string, config: PatchScriptModelConfi
   // {value,label,description} entries — with a runtime .some() dedupe guard so
   // it is safe even if the function runs over the same array twice. Only
   // aliases not already injected are added, so reruns top up cleanly.
+  //
+  // Anchor: the choke-point's own code — its `"opus"`/`"sonnet"` selection, which
+  // is what makes it the MODEL picker and not merely a loop that appends things,
+  // followed by the loop and the per-item appender. Every minified identifier is
+  // wildcarded and repeats are tied together with back-references rather than
+  // spelled out. Claude Code 2.1.238 shipped per-platform builds whose minifier
+  // handed this function different names — `(e,t,r){let n=...}` on five of the
+  // eight published builds, but `(e,t,n){let r=...}` on linux-arm64,
+  // linux-arm64-musl and win32-arm64 — so an anchor naming `r` literally stopped
+  // matching on the other three, and their users silently lost every custom
+  // picker entry.
+  // Keep BOTH halves. The back-references alone only make the identifiers
+  // internally consistent; they do not say the function is the picker, and a
+  // review demonstrated that a same-shaped neighbour could then be patched
+  // instead if the real site ever drifted out of the match. The model-name
+  // comparison is the discriminator; the wildcards are what survive a rename.
+  // The tolerated run between the comparison and the pair is bounded to
+  // `[^;{}]` so it cannot reach out of the statement it starts in.
+  // The appender's FIRST argument is captured and the append snippet is bound to
+  // that name, so we push into the very array the built-in options were just
+  // appended to, under whatever name this build gave it, instead of into a
+  // variable we assumed was called `e`.
+  // The anchor deliberately stops before the function's `return`: the snippet is
+  // spliced in between, so consuming the tail would make a re-run of the patch
+  // report a missing anchor instead of the SKIP that keeps re-patching clean.
+  //
+  // The selection is ALSO counted across the whole bundle, and that check is not
+  // redundant. "The anchor matched once" only means one candidate survived, not
+  // that it was the right one: a review built a second builder with its own
+  // opus/sonnet selection and moved the real picker out of the match by turning
+  // `for(` into `for (` — one space — and PATCH 5 reported OK while injecting
+  // into the impostor, where no user would ever see the entries. The anchor
+  // BEGINS with the selection, so at most one site in the bundle can match it,
+  // and that composition becomes a refusal.
+  // State the guarantee precisely, because it rests on an assumption nothing
+  // here tests: the counted site is the picker only while the picker keeps
+  // spelling its selection THIS way. Respelt upstream to the equivalent
+  // `(x==="sonnet"||x==="opus")` with something else adopting this spelling, the
+  // survivor would be the wrong function again. No published bundle contains a
+  // second selection in any spelling, and that needs two coordinated upstream
+  // changes rather than one, so it is calibrated as unreachable rather than
+  // defended against — adding more discriminators is what broke this patch on
+  // three platforms in the first place. If only the spelling drifts, the count
+  // goes to ZERO and PATCH 5 fails loudly (it is `required:false`, so the rest
+  // of the patch still applies) and the release canary reports it on all eight
+  // platforms. Failing loud is the direction to bias toward here.
   // ---------------------------------------------------------------------------
   {
     const missing = ALIASES.filter((a) => !new RegExp('value:' + reEsc(q(a))).test(js));
@@ -360,16 +406,25 @@ export function applyClodexPatches(source: string, config: PatchScriptModelConfi
         (a) => '{value:' + q(a) + ',label:' + q(a.charAt(0).toUpperCase() + a.slice(1)) + ',description:' + q(displayFor(a, ALIAS_TO_ID[a]!)) + '}'
       )
       .join(',');
-    const inject = missing.length
-      ? '[' + entries + '].forEach(function(_o){if(!e.some(function(_i){return _i.value===_o.value}))e.push(_o)});'
-      : '';
+    /** The append snippet, bound to whatever this build named the options array. */
+    const injectInto = (options: string) =>
+      missing.length
+        ? '[' + entries + '].forEach(function(_o){if(!' + options + '.some(function(_i){return _i.value===_o.value}))' + options + '.push(_o)});'
+        : '';
+    const pickerSite = 'PATCH 5: model picker options';
+    // MUST stay a prefix of the anchor below — that is what makes the count mean
+    // "the anchor can only match the picker". A harness asserts the relationship
+    // and, on every real bundle, that the anchor binds at this very offset.
+    const modelSelections = [...js.matchAll(/\(([\w$]+)==="opus"\|\|\1==="sonnet"\)/g)];
     if (ALIASES.length === 0) {
-      log('SKIP', 'PATCH 5: model picker options', 'no aliases configured');
+      log('SKIP', pickerSite, 'no aliases configured');
+    } else if (modelSelections.length !== 1) {
+      log('FAIL', pickerSite, 'model selection appears ' + modelSelections.length + ' times (expected 1)');
     } else {
       applyOnce(
-        'PATCH 5: model picker options',
-        /(\?\[[\w$]+,r\]:\[r\];for\(let [\w$]+ of [\w$]+\)[\w$]+\(e,[\w$]+,t\);)/,
-        (m) => m + inject,
+        pickerSite,
+        /\(([\w$]+)==="opus"\|\|\1==="sonnet"\)[^;{}]*\?\[\1,([\w$]+)\]:\[\2\];for\(let ([\w$]+) of [\w$]+\)[\w$]+\(([\w$]+),\3,[\w$]+\);/,
+        (m, _selected, _requested, _item, options) => m + injectInto(options!),
         { required: false, noopIsSkip: true }
       );
     }

--- a/tests/fixtures/claude-bundle.ts
+++ b/tests/fixtures/claude-bundle.ts
@@ -10,7 +10,7 @@ export const CLAUDE_CORE_FIXTURE = [
   '.enum(["sonnet","opus","haiku","fable"]).optional().describe(`Optional model override for this agent. Defaults to inherit.`)',
   'var KNOWN=["sonnet","opus","haiku","fable","opusplan"];',
   'function rz(x){switch(x){case"best":{return "opus"}default:return null}}',
-  'function opts(e,t,r){let n=cur(),o=(n==="opus")?[n,r]:[r];for(let i of o)Dlh(e,i,t);return e}',
+  'function opts(e,t,r){let n=cur(),o=(n==="opus"||n==="sonnet")&&n!==r?[n,r]:[r];for(let i of o)Dlh(e,i,t);return e}',
   'function RS(e,t){let r=FAc();if(r!==void 0)return r;if(EHi(e,t))return Dve;return $Ac(e,t)}',
   'function cwdOf(){let p=process.env.PWD;return p}',
   'function childEnv(){let e=extra(),t=Object.keys(e).length>0,n=Object.keys(e).length>0,s=flag(process.env.CLAUDE_CODE_REMOTE)?remote():{};let o=[process.env.CLAUDE_CODE_OAUTH_TOKEN,process.env.CLAUDE_CODE_SUBSCRIPTION_TYPE,process.env.CLAUDE_BG_PTY_AUTH,"OTEL_",process.env.CLAUDE_CODE_OTEL_DIAG_STDERR],u=["CLAUDE_CODE_OAUTH_TOKEN"];if(!t&&!n&&!o[0])return process.env;let v={...process.env,...e,...s};for(let k of u)delete v[k],delete v[`INPUT_${k}`];return v}function mcpAllow(){let e=process.env.CLAUDE_CODE_MCP_ALLOWLIST_ENV;return e}',

--- a/tests/patch-backup.test.ts
+++ b/tests/patch-backup.test.ts
@@ -91,7 +91,7 @@ describe('isPatchedClaudeSource', () => {
     '.enum(["sonnet","opus","haiku","fable"]).optional().describe(`Optional model override for this agent. Defaults to inherit.`)',
     'var KNOWN=["sonnet","opus","haiku","fable","opusplan"];',
     'function rz(x){switch(x){case"best":{return "opus"}default:return null}}',
-    'function opts(e,t,r){let n=cur(),o=(n==="opus")?[n,r]:[r];for(let i of o)Dlh(e,i,t);return e}',
+    'function opts(e,t,r){let n=cur(),o=(n==="opus"||n==="sonnet")&&n!==r?[n,r]:[r];for(let i of o)Dlh(e,i,t);return e}',
     'function RS(e,t){let r=FAc();if(r!==void 0)return r;if(EHi(e,t))return Dve;return $Ac(e,t)}',
     // The required effort sites (PATCH 8a/8b/8c/9). Every binary current clodex
     // publishes carries their `ccpatch` comments, which is why those alone are

--- a/tests/patcher-command.test.ts
+++ b/tests/patcher-command.test.ts
@@ -56,7 +56,7 @@ const PRISTINE_BUNDLE = [
   '.enum(["sonnet","opus","haiku","fable"]).optional().describe(`Optional model override for this agent. Defaults to inherit.`)',
   'var KNOWN=["sonnet","opus","haiku","fable","opusplan"];',
   'function rz(x){switch(x){case"best":{return "opus"}default:return null}}',
-  'function opts(e,t,r){let n=cur(),o=(n==="opus")?[n,r]:[r];for(let i of o)Dlh(e,i,t);return e}',
+  'function opts(e,t,r){let n=cur(),o=(n==="opus"||n==="sonnet")&&n!==r?[n,r]:[r];for(let i of o)Dlh(e,i,t);return e}',
   'function RS(e,t){let r=FAc();if(r!==void 0)return r;if(EHi(e,t))return Dve;return $Ac(e,t)}',
   // PATCH 8a/8b/8c/9 anchors — these sites are REQUIRED (applyPatch throws when
   // any of them FAILs), so the fixture has to carry them or every patch aborts.

--- a/tests/patcher.test.ts
+++ b/tests/patcher.test.ts
@@ -580,8 +580,8 @@ describe('PATCH_TRANSFORMS_VERSION', () => {
       .join('\n');
     const digest = createHash('sha256').update(source).digest('hex');
     expect({ version: PATCH_TRANSFORMS_VERSION, digest }).toEqual({
-      version: 6,
-      digest: 'c2abf1d2b334562c3b3b3e2158d44c9986001c0401415912ef7dd450137eab3e',
+      version: 7,
+      digest: '64e9fc9836e8eda0a6dfa7ab6b77c45838f8df4d38593018f21ea2df122651e0',
     });
   });
 });
@@ -1260,6 +1260,36 @@ function executeDefaultEffort(
   return defaultEffort(modelId);
 }
 
+/**
+ * Run the patched /model picker builder and return the option values it yields.
+ * Reading the injected snippet is not evidence it runs: the snippet names the
+ * options array, and a build that calls that array something other than `e` is
+ * exactly where a hardcoded name becomes a ReferenceError inside the picker.
+ */
+function executePicker(source: string, functionName = 'opts'): string[] {
+  // Sliced by brace matching, not by line prefix: the decoy fixture puts a second
+  // function on the same line as the real one.
+  const start = source.indexOf(`function ${functionName}(`);
+  expect(start, `${functionName} present`).toBeGreaterThan(-1);
+  let depth = 0;
+  let end = -1;
+  for (let i = source.indexOf('{', start); i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}' && --depth === 0) { end = i + 1; break; }
+  }
+  expect(end, `${functionName} is balanced`).toBeGreaterThan(start);
+  const declaration = source.slice(start, end);
+  const build = Function(
+    'cur',
+    'Dlh',
+    `${declaration};return ${functionName};`,
+  )(
+    () => 'opus',
+    (options: { value: string }[], name: string) => options.push({ value: name }),
+  ) as (options: { value: string }[], ctx: unknown, current: unknown) => { value: string }[];
+  return build([], 'ctx', 'opus').map(option => option.value);
+}
+
 const CAPABILITY_GATES: Array<{
   name: string;
   functionName: CapabilityFunctionName;
@@ -1824,6 +1854,159 @@ describe('patch script identity naming', () => {
     const out = runPatchScript({ 'clodex:openai-oauth:gpt-5.6-sol': { alias: 'sol', context: 272_000 } });
     expect(out).toContain('{value:"sol",label:"Sol",description:"Custom model (clodex:openai-oauth:gpt-5.6-sol)"}');
     expect(out).toContain('Additional custom models: sol.');
+  });
+
+  const PICKER_STD =
+    'function opts(e,t,r){let n=cur(),o=(n==="opus"||n==="sonnet")&&n!==r?[n,r]:[r];for(let i of o)Dlh(e,i,t);return e}';
+  const pickerSite = (result: ReturnType<typeof applyClodexPatches>) =>
+    result.results.find(site => site.name.startsWith('PATCH 5'));
+
+  // Claude Code 2.1.238 shipped per-platform builds whose minifier named this
+  // same function differently: `(e,t,r){let n=...}` on five of the eight published
+  // builds, but `(e,t,n){let r=...}` on linux-arm64, linux-arm64-musl and
+  // win32-arm64. An anchor that spelled those identifiers out silently dropped the
+  // picker entries on the other three.
+  const CLAUDE_FIXTURE_238_ARM = CLAUDE_FIXTURE.replace(
+    PICKER_STD,
+    'function opts(e,t,n){let r=cur(),o=(r==="opus"||r==="sonnet")&&r!==n?[r,n]:[n];for(let i of o)Dlh(e,i,t);return e}',
+  );
+
+  // The same build shape, but with the OPTIONS ARRAY itself renamed. Nothing in
+  // the bundle guarantees it is called `e` — the injected snippet has to use the
+  // name this build gave it, or the picker throws a ReferenceError at runtime
+  // while `clodex patch` still reports OK.
+  const CLAUDE_FIXTURE_238_RENAMED_ARRAY = CLAUDE_FIXTURE.replace(
+    PICKER_STD,
+    'function opts(a,t,n){let r=cur(),o=(r==="opus"||r==="sonnet")&&r!==n?[r,n]:[n];for(let i of o)Dlh(a,i,t);return a}',
+  );
+
+  // The strongest competitor: the exact ternary → loop → three-argument-appender
+  // shape AND its own opus/sonnet selection, so nothing in the anchor itself can
+  // tell it from the picker. A review put one of these immediately before the real
+  // builder and moved the real builder out of the match with a single space
+  // (`for(` → `for (`); PATCH 5 reported OK and injected into the impostor. The
+  // whole-bundle selection count is what turns that into a refusal.
+  const DECOY_SELECTING =
+    'function zzTwin(a,b,c){let d=cur(),f=(d==="opus"||d==="sonnet")&&d!==c?[d,c]:[c];for(let g of f)Dlh(a,g,b);return a}';
+  const CLAUDE_FIXTURE_TWIN = CLAUDE_FIXTURE.replace(PICKER_STD, DECOY_SELECTING + PICKER_STD);
+  const CLAUDE_FIXTURE_TWIN_DRIFTED = CLAUDE_FIXTURE_TWIN.replace(
+    'for(let i of o)Dlh(e,i,t);return e}',
+    'for (let i of o)Dlh(e,i,t);return e}',
+  );
+
+  // A competitor with the same shape but selecting on something that is not a
+  // model family: rejected by the discriminator rather than by the count.
+  const DECOY_GENERIC =
+    'function zzGeneric(a,b,c){let d=cur(),f=(d==="fast")&&d!==c?[d,c]:[c];for(let g of f)Dlh(a,g,b);return a}';
+  const CLAUDE_FIXTURE_GENERIC_DECOY = CLAUDE_FIXTURE.replace(
+    PICKER_STD,
+    DECOY_GENERIC + PICKER_STD,
+  );
+  // The same competitor, with the real picker put cosmetically out of reach.
+  const CLAUDE_FIXTURE_DECOY_ONLY = CLAUDE_FIXTURE_GENERIC_DECOY.replace(
+    'for(let i of o)Dlh(e,i,t);return e}',
+    'for (let i of o)Dlh(e,i,t);return e}',
+  );
+
+  it('patches a build whose picker builder minified to different identifiers', () => {
+    expect(CLAUDE_FIXTURE_238_ARM, 'fixture drifted from the shape this test mutates')
+      .not.toBe(CLAUDE_FIXTURE);
+
+    const result = applyClodexPatches(CLAUDE_FIXTURE_238_ARM, config);
+
+    expect(pickerSite(result)).toEqual({ status: 'OK', name: 'PATCH 5: model picker options' });
+    expect(executePicker(result.content)).toContain('sol');
+  });
+
+  it('binds the injected entries to the options array this build actually named', () => {
+    expect(CLAUDE_FIXTURE_238_RENAMED_ARRAY, 'fixture drifted from the shape this test mutates')
+      .not.toBe(CLAUDE_FIXTURE);
+
+    const result = applyClodexPatches(CLAUDE_FIXTURE_238_RENAMED_ARRAY, config);
+
+    expect(pickerSite(result)?.status).toBe('OK');
+    expect(result.content).toContain('a.push(_o)');
+    expect(result.content).not.toContain('e.push(_o)');
+    // The proof that matters: the patched builder RUNS and yields the entries.
+    // `cur()` and the third argument both stub to "opus", so the builder appends
+    // that one built-in before our entries; the unaliased model gets no picker
+    // entry.
+    expect(executePicker(result.content)).toEqual(['opus', 'sol']);
+  });
+
+  it.each([
+    ['alongside the picker', () => CLAUDE_FIXTURE_TWIN],
+    ['while the picker itself drifts out of the match', () => CLAUDE_FIXTURE_TWIN_DRIFTED],
+  ])('refuses to patch anything when a second builder also selects a model, %s', (_case, fixture) => {
+    const source = fixture();
+    expect(source, 'fixture drifted from the shape this test mutates').not.toBe(CLAUDE_FIXTURE);
+
+    const result = applyClodexPatches(source, config);
+
+    expect(pickerSite(result)).toEqual({
+      status: 'FAIL',
+      name: 'PATCH 5: model picker options',
+      extra: 'model selection appears 2 times (expected 1)',
+    });
+    expect(result.content, 'nothing was injected').not.toContain('{value:"sol",label:"Sol"');
+    expect(result.content, 'the competitor is left exactly as it was').toContain(DECOY_SELECTING);
+  });
+
+  it('ignores a same-shaped builder that does not select between opus and sonnet', () => {
+    expect(CLAUDE_FIXTURE_GENERIC_DECOY, 'fixture drifted from the shape this test mutates')
+      .not.toBe(CLAUDE_FIXTURE);
+
+    const result = applyClodexPatches(CLAUDE_FIXTURE_GENERIC_DECOY, config);
+
+    expect(pickerSite(result)?.status).toBe('OK');
+    expect(result.content.match(/\{value:"sol",label:"Sol"/g)).toHaveLength(1);
+    expect(result.content, 'the competitor is left exactly as it was').toContain(DECOY_GENERIC);
+    expect(executePicker(result.content)).toContain('sol');
+    expect(executePicker(result.content, 'zzGeneric'), 'the competitor gained no entries')
+      .not.toContain('sol');
+  });
+
+  it('reports a miss rather than patching a same-shaped builder when the picker drifts', () => {
+    expect(CLAUDE_FIXTURE_DECOY_ONLY, 'fixture drifted from the shape this test mutates')
+      .not.toBe(CLAUDE_FIXTURE_GENERIC_DECOY);
+
+    const result = applyClodexPatches(CLAUDE_FIXTURE_DECOY_ONLY, config);
+
+    // A structure-only anchor reports OK here, having patched zzGeneric.
+    expect(pickerSite(result)).toEqual({
+      status: 'FAIL',
+      name: 'PATCH 5: model picker options',
+      extra: 'anchor not found',
+    });
+    expect(result.content).not.toContain('{value:"sol",label:"Sol"');
+    expect(result.content, 'the competitor is left exactly as it was').toContain(DECOY_GENERIC);
+  });
+
+  // The back-references decide WHICH variable is captured as the options array.
+  // Loosen them and each of these builders matches, with the capture landing on a
+  // variable that is not the list — so the patch must refuse them. The selection
+  // count cannot catch these: each fixture still has exactly one selection.
+  it.each([
+    [
+      'the loop variable is not the appender\'s middle argument',
+      'function opts(e,t,r){let n=cur(),o=(n==="opus"||n==="sonnet")&&n!==r?[n,r]:[r];for(let i of o)Dlh(e,t,i);return e}',
+    ],
+    [
+      'the fallback array does not repeat the pair',
+      'function opts(e,t,r){let n=cur(),o=(n==="opus"||n==="sonnet")&&n!==r?[n,r]:[t];for(let i of o)Dlh(e,i,t);return e}',
+    ],
+  ])('refuses a builder whose shape does not line up: %s', (_case, builder) => {
+    const source = CLAUDE_FIXTURE.replace(PICKER_STD, builder);
+    expect(source, 'fixture drifted from the shape this test mutates').not.toBe(CLAUDE_FIXTURE);
+
+    const result = applyClodexPatches(source, config);
+
+    expect(pickerSite(result)).toEqual({
+      status: 'FAIL',
+      name: 'PATCH 5: model picker options',
+      extra: 'anchor not found',
+    });
+    expect(result.content).not.toContain('{value:"sol",label:"Sol"');
   });
 
   it('supports aliases that match object prototype property names', () => {

--- a/tests/probe-patch-sites.test.ts
+++ b/tests/probe-patch-sites.test.ts
@@ -62,14 +62,18 @@ describe('the canary probe against a healthy bundle', () => {
 });
 
 describe('the canary probe against a bundle whose anchors drifted', () => {
-  // The real Claude Code 2.1.238 regression, reproduced. Its linux-arm64, linux-arm64-musl and
-  // win32-arm64 builds minified the picker helper's second parameter from `r` to `n`, and the
-  // PATCH 5 anchor spells `r` literally — so the anchor matched on the other five builds and not
-  // on those three. Renaming the same identifier in the fixture reproduces exactly that shape.
-  const PICKER_ANCHOR = 'function opts(e,t,r){let n=cur(),o=(n==="opus")?[n,r]:[r];for(let i of o)Dlh(e,i,t);return e}';
-  const PICKER_DRIFTED = 'function opts(e,t,q){let n=cur(),o=(n==="opus")?[n,q]:[q];for(let i of o)Dlh(e,i,t);return e}';
+  // A drift the PATCH 5 anchor does NOT tolerate, which is what the probe has to catch.
+  //
+  // This deliberately does not reproduce the Claude Code 2.1.238 break any more. That break was an
+  // identifier rename (`r` to `n` in the picker helper) and the anchor now wildcards identifiers and
+  // ties repeats with back-references specifically so a rename cannot break it — reproducing it here
+  // would assert the opposite of the behaviour we ship. Braces around the loop body are used instead:
+  // a plausible minifier variation that the anchor genuinely misses, so PATCH 5 reports `anchor not
+  // found` while the whole-bundle model-selection count still resolves to exactly one.
+  const PICKER_ANCHOR = 'function opts(e,t,r){let n=cur(),o=(n==="opus"||n==="sonnet")&&n!==r?[n,r]:[r];for(let i of o)Dlh(e,i,t);return e}';
+  const PICKER_DRIFTED = 'function opts(e,t,r){let n=cur(),o=(n==="opus"||n==="sonnet")&&n!==r?[n,r]:[r];for(let i of o){Dlh(e,i,t);}return e}';
 
-  it('fails when the model-picker anchor no longer matches — the 2.1.238 win32-arm64 break', () => {
+  it('fails when the model-picker anchor no longer matches', () => {
     expect(CLAUDE_FIXTURE, 'fixture drifted from the shape this test mutates')
       .toContain(PICKER_ANCHOR);
     const drifted = CLAUDE_FIXTURE.replace(PICKER_ANCHOR, PICKER_DRIFTED);


### PR DESCRIPTION
Claude Code **2.1.238** stopped accepting one of clodex's patches, so on some platforms your
configured models disappeared from the `/model` picker. This restores them.

## What broke

Anthropic publishes a separate build of Claude Code per platform, and the minifier does not name
things identically across them. In 2.1.238 the function that builds the `/model` picker's option
list came out with different internal variable names on `linux-arm64`, `linux-arm64-musl` and
`win32-arm64` than on the other five builds. clodex's patch looked for the names the other five use,
so on those three it reported

```
PATCH 5: model picker options — anchor not found
```

and left the picker without your aliases while every other patch site applied normally. 2.1.237 and
earlier were unaffected, as were both x64 Linux builds.

## The fix

The patch now recognises the function by its shape rather than by the names in one build: every
identifier is wildcarded, repeated identifiers are tied together with back-references, and the name
of the options array is **taken from the build being patched** instead of hardcoded — so a renamed
variable can neither break the match nor make the patch append to the wrong array.

To keep that flexibility from making the match too loose, the transform first counts Claude Code's
own model-selection expression across the whole bundle and refuses to patch unless it appears
exactly once. Because the anchor begins with that same expression, one occurrence bundle-wide means
the anchor cannot bind anywhere else.

`PATCH_TRANSFORMS_VERSION` is bumped so already-patched installs re-patch and pick this up.

## Verification

Real `clodex patch`, end to end, patched binary still runs — 11 applied, 0 failed on each:
`darwin-arm64` on this host, and `linux-arm64`, `linux-arm64-musl`, `linux-x64`, `linux-x64-musl` in
native-architecture containers. `win32-arm64` and `darwin-x64` are covered at the bundle level only,
since neither can be executed here.

`.claude/harnesses/cc238-patch5-anchor-over-real-bundles.harness.ts` drives the real transform over
the extracted bundles of **all eight published 2.1.238 builds, three 2.1.237 builds and sixteen
earlier releases**, asserting one match per bundle, that the injection pushes into the array the
builder returns, that the patched builder **executes** and yields the entries, and that re-patching
stays a byte-identical `SKIP`. It also re-runs the previous anchor and asserts it misses on exactly
`linux-arm64`, `linux-arm64-musl` and `win32-arm64`.

Every mutation below reddened a behavioural test, never only the source-digest pin:

| Mutation | Result |
| --- | --- |
| remove the selection count | 2 unit tests, 27 bundles |
| drop the discriminator, matching on structure alone | 2 unit tests, 28 bundles |
| loosen the back-references | 2 unit tests |
| hardcode the options-array name again | 1 unit test |
| restore the previous anchor | 3 unit tests, 55 bundles |
| remove a platform from the corpus | 1 harness completeness check |

The existing test fixtures were also corrected: they carried a simplified shape that no real bundle
has.

## Known limits, recorded in `.claude/docs/patcher.md`

The bundle-wide count guarantees a single match, but it identifies the picker only while Claude Code
keeps spelling its model selection the same way. If that spelling changes, the count drops to zero
and the patch fails loudly rather than silently patching something else — a failure the release
canary now catches on all eight platforms. Both patterns match text rather than parsed code, so an
occurrence inside a comment or a string literal counts.

Defending against the remaining case would mean making the anchor more specific again, which is what
caused this outage in the first place, so it is documented rather than defended.
