### PR TITLE
docs(auth): tell credential-helper authors how to keep their own child processes bounded

### DIFF
--- a/docs/credential-helpers.md
+++ b/docs/credential-helpers.md
@@ -156,13 +156,61 @@ helper delete clodex <account>
 
 The service and account arguments are identifiers, not secrets. Credential
 contents are never passed in arguments or environment variables. Helper
-standard error is not copied into Clodex diagnostics, and output and runtime
-are bounded.
+standard error is drained and discarded rather than copied into Clodex
+diagnostics. Captured standard output is capped at 1 MiB; exceeding it fails
+the operation. Runtime is bounded for the process Clodex starts: at ten seconds
+it is sent `SIGKILL` and the operation fails. Processes that helper starts are
+outside both bounds, so a helper that forks has to bound them itself. See
+[Process lifetime](#process-lifetime).
 
 The helper protocol transports credential bytes without interpreting them.
 For non-OAuth provider references, Clodex preserves valid opaque JSON secrets.
 OAuth references accept only complete OAuth records or well-known token
 records; malformed or unknown JSON is never used as a bearer token.
+
+## Process lifetime
+
+Clodex starts the helper directly, waits at most ten seconds, and enforces that
+limit with `SIGKILL`. That is the only signal Clodex ever sends a helper, and it
+reaches only the process Clodex started. A process that one forked may keep
+running after the credential operation has already failed, usually reparented to
+PID 1, still holding the standard output and standard error it inherited.
+
+A wrapper script around `pass`, `gpg`, or `secret-tool` is the common shape for
+a helper, and it is the shape that forks. Nothing Clodex can send will reach
+what it leaves behind, so the wrapper has to take care of its own descendants:
+
+- **Prefer `exec`.** `exec gpg --decrypt "$path"` replaces the wrapper, so the
+  process Clodex kills is the one doing the work. This removes the wrapper as a
+  layer; it does not constrain the program you exec, whose own children are
+  still outside Clodex's bound.
+- **Give anything you fork a hard deadline.** GNU coreutils `timeout` needs
+  `--kill-after` to be a real bound: plain `timeout 5 cmd` sends `SIGTERM` and
+  then waits forever if `cmd` ignores it, while `timeout --kill-after=1 5 cmd`
+  escalates to `SIGKILL`. Note `timeout` ships with GNU coreutils and is absent
+  from stock macOS and from minimal container images.
+- **Clean up on interrupt by pid, never with `kill 0`.** Ctrl-C does reach the
+  helper: Clodex does not detach it, so it shares Clodex's process group. A
+  handler that
+  signals the whole group also re-signals the wrapper and re-enters itself,
+  which has been observed looping over a thousand times in five seconds. Track
+  what you start and signal that:
+
+  ```sh
+  child=""
+  trap 'kill "$child" 2>/dev/null; exit 143' INT TERM HUP
+  gpg --decrypt "$path" & child=$!
+  wait "$child"
+  ```
+
+  This is worth having, but it is not a substitute for the two points above:
+  `SIGKILL` cannot be trapped, so no handler runs at the ten-second limit.
+
+Prefer a non-interactive credential path. Clodex gives the helper pipes for
+standard input, output, and error, but the controlling terminal is still
+reachable through `/dev/tty`, so a program like `gpg` can still prompt through
+`pinentry`. A helper waiting on a passphrase is a helper waiting out the ten
+seconds.
 
 ## Security responsibilities
 


### PR DESCRIPTION
If you use an external credential helper, clodex gives it ten seconds and then kills it. That
kill only reaches the helper itself — not anything the helper started. So a helper written as a
wrapper script around `pass`, `gpg`, or `secret-tool` can leave a process of its own running on
your machine after the credential operation has already failed, and clodex cannot clean it up for
you. This documents that plainly and shows the three techniques that keep it from happening.

Documentation only; no behaviour changes.

## Why

`docs/credential-helpers.md` said "output and runtime are bounded" without qualification, and in
the same document recommends a wrapper executable for passing arguments — which is exactly the
shape that forks. The gap is real and I proved it against the production path: the wrapper is
reaped, its child survives reparented to PID 1 still holding the inherited stdout/stderr, and it
outlives the process that spawned clodex. A `gpg` waiting on `pinentry` is the obvious trigger,
and the helper can still reach a terminal through `/dev/tty` even though clodex hands it pipes.

Found while fixing an unrelated test flake (#138), where the first hypothesis was that the
force-kill was broken. It isn't — it kills the direct child reliably. This is the case where the
instinct behind that hypothesis turns out to be right.

## Why not fix the code

The obvious fix, `detached: true` plus `process.kill(-pid)`, is a net regression:

- **Ctrl-C stops reaching the helper.** Today SIGINT to clodex's foreground group kills the whole
  tree; with `detached` both the wrapper and its child survive. Interrupting three seconds into a
  hang is likelier than riding out the full ten, so it trades a rare leak for a common, larger one.
- `process.kill(-pid)` throws ESRCH where `child.kill()` returns false, and the throw escapes the
  timer callback — uncaught exception plus a promise that never settles.
- On Windows `detached` means a new console window, not a signalable group.

A SIGTERM-then-SIGKILL escalation would be the better code change, since it would let a helper's
own trap handler run. Not proposed here; it deserves its own PR.

## Every claim was executed, and three earlier drafts were wrong

This is the part worth reviewing. An adversarial pass over my first draft found three published
recommendations that do not work, each corrected only after running it:

| Draft claim | What actually happens |
| --- | --- |
| `timeout 5 cmd` bounds a forked child | **Not a bound.** Against a child that ignores SIGTERM it waits forever — my own probe hung the full 2-minute limit. `timeout --kill-after=1 5` exits 137 after 3s. |
| `exec` means "no grandchild exists", the "only complete answer" | `exec` removes the *wrapper*, but the program you exec can fork, and its children are still outside the bound. Both phrases removed. |
| `trap 'kill 0' INT TERM HUP` cleans up the tree | `kill 0` re-signals the wrapper, re-entering its own handler — **1301 trap executions in five seconds**, wrapper still alive, child defunct. Replaced with an explicit-pid handler, run as written: trap fires once, child reaped, wrapper exits 143. |

Verified for this text: `HELPER_TIMEOUT_MS` is 10s and `SIGKILL` is the only signal clodex sends a
helper (one call site; no SIGTERM path, no exit handler); SIGKILL cannot be trapped (handler never
ran, child survived at ppid 1); the same handler does fire on SIGTERM/INT/HUP; Ctrl-C does reach
the helper because clodex does not detach it (node, wrapper, and child shared one PGID); the 1 MiB
cap applies to captured stdout only — 2 MiB on stderr succeeds, because stderr is drained and
discarded; and `/dev/tty` opens from the helper even though fds 0/1/2 are pipes.

`pnpm typecheck` clean, `pnpm test` 1914/1914, `pnpm build` success, on `6e14ba9`.

## Not verified

All probes ran on macOS. The reparenting claim is hedged to "usually reparented to PID 1" because
a subreaper or an init that adopts differently would change it, and I did not test under one.
`timeout` behaviour was checked against GNU coreutils 9.9 from Homebrew; stock macOS has no
`/usr/bin/timeout` at all, which the text now says.
