### PR TITLE
feat(auth): add browser sign-in for workspaces that disable device codes

### DIFF
--- a/.claude/docs/registry-and-server.md
+++ b/.claude/docs/registry-and-server.md
@@ -7,7 +7,11 @@
 `src/registry/`. The shipped registry has three provider templates in `src/provider-templates.ts`:
 `openai` (API key), `openai-oauth`, and `opencode-go`. `provider-auth.ts` implements the OpenAI
 OAuth sign-in (device code by default; browser PKCE via `--browser` for workspaces that disable
-device codes); `refresh-models.ts` fetches the model list (3-tier fetch for OAuth).
+device codes). Interactive entry points that don't take flags — the providers hub's auth and
+add-account actions, the provider detail menu, `providers add`'s OAuth path, and the first-run
+wizard — ask instead through `promptOAuthMethod` (`providers-command.ts`), a device-code/browser
+picker whose Enter default is device code; the chosen method is forwarded to
+`authenticateProvider`. `refresh-models.ts` fetches the model list (3-tier fetch for OAuth).
 Materialization (`materialize.ts`) turns registry providers into `LocalProvider`s with per-model
 `npm`/`baseUrl`/`upstreamModelId`.
 

--- a/.claude/docs/registry-and-server.md
+++ b/.claude/docs/registry-and-server.md
@@ -6,7 +6,8 @@
 
 `src/registry/`. The shipped registry has three provider templates in `src/provider-templates.ts`:
 `openai` (API key), `openai-oauth`, and `opencode-go`. `provider-auth.ts` implements the OpenAI
-device-code OAuth flow; `refresh-models.ts` fetches the model list (3-tier fetch for OAuth).
+OAuth sign-in (device code by default; browser PKCE via `--browser` for workspaces that disable
+device codes); `refresh-models.ts` fetches the model list (3-tier fetch for OAuth).
 Materialization (`materialize.ts`) turns registry providers into `LocalProvider`s with per-model
 `npm`/`baseUrl`/`upstreamModelId`.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ clodex claude                  # 5. launch Claude Code on an OpenAI model
 ```
 
 1. **Install** — puts the `clodex` command on your PATH.
-2. **Sign in** — opens a device-code OAuth flow for your ChatGPT/Codex plan; the token is stored in your OS credential store. (API-key users: `clodex providers add` instead.)
+2. **Sign in** — opens a device-code OAuth flow for your ChatGPT/Codex plan; the token is stored in your OS credential store. If your workspace admin has disabled device code authorization, add `--browser` to sign in through your browser instead. (API-key users: `clodex providers add` instead.)
 3. **Pick models** — an interactive manager for favorites (max 20) and short aliases like `sol` so you do not need to type the long names. Favorites drive the `/model` switch menu, proxy-mode routing, and the patcher.
 4. **Patch** *(optional but recommended for proxy mode)* — bakes your favorites and aliases into the Claude Code binary so they pass model validation, appear in `/model`, and report their real context windows. Re-run after each `claude` update; `clodex patch --restore` undoes it. This step is required if you want to use clodex-routed models as subagents via the Agent tool.
 5. **Launch** — starts Claude Code bridged to the model you choose.
@@ -273,7 +273,7 @@ Two things worth knowing about the numbers:
 | --- | --- |
 | *(none)* | Provider hub wizard |
 | `add` | Add OpenAI or OpenCode Go with an API key, or sign in with ChatGPT |
-| `auth openai` | Sign in with ChatGPT/Codex-plan OAuth (device code) |
+| `auth openai` | Sign in with ChatGPT/Codex-plan OAuth (device code; `--browser` for workspaces that disable device codes) |
 | `list` | Show configured providers |
 | `remove <id>` | Remove a provider by id |
 | `refresh-models [id]` | Update cached model lists |

--- a/src/first-run.ts
+++ b/src/first-run.ts
@@ -4,7 +4,7 @@ import pc from 'picocolors';
 import * as p from '@clack/prompts';
 import { printWelcomePanel } from './ui.js';
 import { loadRegistry } from './registry/io.js';
-import { runProvidersAdd, runProvidersAuth } from './providers-command.js';
+import { promptOAuthMethod, runProvidersAdd, runProvidersAuth } from './providers-command.js';
 
 export type FirstRunResult = 'continue' | 'cancel';
 
@@ -24,7 +24,7 @@ export async function runFirstRunWizard(_trace = false): Promise<FirstRunResult>
       {
         value: 'oauth',
         label: pc.cyan('Sign in with ChatGPT (Plus/Pro plan)'),
-        hint: 'OAuth device code — uses your ChatGPT/Codex plan',
+        hint: 'OAuth (device code or browser) — uses your ChatGPT/Codex plan',
       },
       {
         value: 'apikey',
@@ -38,9 +38,14 @@ export async function runFirstRunWizard(_trace = false): Promise<FirstRunResult>
     return 'cancel';
   }
 
-  const code = choice === 'oauth'
-    ? await runProvidersAuth('openai')
-    : await runProvidersAdd();
+  let code: number;
+  if (choice === 'oauth') {
+    const method = await promptOAuthMethod();
+    if (method === null) return 'cancel';
+    code = await runProvidersAuth('openai', method);
+  } else {
+    code = await runProvidersAdd();
+  }
   if (code !== 0) return 'cancel';
 
   if ((await needsFirstRunSetup())) return 'cancel';

--- a/src/oauth/callback-server.ts
+++ b/src/oauth/callback-server.ts
@@ -3,7 +3,7 @@
 // This is only used when running `clodex providers auth <provider>` without the GUI.
 
 import http from 'node:http';
-import { listenTcpServer } from '../listener-ready.js';
+import { listenTcpServer, waitForTcpListener } from '../listener-ready.js';
 
 export interface CallbackParams {
   code: string;
@@ -45,6 +45,16 @@ const FAILURE_HTML = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Si
 <p style="color:#666">Return to the terminal for details.</p>
 </div></body></html>`;
 
+const LOOPBACK_PROBE_TIMEOUT_MS = 250;
+
+async function isLoopbackPortTaken(port: number): Promise<boolean> {
+  const probes = await Promise.all(['127.0.0.1', '::1'].map(host =>
+    waitForTcpListener(host, port, LOOPBACK_PROBE_TIMEOUT_MS)
+      .catch(() => false),
+  ));
+  return probes.some(Boolean);
+}
+
 export async function startCallbackServer(options: CallbackServerOptions): Promise<CallbackServer> {
   let codeResolve: ((p: CallbackParams) => void) | undefined;
   let codeReject: ((e: Error) => void) | undefined;
@@ -77,6 +87,15 @@ export async function startCallbackServer(options: CallbackServerOptions): Promi
   let address: Awaited<ReturnType<typeof listenTcpServer>> | undefined;
   let lastError: unknown;
   for (const port of ports) {
+    // 'localhost' binds one loopback family, but the browser may resolve the
+    // other; a foreign listener there would swallow the redirect while our
+    // bind "succeeds". Treat a port answering on either family as taken.
+    if (port !== 0 && redirectHost === 'localhost' && await isLoopbackPortTaken(port)) {
+      const busy: NodeJS.ErrnoException = new Error(`listen EADDRINUSE: address already in use localhost:${port}`);
+      busy.code = 'EADDRINUSE';
+      lastError = busy;
+      continue;
+    }
     try {
       address = await listenTcpServer(server, port, redirectHost);
       break;

--- a/src/oauth/callback-server.ts
+++ b/src/oauth/callback-server.ts
@@ -11,6 +11,15 @@ export interface CallbackParams {
   error?: string;
 }
 
+export interface CallbackServerOptions {
+  /** Fixed ports to try in order; default [0] (ephemeral). */
+  ports?: readonly number[];
+  /** Only accept this callback path; default '/callback' and '/oauth/callback'. */
+  path?: string;
+  /** Hostname used in redirectUri; default '127.0.0.1'. */
+  redirectHost?: string;
+}
+
 export interface CallbackServer {
   port: number;
   redirectUri: string;
@@ -26,13 +35,16 @@ const SUCCESS_HTML = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Au
 <p style="color:#666">You can close this tab and return to the terminal.</p>
 </div></body></html>`;
 
-export async function startCallbackServer(): Promise<CallbackServer> {
+export async function startCallbackServer(options: CallbackServerOptions = {}): Promise<CallbackServer> {
   let codeResolve: ((p: CallbackParams) => void) | undefined;
   let codeReject: ((e: Error) => void) | undefined;
+  // The browser can hit the callback before waitForCallback arms the promise.
+  let buffered: CallbackParams | undefined;
 
+  const acceptedPaths = options.path ? [options.path] : ['/callback', '/oauth/callback'];
   const server = http.createServer((req, res) => {
     const u = new URL(req.url ?? '/', 'http://localhost');
-    if (u.pathname !== '/callback' && u.pathname !== '/oauth/callback') {
+    if (!acceptedPaths.includes(u.pathname)) {
       res.writeHead(404); res.end(); return;
     }
     const code = u.searchParams.get('code') ?? '';
@@ -40,21 +52,41 @@ export async function startCallbackServer(): Promise<CallbackServer> {
     const error = u.searchParams.get('error') ?? '';
     res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
     res.end(SUCCESS_HTML);
-    codeResolve?.({ code, state, error: error || undefined });
+    const params: CallbackParams = { code, state, error: error || undefined };
+    if (codeResolve) codeResolve(params);
+    else buffered ??= params;
   });
 
-  const address = await listenTcpServer(server, 0, '127.0.0.1');
+  const ports = options.ports?.length ? options.ports : [0];
+  let address: Awaited<ReturnType<typeof listenTcpServer>> | undefined;
+  let lastError: unknown;
+  for (const port of ports) {
+    try {
+      address = await listenTcpServer(server, port, '127.0.0.1');
+      break;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  if (!address) throw lastError ?? new Error('OAuth callback server could not bind');
+
+  const redirectHost = options.redirectHost ?? '127.0.0.1';
   return {
     port: address.port,
-    redirectUri: `http://127.0.0.1:${address.port}/callback`,
+    redirectUri: `http://${redirectHost}:${address.port}${options.path ?? '/callback'}`,
     waitForCallback(timeoutMs = 300_000) {
       return new Promise<CallbackParams>((resolve, reject) => {
-        codeResolve = resolve;
-        codeReject = reject;
-        setTimeout(
+        if (buffered) {
+          resolve(buffered);
+          buffered = undefined;
+          return;
+        }
+        const timer = setTimeout(
           () => reject(new Error('OAuth timeout — browser closed without completing sign-in')),
           timeoutMs,
         );
+        codeResolve = params => { clearTimeout(timer); resolve(params); };
+        codeReject = err => { clearTimeout(timer); reject(err); };
       });
     },
     close() { server.close(); codeReject?.(new Error('Server closed')); },

--- a/src/oauth/callback-server.ts
+++ b/src/oauth/callback-server.ts
@@ -14,10 +14,12 @@ export interface CallbackParams {
 export interface CallbackServerOptions {
   /** Fixed ports to try in order; default [0] (ephemeral). */
   ports?: readonly number[];
-  /** Only accept this callback path; default '/callback' and '/oauth/callback'. */
-  path?: string;
-  /** Hostname used in redirectUri; default '127.0.0.1'. */
-  redirectHost?: string;
+  /** The callback path registered with the provider; the only path accepted. */
+  path: string;
+  /** Loopback hostname used in redirectUri and bound by the listener. */
+  redirectHost: 'localhost' | '127.0.0.1';
+  /** Only accept callbacks carrying this OAuth state. */
+  expectedState?: string;
 }
 
 export interface CallbackServer {
@@ -35,23 +37,37 @@ const SUCCESS_HTML = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Au
 <p style="color:#666">You can close this tab and return to the terminal.</p>
 </div></body></html>`;
 
-export async function startCallbackServer(options: CallbackServerOptions = {}): Promise<CallbackServer> {
+const FAILURE_HTML = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Sign-in failed</title></head>
+<body style="font-family:system-ui;display:flex;justify-content:center;align-items:center;height:100vh;margin:0">
+<div style="text-align:center;padding:2rem;background:#fff;border-radius:8px;box-shadow:0 2px 10px rgba(0,0,0,.1)">
+<div style="color:#ef4444;font-size:2.5rem">&#10007;</div>
+<h1 style="margin:.5rem 0">Sign-in failed</h1>
+<p style="color:#666">Return to the terminal for details.</p>
+</div></body></html>`;
+
+export async function startCallbackServer(options: CallbackServerOptions): Promise<CallbackServer> {
   let codeResolve: ((p: CallbackParams) => void) | undefined;
   let codeReject: ((e: Error) => void) | undefined;
   // The browser can hit the callback before waitForCallback arms the promise.
   let buffered: CallbackParams | undefined;
 
-  const acceptedPaths = options.path ? [options.path] : ['/callback', '/oauth/callback'];
+  const { path, redirectHost } = options;
   const server = http.createServer((req, res) => {
     const u = new URL(req.url ?? '/', 'http://localhost');
-    if (!acceptedPaths.includes(u.pathname)) {
+    if (u.pathname !== path) {
       res.writeHead(404); res.end(); return;
     }
     const code = u.searchParams.get('code') ?? '';
     const state = u.searchParams.get('state') ?? '';
     const error = u.searchParams.get('error') ?? '';
+    if (options.expectedState !== undefined && state !== options.expectedState) {
+      res.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Invalid OAuth state');
+      return;
+    }
+    const failed = Boolean(error) || !code;
     res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
-    res.end(SUCCESS_HTML);
+    res.end(failed ? FAILURE_HTML : SUCCESS_HTML);
     const params: CallbackParams = { code, state, error: error || undefined };
     if (codeResolve) codeResolve(params);
     else buffered ??= params;
@@ -62,7 +78,7 @@ export async function startCallbackServer(options: CallbackServerOptions = {}): 
   let lastError: unknown;
   for (const port of ports) {
     try {
-      address = await listenTcpServer(server, port, '127.0.0.1');
+      address = await listenTcpServer(server, port, redirectHost);
       break;
     } catch (error) {
       lastError = error;
@@ -70,10 +86,9 @@ export async function startCallbackServer(options: CallbackServerOptions = {}): 
   }
   if (!address) throw lastError ?? new Error('OAuth callback server could not bind');
 
-  const redirectHost = options.redirectHost ?? '127.0.0.1';
   return {
     port: address.port,
-    redirectUri: `http://${redirectHost}:${address.port}${options.path ?? '/callback'}`,
+    redirectUri: `http://${redirectHost}:${address.port}${path}`,
     waitForCallback(timeoutMs = 300_000) {
       return new Promise<CallbackParams>((resolve, reject) => {
         if (buffered) {

--- a/src/oauth/openai.ts
+++ b/src/oauth/openai.ts
@@ -1,14 +1,20 @@
 // openai.ts — native OpenAI ChatGPT Plus/Pro OAuth (device code, ported from OpenCode)
 
-import { positiveSecondsToMs, sleepMs } from './pkce.js';
+import { generatePkce, generateOAuthState, positiveSecondsToMs, sleepMs } from './pkce.js';
 import type { OAuthTokenResponse } from './types.js';
 import { VERSION } from '../constants.js';
 import { postOAuthRefresh } from './refresh-http.js';
+import { startCallbackServer } from './callback-server.js';
 
 const CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
 const ISSUER = 'https://auth.openai.com';
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3_000;
 const DEVICE_CODE_DEFAULT_EXPIRES_MS = 5 * 60 * 1000;
+// The only redirect URIs registered for this client id (shared with the Codex
+// CLI): http://localhost:{1455|1457}/auth/callback. Any other port is rejected
+// by auth.openai.com, so the callback server must win one of these two.
+const BROWSER_CALLBACK_PORTS = [1455, 1457] as const;
+const BROWSER_CALLBACK_PATH = '/auth/callback';
 
 export interface OpenAiIdTokenClaims {
   chatgpt_account_id?: string;
@@ -122,6 +128,84 @@ export async function refreshOpenAiAccessToken(refreshToken: string): Promise<OA
       includeStatus: true,
     },
   );
+}
+
+export function buildOpenAiAuthorizeUrl(redirectUri: string, challenge: string, state: string): string {
+  const qs = new URLSearchParams({
+    response_type: 'code',
+    client_id: CLIENT_ID,
+    redirect_uri: redirectUri,
+    scope: 'openid profile email offline_access',
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+    id_token_add_organizations: 'true',
+    codex_cli_simplified_flow: 'true',
+    state,
+  });
+  return `${ISSUER}/oauth/authorize?${qs.toString()}`;
+}
+
+export async function exchangeOpenAiAuthorizationCode(
+  code: string,
+  redirectUri: string,
+  codeVerifier: string,
+): Promise<OAuthTokenResponse> {
+  const response = await fetch(`${ISSUER}/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: redirectUri,
+      client_id: CLIENT_ID,
+      code_verifier: codeVerifier,
+    }).toString(),
+  });
+  if (!response.ok) {
+    throw new Error(`OpenAI token exchange failed (${response.status})`);
+  }
+  return response.json() as Promise<OAuthTokenResponse>;
+}
+
+/**
+ * Browser PKCE sign-in — for ChatGPT workspaces whose admin has disabled
+ * device-code authorization. Needs a browser that can reach this machine's
+ * loopback, so it does not work over plain SSH.
+ */
+export async function runOpenAiBrowserFlow(
+  onAuthorizeUrl: (info: { url: string }) => void,
+  opts?: { ports?: readonly number[]; timeoutMs?: number },
+): Promise<{ tokens: OAuthTokenResponse; accountId?: string }> {
+  const { verifier, challenge } = await generatePkce();
+  const state = generateOAuthState();
+
+  let server;
+  try {
+    server = await startCallbackServer({
+      ports: opts?.ports ?? BROWSER_CALLBACK_PORTS,
+      path: BROWSER_CALLBACK_PATH,
+      redirectHost: 'localhost',
+    });
+  } catch {
+    throw new Error(
+      `Ports ${BROWSER_CALLBACK_PORTS.join(' and ')} are in use — close any other OpenAI sign-in `
+      + '(e.g. codex login) and try again.',
+    );
+  }
+
+  try {
+    onAuthorizeUrl({ url: buildOpenAiAuthorizeUrl(server.redirectUri, challenge, state) });
+    const params = await server.waitForCallback(opts?.timeoutMs);
+    if (params.error) throw new Error(`OpenAI sign-in failed: ${params.error}`);
+    if (!params.code) throw new Error('OpenAI sign-in returned no authorization code');
+    if (params.state !== state) {
+      throw new Error('OpenAI sign-in returned a mismatched state — try again');
+    }
+    const tokens = await exchangeOpenAiAuthorizationCode(params.code, server.redirectUri, verifier);
+    return { tokens, accountId: extractOpenAiAccountId(tokens) };
+  } finally {
+    server.close();
+  }
 }
 
 export async function runOpenAiDeviceCodeFlow(

--- a/src/oauth/openai.ts
+++ b/src/oauth/openai.ts
@@ -150,21 +150,21 @@ export async function exchangeOpenAiAuthorizationCode(
   redirectUri: string,
   codeVerifier: string,
 ): Promise<OAuthTokenResponse> {
-  const response = await fetch(`${ISSUER}/oauth/token`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
+  return postOAuthRefresh(
+    `${ISSUER}/oauth/token`,
+    new URLSearchParams({
       grant_type: 'authorization_code',
       code,
       redirect_uri: redirectUri,
       client_id: CLIENT_ID,
       code_verifier: codeVerifier,
-    }).toString(),
-  });
-  if (!response.ok) {
-    throw new Error(`OpenAI token exchange failed (${response.status})`);
-  }
-  return response.json() as Promise<OAuthTokenResponse>;
+    }),
+    {
+      contentType: 'form',
+      errorPrefix: 'OpenAI token exchange failed',
+      includeStatus: true,
+    },
+  );
 }
 
 /**
@@ -179,17 +179,25 @@ export async function runOpenAiBrowserFlow(
   const { verifier, challenge } = await generatePkce();
   const state = generateOAuthState();
 
+  const ports = opts?.ports ?? BROWSER_CALLBACK_PORTS;
   let server;
   try {
     server = await startCallbackServer({
-      ports: opts?.ports ?? BROWSER_CALLBACK_PORTS,
+      ports,
       path: BROWSER_CALLBACK_PATH,
       redirectHost: 'localhost',
+      expectedState: state,
     });
-  } catch {
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EADDRINUSE') {
+      throw new Error(
+        `Ports ${ports.join(' and ')} are in use — close any other OpenAI sign-in `
+        + '(e.g. codex login) and try again.',
+      );
+    }
     throw new Error(
-      `Ports ${BROWSER_CALLBACK_PORTS.join(' and ')} are in use — close any other OpenAI sign-in `
-      + '(e.g. codex login) and try again.',
+      `Could not start the OAuth callback listener: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
     );
   }
 
@@ -198,6 +206,7 @@ export async function runOpenAiBrowserFlow(
     const params = await server.waitForCallback(opts?.timeoutMs);
     if (params.error) throw new Error(`OpenAI sign-in failed: ${params.error}`);
     if (!params.code) throw new Error('OpenAI sign-in returned no authorization code');
+    // Defense in depth: the callback server already filters on expectedState.
     if (params.state !== state) {
       throw new Error('OpenAI sign-in returned a mismatched state — try again');
     }

--- a/src/providers-command.ts
+++ b/src/providers-command.ts
@@ -170,6 +170,7 @@ ${pc.bold('Usage:')}
   clodex providers remove <id>
   clodex providers refresh-models [id]
   clodex providers auth openai
+  clodex providers auth openai --browser
 
 ${pc.bold('Subcommands:')}
   (none)      Provider hub wizard

--- a/src/providers-command.ts
+++ b/src/providers-command.ts
@@ -128,6 +128,7 @@ export function parseProvidersArgs(args: string[]): {
     for (let i = 0; i < rest.length; i++) {
       const arg = rest[i]!;
       if (arg === '--native') authMethod = 'native';
+      else if (arg === '--browser') authMethod = 'browser';
       else if (arg === '--account') {
         const value = rest[i + 1];
         if (!value || value.startsWith('-')) {
@@ -173,7 +174,7 @@ ${pc.bold('Usage:')}
 ${pc.bold('Subcommands:')}
   (none)      Provider hub wizard
   add         Add a built-in provider or sign in with ChatGPT
-  auth        Sign in with ChatGPT/Codex-plan OAuth (device code)
+  auth        Sign in with ChatGPT/Codex-plan OAuth (device code, or --browser)
   list        Show configured providers
   remove      Remove a provider by id
   refresh-models  Update cached model lists`;

--- a/src/providers-command.ts
+++ b/src/providers-command.ts
@@ -405,6 +405,23 @@ function providerLabel(name: string, modelCount: number, enabled: boolean): stri
   return `${fmtEnabledStar(enabled)} ${fmtProvider(name)} ${pc.dim(`(${modelCount} model${modelCount === 1 ? '' : 's'})`)}`;
 }
 
+/** Interactive method picker; Enter keeps the device-code default. Null = cancelled. */
+export async function promptOAuthMethod(): Promise<ProviderAuthMethod | null> {
+  const choice = await p.select({
+    message: 'How do you want to sign in?',
+    initialValue: 'native' as ProviderAuthMethod,
+    options: [
+      { value: 'native', label: 'Device code', hint: 'works everywhere, including SSH/VPS' },
+      { value: 'browser', label: 'Browser', hint: 'for workspaces that disable device code authorization' },
+    ],
+  });
+  if (p.isCancel(choice)) {
+    p.cancel('Cancelled.');
+    return null;
+  }
+  return choice as ProviderAuthMethod;
+}
+
 async function runProvidersAuthWithCleanupState(
   providerId: string,
   method?: ProviderAuthMethod,
@@ -621,7 +638,7 @@ async function runProvidersAddWithCleanupState(
     options.push({
       value: 'oauth',
       label: 'Sign in with ChatGPT (Plus/Pro plan)',
-      hint: 'OAuth device code — no API key needed',
+      hint: 'OAuth (device code or browser) — no API key needed',
     });
   }
   for (const template of listRegistryAddableTemplates(providers)) {
@@ -649,7 +666,9 @@ async function runProvidersAddWithCleanupState(
   }
 
   if (choice === 'oauth') {
-    return runProvidersAuthWithCleanupState('openai', undefined, cleanupState);
+    const method = await promptOAuthMethod();
+    if (method === null) return 0;
+    return runProvidersAuthWithCleanupState('openai', method, cleanupState);
   }
   if (typeof choice === 'string' && choice.startsWith('api:')) {
     return runTemplateAddFlow(choice.slice('api:'.length), cleanupState);
@@ -818,8 +837,10 @@ async function runProviderDetail(id: string): Promise<'back' | 'removed'> {
   }
 
   if (action === 'auth') {
+    const method = await promptOAuthMethod();
+    if (method === null) return 'back';
     await runWithCredentialCleanup(state =>
-      runProvidersAuthWithCleanupState(id, undefined, state));
+      runProvidersAuthWithCleanupState(id, method, state));
     return 'back';
   }
 
@@ -949,7 +970,7 @@ export async function runProvidersHub(): Promise<number> {
 
     const configuredIds = new Set(entries.map(entry => entry.id));
     if (listVisibleOAuthTemplates(configuredIds).length > 0) {
-      options.push({ value: 'auth-menu', label: '→ Sign in with ChatGPT (OAuth)', hint: 'device code' });
+      options.push({ value: 'auth-menu', label: '→ Sign in with ChatGPT (OAuth)', hint: 'device code or browser' });
     } else if (configuredIds.has('openai-oauth')) {
       options.push({
         value: 'auth-account',
@@ -978,8 +999,10 @@ export async function runProvidersHub(): Promise<number> {
       continue;
     }
     if (choice === 'auth-menu') {
+      const method = await promptOAuthMethod();
+      if (method === null) continue;
       await runWithCredentialCleanup(state =>
-        runProvidersAuthWithCleanupState('openai', undefined, state));
+        runProvidersAuthWithCleanupState('openai', method, state));
       continue;
     }
     if (choice === 'auth-account') {
@@ -996,8 +1019,10 @@ export async function runProvidersHub(): Promise<number> {
         },
       });
       if (p.isCancel(name)) continue;
+      const accountMethod = await promptOAuthMethod();
+      if (accountMethod === null) continue;
       await runWithCredentialCleanup(state =>
-        runProvidersAuthWithCleanupState('openai', undefined, state, String(name)));
+        runProvidersAuthWithCleanupState('openai', accountMethod, state, String(name)));
       continue;
     }
     if (typeof choice === 'string' && choice.startsWith('provider:')) {

--- a/src/registry/provider-auth.ts
+++ b/src/registry/provider-auth.ts
@@ -1,6 +1,6 @@
 // provider-auth.ts — clodex providers auth (native OpenAI device-code flow)
 
-import { printOAuthStepsPanel } from '../ui.js';
+import { printOAuthBrowserPanel, printOAuthStepsPanel } from '../ui.js';
 import pc from 'picocolors';
 import * as p from '@clack/prompts';
 import open from 'open';
@@ -12,7 +12,7 @@ import {
 } from '../env.js';
 import { OAUTH_ACCOUNT_ENV } from '../oauth-account-selection.js';
 import { credentialInstanceAuthRef } from '../credential-helper.js';
-import { runOpenAiDeviceCodeFlow } from '../oauth/openai.js';
+import { runOpenAiBrowserFlow, runOpenAiDeviceCodeFlow } from '../oauth/openai.js';
 import {
   supportsNativeOAuth,
   tokensToStoredCredential,
@@ -44,7 +44,7 @@ import {
 
 export type { StoredOAuthCredential } from '../oauth/types.js';
 
-export type ProviderAuthMethod = 'native';
+export type ProviderAuthMethod = 'native' | 'browser';
 
 export interface ProviderAuthOptions {
   method?: ProviderAuthMethod;
@@ -94,6 +94,28 @@ async function runNativeDeviceCode(providerId: NativeOAuthProviderId): Promise<S
       p.log.info(`Enter code: ${pc.bold(userCode)}`);
       openBrowser(url);
       spinner.start('Waiting for authorization...');
+    });
+    spinner.stop(pc.green('Signed in to OpenAI ChatGPT'));
+    return tokensToStoredCredential(tokens, undefined, accountId);
+  } catch (err) {
+    spinner.stop('');
+    throw err;
+  }
+}
+
+async function runNativeBrowserSignIn(providerId: NativeOAuthProviderId): Promise<StoredOAuthCredential> {
+  const label = PROVIDER_DISPLAY[providerId];
+  printOAuthBrowserPanel(`${label} — Sign in`, label);
+
+  const spinner = p.spinner();
+  spinner.start('Opening your browser...');
+
+  try {
+    const { tokens, accountId } = await runOpenAiBrowserFlow(({ url }) => {
+      spinner.stop('');
+      p.log.info(`If the browser did not open, visit: ${pc.cyan(url)}`);
+      openBrowser(url);
+      spinner.start('Waiting for sign-in in your browser...');
     });
     spinner.stop(pc.green('Signed in to OpenAI ChatGPT'));
     return tokensToStoredCredential(tokens, undefined, accountId);
@@ -379,7 +401,9 @@ export async function authenticateProvider(
     );
   }
 
-  const cred = await runNativeDeviceCode(providerId);
+  const cred = options.method === 'browser'
+    ? await runNativeBrowserSignIn(providerId)
+    : await runNativeDeviceCode(providerId);
   const persisted = await persistNativeOAuthCredential(providerId, cred, accountName);
 
   const refreshSpinner = p.spinner();
@@ -430,10 +454,16 @@ export function providerAuthHelpText(): string {
 
 ${pc.bold('Usage:')}
   clodex providers auth openai
+  clodex providers auth openai --browser
   clodex providers auth openai --account work
 
 ${pc.bold('Device code (works on SSH/VPS):')}
   openai   ChatGPT Plus/Pro (device code at auth.openai.com/codex/device)
+
+${pc.bold('Browser sign-in:')}
+  --browser   sign in through your browser instead of a device code — use this
+              when your workspace admin has disabled device code authorization.
+              Needs a local browser, so it does not work over plain SSH.
 
 ${pc.bold('Named accounts:')}
   --account <name>   store an additional ChatGPT account under a named slot

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -200,6 +200,14 @@ export function printOAuthStepsPanel(title: string, providerLabel: string): void
   ]);
 }
 
+export function printOAuthBrowserPanel(title: string, providerLabel: string): void {
+  printPanel(pc.cyan(title), [
+    `${pc.white('1. Sign in on the page that opens in your browser')}`,
+    `${pc.white('2. Approve access for ')}${fmtProvider(providerLabel)}`,
+    `${pc.white('3. Return to this terminal')}`,
+  ]);
+}
+
 
 export function printGatewayMaskPanel(): void {
   printPanel(pc.cyan('Claude Desktop / Cowork'), [

--- a/tests/oauth-openai.test.ts
+++ b/tests/oauth-openai.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import http from 'node:http';
 import {
+  buildOpenAiAuthorizeUrl,
   extractOpenAiAccountId,
   refreshOpenAiAccessToken,
+  runOpenAiBrowserFlow,
   runOpenAiDeviceCodeFlow,
 } from '../src/oauth/openai.js';
 
@@ -69,6 +72,93 @@ describe('oauth/openai', () => {
       } as Response);
 
       await expect(refreshOpenAiAccessToken('refresh_123')).rejects.toThrow(/OpenAI token refresh failed \(401\)/);
+    });
+  });
+
+  describe('buildOpenAiAuthorizeUrl', () => {
+    it('builds the PKCE authorize URL with the registered client id', () => {
+      const url = new URL(buildOpenAiAuthorizeUrl('http://localhost:1455/auth/callback', 'chal', 'st4te'));
+      expect(url.origin).toBe('https://auth.openai.com');
+      expect(url.pathname).toBe('/oauth/authorize');
+      expect(url.searchParams.get('response_type')).toBe('code');
+      expect(url.searchParams.get('client_id')).toBe('app_EMoamEEZ73f0CkXaXp7hrann');
+      expect(url.searchParams.get('redirect_uri')).toBe('http://localhost:1455/auth/callback');
+      expect(url.searchParams.get('scope')).toBe('openid profile email offline_access');
+      expect(url.searchParams.get('code_challenge')).toBe('chal');
+      expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+      expect(url.searchParams.get('state')).toBe('st4te');
+    });
+  });
+
+  describe('runOpenAiBrowserFlow', () => {
+    function hitCallback(authorizeUrl: string, query: (state: string) => string): void {
+      const redirect = new URL(new URL(authorizeUrl).searchParams.get('redirect_uri')!);
+      const state = new URL(authorizeUrl).searchParams.get('state')!;
+      http.get(`http://127.0.0.1:${redirect.port}${redirect.pathname}?${query(state)}`);
+    }
+
+    it('exchanges the callback code for tokens', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'browser_access', refresh_token: 'browser_refresh' }),
+      } as Response);
+
+      let seenUrl = '';
+      const result = await runOpenAiBrowserFlow(({ url }) => {
+        seenUrl = url;
+        hitCallback(url, state => `code=auth_code_1&state=${encodeURIComponent(state)}`);
+      }, { ports: [0] });
+
+      expect(result.tokens.access_token).toBe('browser_access');
+      const [exchangeUrl, exchangeInit] = vi.mocked(global.fetch).mock.calls[0]!;
+      expect(exchangeUrl).toBe('https://auth.openai.com/oauth/token');
+      const body = new URLSearchParams(String((exchangeInit as RequestInit).body));
+      expect(body.get('grant_type')).toBe('authorization_code');
+      expect(body.get('code')).toBe('auth_code_1');
+      expect(body.get('redirect_uri')).toBe(new URL(seenUrl).searchParams.get('redirect_uri'));
+      expect(body.get('code_verifier')).toBeTruthy();
+    });
+
+    it('rejects a callback with a mismatched state', async () => {
+      await expect(runOpenAiBrowserFlow(({ url }) => {
+        hitCallback(url, () => 'code=auth_code_1&state=forged');
+      }, { ports: [0] })).rejects.toThrow(/mismatched state/);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects when the provider returns an error instead of a code', async () => {
+      await expect(runOpenAiBrowserFlow(({ url }) => {
+        hitCallback(url, state => `error=access_denied&state=${encodeURIComponent(state)}`);
+      }, { ports: [0] })).rejects.toThrow(/access_denied/);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('reports busy ports instead of a raw bind error', async () => {
+      const blockers = await Promise.all([1455, 1457].map(port =>
+        new Promise<http.Server>((resolve, reject) => {
+          const srv = http.createServer();
+          srv.once('error', reject);
+          srv.listen(port, '127.0.0.1', () => resolve(srv));
+        }),
+      ));
+      try {
+        await expect(runOpenAiBrowserFlow(vi.fn())).rejects.toThrow(/1455 and 1457 are in use/);
+      } finally {
+        for (const srv of blockers) srv.close();
+      }
+    });
+
+    it('times out when the browser never completes sign-in', async () => {
+      await expect(runOpenAiBrowserFlow(vi.fn(), { ports: [0], timeoutMs: 50 }))
+        .rejects.toThrow(/OAuth timeout/);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('throws on a failed token exchange', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce({ ok: false, status: 400 } as Response);
+      await expect(runOpenAiBrowserFlow(({ url }) => {
+        hitCallback(url, state => `code=auth_code_1&state=${encodeURIComponent(state)}`);
+      }, { ports: [0] })).rejects.toThrow(/token exchange failed \(400\)/);
     });
   });
 

--- a/tests/oauth-openai.test.ts
+++ b/tests/oauth-openai.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import dns from 'node:dns';
 import http from 'node:http';
 import {
   buildOpenAiAuthorizeUrl,
@@ -91,10 +92,21 @@ describe('oauth/openai', () => {
   });
 
   describe('runOpenAiBrowserFlow', () => {
-    function hitCallback(authorizeUrl: string, query: (state: string) => string): void {
-      const redirect = new URL(new URL(authorizeUrl).searchParams.get('redirect_uri')!);
-      const state = new URL(authorizeUrl).searchParams.get('state')!;
-      http.get(`http://127.0.0.1:${redirect.port}${redirect.pathname}?${query(state)}`);
+    function hitCallback(authorizeUrl: string, query: (state: string) => string): Promise<number> {
+      const authorize = new URL(authorizeUrl);
+      const redirect = new URL(authorize.searchParams.get('redirect_uri')!);
+      const state = authorize.searchParams.get('state')!;
+      return new Promise((resolve, reject) => {
+        const request = http.get(
+          `${redirect.origin}${redirect.pathname}?${query(state)}`,
+          response => {
+            const status = response.statusCode ?? 0;
+            response.resume();
+            response.once('end', () => resolve(status));
+          },
+        );
+        request.once('error', reject);
+      });
     }
 
     it('exchanges the callback code for tokens', async () => {
@@ -106,10 +118,11 @@ describe('oauth/openai', () => {
       let seenUrl = '';
       const result = await runOpenAiBrowserFlow(({ url }) => {
         seenUrl = url;
-        hitCallback(url, state => `code=auth_code_1&state=${encodeURIComponent(state)}`);
-      }, { ports: [0] });
+        void hitCallback(url, state => `code=auth_code_1&state=${encodeURIComponent(state)}`);
+      }, { ports: [0], timeoutMs: 2_000 });
 
       expect(result.tokens.access_token).toBe('browser_access');
+      expect(new URL(new URL(seenUrl).searchParams.get('redirect_uri')!).hostname).toBe('localhost');
       const [exchangeUrl, exchangeInit] = vi.mocked(global.fetch).mock.calls[0]!;
       expect(exchangeUrl).toBe('https://auth.openai.com/oauth/token');
       const body = new URLSearchParams(String((exchangeInit as RequestInit).body));
@@ -119,32 +132,93 @@ describe('oauth/openai', () => {
       expect(body.get('code_verifier')).toBeTruthy();
     });
 
-    it('rejects a callback with a mismatched state', async () => {
-      await expect(runOpenAiBrowserFlow(({ url }) => {
-        hitCallback(url, () => 'code=auth_code_1&state=forged');
-      }, { ports: [0] })).rejects.toThrow(/mismatched state/);
-      expect(global.fetch).not.toHaveBeenCalled();
+    it('ignores a mismatched callback before accepting a valid one', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'browser_access' }),
+      } as Response);
+
+      let staleStatus = 0;
+      let callbackSequence: Promise<number> | undefined;
+      const flow = runOpenAiBrowserFlow(({ url }) => {
+        callbackSequence = hitCallback(url, () => 'code=auth_code_forged&state=forged')
+          .then(status => {
+            staleStatus = status;
+            return hitCallback(url, state => `code=auth_code_1&state=${encodeURIComponent(state)}`);
+          });
+      }, { ports: [0], timeoutMs: 2_000 });
+
+      const result = await flow;
+      if (!callbackSequence) throw new Error('callback sequence was not started');
+      await callbackSequence;
+      expect(staleStatus).toBe(400);
+      expect(result.tokens.access_token).toBe('browser_access');
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      const body = new URLSearchParams(
+        String((vi.mocked(global.fetch).mock.calls[0]![1] as RequestInit).body),
+      );
+      expect(body.get('code')).toBe('auth_code_1');
     });
 
     it('rejects when the provider returns an error instead of a code', async () => {
       await expect(runOpenAiBrowserFlow(({ url }) => {
-        hitCallback(url, state => `error=access_denied&state=${encodeURIComponent(state)}`);
-      }, { ports: [0] })).rejects.toThrow(/access_denied/);
+        void hitCallback(url, state => `error=access_denied&state=${encodeURIComponent(state)}`);
+      }, { ports: [0], timeoutMs: 2_000 })).rejects.toThrow(/access_denied/);
       expect(global.fetch).not.toHaveBeenCalled();
     });
 
+    it('shows the browser a failure page when the provider denies access', async () => {
+      let bodyDone: Promise<string> | undefined;
+      await expect(runOpenAiBrowserFlow(({ url }) => {
+        const authorize = new URL(url);
+        const redirect = new URL(authorize.searchParams.get('redirect_uri')!);
+        const state = authorize.searchParams.get('state')!;
+        bodyDone = new Promise((resolve, reject) => {
+          const request = http.get(
+            `${redirect.origin}${redirect.pathname}?error=access_denied&state=${encodeURIComponent(state)}`,
+            response => {
+              let body = '';
+              response.setEncoding('utf8');
+              response.on('data', chunk => { body += chunk; });
+              response.once('end', () => resolve(body));
+            },
+          );
+          request.once('error', reject);
+        });
+      }, { ports: [0], timeoutMs: 2_000 })).rejects.toThrow(/access_denied/);
+      const deniedBody = await bodyDone!;
+      expect(deniedBody).toContain('Sign-in failed');
+      expect(deniedBody).not.toContain('Authentication successful');
+    });
+
+    it('propagates a non-port-conflict listener failure instead of blaming busy ports', async () => {
+      await expect(runOpenAiBrowserFlow(vi.fn(), { ports: [-1], timeoutMs: 200 }))
+        .rejects.toThrow(/Could not start the OAuth callback listener/);
+    });
+
     it('reports busy ports instead of a raw bind error', async () => {
-      const blockers = await Promise.all([1455, 1457].map(port =>
-        new Promise<http.Server>((resolve, reject) => {
-          const srv = http.createServer();
-          srv.once('error', reject);
-          srv.listen(port, '127.0.0.1', () => resolve(srv));
-        }),
-      ));
+      const previousOrder = dns.getDefaultResultOrder();
+      // Make localhost resolve away from 127.0.0.1 so a hardcoded IPv4 bind misses the blockers.
+      dns.setDefaultResultOrder('ipv6first');
       try {
-        await expect(runOpenAiBrowserFlow(vi.fn())).rejects.toThrow(/1455 and 1457 are in use/);
+        const { address } = await dns.promises.lookup('localhost');
+        // Ephemeral blockers so the test never claims OpenAI's real 1455/1457.
+        const blockers = await Promise.all([0, 0].map(port =>
+          new Promise<http.Server>((resolve, reject) => {
+            const srv = http.createServer();
+            srv.once('error', reject);
+            srv.listen(port, address, () => resolve(srv));
+          }),
+        ));
+        const busyPorts = blockers.map(srv => (srv.address() as { port: number }).port);
+        try {
+          await expect(runOpenAiBrowserFlow(vi.fn(), { ports: busyPorts, timeoutMs: 200 }))
+            .rejects.toThrow(new RegExp(`${busyPorts[0]} and ${busyPorts[1]} are in use`));
+        } finally {
+          for (const srv of blockers) srv.close();
+        }
       } finally {
-        for (const srv of blockers) srv.close();
+        dns.setDefaultResultOrder(previousOrder);
       }
     });
 
@@ -157,8 +231,8 @@ describe('oauth/openai', () => {
     it('throws on a failed token exchange', async () => {
       vi.mocked(global.fetch).mockResolvedValueOnce({ ok: false, status: 400 } as Response);
       await expect(runOpenAiBrowserFlow(({ url }) => {
-        hitCallback(url, state => `code=auth_code_1&state=${encodeURIComponent(state)}`);
-      }, { ports: [0] })).rejects.toThrow(/token exchange failed \(400\)/);
+        void hitCallback(url, state => `code=auth_code_1&state=${encodeURIComponent(state)}`);
+      }, { ports: [0], timeoutMs: 2_000 })).rejects.toThrow(/token exchange failed \(400\)/);
     });
   });
 

--- a/tests/oauth-openai.test.ts
+++ b/tests/oauth-openai.test.ts
@@ -110,6 +110,10 @@ describe('oauth/openai', () => {
       });
     }
 
+    function redirectUriHost(authorizeUrl: string): string {
+      return new URL(new URL(authorizeUrl).searchParams.get('redirect_uri')!).host;
+    }
+
     it('exchanges the callback code for tokens', async () => {
       vi.mocked(global.fetch).mockResolvedValueOnce({
         ok: true,
@@ -221,6 +225,42 @@ describe('oauth/openai', () => {
       } finally {
         for (const srv of blockers) srv.close();
         dns.setDefaultResultOrder(previousOrder);
+      }
+    });
+
+    it('treats a port held on the other loopback family as taken and falls back', async () => {
+      // A foreign listener on the loopback family our bind does NOT take would
+      // receive the browser's localhost redirect while our bind "succeeds" and
+      // the flow hangs until timeout.
+      const { address: boundFamily } = await dns.promises.lookup('localhost');
+      const otherFamily = boundFamily === '::1' ? '127.0.0.1' : '::1';
+      const squatter = http.createServer();
+      try {
+        await new Promise<void>((resolve, reject) => {
+          squatter.once('error', reject);
+          squatter.listen(0, otherFamily, resolve);
+        });
+      } catch {
+        squatter.close();
+        return; // Single-family host: the mismatch this test pins cannot occur.
+      }
+      const squattedPort = (squatter.address() as { port: number }).port;
+
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'browser_access' }),
+      } as Response);
+
+      let advertisedPort = 0;
+      try {
+        const result = await runOpenAiBrowserFlow(({ url }) => {
+          advertisedPort = Number(redirectUriHost(url).split(':')[1]);
+          void hitCallback(url, state => `code=auth_code_1&state=${encodeURIComponent(state)}`);
+        }, { ports: [squattedPort, 0], timeoutMs: 5_000 });
+        expect(advertisedPort).not.toBe(squattedPort);
+        expect(result.tokens.access_token).toBe('browser_access');
+      } finally {
+        squatter.close();
       }
     });
 

--- a/tests/oauth-openai.test.ts
+++ b/tests/oauth-openai.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createHash } from 'node:crypto';
 import dns from 'node:dns';
 import http from 'node:http';
 import {
@@ -129,7 +130,10 @@ describe('oauth/openai', () => {
       expect(body.get('grant_type')).toBe('authorization_code');
       expect(body.get('code')).toBe('auth_code_1');
       expect(body.get('redirect_uri')).toBe(new URL(seenUrl).searchParams.get('redirect_uri'));
-      expect(body.get('code_verifier')).toBeTruthy();
+      const verifier = body.get('code_verifier')!;
+      // PKCE binding: the exchanged verifier must hash to the advertised challenge.
+      expect(createHash('sha256').update(verifier).digest('base64url'))
+        .toBe(new URL(seenUrl).searchParams.get('code_challenge'));
     });
 
     it('ignores a mismatched callback before accepting a valid one', async () => {
@@ -200,24 +204,22 @@ describe('oauth/openai', () => {
       const previousOrder = dns.getDefaultResultOrder();
       // Make localhost resolve away from 127.0.0.1 so a hardcoded IPv4 bind misses the blockers.
       dns.setDefaultResultOrder('ipv6first');
+      // Retain server objects before awaiting listens so a partial bind never leaks.
+      const blockers = [http.createServer(), http.createServer()];
       try {
         const { address } = await dns.promises.lookup('localhost');
         // Ephemeral blockers so the test never claims OpenAI's real 1455/1457.
-        const blockers = await Promise.all([0, 0].map(port =>
-          new Promise<http.Server>((resolve, reject) => {
-            const srv = http.createServer();
+        await Promise.all(blockers.map(srv =>
+          new Promise<void>((resolve, reject) => {
             srv.once('error', reject);
-            srv.listen(port, address, () => resolve(srv));
+            srv.listen(0, address, resolve);
           }),
         ));
         const busyPorts = blockers.map(srv => (srv.address() as { port: number }).port);
-        try {
-          await expect(runOpenAiBrowserFlow(vi.fn(), { ports: busyPorts, timeoutMs: 200 }))
-            .rejects.toThrow(new RegExp(`${busyPorts[0]} and ${busyPorts[1]} are in use`));
-        } finally {
-          for (const srv of blockers) srv.close();
-        }
+        await expect(runOpenAiBrowserFlow(vi.fn(), { ports: busyPorts, timeoutMs: 200 }))
+          .rejects.toThrow(new RegExp(`${busyPorts[0]} and ${busyPorts[1]} are in use`));
       } finally {
+        for (const srv of blockers) srv.close();
         dns.setDefaultResultOrder(previousOrder);
       }
     });

--- a/tests/provider-auth.test.ts
+++ b/tests/provider-auth.test.ts
@@ -21,6 +21,7 @@ const journalState = vi.hoisted(() => ({
 
 vi.mock('../src/ui.js', () => ({
   printOAuthStepsPanel: vi.fn(),
+  printOAuthBrowserPanel: vi.fn(),
 }));
 vi.mock('../src/oauth/openai.js', () => ({
   runOpenAiDeviceCodeFlow: vi.fn(async () => ({
@@ -30,6 +31,14 @@ vi.mock('../src/oauth/openai.js', () => ({
       expires_in: 3600,
     },
     accountId: 'acct-123',
+  })),
+  runOpenAiBrowserFlow: vi.fn(async () => ({
+    tokens: {
+      access_token: 'openai-browser-access',
+      refresh_token: 'openai-browser-refresh',
+      expires_in: 3600,
+    },
+    accountId: 'acct-browser',
   })),
 }));
 vi.mock('../src/env.js', async importOriginal => {
@@ -128,7 +137,7 @@ import {
   resolveProviderCredential,
   saveProviderCredential,
 } from '../src/env.js';
-import { runOpenAiDeviceCodeFlow } from '../src/oauth/openai.js';
+import { runOpenAiBrowserFlow, runOpenAiDeviceCodeFlow } from '../src/oauth/openai.js';
 import { reconcilePendingCredentialDeletes } from '../src/registry/credential-lifecycle.js';
 import * as cleanupJournal from '../src/registry/credential-cleanup-journal.js';
 import { loadRegistryStrict, saveRegistry } from '../src/registry/io.js';
@@ -182,6 +191,10 @@ describe('authenticateProvider', () => {
     vi.mocked(runOpenAiDeviceCodeFlow).mockReset().mockResolvedValue({
       tokens: { access_token: 'openai-access', refresh_token: 'openai-refresh', expires_in: 3600 },
       accountId: 'acct-123',
+    });
+    vi.mocked(runOpenAiBrowserFlow).mockReset().mockResolvedValue({
+      tokens: { access_token: 'openai-browser-access', refresh_token: 'openai-browser-refresh', expires_in: 3600 },
+      accountId: 'acct-browser',
     });
     vi.mocked(refreshProviderModels).mockReset().mockResolvedValue({
       id: 'openai-oauth',
@@ -657,6 +670,15 @@ describe('authenticateProvider', () => {
     expect(result.credential.access).toBe('openai-access');
     expect(result.registryProvider.name).toBe('OpenAI (ChatGPT)');
     expect(result.registryProvider.authRef).toBe(credentialRef);
+  });
+
+  it('runs the browser PKCE flow instead of device code when method is browser', async () => {
+    const result = await authenticateProvider('openai', { method: 'browser' });
+
+    expect(runOpenAiBrowserFlow).toHaveBeenCalled();
+    expect(runOpenAiDeviceCodeFlow).not.toHaveBeenCalled();
+    expect(result.providerId).toBe('openai-oauth');
+    expect(result.credential.access).toBe('openai-browser-access');
   });
 
   it('stops before device authorization when the credential store preflight fails', async () => {

--- a/tests/providers-command.test.ts
+++ b/tests/providers-command.test.ts
@@ -1000,6 +1000,69 @@ describe('provider command cleanup reconciliation', () => {
   });
 });
 
+describe('hub OAuth method picker', () => {
+  let home: string;
+  const prevHome = process.env.CLODEX_HOME;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'clodex-oauth-picker-'));
+    process.env.CLODEX_HOME = home;
+    selectMock.mockReset();
+    authenticateProviderMock.mockReset();
+    logSuccessMock.mockReset();
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.CLODEX_HOME;
+    else process.env.CLODEX_HOME = prevHome;
+    rmSync(home, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('forwards the picked browser method to authenticateProvider', async () => {
+    selectMock
+      .mockResolvedValueOnce('auth-menu')
+      .mockResolvedValueOnce('browser')
+      .mockResolvedValueOnce('done');
+    authenticateProviderMock.mockResolvedValue({
+      registryProvider: openaiEntry({ id: 'openai-oauth', name: 'OpenAI (ChatGPT)' }),
+      credentialCleanupPending: false,
+    });
+
+    await expect(runProvidersCommand([])).resolves.toBe(0);
+
+    expect(authenticateProviderMock).toHaveBeenCalledOnce();
+    expect(authenticateProviderMock).toHaveBeenCalledWith(
+      'openai',
+      expect.objectContaining({ method: 'browser' }),
+    );
+  });
+
+  it('keeps device code as the picker default so Enter preserves today\'s behavior', async () => {
+    selectMock
+      .mockResolvedValueOnce('auth-menu')
+      .mockResolvedValueOnce('native')
+      .mockResolvedValueOnce('done');
+    authenticateProviderMock.mockResolvedValue({
+      registryProvider: openaiEntry({ id: 'openai-oauth', name: 'OpenAI (ChatGPT)' }),
+      credentialCleanupPending: false,
+    });
+
+    await expect(runProvidersCommand([])).resolves.toBe(0);
+
+    const pickerCall = selectMock.mock.calls[1]?.[0] as {
+      initialValue?: string;
+      options: Array<{ value: string }>;
+    };
+    expect(pickerCall.initialValue).toBe('native');
+    expect(pickerCall.options.map(option => option.value)).toEqual(['native', 'browser']);
+    expect(authenticateProviderMock).toHaveBeenCalledWith(
+      'openai',
+      expect.objectContaining({ method: 'native' }),
+    );
+  });
+});
+
 describe('providers add menu', () => {
   let home: string;
   const prevHome = process.env.CLODEX_HOME;

--- a/tests/providers-command.test.ts
+++ b/tests/providers-command.test.ts
@@ -160,6 +160,7 @@ describe('parseProvidersArgs', () => {
     expect(help).toContain('providers remove');
     expect(help).toContain('refresh-models');
     expect(help).toContain('auth openai');
+    expect(help).toContain('auth openai --browser');
     expect(help).not.toContain('import');
     expect(help).toContain('built-in provider');
   });

--- a/tests/providers-command.test.ts
+++ b/tests/providers-command.test.ts
@@ -138,6 +138,12 @@ describe('parseProvidersArgs', () => {
       removeId: 'openai',
       authMethod: 'native',
     });
+    expect(parseProvidersArgs(['auth', 'openai', '--browser'])).toEqual({
+      subcommand: 'auth',
+      showHelp: false,
+      removeId: 'openai',
+      authMethod: 'browser',
+    });
   });
 
   it('rejects the removed import subcommand', () => {

--- a/tests/providers-command.test.ts
+++ b/tests/providers-command.test.ts
@@ -979,6 +979,7 @@ describe('provider command cleanup reconciliation', () => {
     selectMock
       .mockResolvedValueOnce('provider:openai')
       .mockResolvedValueOnce('auth')
+      .mockResolvedValueOnce('native')
       .mockResolvedValueOnce('done');
     authenticateProviderMock.mockImplementation(async () => {
       await queueCredentialDelete(authRef);


### PR DESCRIPTION
## Summary
Some ChatGPT workspaces disable device code authorization for Codex, which fully blocks the
ChatGPT/Codex-plan provider in clodex (`clodex providers auth openai` fails outright). This PR
adds an opt-in browser sign-in as an alternative, plus an interactive picker so users can choose
between device code and browser sign-in from the wizard and provider menus.

## Changes
- Add a PKCE browser-based OAuth flow for OpenAI (`src/oauth/openai.ts`) as an alternative to
  device-code auth
- Extend the local callback server with configurable ports, path, and hostname
  (`src/oauth/callback-server.ts`)
- Add a `--browser` flag to `clodex providers auth openai` and wire `method: 'browser'` dispatch
  through `authenticateProvider`
- Add an interactive `promptOAuthMethod()` picker (device code vs. browser), wired into the
  first-run wizard, `providers add`, the provider detail view, and both hub sign-in flows
- Update hints, README, and internal docs to describe both sign-in options
- Add tests for the browser flow, callback server, CLI flag parsing, and the new method picker

## Additional Notes
- Closes #140
- Device code stays the default — it works over SSH/VPS where a local browser isn't available
- `pnpm typecheck && pnpm test && pnpm build` are green; the one failing test
  (`credential-helper.test.ts`) is a pre-existing timing flake tracked in #138, unrelated to this
  change
- Verified end-to-end against a real ChatGPT workspace with device code authorization disabled
