### PR TITLE
test(auth): stop a credential-helper test leaking helper processes on a slow machine

### DIFF
--- a/tests/credential-helper.test.ts
+++ b/tests/credential-helper.test.ts
@@ -45,6 +45,26 @@ async function waitForPath(path: string): Promise<void> {
   if (!existsSync(path)) throw new Error(`Timed out waiting for ${path}`);
 }
 
+/**
+ * Poll a condition on a clock the fake timers are not driving. Callers under
+ * `vi.useFakeTimers()` cannot use `waitForPath`: its `setTimeout` and `Date.now`
+ * are both faked, so it would spin without ever yielding to the real world.
+ * `performance.now()` keeps advancing, which is what makes the budget a real
+ * wall-clock bound rather than a count of sleeps that each last longer than asked.
+ */
+async function pollOnRealClock(
+  done: () => boolean,
+  sleep: (ms: number) => Promise<void>,
+  budgetMs: number,
+): Promise<boolean> {
+  const deadline = performance.now() + budgetMs;
+  while (performance.now() < deadline) {
+    if (done()) return true;
+    await sleep(5);
+  }
+  return done();
+}
+
 describe('external credential helper', () => {
   let tempDir = '';
 
@@ -273,35 +293,76 @@ describe('external credential helper', () => {
     expect(diagnostics.join('\n')).toContain('does not match the helper that owns this credential');
   });
 
+  // The watchdog that force-kills a hung helper has to be disarmed when the helper
+  // answers in time, or every successful credential read holds the event loop open
+  // for the full timeout and the command appears to hang before it exits.
+  it('disarms the runtime watchdog when the helper answers in time', async () => {
+    await writeCredentialHelperAccount('provider:test', 'value');
+    vi.useFakeTimers();
+    try {
+      await expect(readCredentialHelperAccount('provider:test')).resolves.toBe('value');
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('force-kills a helper that exceeds the runtime limit', async () => {
     process.env.CLODEX_TEST_CREDENTIAL_HELPER_MODE = 'hang-ignore-term';
     const storePath = process.env.CLODEX_TEST_CREDENTIAL_HELPER_STORE!;
+    const pidPath = `${storePath}.helper-pid`;
     const realSetTimeout = globalThis.setTimeout;
+    const sleep = (ms: number): Promise<void> =>
+      new Promise(resolve => { realSetTimeout(resolve, ms); });
+    let pid = 0;
     vi.useFakeTimers();
     try {
       const outcome = readCredentialHelperAccount('provider:test').catch(error => error);
-      await new Promise(resolve => realSetTimeout(resolve, 100));
-      const pid = Number.parseInt(readFileSync(`${storePath}.helper-pid`, 'utf8'), 10);
+
+      // Wait for the helper to announce itself instead of guessing how long its
+      // interpreter needs to boot: that took 322ms on an idle machine against the
+      // 100ms this once allowed, and losing the race stranded the helper for the
+      // life of the host rather than merely failing.
+      await pollOnRealClock(() => existsSync(pidPath), sleep, 15_000);
+      // Whole-file match, not `parseInt`: `parseInt('999999junk')` yields a pid this
+      // test would then happily probe, passing on an unrelated process while its own
+      // helper ran on. The range check matters for the same reason -- an over-long
+      // run of digits becomes `Infinity`, which no `process.kill` can ever find.
+      const announced = readFileSync(pidPath, 'utf8').trim();
+      expect(announced).toMatch(/^[1-9][0-9]*$/);
+      pid = Number(announced);
+      expect(Number.isSafeInteger(pid)).toBe(true);
 
       await vi.advanceTimersByTimeAsync(10_001);
       await expect(outcome).resolves.toMatchObject({
         message: 'credential helper get timed out',
       });
 
-      vi.useRealTimers();
-      let running = true;
-      const deadline = Date.now() + 2_000;
-      while (running && Date.now() < deadline) {
+      const exited = await pollOnRealClock(() => {
         try {
           process.kill(pid, 0);
-          await new Promise(resolve => realSetTimeout(resolve, 10));
+          return false;
         } catch {
-          running = false;
+          return true;
+        }
+      }, sleep, 5_000);
+      expect(exited).toBe(true);
+    } finally {
+      // Fire a timeout still pending on the fake clock before that clock is torn
+      // down, so a failure above still reaches the force-kill. Restoring real
+      // timers discards pending fake ones silently, and the helper ignores SIGTERM,
+      // so a skipped kill strands it until the fixture's own 60s fail-safe fires.
+      await vi.advanceTimersByTimeAsync(10_001);
+      vi.useRealTimers();
+      if (Number.isInteger(pid) && pid > 0) {
+        // Unreachable on a passing run: the assertion above is what proves the
+        // helper is already gone.
+        try {
+          process.kill(pid, 'SIGKILL');
+        } catch {
+          // Already reaped, which is the expected outcome.
         }
       }
-      expect(running).toBe(false);
-    } finally {
-      vi.useRealTimers();
     }
-  });
+  }, 30_000);
 });

--- a/tests/fixtures/credential-helper.mjs
+++ b/tests/fixtures/credential-helper.mjs
@@ -11,7 +11,11 @@ if (mode === 'fail' || mode === `fail-${operation}`) process.exit(1);
 if (mode === 'hang-ignore-term') {
   writeFileSync(`${storePath}.helper-pid`, String(process.pid), { encoding: 'utf8', mode: 0o600 });
   process.on('SIGTERM', () => {});
-  setInterval(() => {}, 1_000);
+  // Hang for the test, but bound the hang. A runner that dies without reaching its
+  // cleanup (a vitest timeout, a killed worker) cannot kill this process, and it
+  // ignores SIGTERM by design, so without a fail-safe the leak is permanent. 60s is
+  // far longer than any passing run and far shorter than forever.
+  setTimeout(() => process.exit(9), 60_000);
   await new Promise(() => {});
 }
 


### PR DESCRIPTION
If you run clodex's test suite, one test could fail for no reason on a busy or slow machine — and
when it did, it left a stray process running on your computer that never went away. Three had piled
up on one machine before anyone noticed. This fixes the test so it stops failing spuriously, and
makes sure that even a test run that dies badly cannot leave anything behind.

Nothing in shipped clodex behaviour changes; this is test-only.

## The failure

`tests/credential-helper.test.ts > force-kills a helper that exceeds the runtime limit` was flaky
and stranded processes. It reproduces on `main` and predates any current work. Found by the
patch-canary triage agent, which reported three orphaned helpers still alive 10–15 minutes after a
run, reparented to init.

## Root cause

Not the production kill path. That was the first hypothesis, and it is wrong: driven with real
timers against the repo's hanging fixture, `child.kill('SIGKILL')` reaps the direct child on macOS
every time.

The test is at fault, and one mechanism produces both the flake and the leak:

1. It installs `vi.useFakeTimers()`, starts the real production call, then waits a **fixed 100ms**
   for the fixture to publish its pid.
2. The fixture is `#!/usr/bin/env node`. Node took **322ms** to boot on an idle machine, so the
   wait loses the race routinely under a loaded 102-file suite.
3. `readFileSync` throws ENOENT and the test aborts into `finally`.
4. `vi.useRealTimers()` **silently discards the pending fake 10s timeout** — pinned in isolation:
   a timer armed on the fake clock never fires after real timers are restored.
5. So `finishReject` never runs, the force-kill never runs, and the fixture — which ignores SIGTERM
   and never exited on its own — outlives the machine's uptime.

Reproduced deterministically by shortening the wait to 1ms: ENOENT, plus `46057 1 node
…/credential-helper.mjs` at `ppid 1`.

## The change

- Poll for the pid file on a real `performance.now()` deadline. `Date.now()` is frozen under fake
  timers while `performance.now()` keeps advancing — verified directly (120ms real vs 0ms), which is
  also why the file's existing `waitForPath` cannot be reused here.
- Validate the announced pid as a whole-file positive safe integer. `parseInt('999999junk')` would
  otherwise yield a pid the test happily probes, passing against an unrelated process while its own
  helper ran on; an over-long digit run becomes `Infinity`.
- In `finally`, fire a still-pending timeout **before** the fake clock is torn down, then SIGKILL the
  recorded pid as a backstop.
- **The fixture now exits on its own after 60s.** A runner that dies without running cleanup at all
  — a vitest timeout, a `kill -9`'d worker — cannot be covered by any `finally`, so the hang has to
  be self-limiting. This is the part that actually closes the leak class.

## Discriminating tests and mutations

Every mutation is a full-file or full-suite run, never `-t` isolation.

| Mutation | Result |
| --- | --- |
| delete `child.kill('SIGKILL')` from `src/credential-helper.ts` | 1 failed / 1914, no orphan left |
| delete the success-path `clearTimeout` | new watchdog test red |
| production timeout callback made a no-op (test hits the 30s vitest timeout) | orphaned to init, **self-terminates at 61s** |
| `kill -9` the vitest worker mid-test | orphaned, **self-terminates at 61.6s** |
| fixture announces `999999junk` | red on the regex |
| fixture announces 400 digits (`Infinity`) | red on `Number.isSafeInteger` |
| poll gives up instantly (forces the original ENOENT) | red — and **no orphan**, the `finally` reaches the kill |

The new `disarms the runtime watchdog when the helper answers in time` test pins the other half of
the same timer: without the success-path `clearTimeout`, every credential read holds the event loop
open for the full 10s timeout. A standalone successful call measured 0.33s normally against 10.09s
mutated. That half was entirely unpinned before.

The `finally` backstop does **not** mask a broken production kill: the exit poll gives up after 5s
and the assertion fails first, verified by the first mutation above.

## Evidence and environment

macOS 15 (Darwin 25.6.0), node v24.14.1, `CLODEX_HOME=$(mktemp -d)`,
`CLAUDE_CODE_ENTRYPOINT=cli`, based on `6e14ba9`.

`pnpm typecheck` clean, `pnpm test` **1915/1915** across five full runs, `pnpm build` success.
Fifteen consecutive single-file runs under CPU load passed (2.0–3.1s each). Process census — using
`grep '[c]redential-helper.mjs'` so the check cannot match its own command line — was 0 before and 0
immediately after each of two passing full-suite runs.

No launch path, gateway, or provider code is touched, so no smoke-test leg applies.

## Deliberately not in this PR

`child.kill()` signals only the direct child, so a helper that is a **shell wrapper** leaks its
grandchild. I proved this against the real production path: the wrapper is reaped, `sleep 600`
survives reparented to init still holding the inherited stdio pipes, and it outlives the vitest
process. `docs/credential-helpers.md` aims helpers at headless Linux, containers, and WSL — where
wrapping `pass`/`gpg`/`secret-tool` is the canonical shape — and its protocol section says "output
and runtime are bounded", which holds only for the process clodex spawns directly.

The obvious fix is a net regression and is not taken here: with `detached: true`, SIGINT no longer
reaches the helper's process group, so Ctrl-C during a hang leaks the wrapper *and* its child
(demonstrated), which is both more likely and larger than the case it repairs. It would also need
ESRCH handling — `process.kill(-pid)` throws where `child.kill()` returns false, and the throw
escapes the timer callback leaving the promise unsettled — plus a `win32` guard, where `detached`
means a new console window rather than a signalable group. Being handled as a documentation change
for helper authors instead.

## What was not verified

Everything here is macOS. The race is worse on slower interpreters and CI, but I did not measure
node startup on Linux or Windows runners. The 60s fixture fail-safe is a bound, not an elimination:
a run killed at second 1 still leaves a helper for 59 seconds.
