### PR TITLE
fix(patch): restore custom model aliases on Claude Code 2.1.242 and newer

### DIFF
--- a/.claude/docs/claude-code-internals.md
+++ b/.claude/docs/claude-code-internals.md
@@ -28,10 +28,12 @@ skipping any it has already extracted. It uses clodex's own tweakcc dependency f
 `readClaudeBundle` for the JavaScript, which is why it has to run from inside this repo, where
 `node_modules` resolves.
 
-**Since 2.1.242 the file it writes is a JOIN of every JavaScript module**, separated by
-`/*clodex:module-boundary*/` lines — the same document `clodex patch` matches its anchors against.
-Do not go back to tweakcc's `readContent` for this: it returns only the module it recognizes by
-name, which since 2.1.242 is a ~20 KB stub holding none of Claude Code's behaviour.
+**The file it writes is a JOIN of every JavaScript module**, separated by
+``/*clodex:module-boundary`;{}"]*/`` lines — the same document `clodex patch` matches its anchors
+against. That is true of every version, not only the split ones: a pre-2.1.242 binary carries the
+bundle plus five ~2 KB helper modules, so its extract is a six-module join. Since 2.1.242 it is
+roughly 1,380. Do not go back to tweakcc's `readContent` for this: it returns only the module it
+recognizes by name, which since 2.1.242 is a ~20 KB stub holding none of Claude Code's behaviour.
 
 Extract from a **pristine** `.orig` backup, never a patched live binary: a patched claude reports
 its version perfectly well, so the only thing distinguishing them is the patch marker.

--- a/.claude/docs/claude-code-internals.md
+++ b/.claude/docs/claude-code-internals.md
@@ -23,9 +23,15 @@ export REVIEW_BUNDLE_DIR=<that directory>     # the real-bundle harnesses read t
 ```
 
 That script walks every pristine `*.orig` backup in `~/.tweakcc` (override with
-`TWEAKCC_CONFIG_DIR`) and writes one ~23 MB `.js` per version, skipping any it has already
-extracted. It uses clodex's own tweakcc dependency — `tryDetectInstallation({ path })` then
-`readContent` — which is why it has to run from inside this repo, where `node_modules` resolves.
+`TWEAKCC_CONFIG_DIR`) and writes one `.js` per version (~23 MB before 2.1.242, ~36 MB after),
+skipping any it has already extracted. It uses clodex's own tweakcc dependency for detection, and
+`readClaudeBundle` for the JavaScript, which is why it has to run from inside this repo, where
+`node_modules` resolves.
+
+**Since 2.1.242 the file it writes is a JOIN of every JavaScript module**, separated by
+`/*clodex:module-boundary*/` lines — the same document `clodex patch` matches its anchors against.
+Do not go back to tweakcc's `readContent` for this: it returns only the module it recognizes by
+name, which since 2.1.242 is a ~20 KB stub holding none of Claude Code's behaviour.
 
 Extract from a **pristine** `.orig` backup, never a patched live binary: a patched claude reports
 its version perfectly well, so the only thing distinguishing them is the patch marker.
@@ -34,15 +40,45 @@ Then **enumerate every branch of the function yourself.** Shipped bugs have come
 gates that happened to be visible, and from grepping one syntactic form of a comparison — grep the
 *value*, then trace every hit.
 
+## The bundle was code-split in 2.1.242
+
+Through 2.1.241 the whole ~28 MB bundle was ONE Bun module. 2.1.242 split it: the entry module is
+now a ~20 KB ESM stub whose body is `import{…}from"/$bunfs/root/chunk-<hash>.js"` plus a `main()`
+call, and the code lives in ~1,374 sibling `chunk-*.js` modules — 1,391 modules in the blob, against
+15 before. Chunk names are content-hashed, so they differ between releases AND between platform
+builds of the same release.
+
+| Version | Modules in the blob | Entry module payload |
+| --- | --- | --- |
+| 2.1.232 | 15 | 26,504,651 bytes — the whole bundle |
+| 2.1.241 | 15 | 28,252,504 bytes — the whole bundle |
+| 2.1.242, 2.1.243 | 1,391 | ~19,950 bytes — an import stub |
+
+(Measured on darwin-arm64. 2.1.242 and 2.1.243 have the same module count and differ only in their
+chunk hashes and version string.)
+
+Consequences worth knowing before you touch any of this:
+
+- **The anchors did not move; the reader did.** Every clodex patch site still occurs exactly once
+  across the bundle — they are just in six different chunks on 2.1.243, none of them the entry.
+- **Bun executes the chunk SOURCE, not the chunk bytecode.** Verified on 2.1.243 darwin-arm64 by
+  overwriting eleven bytes of one chunk's payload in place (`Your prompt` → `YOUR_PROMPT`),
+  re-signing, and running `claude --help`: the edited string is what printed.
+- **A module's payload can be repointed without moving it.** `{ offset, length }` in the module
+  struct is the only thing that says where a module's source is, so several modules can be patched
+  in ONE repack by concatenating their new sources into the buffer tweakcc writes and then pointing
+  each module at its own slice. That is what `src/bun-bundle.ts` does.
+
 ## The entry module's name is not stable (renamed in 2.1.229)
 
-The bundle lives in a Bun data blob as one module among ~15, and tweakcc finds it **by name**:
+The bundle lived in a Bun data blob as one module among ~15 (see the code-split section above for
+what changed in 2.1.242), and tweakcc finds it **by name**:
 `/claude`, `claude`, `/claude.exe`, `claude.exe`, `/src/entrypoints/cli.js`, `src/entrypoints/cli.js`.
 
 | Version | Entry module |
 | --- | --- |
 | 2.1.224, 2.1.226, 2.1.228 | `/$bunfs/root/src/entrypoints/cli.js` |
-| 2.1.229, 2.1.231–2.1.234 | `/$bunfs/root/cli` |
+| 2.1.229, 2.1.231–2.1.234, 2.1.241–2.1.243 | `/$bunfs/root/cli` |
 
 (2.1.228 is the last release clodex's pinned tweakcc 4.3.0 — and clodex's own mirrored copy of its
 name list — can discover, and 2.1.230 was never published for any platform package, so 2.1.229 is
@@ -56,8 +92,9 @@ packaging fault described in `patcher.md` and is not it. tweakcc carried the old
 
 Two things that are easy to assume wrongly about the blob:
 
-- **The entry module also carries ~190 MB of Bun bytecode** (`// @bun @bytecode @bun-cjs`), and
-  repacking preserves it verbatim. It does **not** win over the patched source — a canary injected
+- **Every JavaScript module also carries Bun bytecode** (`// @bun @bytecode`) — ~190 MB on the
+  single-module releases, a few hundred KB per chunk since the split — and repacking preserves it
+  verbatim. It does **not** win over the patched source — a canary injected
   into the JS prints at startup on a repacked 2.1.231 (verified twice on macOS arm64 — once by
   hand and once through clodex's own local-patches feature, both printing the canary on stderr
   ahead of `--version`). Bytecode has been present since at least 2.1.226, so this was never the

--- a/.claude/docs/patcher.md
+++ b/.claude/docs/patcher.md
@@ -87,13 +87,23 @@ the whole-bundle count guards in PATCH 5 and PATCH 10 look at.
   module, because a pre-split blob carries five loader-1 helper stubs beside it — verified on 18
   binaries from 2.1.208 to 2.1.241, all six-module, entry first. For a built-in that is inert
   (measured on a real 2.1.232: no anchor and no count-guard text in any of the five), but a LOCAL
-  patch that appends or prepends by position rather than matching an anchor now lands in a
-  different module than it used to. README says so where a local-patch author will see it.
+  patch that APPENDS by position rather than matching an anchor now lands in a different module
+  than it used to — the end of the joined document is the last helper stub, not the end of the
+  entry. Prepending is unchanged on those releases, because they are all entry-first; on a split
+  build neither end is the entry. README says so where a local-patch author will see it.
 - **A repoint is a write AFTER tweakcc's repack, which signs on its way out.** Restoring the
   entry-module name re-signs and covers the normal path; `resignMachOBinary` covers the binary that
   needed no shim. Skip either and macOS refuses to start the result.
 - Bun runs the module SOURCE, not the bytecode that sits beside it — verified on a real 2.1.243
   build, see `claude-code-internals.md`. Without that, none of this would have any effect.
+  **That guarantee has no automated coverage and cannot get any**: 1,377 of the 1,391 module
+  structs on a real darwin-arm64 2.1.243 carry a non-empty bytecode range (and a matching
+  `moduleInfo` and `bytecodeOriginPath`), while `repointBunModuleContents` rewrites only the
+  `contents` pair — so after a patch every chunk points at new source beside its pre-patch
+  compiled form. The blob fixture writes empty bytecode ranges for every module, so there is
+  nothing stale for a test to trip over. This is the one place where fixture and implementation
+  share an assumption the fixture cannot falsify; re-check it with the probe on a real binary
+  whenever the write path changes.
 
 ## The entry-module shim (`bun-entry-module.ts`)
 

--- a/.claude/docs/patcher.md
+++ b/.claude/docs/patcher.md
@@ -1,20 +1,22 @@
 <!-- Read when changing src/patcher.ts, patch-transforms.ts, patch-backup.ts, local-patches.ts,
-     built-in-patch-proofs.ts, bun-entry-module.ts, or anything about `clodex patch`. -->
+     built-in-patch-proofs.ts, bun-entry-module.ts, bun-bundle.ts, or anything about
+     `clodex patch`. -->
 
 # Patcher
 
 `src/patcher.ts` + `src/patch-transforms.ts` + `src/built-in-patch-proofs.ts` +
-`src/local-patches.ts` + `src/patch-backup.ts` + `src/bun-entry-module.ts`.
+`src/local-patches.ts` + `src/patch-backup.ts` + `src/bun-entry-module.ts` + `src/bun-bundle.ts`.
 
 `clodex patch` uses tweakcc's programmatic API — an exact-pinned, declared runtime dependency
 (externalized in `tsup.config.ts`; it brings `node-lief` for native repacking and `ink`/`react` for
 its picker, which is why `patcher.ts` loads it via lazy `import()`). **Never `npx`, never the
-network.** Flow: `tryDetectInstallation({ path })` → `readContent` → `applyClodexPatches(source,
+network.** Flow: `tryDetectInstallation({ path })` → `readClaudeBundle` → `applyClodexPatches(source,
 config)` (in-process pure function applying built-in PATCH 1–10 sites) → optional
 `applyLocalPatches` transaction with built-in postcondition verification → `writeContent` (repacks
-the native binary). Both layers return per-site OK/SKIP/FAIL results shown by `--trace`. Since
-2.1.229, the reads and the repack are each wrapped in the entry-module shim below, without which
-tweakcc cannot find the bundle at all.
+the native binary) → `applyBundleWritePlan` (points each patched module at its own payload). Both
+layers return per-site OK/SKIP/FAIL results shown by `--trace`. Since 2.1.229, the reads and the
+repack are each wrapped in the entry-module shim below, without which tweakcc cannot find the
+bundle at all.
 
 tweakcc ships no `.d.ts` despite its `types` field — `src/tweakcc.d.ts` declares the verified API
 surface; re-verify when bumping the pin. `node-gyp-build` is a deliberate direct dependency even
@@ -32,6 +34,66 @@ layout with exact pins. Keep it even after node-lief fixes the packaging.
 The built-ins bake favorites + aliases into the binary: model validation, `/model` listing, alias
 resolution, context windows via a `/*ccpatch:ctx*/`-marked map, per-model effort
 capabilities/defaults, and child-command network isolation.
+
+## The bundle is many modules (`bun-bundle.ts`)
+
+Claude Code 2.1.242 code-split its bundle — one ~28 MB Bun module became a ~20 KB entry stub plus
+~1,374 `chunk-*.js` siblings. tweakcc reads and writes exactly ONE module, the one it recognizes by
+name, so `clodex patch` started seeing a stub with none of its anchors in it and aborted at
+`PATCH 1` on all eight published builds at once. `.claude/docs/claude-code-internals.md` has the
+bundle-side detail and the module counts.
+
+`bun-bundle.ts` keeps the old contract: `readClaudeBundle` reads every module Bun will execute as
+JavaScript and joins them with a ``/*clodex:module-boundary`;{}"]*/`` line, `applyClodexPatches` still sees
+one document, and `splitBundleSource` cuts it back up. **The transforms did not change and must not
+have to.** A patched document with the wrong number of boundaries is a hard failure, not a best
+effort: a boundary consumed by an anchor would silently move code between modules.
+
+**Selection is by Bun's loader id, not by name.** Only `loader === 1` — what Bun executes as
+JavaScript — is part of the bundle. The vendored assets (`mermaid.min.js`,
+`hljsBundle.generated.min.js`, `chart.umd.min.js`) are `.js` files that Bun never runs, and feeding
+megabytes of foreign JavaScript to anchors that must match exactly once is a way to invent
+ambiguity and refuse a release that is perfectly patchable. Two consequences follow, and the second
+is easy to miss: **a module's position in the blob table is not its position in the bundle**, so
+every repoint is addressed by table index; and **the read corpus grew for old releases too** — a
+pre-split blob holds five ~2 KB loader-1 stubs (`image-processor.js`, `audio-capture.js`,
+`url-handler.js`, `computer-use-*.js`) beside the bundle, which tweakcc's read never included.
+Checked on a real 2.1.232: none of them contains any anchor, any `process.env` read, or anything
+the whole-bundle count guards in PATCH 5 and PATCH 10 look at.
+
+**The write is one repack plus a pointer edit, and both halves are load-bearing.**
+
+- Calling `writeContent` once per changed module is not an alternative. Each ELF repack relocates
+  the whole ~290 MB blob to `align(nextVirtualAddress())` and extends the segment, so six of them
+  would leave a multi-gigabyte `claude` and take minutes. Mach-O and PE assign in place, so this is
+  invisible on macOS and Windows — the same asymmetry that hid the restore-sweep bug.
+- So every changed module's patched source is concatenated (NUL-separated, because Bun
+  NUL-terminates every string in the blob and tweakcc only terminates the buffer as a whole) into
+  the one buffer tweakcc writes, and then `repointBunModuleContents` rewrites the 8-byte
+  `{ offset, length }` pair in each module's struct to address its own slice. Nothing moves and
+  nothing grows; the bytes are already in the blob.
+- **The module tweakcc writes has to come first in that buffer**, because its position is the only
+  one knowable before the repack — every other slice is addressed relative to it. After the repack
+  `applyBundleWritePlan` re-reads the table, refuses if the recognized module is not the one the
+  plan was built around or does not hold exactly the bytes that were written, and then reads every
+  repointed module back and compares it to the patched source it should be. A module left pointing
+  at its neighbour's bytes would start and then misbehave, which is much worse than a patch that
+  refuses.
+- **When the only changed module is the one tweakcc writes, the plan degrades to today's single
+  call with no pointer edit** — which is every release up to 2.1.241, **for the built-ins**. Read it
+  as a statement about the WRITE, and only about a patch whose edits all land in that one module: a
+  local patch that changes a helper module does produce a repoint on those releases too.
+  The READ changed on every version. The joined document has always been more than the entry
+  module, because a pre-split blob carries five loader-1 helper stubs beside it — verified on 18
+  binaries from 2.1.208 to 2.1.241, all six-module, entry first. For a built-in that is inert
+  (measured on a real 2.1.232: no anchor and no count-guard text in any of the five), but a LOCAL
+  patch that appends or prepends by position rather than matching an anchor now lands in a
+  different module than it used to. README says so where a local-patch author will see it.
+- **A repoint is a write AFTER tweakcc's repack, which signs on its way out.** Restoring the
+  entry-module name re-signs and covers the normal path; `resignMachOBinary` covers the binary that
+  needed no shim. Skip either and macOS refuses to start the result.
+- Bun runs the module SOURCE, not the bytecode that sits beside it — verified on a real 2.1.243
+  build, see `claude-code-internals.md`. Without that, none of this would have any effect.
 
 ## The entry-module shim (`bun-entry-module.ts`)
 
@@ -330,7 +392,17 @@ tweakcc's own repack reads back as an ordinary module name.
   publishes the complete built-ins. Host-generated `/*clodex-local:<id>*/` markers are distinct from
   the blocking `/*ccpatch:` tier, and local transforms may not alter prior local markers or built-in
   sites. Keep the module deterministic and self-contained — only its entry bytes participate in
-  freshness.
+  freshness. The `source` a local patch receives is **every JavaScript module joined with
+  ``/*clodex:module-boundary`;{}"]*/`` lines**, not one module's text — on every version, not only the
+  split ones, because a pre-split blob already carried five helper modules beside the bundle.
+  A transform that adds or removes a boundary fails the whole patch loudly. State the rest of the
+  guarantee precisely, because it is narrower than it looks: that is a COUNT check, so a local
+  transform that MOVES text across a boundary while leaving the separators intact would relocate
+  code into another module's scope and nothing would report it. What rules the built-ins out is the
+  separator itself, not the count — see `bun-bundle.ts` — and local patches are explicitly trusted
+  code that may use any regex at all, so for them this is a documented limit rather than a hole to
+  plug. The positional case (append/prepend rather than match) is called out in README, where a
+  local-patch author will see it.
 - **Patch-marker detection is two-tier** (`patch-backup.ts`). Only the `/*ccpatch:` prefix —
   clodex's own injected text — may *block*, and it covers everything current clodex publishes
   because PATCH 8a/8b/8c/9 are required and each emits one. The weaker legacy signals (PATCH 4's

--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ Enabling this feature executes that JavaScript with your full user permissions; 
 
 The module must default-export an array. Each site has a unique lowercase `id` and an `apply` function that returns the complete source and emits the generated `marker` exactly once when it applies:
 
+The `source` your `apply` receives is every JavaScript module in the binary joined together, with a ``/*clodex:module-boundary`;{}"]*/`` line between them. This is true of every Claude Code version — a pre-2.1.242 binary carries the bundle plus five small helper modules; a 2.1.242-or-later one carries the bundle split across roughly 1,370. Match and replace as you always have; just do not add or remove one of those lines, or the whole patch is refused. (The punctuation in the marker is there so that a wildcard bounded by a character class cannot run across a module boundary.)
+
+If your transform works by **position** rather than by matching an anchor, mind where it lands: text prepended to `source` goes into the first module and text appended to it goes into the last, and neither is necessarily the module that runs at startup. Anchor your edit to text you match, the way the examples below do.
+
 ```js
 export default [
   {

--- a/scripts/extract-cc-bundles.mjs
+++ b/scripts/extract-cc-bundles.mjs
@@ -30,6 +30,7 @@ import {
 import { homedir, tmpdir } from 'node:os';
 import path from 'node:path';
 import { inspectEntryModule, shimEntryModuleName } from '../src/bun-entry-module.ts';
+import { readClaudeBundle } from '../src/bun-bundle.ts';
 
 const args = process.argv.slice(2);
 if (args.includes('-h') || args.includes('--help')) {
@@ -117,7 +118,12 @@ for (const f of files) {
     }
     const inst = await tryDetectInstallation({ path: readFrom });
     if (!inst) throw new Error('tweakcc did not recognize the binary');
-    const src = await readContent(inst);
+    // Since Claude Code 2.1.242 the bundle is split across ~1,370 modules and tweakcc's
+    // `readContent` returns only the ~20 KB entry stub. Extracting that alone is worse than
+    // failing: every "I checked the bundle" claim made from it would be about 0.05% of the code.
+    // Read it the way `clodex patch` does, and fall back to tweakcc for older releases.
+    const bundle = readClaudeBundle(readFrom);
+    const src = bundle ? bundle.source : await readContent(inst);
     if (!src) throw new Error('readContent returned nothing');
     // These backups are only *named* pristine. clodex documents poisoned backups as reachable,
     // and a patched claude reports its version perfectly well — the patch marker is the only
@@ -127,7 +133,10 @@ for (const f of files) {
       console.log(`WARN ${f} carries a clodex patch marker — this backup is NOT pristine`);
     }
     writeFileSync(target, src);
-    console.log(`OK ${f} version=${inst.version} kind=${inst.kind} bytes=${src.length}`);
+    console.log(
+      `OK ${f} version=${inst.version} kind=${inst.kind} bytes=${src.length}`
+      + (bundle ? ` modules=${bundle.modules.length}` : ' modules=1 (tweakcc single-module read)'),
+    );
     ok++;
   } catch (e) {
     console.log('FAIL', f, String(e).slice(0, 200));

--- a/scripts/extract-cc-bundles.mjs
+++ b/scripts/extract-cc-bundles.mjs
@@ -27,10 +27,29 @@ import {
   copyFileSync,
   rmSync,
 } from 'node:fs';
+import { registerHooks } from 'node:module';
 import { homedir, tmpdir } from 'node:os';
 import path from 'node:path';
 import { inspectEntryModule, shimEntryModuleName } from '../src/bun-entry-module.ts';
-import { readClaudeBundle } from '../src/bun-bundle.ts';
+
+// `src/` spells its own imports the TypeScript way — `./bun-entry-module.js` for a file that is
+// really `./bun-entry-module.ts`. tsup and vitest understand that; bare `node` does not, and
+// resolves it to a file that does not exist. bun-entry-module.ts imports nothing relative, which is
+// why the static import above works; bun-bundle.ts does, so it is loaded dynamically BELOW this
+// hook — a static import would be resolved before this line ever runs. Same pattern, and the same
+// reason, as scripts/probe-patch-mechanism.mjs.
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier.startsWith('.') && specifier.endsWith('.js') && context.parentURL) {
+      const candidate = new URL(`${specifier.slice(0, -3)}.ts`, context.parentURL);
+      if (candidate.protocol === 'file:' && existsSync(candidate)) {
+        return nextResolve(candidate.href, context);
+      }
+    }
+    return nextResolve(specifier, context);
+  },
+});
+const { readClaudeBundle } = await import('../src/bun-bundle.ts');
 
 const args = process.argv.slice(2);
 if (args.includes('-h') || args.includes('--help')) {

--- a/scripts/probe-patch-mechanism.mjs
+++ b/scripts/probe-patch-mechanism.mjs
@@ -55,6 +55,7 @@ import path from 'node:path';
 import {
   inspectEntryModule,
   listBunModuleNames,
+  resignMachOBinary,
   restoreEntryModuleName,
   shimEntryModuleName,
 } from '../src/bun-entry-module.ts';
@@ -77,6 +78,15 @@ registerHooks({
   },
 });
 const { checkPatchSites } = await import('./probe-patch-sites.mjs');
+// Same reason as above: bun-bundle.ts imports a sibling the TypeScript way, so it can only be
+// loaded once the resolve hook is installed.
+const {
+  applyBundleWritePlan,
+  planBundleWrite,
+  readClaudeBundle,
+  splitBundleSource,
+  writableModuleIndex,
+} = await import('../src/bun-bundle.ts');
 
 const args = process.argv.slice(2);
 if (args.length === 0 || args.includes('-h') || args.includes('--help')) {
@@ -324,10 +334,20 @@ try {
     );
   }
 
-  const source = await readContent(installation);
-  record('read-content', Boolean(source) && source.length > 1_000_000, `${source ? source.length : 0} bytes of JavaScript`);
+  // The whole bundle, not just the module tweakcc names: since 2.1.242 that module is a stub and
+  // every anchor clodex matches lives in a sibling chunk. `clodex patch` reads it the same way, so
+  // a build whose split shape defeats the reader is caught here rather than on a user's machine.
+  const bundle = readClaudeBundle(scratch);
+  const source = bundle ? bundle.source : await readContent(installation);
+  record(
+    'read-content',
+    Boolean(source) && source.length > 1_000_000,
+    `${source ? source.length : 0} bytes of JavaScript`
+      + (bundle ? ` across ${bundle.modules.length} module(s)` : ' (tweakcc single-module read)'),
+  );
   if (!source) throw new Error('nothing further can be probed');
   info.sourceBytes = source.length;
+  info.bundleModules = bundle ? bundle.modules.length : null;
   info.readMs = Date.now() - started;
 
   if (readShim) restoreEntryModuleName(scratch, readShim, { resign: false });
@@ -365,7 +385,17 @@ try {
   const repackStarted = Date.now();
   const written = `${patch.patchedSource ?? source}\n${PROBE_MARKER}${PROBE_PADDING}`;
   const writeShim = shimEntryModuleName(scratch);
-  await writeContent(installation, written);
+  let repointed = false;
+  if (bundle) {
+    const writable = writableModuleIndex(scratch);
+    if (writable === null) throw new Error('no module of this build carries a name tweakcc can write to');
+    const plan = planBundleWrite(bundle, splitBundleSource(bundle, written), writable);
+    await writeContent(installation, plan.content);
+    applyBundleWritePlan(scratch, plan);
+    repointed = plan.repoints.length > 0;
+  } else {
+    await writeContent(installation, written);
+  }
   let restoreError = null;
   if (writeShim) {
     try {
@@ -373,6 +403,8 @@ try {
     } catch (err) {
       restoreError = err instanceof Error ? err.message : String(err);
     }
+  } else if (repointed) {
+    resignMachOBinary(scratch);
   }
   info.repackMs = Date.now() - repackStarted;
   info.publishedSize = statSync(scratch).size;
@@ -476,7 +508,10 @@ try {
   );
   try {
     const verifyInstallation = await tryDetectInstallation({ path: scratch });
-    const republished = verifyInstallation ? await readContent(verifyInstallation) : '';
+    const republishedBundle = readClaudeBundle(scratch);
+    const republished = republishedBundle
+      ? republishedBundle.source
+      : (verifyInstallation ? await readContent(verifyInstallation) : '');
     // Exact equality, not "the marker is in there". Checking only for the marker passed a mutation
     // that dropped the first byte of Claude Code's entry JavaScript: a repack that flips, drops,
     // duplicates or re-encodes source bytes while carrying the marker through is precisely the
@@ -547,13 +582,22 @@ try {
   const publishedModules = listBunModuleNames(scratch) ?? [];
   const lost = pristineModules.filter((n) => !publishedModules.includes(n));
   const gained = publishedModules.filter((n) => !pristineModules.includes(n));
+  // ORDER, not just membership. This used to compare the two as sets, so a repack that kept every
+  // module but shuffled the table read as green — and clodex now addresses each patched module by
+  // its table position, so a silent reorder between the read and the write is exactly the shape
+  // that would point a module at its neighbour's source.
+  const reordered = lost.length === 0 && gained.length === 0
+    && pristineModules.some((name, at) => publishedModules[at] !== name);
   info.moduleCount = { pristine: pristineModules.length, published: publishedModules.length };
   record(
     'modules-intact',
-    lost.length === 0 && gained.length === 0 && pristineModules.length === publishedModules.length,
-    lost.length === 0 && gained.length === 0
-      ? `all ${publishedModules.length} modules survived the repack`
-      : `the repack changed the module list — lost [${lost.slice(0, 5).join(', ')}], gained [${gained.slice(0, 5).join(', ')}]`,
+    lost.length === 0 && gained.length === 0 && !reordered
+      && pristineModules.length === publishedModules.length,
+    reordered
+      ? 'the repack kept every module but changed their order in the table'
+      : lost.length === 0 && gained.length === 0
+        ? `all ${publishedModules.length} modules survived the repack, in the same order`
+        : `the repack changed the module list — lost [${lost.slice(0, 5).join(', ')}], gained [${gained.slice(0, 5).join(', ')}]`,
   );
 
   exitCode = failed === 0 ? 0 : 1;

--- a/src/built-in-patch-proofs.ts
+++ b/src/built-in-patch-proofs.ts
@@ -119,7 +119,7 @@ export function captureBuiltInPatchProofs(
   // postconditions" — the same drift PATCH 4's own anchor had to absorb.
   addPattern(
     'PATCH 4: Agent tool model description',
-    /describe\(`Optional model override for this agent[^`]*?`/,
+    /describe\(`Optional model override for this agent(?:[^`\\]|\\.)*?`/,
   );
 
   const aliases = configuredAliases(config);

--- a/src/built-in-patch-proofs.ts
+++ b/src/built-in-patch-proofs.ts
@@ -113,9 +113,13 @@ export function captureBuiltInPatchProofs(
     'PATCH 3: known-alias validator list',
     /\["sonnet","opus","haiku","fable"(?:,"[^"]+")*,"opusplan"(?:,"[^"]+")*\]/,
   );
+  // Ends at the template's own closing backtick, not at the `)` that used to follow it: Claude
+  // Code 2.1.242 started concatenating a conditional sentence onto the same string, and a proof
+  // that could no longer find the site turned every local patch into "could not capture built-in
+  // postconditions" — the same drift PATCH 4's own anchor had to absorb.
   addPattern(
     'PATCH 4: Agent tool model description',
-    /describe\(`Optional model override for this agent[^`]*?`\)/,
+    /describe\(`Optional model override for this agent[^`]*?`/,
   );
 
   const aliases = configuredAliases(config);

--- a/src/bun-bundle.ts
+++ b/src/bun-bundle.ts
@@ -1,0 +1,245 @@
+// src/bun-bundle.ts — the Claude Code bundle as ONE string, however many Bun modules hold it.
+//
+// Through Claude Code 2.1.241 the bundle was a single Bun module: tweakcc read it, clodex patched
+// the string, tweakcc wrote it back. 2.1.242 code-split it — the entry module became a ~20 KB ESM
+// stub that imports ~1,370 `chunk-*.js` siblings — so `readContent` started returning a stub with
+// none of clodex's anchors in it and `PATCH 1` failed on every platform and every executable
+// format at once.
+//
+// This module restores the old contract without changing a single patch transform: every
+// JavaScript module is read, joined into one document for `applyClodexPatches`, and split back
+// afterwards. `applyClodexPatches` stays a pure string -> string function that neither knows nor
+// cares how many modules the bundle arrived in.
+//
+// WRITING IT BACK IS THE HARD HALF. tweakcc's `writeContent` replaces the payload of every module
+// whose NAME it recognizes, with one buffer — it has no way to say "this module gets these bytes
+// and that one gets those". Calling it once per changed module is not an option either: every
+// repack of an ELF build relocates the whole ~290 MB blob to the end of the binary, so six repacks
+// would leave a multi-gigabyte claude and take minutes.
+//
+// So the write is one repack plus a pointer edit. Every changed module's patched source is
+// concatenated into the single buffer tweakcc writes, and then each module's `{ offset, length }`
+// pair in the blob's module table is repointed at its own slice of that buffer. The bytes are
+// already in the blob by then, so nothing moves and nothing grows: `repointBunModuleContents`
+// writes 8 bytes per module. When the ONLY changed module is the one tweakcc writes anyway — every
+// release up to 2.1.241, and any later one whose patches all land in the entry — the plan degrades
+// to exactly the call clodex has always made, with no pointer edit at all.
+
+import {
+  readBunJavaScriptModules,
+  readBunModuleTable,
+  repointBunModuleContents,
+  tweakccRecognizesModuleName,
+  type BunModuleRange,
+  type BunModuleSnapshot,
+} from './bun-entry-module.js';
+
+/**
+ * Position in the blob's module table of the module tweakcc will overwrite: the first one whose
+ * name it recognizes. Null when it would find nothing, which is the case the entry-module shim
+ * exists to prevent — so callers apply the shim first and treat null as "tweakcc cannot write
+ * this binary".
+ */
+export function writableModuleIndex(path: string): number | null {
+  const table = readBunModuleTable(path);
+  if (!table) return null;
+  const index = table.names.findIndex(tweakccRecognizesModuleName);
+  return index < 0 ? null : index;
+}
+
+/**
+ * What the modules are joined with: a line-delimited block comment, so the joined document stays
+ * parseable JavaScript and reads as a boundary to anyone looking at it.
+ *
+ * The punctuation inside it is not decoration. Every built-in anchor bounds its wildcards with a
+ * character class — `[^`]*?` in PATCH 4, `[^{}]*` in PATCH 6, `[^;{}]` in PATCH 5, `[^"]+` in the
+ * alias arrays, `[^\]]*` in PATCH 7 — and a separator those classes accept is one they can match
+ * ACROSS, binding a patch to a span that belongs to two modules at once. Carrying one of each
+ * makes that impossible by construction rather than by inspection. They are inside a comment, so
+ * none of them mean anything to JavaScript.
+ *
+ * `splitBundleSource` still counts the separators back out, because a patch that DELETED one would
+ * be caught by nothing else.
+ */
+export const BUNDLE_MODULE_SEPARATOR = '\n/*clodex:module-boundary`;{}"]*/\n';
+
+export interface ClaudeBundle {
+  /** Every JavaScript module in the binary, in blob order. */
+  modules: BunModuleSnapshot[];
+  /** All of them as one document — what the patch transforms see. */
+  source: string;
+}
+
+/**
+ * Read the whole bundle out of a native Claude Code binary, or null when the Bun blob cannot be
+ * parsed — in which case the caller falls back to tweakcc's own single-module read, which is what
+ * clodex did before code splitting existed.
+ */
+export function readClaudeBundle(path: string): ClaudeBundle | null {
+  const modules = readBunJavaScriptModules(path);
+  if (!modules || modules.length === 0) return null;
+  if (modules.some(module => module.source.includes(BUNDLE_MODULE_SEPARATOR))) return null;
+  // Every module is decoded as UTF-8 here and re-encoded as UTF-8 on the way back, so a module
+  // Bun stores in some other encoding would come back as replacement characters — and NOTHING
+  // downstream could see it, because the read-back check and the probe both decode the same way
+  // and would agree with each other. Every module of every real build measured (2.1.232 and
+  // 2.1.243) is pure ASCII, so this refuses rather than defends: an encoding that does not
+  // round-trip means fall back to tweakcc's single-module read, which on a split binary is a loud
+  // `PATCH 1` failure instead of a silently mangled module.
+  if (modules.some(module => !roundTripsAsUtf8(module.source, module.byteLength))) return null;
+  return { modules, source: modules.map(module => module.source).join(BUNDLE_MODULE_SEPARATOR) };
+}
+
+function roundTripsAsUtf8(source: string, byteLength: number): boolean {
+  return Buffer.byteLength(source, 'utf8') === byteLength && !source.includes('\uFFFD');
+}
+
+/**
+ * Split a patched document back into one source per module.
+ *
+ * A patch that consumed or duplicated a boundary would silently redistribute code between modules,
+ * so a piece count that does not match the bundle is a hard failure rather than a best effort.
+ */
+export function splitBundleSource(bundle: ClaudeBundle, patched: string): string[] {
+  const parts = patched.split(BUNDLE_MODULE_SEPARATOR);
+  if (parts.length !== bundle.modules.length) {
+    throw new Error(
+      `the patched bundle has ${parts.length} module boundaries, expected ${bundle.modules.length}`,
+    );
+  }
+  return parts;
+}
+
+/** One module's new payload, and where it sits inside the buffer tweakcc is asked to write. */
+interface BundleRepoint {
+  /** Position in the blob's module table. */
+  index: number;
+  /** Byte offset of this module's slice within the written buffer. */
+  start: number;
+  /** Byte length of this module's slice. */
+  length: number;
+  /** What those bytes must read back as. */
+  expected: string;
+}
+
+export interface BundleWritePlan {
+  /** The buffer handed to tweakcc's `writeContent`. */
+  content: string;
+  /** Empty when the write needs no pointer edit — the pre-2.1.242 shape. */
+  repoints: BundleRepoint[];
+}
+
+/**
+ * Work out what to hand `writeContent`, given the patched source of every module.
+ *
+ * `writableIndex` addresses the module tweakcc will overwrite — `writableModuleIndex`, taken with
+ * the shim in place. Its slice has to come FIRST, because that is the only slice whose position is
+ * known before the repack: everything else is addressed relative to where tweakcc puts this one.
+ * The module is identified by table position rather than by name because the shim renames it, so
+ * the name it answers to depends on when you look.
+ */
+export function planBundleWrite(
+  bundle: ClaudeBundle,
+  patchedSources: string[],
+  writableIndex: number,
+): BundleWritePlan {
+  if (patchedSources.length !== bundle.modules.length) {
+    throw new Error(
+      `expected ${bundle.modules.length} patched module sources, got ${patchedSources.length}`,
+    );
+  }
+  const writable = bundle.modules.findIndex(module => module.index === writableIndex);
+  if (writable < 0) {
+    throw new Error(`module ${writableIndex} is not one of this binary's JavaScript modules`);
+  }
+
+  const changed = bundle.modules
+    .map((module, at) => at)
+    .filter(at => at !== writable && patchedSources[at] !== bundle.modules[at]!.source);
+  // Nothing outside the module tweakcc writes changed, so write it the way clodex always has.
+  if (changed.length === 0) return { content: patchedSources[writable]!, repoints: [] };
+
+  const order = [writable, ...changed];
+  const repoints: BundleRepoint[] = [];
+  let content = '';
+  let start = 0;
+  for (const at of order) {
+    const source = patchedSources[at]!;
+    const length = Buffer.byteLength(source, 'utf8');
+    repoints.push({ index: bundle.modules[at]!.index, start, length, expected: source });
+    // Bun NUL-terminates every string in the blob, and tweakcc only appends one terminator — for
+    // the buffer as a whole. Separating the slices with a NUL gives every one of them the same
+    // trailing byte it would have had as a module of its own.
+    content += source + '\0';
+    start += length + 1;
+  }
+  return { content, repoints };
+}
+
+/**
+ * Point every changed module at its slice of the buffer tweakcc just wrote, and prove it landed.
+ *
+ * Called on the repacked candidate, where the blob has been rebuilt and the written buffer sits at
+ * an offset only the new module table knows.
+ */
+export function applyBundleWritePlan(path: string, plan: BundleWritePlan): void {
+  const table = readBunModuleTable(path);
+  // No table to check and no repoint to make: a binary clodex read through tweakcc's single-module
+  // path is one it also wrote that way, exactly as it always did.
+  if (!table) {
+    if (plan.repoints.length === 0) return;
+    throw new Error(`cannot read the Bun module table of ${path} after repacking`);
+  }
+  // tweakcc writes its buffer into EVERY module it recognizes, not just the first. The plan is
+  // built around exactly one, and the entry-module shim declines to fire when a recognized name
+  // already exists precisely so there is only ever one — so a second is a state nothing here
+  // understands, not a case to muddle through.
+  //
+  // Checked BEFORE the early return below. A plan with nothing to repoint is the common case — it
+  // is every release up to 2.1.241 — and it is not exempt: tweakcc would still have put the same
+  // buffer into that second module, and there would be no repoint afterwards to notice.
+  const recognized = table.names.filter(tweakccRecognizesModuleName);
+  if (recognized.length !== 1) {
+    throw new Error(
+      `${path} has ${recognized.length} modules tweakcc would write to; the patch was planned `
+      + 'around exactly one',
+    );
+  }
+  if (plan.repoints.length === 0) return;
+  const writable = table.names.findIndex(tweakccRecognizesModuleName);
+  if (writable !== plan.repoints[0]!.index) {
+    throw new Error(
+      `${path} exposes module ${writable} to tweakcc, but the patch was planned around module `
+      + `${plan.repoints[0]!.index}`,
+    );
+  }
+  const written = table.contents[writable]!;
+  const expectedBytes = Buffer.byteLength(plan.content, 'utf8');
+  // The repack is what put these bytes in the blob. If it wrote a different module, or a different
+  // number of bytes, every offset below would be computed against the wrong base — so refuse
+  // instead of repointing modules at whatever happens to be there.
+  if (written.length !== expectedBytes) {
+    throw new Error(
+      `${path} holds ${written.length} bytes where the ${expectedBytes} bytes clodex wrote should `
+      + 'be; refusing to repoint its modules',
+    );
+  }
+
+  const edits = plan.repoints.map(repoint => ({
+    index: repoint.index,
+    range: { offset: written.offset + repoint.start, length: repoint.length } satisfies BunModuleRange,
+  }));
+  repointBunModuleContents(path, edits);
+
+  // Read the result back through the same parser Bun's loader agrees with, rather than trusting
+  // the arithmetic above. A module left pointing at its neighbour's bytes is a binary that starts
+  // and then misbehaves, which is far worse than a patch that refuses.
+  const after = readBunJavaScriptModules(path);
+  if (!after) throw new Error(`cannot re-read the modules of ${path} after repointing them`);
+  const byIndex = new Map(after.map(module => [module.index, module.source]));
+  for (const repoint of plan.repoints) {
+    if (byIndex.get(repoint.index) !== repoint.expected) {
+      throw new Error(`module ${repoint.index} of ${path} did not read back as the patched source`);
+    }
+  }
+}

--- a/src/bun-bundle.ts
+++ b/src/bun-bundle.ts
@@ -51,12 +51,19 @@ export function writableModuleIndex(path: string): number | null {
  * What the modules are joined with: a line-delimited block comment, so the joined document stays
  * parseable JavaScript and reads as a boundary to anyone looking at it.
  *
- * The punctuation inside it is not decoration. Every built-in anchor bounds its wildcards with a
- * character class — `[^`]*?` in PATCH 4, `[^{}]*` in PATCH 6, `[^;{}]` in PATCH 5, `[^"]+` in the
- * alias arrays, `[^\]]*` in PATCH 7 — and a separator those classes accept is one they can match
- * ACROSS, binding a patch to a span that belongs to two modules at once. Carrying one of each
- * makes that impossible by construction rather than by inspection. They are inside a comment, so
- * none of them mean anything to JavaScript.
+ * The punctuation inside it is not decoration. Nearly every built-in anchor bounds its wildcards
+ * with a character class — `` (?:[^`\]|\.)*? `` in PATCH 4, `[^{}]*` in PATCH 6, `[^;{}]` in
+ * PATCH 5, `[^"]+` in the alias arrays, `[^\]]*` in PATCH 7 — and a separator those classes
+ * accept is one they can match ACROSS, binding a patch to a span that belongs to two modules at
+ * once. Carrying one of each makes that impossible by construction rather than by inspection.
+ * They are inside a comment, so none of them mean anything to JavaScript.
+ *
+ * It is NOT a whole-file invariant, and do not write one down: PATCH 10's anchor and its proof
+ * bound their wildcards with a negative lookahead (`(?:(?!\}\s*function )[\s\S])*?`) rather
+ * than a class, so those two CAN run across this separator. PATCH 10 is safe for its own reason —
+ * it separately validates that the end it matched is the starting function's real block end, which
+ * rejects a cross-module bind — and local patches are trusted code that may use any regex at all.
+ * The punctuation is what protects the class-bounded majority; it is not a proof about every site.
  *
  * `splitBundleSource` still counts the separators back out, because a patch that DELETED one would
  * be caught by nothing else.
@@ -90,6 +97,11 @@ export function readClaudeBundle(path: string): ClaudeBundle | null {
   return { modules, source: modules.map(module => module.source).join(BUNDLE_MODULE_SEPARATOR) };
 }
 
+// Only the U+FFFD half is independently pinned, and that is not an oversight: `byteLength` is the
+// length of the very bytes `source` was decoded from, so the length comparison can only differ
+// when the decode inserted a replacement character — which the second half already catches. It is
+// kept as belt-and-braces against a future reader path that supplies the two from different
+// places. Do not write a test claiming to pin it alone; no input can trip it alone.
 function roundTripsAsUtf8(source: string, byteLength: number): boolean {
   return Buffer.byteLength(source, 'utf8') === byteLength && !source.includes('\uFFFD');
 }

--- a/src/bun-entry-module.ts
+++ b/src/bun-entry-module.ts
@@ -49,6 +49,21 @@ const TAIL_SCAN_BYTES = 16 * 1024 * 1024;
 const MODULE_STRUCT_BYTES_CURRENT = 52;
 const MODULE_STRUCT_BYTES_LEGACY = 36;
 
+/**
+ * A module struct opens with `{ name, contents }` as two `{ u32 offset, u32 length }` pairs, so
+ * the payload pointer is always the second one, in both struct sizes.
+ */
+const CONTENTS_FIELD_AT = 8;
+
+/**
+ * The struct ends with four `u8`s — `encoding, loader, moduleFormat, side` — so the loader is
+ * three bytes from the end whichever struct size this blob uses.
+ */
+const LOADER_FROM_END = 3;
+
+/** Bun's loader id for a module it will execute as JavaScript. */
+export const BUN_JAVASCRIPT_LOADER = 1;
+
 /** A module path far longer than this is a misparse, not a name. */
 const MAX_MODULE_NAME_BYTES = 4096;
 
@@ -96,6 +111,24 @@ interface BunModuleNames {
   entryPointId: number;
   /** Absolute file offset of each name's bytes, parallel to `names`. */
   offsets: number[];
+  /** Where each module's payload lives, blob-relative, parallel to `names`. */
+  contents: BunModuleRange[];
+  /** Bun's loader id for each module, parallel to `names`. `1` is JavaScript. */
+  loaders: number[];
+  /** Absolute file offset the blob starts at; `contents` offsets are relative to it. */
+  blobAt: number;
+  /** Absolute file offset of the module struct table. */
+  modulesAt: number;
+  /** Bytes per module struct (36 or 52). */
+  structBytes: number;
+  /** The blob's own recorded size, used to bounds-check a rewritten range. */
+  byteCount: number;
+}
+
+/** A `{ offset, length }` pair out of a module struct, blob-relative. */
+export interface BunModuleRange {
+  offset: number;
+  length: number;
 }
 
 function readAt(fd: number, length: number, position: number): Buffer | null {
@@ -173,6 +206,8 @@ function parseBunModuleNamesAtUnchecked(fd: number, offsetsAt: number): BunModul
 
   const names: string[] = [];
   const nameOffsets: number[] = [];
+  const contents: BunModuleRange[] = [];
+  const loaders: number[] = [];
   for (let index = 0; index < moduleCount; index++) {
     const nameOffset = modules.readUInt32LE(index * structBytes);
     const nameLength = modules.readUInt32LE(index * structBytes + 4);
@@ -186,8 +221,23 @@ function parseBunModuleNamesAtUnchecked(fd: number, offsetsAt: number): BunModul
     if (!/^[\x20-\x7e]+$/.test(name)) return null;
     names.push(name);
     nameOffsets.push(blobAt + nameOffset);
+    contents.push({
+      offset: modules.readUInt32LE(index * structBytes + CONTENTS_FIELD_AT),
+      length: modules.readUInt32LE(index * structBytes + CONTENTS_FIELD_AT + 4),
+    });
+    loaders.push(modules.readUInt8(index * structBytes + structBytes - LOADER_FROM_END));
   }
-  return { names, entryPointId, offsets: nameOffsets };
+  return {
+    names,
+    entryPointId,
+    offsets: nameOffsets,
+    contents,
+    loaders,
+    blobAt,
+    modulesAt: blobAt + modulesOffset,
+    structBytes,
+    byteCount: Number(byteCount),
+  };
 }
 
 /** Every absolute offset of `marker`. A match cannot fit inside the needle-1 carry, so each is
@@ -306,6 +356,128 @@ export function listBunModuleNames(path: string): string[] | null {
   }
 }
 
+/** Everything about the blob's module table a caller needs to read or repoint a payload. */
+export interface BunModuleTable {
+  names: string[];
+  loaders: number[];
+  /** Where each module's payload lives, blob-relative. */
+  contents: BunModuleRange[];
+  entryPointId: number;
+  blobAt: number;
+  modulesAt: number;
+  structBytes: number;
+  byteCount: number;
+}
+
+/**
+ * The blob's module table, or null when the blob cannot be located and validated. Opens read-only,
+ * so it is safe on a pristine backup.
+ */
+export function readBunModuleTable(path: string): BunModuleTable | null {
+  const fd = openSync(path, 'r');
+  try {
+    const parsed = readBunModuleNames(fd, statSync(path).size);
+    if (!parsed) return null;
+    const { names, loaders, contents, entryPointId, blobAt, modulesAt, structBytes, byteCount } = parsed;
+    return { names, loaders, contents, entryPointId, blobAt, modulesAt, structBytes, byteCount };
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/** One module's name, position and payload, read out of the blob. */
+export interface BunModuleSnapshot {
+  /** Position in the blob's module table — the key a repoint is addressed by. */
+  index: number;
+  name: string;
+  source: string;
+  /** How many bytes the payload occupies in the blob, before any decoding. */
+  byteLength: number;
+}
+
+/**
+ * Every module Bun will execute as JavaScript, in blob order, or null when the blob cannot be read.
+ *
+ * Claude Code 2.1.242 split its bundle: what used to be one ~28 MB module is now a ~20 KB entry
+ * that imports ~1,370 `chunk-*.js` siblings, and tweakcc's `readContent` returns only the module it
+ * recognizes by name — the entry — which no longer holds any of the code clodex patches. Reading
+ * every JavaScript module is what puts the whole bundle back in front of the transforms.
+ *
+ * Assets (`mermaid.min.js`, `*.node`, the HTML payload) carry a different loader id and are left
+ * out: they are never executed as part of the bundle, and feeding megabytes of vendored JavaScript
+ * to anchors that must match exactly once is a way to invent ambiguity.
+ */
+export function readBunJavaScriptModules(path: string): BunModuleSnapshot[] | null {
+  const fd = openSync(path, 'r');
+  try {
+    const parsed = readBunModuleNames(fd, statSync(path).size);
+    if (!parsed) return null;
+    const modules: BunModuleSnapshot[] = [];
+    for (let index = 0; index < parsed.names.length; index++) {
+      if (parsed.loaders[index] !== BUN_JAVASCRIPT_LOADER) continue;
+      const range = parsed.contents[index]!;
+      // Bounds-checked against the blob's own recorded size, like every other derived offset here:
+      // a misparsed length is a `Buffer.alloc` of up to 4 GB, and a misparse has to degrade to "no
+      // bundle" rather than to a throw from inside a read.
+      if (range.offset < 0 || range.length < 0 || range.offset + range.length > parsed.byteCount) {
+        return null;
+      }
+      const bytes = range.length === 0
+        ? Buffer.alloc(0)
+        : readAt(fd, range.length, parsed.blobAt + range.offset);
+      if (!bytes) return null;
+      modules.push({
+        index,
+        name: parsed.names[index]!,
+        source: bytes.toString('utf8'),
+        byteLength: bytes.length,
+      });
+    }
+    return modules;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/**
+ * Point modules at different payload bytes, by rewriting the `{ offset, length }` pair in their
+ * module structs. Nothing is moved: every new range must already lie inside the blob, which is what
+ * makes this a pure pointer edit rather than a repack.
+ *
+ * `path` must be a private copy: this WRITES to it.
+ */
+export function repointBunModuleContents(
+  path: string,
+  edits: { index: number; range: BunModuleRange }[],
+): void {
+  if (edits.length === 0) return;
+  const fd = openSync(path, 'r+');
+  try {
+    const parsed = readBunModuleNames(fd, statSync(path).size);
+    if (!parsed) throw new Error(`cannot read the Bun module table of ${path}`);
+    for (const { index, range } of edits) {
+      if (index < 0 || index >= parsed.names.length) {
+        throw new Error(`module ${index} is outside the ${parsed.names.length}-module table of ${path}`);
+      }
+      if (range.offset < 0 || range.length < 0 || range.offset + range.length > parsed.byteCount) {
+        throw new Error(
+          `module ${index} would point at ${range.offset}+${range.length}, outside the `
+          + `${parsed.byteCount}-byte blob of ${path}`,
+        );
+      }
+      const at = parsed.modulesAt + index * parsed.structBytes + CONTENTS_FIELD_AT;
+      const pair = Buffer.alloc(8);
+      pair.writeUInt32LE(range.offset, 0);
+      pair.writeUInt32LE(range.length, 4);
+      if (writeSync(fd, pair, 0, pair.length, at) !== pair.length) {
+        throw new Error(`short write repointing module ${index} of ${path}`);
+      }
+    }
+  } finally {
+    closeSync(fd);
+  }
+}
+
 /**
  * Give an unpatchable Claude Code binary a module name tweakcc recognizes, so it
  * can read and repack it. Returns null — no write — when the binary already has a
@@ -380,7 +552,25 @@ export function restoreEntryModuleName(
     }
     writeNameBytes(fd, shim.original, offset);
     restoreEveryStandIn(fd, statSync(path).size, shim);
-    machO = resign && isMachO(fd);
+    machO = resign;
+  } finally {
+    closeSync(fd);
+  }
+  if (machO) resignMachOBinary(path);
+}
+
+/**
+ * Re-apply an ad-hoc Mach-O signature, which any write to a signed binary invalidates. A no-op on
+ * every other format and on every other host, because `codesign` only exists on macOS.
+ *
+ * Call this after ANY byte written past tweakcc's repack — the repack signs on its way out, so an
+ * edit after it leaves a binary macOS refuses to start.
+ */
+export function resignMachOBinary(path: string): void {
+  const fd = openSync(path, 'r');
+  let machO: boolean;
+  try {
+    machO = isMachO(fd);
   } finally {
     closeSync(fd);
   }

--- a/src/patch-transforms.ts
+++ b/src/patch-transforms.ts
@@ -38,7 +38,7 @@ import {
  * hash of the transform inputs to force that decision to be made rather than
  * forgotten.
  */
-export const PATCH_TRANSFORMS_VERSION = 8;
+export const PATCH_TRANSFORMS_VERSION = 9;
 
 export interface PatchScriptModelEntry {
   alias?: string;
@@ -436,6 +436,14 @@ export function applyClodexPatches(source: string, config: PatchScriptModelConfi
   // backtick so the model knows which extra names it may request and what they
   // actually are. Best-effort (cosmetic). The text is spliced into a backtick
   // template literal, so backticks and interpolation openers are stripped.
+  //
+  // The anchor ends at the template's own closing backtick and says nothing about
+  // what follows it. Through 2.1.241 the call closed immediately (`` `) ``);
+  // 2.1.242 started appending a conditional sentence to the same string
+  // (`` `+(fn()?"...":"") ``), and an anchor that insisted on the `)` read that as
+  // "not found" and silently dropped every custom model from the description the
+  // Agent tool shows. Nothing needs the closing paren: `[^`]*?` cannot cross a
+  // backtick, so the match still ends exactly where the template does.
   // ---------------------------------------------------------------------------
   {
     const safe = (s: string) => String(s).replace(/`/g, "'").replace(/\$\{/g, '(');
@@ -445,7 +453,7 @@ export function applyClodexPatches(source: string, config: PatchScriptModelConfi
     }).join('; ');
     applyOnce(
       'PATCH 4: Agent tool model description',
-      /(describe\(`Optional model override for this agent[^`]*?)(`\))/,
+      /(describe\(`Optional model override for this agent[^`]*?)(`)/,
       (_m, body, close) =>
         body!.includes('Additional custom models')
           ? body! + close!

--- a/src/patch-transforms.ts
+++ b/src/patch-transforms.ts
@@ -442,8 +442,16 @@ export function applyClodexPatches(source: string, config: PatchScriptModelConfi
   // 2.1.242 started appending a conditional sentence to the same string
   // (`` `+(fn()?"...":"") ``), and an anchor that insisted on the `)` read that as
   // "not found" and silently dropped every custom model from the description the
-  // Agent tool shows. Nothing needs the closing paren: `[^`]*?` cannot cross a
-  // backtick, so the match still ends exactly where the template does.
+  // Agent tool shows.
+  //
+  // The wildcard skips backslash pairs rather than stopping at the first backtick
+  // BYTE, so it ends at the template's real close even if the description ever
+  // contains an escaped backtick. A plain `[^`]*?` would stop mid-escape there and
+  // splice the addition after the backslash, turning the once-escaped backtick into
+  // a live terminator — a syntax error in a module Bun loads at startup. No shipped
+  // release has one (checked on 2.1.208-2.1.232 and all eight 2.1.243 builds), and
+  // this keeps that corner fail-closed instead of fail-open. Constraining what
+  // FOLLOWS the template is what drifted in 2.1.242; this constrains nothing.
   // ---------------------------------------------------------------------------
   {
     const safe = (s: string) => String(s).replace(/`/g, "'").replace(/\$\{/g, '(');
@@ -453,7 +461,7 @@ export function applyClodexPatches(source: string, config: PatchScriptModelConfi
     }).join('; ');
     applyOnce(
       'PATCH 4: Agent tool model description',
-      /(describe\(`Optional model override for this agent[^`]*?)(`)/,
+      /(describe\(`Optional model override for this agent(?:[^`\\]|\\.)*?)(`)/,
       (_m, body, close) =>
         body!.includes('Additional custom models')
           ? body! + close!

--- a/src/patcher.ts
+++ b/src/patcher.ts
@@ -63,7 +63,19 @@ import { projectProviderCachedModels } from './registry/materialize.js';
 import { isRetainedOpenCodeGoProvider } from './registry/resolve-template.js';
 import { findModelsDevModel } from './registry/models-dev.js';
 import { findClaudeBinary, getClaudeVersionForBinary } from './launch.js';
-import { restoreEntryModuleName, shimEntryModuleName } from './bun-entry-module.js';
+import {
+  resignMachOBinary,
+  restoreEntryModuleName,
+  shimEntryModuleName,
+} from './bun-entry-module.js';
+import {
+  applyBundleWritePlan,
+  planBundleWrite,
+  readClaudeBundle,
+  splitBundleSource,
+  writableModuleIndex,
+  type ClaudeBundle,
+} from './bun-bundle.js';
 import {
   backupDir,
   collectPristineFacts,
@@ -697,7 +709,9 @@ export async function applyPatch(
     // unless the seed itself has to change.
     candidateDir = mkdtempSync(join(dirname(binaryPath), '.clodex-patch-'));
     const candidatePath = join(candidateDir, basename(binaryPath));
-    const seedCandidate = async (from: string): Promise<{ installation: Installation; source: string }> => {
+    const seedCandidate = async (
+      from: string,
+    ): Promise<{ installation: Installation; source: string; bundle: ClaudeBundle | null }> => {
       copyFileSync(from, candidatePath);
       // Claude Code 2.1.229 renamed the module tweakcc looks for; the shim is a
       // same-length rename that only has to be in place while tweakcc reads. It
@@ -707,9 +721,29 @@ export async function applyPatch(
       // Claude Code's signature for an ad-hoc one) must not happen.
       const shim = shimEntryModuleName(candidatePath);
       const installation = await tryDetectInstallation({ path: candidatePath });
-      const source = await readContent(installation);
+      // Claude Code 2.1.242 split the bundle across ~1,370 modules, and tweakcc's
+      // `readContent` returns only the one it recognizes by name — since that
+      // release, a stub holding none of the code clodex patches. Read every
+      // JavaScript module instead and hand the transforms all of it; fall back to
+      // tweakcc when the blob cannot be parsed, which is exactly what clodex did
+      // before code splitting existed.
+      const bundle = readClaudeBundle(candidatePath);
+      // Say so when the fallback fires on a native binary. Otherwise a bundle clodex declined to
+      // read looks EXACTLY like a drifted anchor: the single-module read returns the entry, which
+      // on 2.1.242 and later is a stub, so the patch fails at its first required site and the
+      // report names that site and nothing else. (An npm install is plain JavaScript with no Bun
+      // blob in it, so its fallback is the normal path and says nothing.)
+      if (!bundle && installation.kind === 'native') {
+        p.log.warn(
+          `Could not read ${candidatePath} as a Bun module table, so only the module tweakcc names `
+          + 'is being patched. On Claude Code 2.1.242 and later that module is a stub holding none '
+          + 'of the code clodex patches, and the patch below will fail at its first required '
+          + 'site — the cause is this read, not a changed anchor.',
+        );
+      }
+      const source = bundle ? bundle.source : await readContent(installation);
       if (shim) restoreEntryModuleName(candidatePath, shim, { resign: false });
-      return { installation, source };
+      return { installation, source, bundle };
     };
 
     const facts: PristineFacts = collectPristineFacts({
@@ -719,7 +753,7 @@ export async function applyPatch(
     });
 
     const initial = planPristineSource(facts);
-    let loaded: { installation: Installation; source: string } | null = null;
+    let loaded: { installation: Installation; source: string; bundle: ClaudeBundle | null } | null = null;
     let plan: ResolvedPristinePlan;
     if (initial.action === 'inspect') {
       // Unrecognized bytes. The only reliable "is this already patched?" signal
@@ -865,8 +899,30 @@ export async function applyPatch(
     // because Claude Code's sibling native modules resolve against the entry
     // module's own path.
     const writeShim = shimEntryModuleName(candidatePath);
-    await writeContent(loaded.installation, local.content);
+    let repointed = false;
+    if (loaded.bundle) {
+      // One repack, however many modules the patch touched: everything changed goes into the
+      // buffer tweakcc writes, and each module is then pointed at its own slice of it. Repacking
+      // once per module instead would relocate the whole blob every time on ELF builds.
+      const writable = writableModuleIndex(candidatePath);
+      if (writable === null) {
+        throw new Error('no module of the patch candidate carries a name tweakcc can write to');
+      }
+      const plan = planBundleWrite(
+        loaded.bundle,
+        splitBundleSource(loaded.bundle, local.content),
+        writable,
+      );
+      await writeContent(loaded.installation, plan.content);
+      applyBundleWritePlan(candidatePath, plan);
+      repointed = plan.repoints.length > 0;
+    } else {
+      await writeContent(loaded.installation, local.content);
+    }
     if (writeShim) restoreEntryModuleName(candidatePath, writeShim, { resign: true });
+    // The repack signs on its way out, so a repoint after it leaves an invalid signature. Restoring
+    // the entry-module name re-signs already; this covers the binary that needed no shim.
+    else if (repointed) resignMachOBinary(candidatePath);
     patchedSize = statSync(candidatePath).size;
     patchedSha256 = sha256File(candidatePath);
     renameSync(candidatePath, binaryPath);

--- a/tests/bun-blob-fixture.ts
+++ b/tests/bun-blob-fixture.ts
@@ -16,6 +16,14 @@ export interface BunModuleFixture {
   name: string;
   /** The module's payload. Only the entry module's is ever read as the bundle. */
   contents?: string;
+  /**
+   * Bun's loader id. `1` is JavaScript and is the default; real binaries also carry `5` (vendored
+   * text assets like `mermaid.min.js`) and `10` (napi `*.node` modules). Those are NOT part of the
+   * bundle, so `readBunJavaScriptModules` skips them — which means blob-table positions and
+   * positions within the bundle are different numbers, and a fixture with only JavaScript in it
+   * cannot tell the two apart.
+   */
+  loader?: number;
 }
 
 export interface BunBlobOptions {
@@ -77,7 +85,7 @@ export function buildBunBlob(
       at += 8;
     }
     blob.writeUInt8(1, at); // encoding
-    blob.writeUInt8(1, at + 1); // loader
+    blob.writeUInt8(modules[module]!.loader ?? 1, at + 1); // loader
     blob.writeUInt8(2, at + 2); // moduleFormat
     blob.writeUInt8(0, at + 3); // side
   }
@@ -100,6 +108,7 @@ export function buildBunBlob(
 export interface ParsedBunBlob {
   names: string[];
   contents: string[];
+  loaders: number[];
   entryPointId: number;
 }
 
@@ -119,6 +128,7 @@ export function parseBunBlob(binary: Buffer): ParsedBunBlob {
 
   const names: string[] = [];
   const contents: string[] = [];
+  const loaders: number[] = [];
   for (let module = 0; module < modulesLength / structBytes; module++) {
     const at = blobAt + modulesOffset + module * structBytes;
     const read = (field: number) => {
@@ -128,8 +138,9 @@ export function parseBunBlob(binary: Buffer): ParsedBunBlob {
     };
     names.push(read(0));
     contents.push(read(1));
+    loaders.push(binary.readUInt8(at + structBytes - 3));
   }
-  return { names, contents, entryPointId };
+  return { names, contents, loaders, entryPointId };
 }
 
 /**
@@ -157,6 +168,7 @@ export function rebuildFakeNativeClaude(
     parsed.names.map((name, index) => ({
       name,
       contents: contentsByIndex(index, parsed.contents[index]!),
+      loader: parsed.loaders[index]!,
     })),
     { entryPointId: parsed.entryPointId },
   );

--- a/tests/bun-bundle.test.ts
+++ b/tests/bun-bundle.test.ts
@@ -1,0 +1,340 @@
+// Reading a code-split Claude Code bundle as one document, and writing it back in one repack.
+//
+// Claude Code 2.1.242 turned its single ~28 MB Bun module into a ~20 KB entry plus ~1,370 chunks.
+// tweakcc reads and writes ONE module — the one it recognizes by name — so everything here is
+// about the other 1,369: getting their source in front of the transforms, and getting the patched
+// result back into the blob without repacking once per module.
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  applyBundleWritePlan,
+  BUNDLE_MODULE_SEPARATOR,
+  planBundleWrite,
+  readClaudeBundle,
+  splitBundleSource,
+  writableModuleIndex,
+} from '../src/bun-bundle.js';
+import {
+  readBunJavaScriptModules,
+  readBunModuleTable,
+  repointBunModuleContents,
+  tweakccRecognizesModuleName,
+} from '../src/bun-entry-module.js';
+import { closeSync, openSync, writeSync } from 'node:fs';
+import { buildFakeNativeClaude, parseBunBlob, rebuildFakeNativeClaude } from './bun-blob-fixture.js';
+
+/**
+ * Table positions and bundle positions are DIFFERENT NUMBERS, and this fixture is built so they
+ * disagree: assets sit between the JavaScript modules, so the JavaScript lives at table positions
+ * 0, 2, 4, 5. On every Claude Code shipped so far the assets happen to sort last, which makes the
+ * two accidentally equal — and a repoint addressed by the wrong one would still pass.
+ *
+ * `entryPointId` is also deliberately not the module tweakcc writes: tweakcc finds its module by
+ * NAME, and reading `entryPointId` instead would agree with it on every real build.
+ */
+const MODULES = [
+  { name: '/$bunfs/root/chunk-a.js', contents: 'export const a=1;' },
+  { name: '/$bunfs/root/mermaid.min.js', loader: 5, contents: 'export const a=99;' },
+  { name: '/$bunfs/root/chunk-b.js', contents: 'export const b=2;' },
+  { name: '/$bunfs/root/image-processor.node', loader: 10, contents: 'native helper' },
+  { name: '/$bunfs/root/claude', contents: 'import{a}from"./chunk-a.js";a;' },
+  { name: '/$bunfs/root/chunk-c.js', contents: 'export const c=3;' },
+];
+/** Table position of the module tweakcc recognizes and writes. */
+const WRITABLE_ID = 4;
+/** Its position within the bundle — not the same number. */
+const WRITABLE_AT = 2;
+/** The module Bun starts at, deliberately not the one tweakcc writes. */
+const ENTRY_ID = 0;
+/** Table positions of the JavaScript modules, in bundle order. */
+const JS_IDS = [0, 2, 4, 5];
+
+function withBinary(
+  modules: { name: string; contents: string; loader?: number }[],
+  run: (path: string) => void,
+): void {
+  const dir = mkdtempSync(join(tmpdir(), 'clodex-bun-bundle-'));
+  try {
+    const path = join(dir, 'claude');
+    writeFileSync(path, buildFakeNativeClaude('2.1.243', modules, { entryPointId: ENTRY_ID }));
+    run(path);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Stand in for tweakcc's `writeContent`, which replaces the payload of every module whose NAME it
+ * recognizes and rebuilds the blob around it — the behaviour that makes one call per module the
+ * only thing its API offers, and the reason the repoint below exists.
+ */
+function fakeWriteContent(path: string, content: string): void {
+  const parsed = parseBunBlob(readFileSync(path));
+  writeFileSync(path, rebuildFakeNativeClaude(
+    readFileSync(path),
+    '2.1.243',
+    // EVERY recognized module, exactly as tweakcc does — it has no way to say "this one".
+    (index, previous) => (tweakccRecognizesModuleName(parsed.names[index]!) ? content : previous),
+  ));
+}
+
+/** Overwrite one module's `{offset,length}` pair directly, without the bounds check on the way. */
+function forceContentRange(path: string, index: number, offset: number, length: number): void {
+  const table = readBunModuleTable(path)!;
+  const pair = Buffer.alloc(8);
+  pair.writeUInt32LE(offset, 0);
+  pair.writeUInt32LE(length, 4);
+  const fd = openSync(path, 'r+');
+  try {
+    writeSync(fd, pair, 0, 8, table.modulesAt + index * table.structBytes + 8);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+const jsModules = MODULES.filter((_, index) => JS_IDS.includes(index));
+
+describe('readClaudeBundle', () => {
+  it('joins every JavaScript module into one document, in blob order', () => {
+    withBinary(MODULES, path => {
+      const bundle = readClaudeBundle(path)!;
+      expect(bundle.modules.map(module => module.name))
+        .toEqual(jsModules.map(module => module.name));
+      expect(bundle.source)
+        .toBe(jsModules.map(module => module.contents).join(BUNDLE_MODULE_SEPARATOR));
+    });
+  });
+
+  it('leaves out the modules Bun does not execute as JavaScript, and keeps their table positions', () => {
+    withBinary(MODULES, path => {
+      const bundle = readClaudeBundle(path)!;
+      // The vendored asset at table position 1 carries `export const a=99;` — text a transform
+      // could match. Including it would make an anchor ambiguous; addressing a repoint by bundle
+      // position instead of table position would rewrite the WRONG module.
+      expect(bundle.modules.map(module => module.index)).toEqual(JS_IDS);
+      expect(bundle.source).not.toContain('a=99');
+      expect(bundle.source).not.toContain('native helper');
+    });
+  });
+
+  it('reports no bundle when a module already contains the boundary marker', () => {
+    // Splitting would then cut in a place no patch put a boundary, silently moving code between
+    // modules. Falling back to tweakcc's single-module read fails loudly instead.
+    const poisoned = MODULES.map((module, index) => index === 0
+      ? { ...module, contents: `export const a=1;${BUNDLE_MODULE_SEPARATOR}` }
+      : module);
+    withBinary(poisoned, path => expect(readClaudeBundle(path)).toBeNull());
+  });
+
+  it('reports no bundle when a module is not valid UTF-8', () => {
+    // Decoding and re-encoding would replace those bytes, and every check downstream decodes the
+    // same way — so it would agree with itself and publish a mangled module.
+    //
+    // A TRUNCATED four-byte sequence, deliberately: it decodes to one replacement character that
+    // re-encodes to the same three bytes it occupied, so the byte-length half of the check is
+    // satisfied and only the replacement-character half can catch it. `ff fe` would be caught by
+    // the length alone and would leave the other half unpinned.
+    withBinary(MODULES, path => {
+      const table = readBunModuleTable(path)!;
+      const range = table.contents[0]!;
+      const fd = openSync(path, 'r+');
+      try {
+        writeSync(fd, Buffer.from([0xf0, 0x90, 0x80]), 0, 3, table.blobAt + range.offset);
+      } finally {
+        closeSync(fd);
+      }
+      expect(readClaudeBundle(path)).toBeNull();
+    });
+  });
+
+  it('keeps the module boundary out of reach of every anchor\'s wildcards', () => {
+    // Each built-in anchor bounds its wildcard with a character class. A separator any of them
+    // accepts is one they can match ACROSS, binding a patch to a span belonging to two modules —
+    // and the boundary COUNT would be unchanged, so nothing downstream would notice.
+    for (const forbidden of ['`', '{', '}', ';', '"', ']']) {
+      expect(BUNDLE_MODULE_SEPARATOR).toContain(forbidden);
+    }
+    // ...and it is still a comment, so the joined document is still JavaScript.
+    expect(BUNDLE_MODULE_SEPARATOR.trim().startsWith('/*')).toBe(true);
+    expect(BUNDLE_MODULE_SEPARATOR.trim().endsWith('*/')).toBe(true);
+    expect(BUNDLE_MODULE_SEPARATOR.trim().slice(2, -2)).not.toContain('*/');
+  });
+
+  it('reports no bundle when a payload range runs past the end of the blob', () => {
+    // Padded so the bytes past the blob are still IN the file and are still valid ASCII — which is
+    // the real shape (a Mach-O code signature follows the `__BUN` section) and the only one where
+    // this guard is what does the work. Without the padding the read simply runs off the end, and
+    // the guard could be deleted with nothing to show for it.
+    const dir = mkdtempSync(join(tmpdir(), 'clodex-bun-bundle-'));
+    try {
+      const path = join(dir, 'claude');
+      writeFileSync(path, Buffer.concat([
+        buildFakeNativeClaude('2.1.243', MODULES, { entryPointId: ENTRY_ID }),
+        Buffer.from('A'.repeat(4096)),
+      ]));
+      const table = readBunModuleTable(path)!;
+      expect(readClaudeBundle(path)).not.toBeNull();
+      // The blob's own recorded size is the only thing that says how far a payload may go. Point a
+      // module past it and what gets read as Claude Code source is whatever the container put
+      // there — here 64 bytes of perfectly valid ASCII, which every other guard is happy with.
+      forceContentRange(path, 0, table.byteCount + 47, 64);
+      expect(readClaudeBundle(path)).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses to point a module outside the blob', () => {
+    withBinary(MODULES, path => {
+      const table = readBunModuleTable(path)!;
+      expect(() => repointBunModuleContents(path, [
+        { index: 0, range: { offset: 1, length: table.byteCount } },
+      ])).toThrow(/outside the .*-byte blob/);
+    });
+  });
+
+  it('reports no bundle when the file carries no readable Bun blob', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'clodex-bun-bundle-'));
+    try {
+      const path = join(dir, 'claude');
+      writeFileSync(path, 'not a native binary at all');
+      expect(readClaudeBundle(path)).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('splitBundleSource', () => {
+  it('refuses a patched document that lost a module boundary', () => {
+    withBinary(MODULES, path => {
+      const bundle = readClaudeBundle(path)!;
+      // What a patch that matched ACROSS two modules would leave behind. Splitting it anyway would
+      // hand one module its neighbour's code and leave the neighbour empty.
+      const mangled = bundle.source.replace(BUNDLE_MODULE_SEPARATOR, '');
+      expect(() => splitBundleSource(bundle, mangled)).toThrow(/3 module boundaries, expected 4/);
+    });
+  });
+});
+
+describe('planBundleWrite', () => {
+  it('writes only the module tweakcc writes when nothing else changed', () => {
+    withBinary(MODULES, path => {
+      const bundle = readClaudeBundle(path)!;
+      const patched = bundle.modules.map(module => module.source);
+      patched[WRITABLE_AT] = 'patched entry';
+      const plan = planBundleWrite(bundle, patched, WRITABLE_ID);
+      // The pre-2.1.242 shape: exactly the call clodex has always made, and no pointer edit.
+      expect(plan).toEqual({ content: 'patched entry', repoints: [] });
+    });
+  });
+
+  it('puts the writable module first and NUL-separates the slices', () => {
+    withBinary(MODULES, path => {
+      const bundle = readClaudeBundle(path)!;
+      const patched = bundle.modules.map(module => module.source);
+      patched[3] = 'export const c=33;';
+      const plan = planBundleWrite(bundle, patched, WRITABLE_ID);
+      expect(plan.content).toBe(`${MODULES[WRITABLE_ID]!.contents}\0export const c=33;\0`);
+      // Addressed by TABLE position, not by position within the bundle.
+      expect(plan.repoints.map(repoint => repoint.index)).toEqual([WRITABLE_ID, JS_IDS[3]]);
+      expect(plan.repoints[1]!.start).toBe(MODULES[WRITABLE_ID]!.contents.length + 1);
+    });
+  });
+});
+
+describe('applyBundleWritePlan', () => {
+  it('points every patched module at its own slice of the one buffer that was written', () => {
+    withBinary(MODULES, path => {
+      const bundle = readClaudeBundle(path)!;
+      const patched = bundle.modules.map(module => module.source);
+      patched[0] = 'export const a=111;';
+      patched[3] = 'export const c=333;';
+      // Found by the name tweakcc recognizes, which is NOT `entryPointId` here.
+      expect(writableModuleIndex(path)).toBe(WRITABLE_ID);
+      const plan = planBundleWrite(bundle, patched, writableModuleIndex(path)!);
+
+      fakeWriteContent(path, plan.content);
+      // Before the repoint, the module tweakcc wrote holds ALL of it — which is exactly the
+      // corruption this step exists to undo.
+      expect(readBunJavaScriptModules(path)![WRITABLE_AT]!.source).toBe(plan.content);
+
+      applyBundleWritePlan(path, plan);
+      expect(readBunJavaScriptModules(path)!.map(module => module.source)).toEqual([
+        'export const a=111;',
+        MODULES[2]!.contents,
+        MODULES[WRITABLE_ID]!.contents,
+        'export const c=333;',
+      ]);
+    });
+  });
+
+  it('refuses to repoint when the bytes in the binary are not the ones it planned around', () => {
+    withBinary(MODULES, path => {
+      const bundle = readClaudeBundle(path)!;
+      const patched = bundle.modules.map(module => module.source);
+      patched[0] = 'export const a=111;';
+      const plan = planBundleWrite(bundle, patched, WRITABLE_ID);
+      // A repack that wrote a different string — or a different module — would leave every offset
+      // below computed against the wrong base, so this has to fail loudly rather than repoint into
+      // whatever happens to be there.
+      fakeWriteContent(path, `${plan.content}unexpected extra bytes`);
+      expect(() => applyBundleWritePlan(path, plan)).toThrow(/refusing to repoint/);
+    });
+  });
+
+  it('refuses more than one module tweakcc would write to even when nothing needs repointing', () => {
+    // The common shape — every release up to 2.1.241 patches only the module tweakcc writes — and
+    // therefore the one an early return would exempt. tweakcc would still have put the same buffer
+    // into the second recognized module, and with no repoint to follow there is nothing else that
+    // would ever look at it.
+    const twoRecognized = MODULES.map((module, index) => index === 0
+      ? { ...module, name: '/$bunfs/root/src/entrypoints/cli.js' }
+      : module);
+    withBinary(twoRecognized, path => {
+      const bundle = readClaudeBundle(path)!;
+      const patched = bundle.modules.map(module => module.source);
+      patched[0] = 'patched entry';
+      const plan = planBundleWrite(bundle, patched, 0);
+      expect(plan.repoints).toEqual([]);
+      fakeWriteContent(path, plan.content);
+      expect(() => applyBundleWritePlan(path, plan)).toThrow(/2 modules tweakcc would write to/);
+    });
+  });
+
+  it('refuses when the blob has more than one module tweakcc would write to', () => {
+    // tweakcc puts its buffer into EVERY recognized module, and the plan repoints exactly one — so
+    // the second would be published holding the whole concatenation of unrelated chunks. The
+    // read-back loop cannot see it, because a module nobody repointed is a module nobody checks.
+    const twoRecognized = MODULES.map((module, index) => index === 0
+      ? { ...module, name: '/$bunfs/root/src/entrypoints/cli.js' }
+      : module);
+    withBinary(twoRecognized, path => {
+      const bundle = readClaudeBundle(path)!;
+      const patched = bundle.modules.map(module => module.source);
+      patched[3] = 'export const c=333;';
+      const plan = planBundleWrite(bundle, patched, 0);
+      fakeWriteContent(path, plan.content);
+      expect(() => applyBundleWritePlan(path, plan))
+        .toThrow(/2 modules tweakcc would write to/);
+    });
+  });
+
+  it('refuses when a repointed module does not read back as the patched source', () => {
+    withBinary(MODULES, path => {
+      const bundle = readClaudeBundle(path)!;
+      const patched = bundle.modules.map(module => module.source);
+      patched[0] = 'export const a=111;';
+      patched[3] = 'export const c=333;';
+      const plan = planBundleWrite(bundle, patched, WRITABLE_ID);
+      fakeWriteContent(path, plan.content);
+      // The buffer is intact and the right length, so the length check above still passes — only
+      // reading each module back can catch a slice that starts one byte late.
+      plan.repoints[1]!.start += 1;
+      expect(() => applyBundleWritePlan(path, plan)).toThrow(/did not read back/);
+    });
+  });
+});

--- a/tests/bun-bundle.test.ts
+++ b/tests/bun-bundle.test.ts
@@ -25,6 +25,8 @@ import {
 } from '../src/bun-entry-module.js';
 import { closeSync, openSync, writeSync } from 'node:fs';
 import { buildFakeNativeClaude, parseBunBlob, rebuildFakeNativeClaude } from './bun-blob-fixture.js';
+import { applyClodexPatches } from '../src/patch-transforms.js';
+import { CLAUDE_FIXTURE } from './fixtures/claude-bundle.js';
 
 /**
  * Table positions and bundle positions are DIFFERENT NUMBERS, and this fixture is built so they
@@ -150,6 +152,32 @@ describe('readClaudeBundle', () => {
     });
   });
 
+  it('stops an anchor binding across a boundary, which a punctuation-free separator would not', () => {
+    // The BEHAVIOURAL version of the assertion below, and the reason the punctuation is there. A
+    // module whose text ends mid-template — a shape a code-split chunk can genuinely have — is
+    // joined ahead of the real bundle.
+    //
+    // With a plain `/*clodex:module-boundary*/` separator, PATCH 4's wildcard runs from the stray
+    // `describe(` ACROSS the boundary and the replacement consumes the span between them, so the
+    // real Agent-tool description is DESTROYED — what is left is `describe(` with its template
+    // opener eaten — and the site still reports OK. The boundary count is unchanged, the split
+    // succeeds and the read-back succeeds, so nothing else in the pipeline notices.
+    const stray = 'var stray=describe(`Optional model override for this agent. Truncated';
+    const config = { 'clodex:openai:m': { alias: 'luna', display: 'Luna' } };
+    const across = (separator: string) => {
+      const out = applyClodexPatches([stray, CLAUDE_FIXTURE].join(separator), config);
+      return {
+        status: out.results.find(result => result.name.startsWith('PATCH 4'))!.status,
+        // The template opener the real module owned, eaten by a match that started in the stray.
+        mangled: out.content.includes('describe( '),
+      };
+    };
+    expect(across('\n/*clodex:module-boundary*/\n')).toEqual({ status: 'OK', mangled: true });
+    // The separator carries a backtick, so it closes the stray template instead of being crossed:
+    // the anchor finds two candidates and refuses rather than corrupting a module it never owned.
+    expect(across(BUNDLE_MODULE_SEPARATOR)).toEqual({ status: 'FAIL', mangled: false });
+  });
+
   it('keeps the module boundary out of reach of every anchor\'s wildcards', () => {
     // Each built-in anchor bounds its wildcard with a character class. A separator any of them
     // accepts is one they can match ACROSS, binding a patch to a span belonging to two modules —
@@ -269,6 +297,35 @@ describe('applyBundleWritePlan', () => {
         MODULES[WRITABLE_ID]!.contents,
         'export const c=333;',
       ]);
+    });
+  });
+
+  it('refuses to repoint when the repack reordered the module table', () => {
+    // The ONLY guard that can see a repack which preserves every module but changes their table
+    // order — and the read-back loop provably cannot substitute for it, because it compares each
+    // index AFTER writing that index, so a repoint into a shuffled table reads back as exactly
+    // what was just written. The pinned tweakcc preserves order today, which is what makes this
+    // calibration rather than a live hole; it is also what would silently disarm on a bump.
+    withBinary(MODULES, path => {
+      const bundle = readClaudeBundle(path)!;
+      const patched = bundle.modules.map(module => module.source);
+      patched[0] = 'export const a=111;';
+      const plan = planBundleWrite(bundle, patched, WRITABLE_ID);
+      fakeWriteContent(path, plan.content);
+      // Rebuild the blob with the SAME modules in a rotated order: nothing is lost, but the
+      // module tweakcc now exposes is no longer the one the plan was addressed to.
+      const parsed = parseBunBlob(readFileSync(path));
+      const rotate = <T,>(xs: T[]) => [...xs.slice(1), xs[0]!];
+      writeFileSync(path, buildFakeNativeClaude(
+        '2.1.243',
+        rotate(parsed.names.map((name, index) => ({
+          name,
+          contents: parsed.contents[index]!,
+          loader: parsed.loaders[index]!,
+        }))),
+        { entryPointId: parsed.entryPointId },
+      ));
+      expect(() => applyBundleWritePlan(path, plan)).toThrow(/planned around module/);
     });
   });
 

--- a/tests/fixtures/claude-bundle.ts
+++ b/tests/fixtures/claude-bundle.ts
@@ -6,8 +6,18 @@
 // is what stops a new or renamed PATCH site from reaching the hourly canary as a mystery failure
 // on every platform at once.
 
+/**
+ * The Agent tool's `model` enum and its description, as Claude Code 2.1.242 spells them: the
+ * description template no longer closes its `describe(` call directly, it is concatenated with a
+ * conditional sentence first. PATCH 4's anchor used to require the closing paren and silently
+ * stopped matching on that release.
+ */
+const ENUM_AND_DESCRIPTION =
+  '.enum(["sonnet","opus","haiku","fable"]).optional().describe(`Optional model override for this '
+  + 'agent. Defaults to inherit.`+(hint()?" Prefer the session model.":""))';
+
 export const CLAUDE_CORE_FIXTURE = [
-  '.enum(["sonnet","opus","haiku","fable"]).optional().describe(`Optional model override for this agent. Defaults to inherit.`)',
+  ENUM_AND_DESCRIPTION,
   'var KNOWN=["sonnet","opus","haiku","fable","opusplan"];',
   'function rz(x){switch(x){case"best":{return "opus"}default:return null}}',
   'function opts(e,t,r){let n=cur(),o=(n==="opus"||n==="sonnet")&&n!==r?[n,r]:[r];for(let i of o)Dlh(e,i,t);return e}',
@@ -31,3 +41,70 @@ export const CLAUDE_PROXY_EFFORT_FIXTURE = [
   'function eqe(e){if(SNr(e))return!1;let t=Ede(e,"max_effort");if(t!==void 0)return t;return proxyMode(e)}',
   'function ait(e){return ww(lo(e))?.default_effort??"high"}',
 ].join('\n');
+
+/**
+ * The same bundle, code-split the way Claude Code 2.1.242 splits it: a small entry module that
+ * imports its siblings, with the patch anchors spread across chunks that tweakcc's name-based read
+ * never returns.
+ *
+ * Three things about the shape are deliberate, because a fixture without them lets real defects
+ * through:
+ *
+ *  * The entry module is NOT at table index 0, so a plan that assumed the module tweakcc writes
+ *    comes first in the table would still pass.
+ *  * A non-JavaScript module sits BETWEEN two chunks, so a module's position in the blob table and
+ *    its position in the bundle are different numbers. On every build shipped so far the assets
+ *    happen to sort last, which makes the two accidentally equal.
+ *  * That module's payload contains a patch anchor. Bun never executes it, so clodex must never
+ *    patch it — vendored JavaScript (`mermaid.min.js`, `hljsBundle.generated.min.js`) is exactly
+ *    this shape. Include it in the bundle and the anchor matches twice and the patch refuses.
+ */
+export const CLAUDE_SPLIT_MODULES = [
+  {
+    name: '/$bunfs/root/chunk-agent.js',
+    contents: `export var agentTool=z${CLAUDE_CORE_FIXTURE.split('\n')[0]};`,
+  },
+  {
+    name: '/$bunfs/root/vendored.min.js',
+    loader: 5,
+    contents: `var vendored=z${CLAUDE_CORE_FIXTURE.split('\n')[0]};`,
+  },
+  {
+    name: '/$bunfs/root/chunk-aliases.js',
+    contents: CLAUDE_CORE_FIXTURE.split('\n').slice(1, 3).join('\n'),
+  },
+  {
+    name: '/$bunfs/root/cli',
+    contents: 'import{agentTool}from"/$bunfs/root/chunk-agent.js";'
+      + 'import{main}from"/$bunfs/root/chunk-runtime.js";main(agentTool);',
+  },
+  {
+    name: '/$bunfs/root/image-processor.node',
+    loader: 10,
+    contents: 'native helper',
+  },
+  {
+    // A real pre-split blob carries five of these ~2 KB loader-1 stubs beside the bundle, and they
+    // now reach the transforms too. One is here so a near-miss in an auxiliary module is a shape
+    // the suite has seen.
+    name: '/$bunfs/root/audio-capture.js',
+    contents: 'export default require("/$bunfs/root/audio-capture.node");'
+      + 'var notTheEnum=["sonnet","opus"];',
+  },
+  {
+    name: '/$bunfs/root/chunk-runtime.js',
+    contents: [
+      CLAUDE_CORE_FIXTURE.split('\n').slice(3).join('\n'),
+      ...CLAUDE_FIXTURE.split('\n').slice(CLAUDE_CORE_FIXTURE.split('\n').length),
+    ].join('\n'),
+  },
+];
+
+/**
+ * Table position of `/$bunfs/root/cli`: Bun's entry point, and — once the shim has renamed it —
+ * the module tweakcc writes. Those are the same module on every real build.
+ */
+export const CLAUDE_SPLIT_ENTRY_ID = 3;
+
+/** Table positions of the modules Bun executes as JavaScript. Sparse, because assets sit between. */
+export const CLAUDE_SPLIT_JS_IDS = [0, 2, 3, 5, 6];

--- a/tests/patcher-command.test.ts
+++ b/tests/patcher-command.test.ts
@@ -178,6 +178,24 @@ describe('runPatchCommand version resolution', () => {
     expect(manifest?.pristineSha256).toBe(createHash('sha256').update(pristineBytes).digest('hex'));
   });
 
+  it('says so when it can only read the one module tweakcc names', async () => {
+    // These fixtures carry their "bundle" after a sentinel rather than in a Bun blob, so the
+    // module table is unreadable and the single-module fallback is what runs — the same state a
+    // real binary would be in if its blob ever stopped parsing.
+    //
+    // On Claude Code 2.1.242 and later that fallback returns a stub with no anchors in it, and the
+    // patch then fails at its first required site. Without this line the report names that site
+    // and nothing else, which reads exactly like an anchor that drifted upstream and sends whoever
+    // triages it looking in the wrong place.
+    const real = installClaude('2.1.220');
+
+    expect(await runPatchCommand({})).toBe(0);
+
+    expect(bundleOf(real)).toContain('"sol"');
+    expect(logs.join('\n')).toMatch(/Could not read .* as a Bun module table/);
+    expect(logs.join('\n')).toMatch(/the cause is this read, not a changed anchor/);
+  });
+
   it('takes the version from TWEAKCC_CC_INSTALLATION_PATH\'s binary, not from PATH', async () => {
     const target = join(home, 'opt', 'claude-2.1.999');
     writeFakeClaude(target, '2.1.999');

--- a/tests/patcher.test.ts
+++ b/tests/patcher.test.ts
@@ -4,6 +4,8 @@ import {
   CLAUDE_CORE_FIXTURE,
   CLAUDE_FIXTURE,
   CLAUDE_PROXY_EFFORT_FIXTURE,
+  CLAUDE_SPLIT_ENTRY_ID,
+  CLAUDE_SPLIT_MODULES,
 } from './fixtures/claude-bundle.js';
 import {
   buildFakeNativeClaude,
@@ -580,8 +582,8 @@ describe('PATCH_TRANSFORMS_VERSION', () => {
       .join('\n');
     const digest = createHash('sha256').update(source).digest('hex');
     expect({ version: PATCH_TRANSFORMS_VERSION, digest }).toEqual({
-      version: 8,
-      digest: '27786b410c68236925ea247f0ca46eacae3a71e035a7017694be7c0c688abf8b',
+      version: 9,
+      digest: '16f99bc4a9cf55f59119268ca7bc4d8a3c4ef688b61b894f5349286456f0da8e',
     });
   });
 });
@@ -1171,6 +1173,139 @@ describe('applyPatch', () => {
       // Code's own signature and made the bytes above stop matching the install they came from.
       const signings = vi.mocked(execFileSync).mock.calls.filter(([command]) => command === 'codesign');
       expect(signings).toHaveLength(1);
+    } finally {
+      Object.defineProperty(process, 'platform', platform);
+      if (previousAppHome === undefined) delete process.env.CLODEX_HOME;
+      else process.env.CLODEX_HOME = previousAppHome;
+      if (previousTweakccHome === undefined) delete process.env.TWEAKCC_CONFIG_DIR;
+      else process.env.TWEAKCC_CONFIG_DIR = previousTweakccHome;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  /**
+   * Claude Code 2.1.242 code-split its bundle. What used to be one module became a small entry that
+   * imports ~1,370 `chunk-*.js` siblings, and tweakcc reads and writes only the module it
+   * recognizes by name — so `clodex patch` saw a stub with none of its anchors in it and PATCH 1
+   * failed on every platform and every executable format at once.
+   *
+   * The stand-in below reproduces the shape exactly, including the part that makes the write hard:
+   * `writeContent` puts the WHOLE buffer into the one module it recognizes. Everything the patch
+   * changed rides along in that buffer and is then repointed, so a regression that drops the
+   * repoint publishes an entry module holding every chunk's source concatenated — which the entry
+   * assertion below catches.
+   */
+  it('patches a code-split binary whose anchors live in chunks tweakcc never returns', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'clodex-split-bundle-'));
+    const binaryPath = join(dir, 'claude');
+    const tweakccHome = join(dir, 'tweakcc-home');
+    const previousAppHome = process.env.CLODEX_HOME;
+    const previousTweakccHome = process.env.TWEAKCC_CONFIG_DIR;
+    const pristine = Buffer.concat([MACHO_MAGIC, buildFakeNativeClaude(
+      'test-version',
+      CLAUDE_SPLIT_MODULES,
+      { entryPointId: CLAUDE_SPLIT_ENTRY_ID },
+    )]);
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+    vi.mocked(execFileSync).mockReset();
+    // What the binary looked like at the moment it was signed. A signature taken BEFORE the
+    // pointer edit covers bytes the published file no longer has, and macOS refuses to start it —
+    // a failure that counting `codesign` calls cannot see, because the count is the same.
+    let signedBytes: Buffer | null = null;
+    vi.mocked(execFileSync).mockImplementation(((command: string, args: string[]) => {
+      if (command === 'codesign') signedBytes = readFileSync(args[args.length - 1]!);
+      return '';
+    }) as unknown as typeof execFileSync);
+    mkdirSync(tweakccHome, { recursive: true });
+    writeFileSync(binaryPath, pristine, { mode: 0o755 });
+    process.env.CLODEX_HOME = dir;
+    process.env.TWEAKCC_CONFIG_DIR = tweakccHome;
+
+    tweakccMocks.tryDetectInstallation.mockReset();
+    tweakccMocks.readContent.mockReset();
+    tweakccMocks.writeContent.mockReset();
+    tweakccMocks.tryDetectInstallation.mockImplementation(
+      async ({ path }: { path: string }) => ({ path, version: 'test-version', kind: 'native' }),
+    );
+    tweakccMocks.readContent.mockImplementation(async ({ path }: { path: string }) => {
+      const parsed = parseBunBlob(readFileSync(path));
+      const index = parsed.names.findIndex(tweakccRecognizesModuleName);
+      if (index < 0) {
+        throw new Error(`Failed to extract JavaScript from native installation: ${path}`);
+      }
+      return parsed.contents[index]!;
+    });
+    tweakccMocks.writeContent.mockImplementation(
+      async ({ path }: { path: string }, content: string) => {
+        const parsed = parseBunBlob(readFileSync(path));
+        writeFileSync(
+          path,
+          Buffer.concat([MACHO_MAGIC, rebuildFakeNativeClaude(
+            readFileSync(path),
+            'test-version',
+            // EVERY recognized module, exactly as tweakcc does — it has no way to say "this one".
+            (index, previous) => (tweakccRecognizesModuleName(parsed.names[index]!)
+              ? content
+              : previous),
+          )]),
+          { mode: 0o755 },
+        );
+      },
+    );
+
+    try {
+      const outcome = await applyPatch(
+        binaryPath,
+        'test-version',
+        {
+          config: {
+            'clodex:test:extended': {
+              alias: 'extended',
+              context: 272_000,
+              display: 'Extended (test)',
+              effort: { levels: ['low', 'medium', 'high', 'xhigh', 'max'], defaultLevel: 'high' },
+            },
+          },
+          unknownWindows: [],
+        },
+        'desired-config-hash',
+        { trace: false, manifest: null },
+      );
+
+      expect(outcome.ok ? 'ok' : outcome.message).toBe('ok');
+
+      const published = parseBunBlob(readFileSync(binaryPath));
+      expect(published.names[published.entryPointId]).toBe('/$bunfs/root/cli');
+      // Every chunk got its OWN patch — the enum in one module, the alias resolver in another,
+      // the context and effort tables in a third.
+      expect(published.contents[0]).toContain('"extended"');
+      expect(published.contents[0]).toContain('Additional custom models: extended = Extended (test).');
+      expect(published.contents[2]).toContain('case"extended":return "extended";');
+      expect(published.contents[6]).toContain('/*ccpatch:ctx*/');
+      expect(published.contents[6]).toContain('/*ccpatch:effort*/');
+      // ...and the entry module is still the entry module, not every chunk concatenated into it.
+      expect(published.contents[CLAUDE_SPLIT_ENTRY_ID])
+        .toBe(CLAUDE_SPLIT_MODULES[CLAUDE_SPLIT_ENTRY_ID]!.contents);
+      // The modules Bun does not execute as JavaScript are untouched — including the vendored one
+      // at index 1 that carries a copy of the enum anchor. Patch it and the anchor matches twice
+      // and the whole patch refuses, which is the only thing keeping the bundle selection honest.
+      // Index 5 is different in kind: a real JavaScript helper that IS in the bundle and carries a
+      // near-miss, so it proves the transforms left it alone rather than that it was excluded.
+      for (const untouched of [1, 4, 5]) {
+        expect(published.contents[untouched]).toBe(CLAUDE_SPLIT_MODULES[untouched]!.contents);
+      }
+
+      // The pristine backup is the install's own bytes, not a shimmed or re-signed variant.
+      expect(readFileSync(join(tweakccHome, 'native-binary.backup')).equals(pristine)).toBe(true);
+      // One re-sign, and the bytes it covered already carried the repointed modules.
+      const signings = vi.mocked(execFileSync).mock.calls.filter(([command]) => command === 'codesign');
+      expect(signings).toHaveLength(1);
+      expect(signedBytes).not.toBeNull();
+      const atSigning = parseBunBlob(signedBytes!);
+      expect(atSigning.contents[0]).toContain('"extended"');
+      expect(atSigning.contents[CLAUDE_SPLIT_ENTRY_ID])
+        .toBe(CLAUDE_SPLIT_MODULES[CLAUDE_SPLIT_ENTRY_ID]!.contents);
     } finally {
       Object.defineProperty(process, 'platform', platform);
       if (previousAppHome === undefined) delete process.env.CLODEX_HOME;

--- a/tests/patcher.test.ts
+++ b/tests/patcher.test.ts
@@ -583,7 +583,7 @@ describe('PATCH_TRANSFORMS_VERSION', () => {
     const digest = createHash('sha256').update(source).digest('hex');
     expect({ version: PATCH_TRANSFORMS_VERSION, digest }).toEqual({
       version: 9,
-      digest: '16f99bc4a9cf55f59119268ca7bc4d8a3c4ef688b61b894f5349286456f0da8e',
+      digest: '035f6e47ba23d35432405deb64b7b3a91c759fd528d1a1862ff5e1549d30fdfe',
     });
   });
 });
@@ -2405,6 +2405,32 @@ describe('patch script identity naming', () => {
 
     expect(out).toContain('case"constructor":return "constructor";');
     expect(out).toContain('{value:"constructor",label:"Constructor",description:"Model"}');
+  });
+
+  it('splices the model list at the template\'s real close even when it holds an escaped backtick', () => {
+    // The anchor ends at the template's closing backtick and deliberately says nothing about what
+    // FOLLOWS it — requiring `)` is exactly what drifted when 2.1.242 started concatenating a
+    // conditional sentence onto the same string. But a wildcard that stops at the first backtick
+    // BYTE stops mid-escape on a description containing `` \` ``, and splicing there turns the
+    // once-escaped backtick into a live terminator: a syntax error in a module Bun loads at
+    // startup. The wildcard skips backslash pairs so it cannot stop there.
+    //
+    // No shipped release has an escaped backtick here, so this pins a corner that must stay
+    // fail-safe rather than one that fires today.
+    const escaped = CLAUDE_FIXTURE.replace(
+      'Optional model override for this agent',
+      'Optional model override for this agent, or \\` inherit \\` instead',
+    );
+    expect(escaped, 'fixture drifted from the shape this test rewrites').not.toBe(CLAUDE_FIXTURE);
+
+    const out = applyClodexPatches(escaped, config);
+    expect(out.results.find(r => r.name.startsWith('PATCH 4'))!.status).toBe('OK');
+    // The addition lands after the LAST segment of the description, not after the backslash.
+    expect(out.content).toContain('inherit \\` instead. Defaults to inherit. Additional custom models:');
+    // ...and the result is still parseable JavaScript: the template still has exactly one opener
+    // and one closer, so nothing after it became live tokens.
+    const described = /describe\(`(?:[^`\\]|\\.)*`/.exec(out.content)![0];
+    expect(() => new Function('describe', `return ${described});`)).not.toThrow();
   });
 
   it('is idempotent — re-running the same patch changes nothing', () => {


### PR DESCRIPTION
`clodex patch` stopped working on Claude Code 2.1.242 and 2.1.243. Every platform, every install:
it printed `required patch failed: PATCH 1: Agent tool model enum` and exited 1, so nobody on a
current Claude Code could get their custom model aliases, per-model context windows or effort
settings baked in. This restores it, and it keeps working on older Claude Code releases exactly as
before.

## What broke

Claude Code 2.1.242 code-split its bundle. Through 2.1.241 the whole ~28 MB of JavaScript was **one**
Bun module; since 2.1.242 the entry module is a ~19,950-byte ESM stub whose body is a list of
`import{…}from"/$bunfs/root/chunk-<hash>.js"` lines, and the code lives in ~1,374 sibling chunk
modules — 1,391 modules in the blob against 15 before.

tweakcc's `readContent` returns only the module it recognizes **by name**, which is that stub. So
`clodex patch` was matching its anchors against 19.9 KB of import statements. `PATCH 1` is the first
required site, so it aborted there and the other ten were never attempted — which is why the canary
reported a single failing site and made this look like one drifted anchor.

It is not an anchor drift. Every clodex anchor is still present in 2.1.243 and still occurs exactly
once across the bundle; they are just spread over six different chunks, none of them the entry.

The hourly patch canary caught this on 2.1.243. 2.1.242 carries the same split and would have failed
identically.

## Root cause and reachability

`src/patcher.ts` read the bundle with `readContent` and wrote it with `writeContent`, both of which
address exactly one module. Any user running `clodex patch` against Claude Code 2.1.242 or later hit
this — it is the only supported way to get aliases into the binary, and the failure is total, not
partial.

## The change

**Reading.** `readClaudeBundle` (new `src/bun-bundle.ts`) reads every module Bun will execute as
JavaScript — selected by Bun's **loader id**, so vendored `.js` assets like `mermaid.min.js` and the
`*.node` helpers stay out; feeding megabytes of foreign JavaScript to anchors that must match
exactly once is a way to invent ambiguity and refuse a release that is perfectly patchable — and
joins them with a `/*clodex:module-boundary*/` line. `applyClodexPatches` still receives one document
and **no patch transform changed shape**; `splitBundleSource` cuts it back up afterwards and refuses
a document whose boundary count moved.

Two consequences worth stating plainly, because both are easy to get wrong:

- **A module's position in the blob table is not its position in the bundle**, so every repoint is
  addressed by table index. On every build shipped so far the non-JavaScript modules happen to sort
  last, which makes the two accidentally equal — the test fixture deliberately interleaves them so
  they don't.
- **The read corpus grew for OLD releases too, not just split ones.** A pre-split blob carries five
  ~2 KB loader-1 helper stubs (`image-processor.js`, `audio-capture.js`, `url-handler.js`,
  `computer-use-*.js`) beside the bundle, which tweakcc's read never returned. Measured on a real
  2.1.232: none of them contains any anchor, any `process.env` read, or anything PATCH 5's and
  PATCH 10's whole-bundle count guards look at, so no built-in behaves differently. A **local**
  patch that appends or prepends by position rather than matching an anchor would now land in a
  different module on those releases; that is documented in README where local-patch authors see
  it, and the earlier README wording — which claimed the joined document only applied from 2.1.242 —
  was wrong and is corrected here.

**Writing** is the hard half. `writeContent` puts one buffer into one module, and calling it once per
changed module is not an option: every ELF repack relocates the whole ~290 MB blob to the end of the
binary, so six repacks would leave a multi-gigabyte `claude` and take minutes. (Mach-O and PE assign
in place, so that cost is invisible on macOS and Windows — the same asymmetry that hid the restore
sweep bug.) Instead there is **one repack plus a pointer edit**: every changed module's patched source
is concatenated, NUL-separated, into the single buffer tweakcc writes, and then
`repointBunModuleContents` rewrites the 8-byte `{offset, length}` pair in each module's struct to
address its own slice. Nothing moves and nothing grows — the bytes are already in the blob. After the
repack, `applyBundleWritePlan` refuses if the module tweakcc wrote is not the one the plan was built
around or does not hold exactly the bytes that were written, then reads every repointed module back
and compares it to the source it should be.

**When the only changed module is the one tweakcc writes, the plan degrades to the single call clodex
has always made, with no pointer edit at all** — which is every release up to 2.1.241. Verified: on
2.1.241 the join changes only the `cli` module, so the write is byte-for-byte the old path.

Several refusals and one design change came out of adversarial review rather than the original
design, and each closes a way this could have published something subtly wrong:

- **The separator carries punctuation.** Every built-in anchor bounds its wildcards with a character
  class — `` [^`]*? `` in PATCH 4, `[^{}]*` in PATCH 6, `[^;{}]` in PATCH 5, `[^"]+` in the alias
  arrays, `[^\]]*` in PATCH 7 — and a separator those accept is one they can match ACROSS, binding
  a patch to a span belonging to two modules at once. The boundary COUNT check cannot see that; it
  only sees a boundary added or removed. The marker therefore carries one of each character, inside
  a comment where none of them mean anything to JavaScript. It is
  ``/*clodex:module-boundary`;{}"]*/``.

- **UTF-8 round-trip.** Every module is decoded and re-encoded as UTF-8, so a module stored in any
  other encoding would come back as replacement characters — and nothing downstream could see it,
  because the read-back check and the probe both decode the same way and would agree with each
  other. Measured pure ASCII on every module of 2.1.232 and 2.1.243; this refuses rather than
  repairs.
- **Exactly one module tweakcc would write to.** `writeContent` puts its buffer into *every*
  recognized module, not the first; a second would ship holding the whole concatenation and the
  read-back loop could not see it, because a module nobody repointed is a module nobody checks. No
  published build has two, and the entry-module shim declines to fire when one already exists — so
  this is a refusal, not a repair. It runs **before** the "nothing to repoint" early return, because
  that is the common shape on every release up to 2.1.241 and is not exempt from the problem.
- **The single-module fallback says so.** When the Bun table cannot be read on a native binary,
  clodex falls back to tweakcc's one-module read — and on a split build the result is a
  first-required-site failure that reads exactly like a drifted anchor. A one-line warning turns a
  future canary mystery into a one-glance diagnosis.
- **Order-sensitive `modules-intact` in the probe.** It compared the module lists as sets, so a
  repack that kept every module but shuffled the table read as green. That never mattered before;
  now that modules are addressed by table position, it does.

**Two independent PATCH 4 drifts, in the same family.** 2.1.242 also started concatenating a
conditional sentence onto the Agent tool's `model` description
(``describe(`…`+(fn()?"…":""))``), and both the anchor in `patch-transforms.ts` and its
postcondition proof in `built-in-patch-proofs.ts` required the template to be followed immediately by
`)`. The anchor silently dropped every custom model from that description; the proof turned every
local patch into "could not capture built-in postconditions". Both now end at the template's own
closing backtick, which `[^`]*?` cannot cross anyway.

`PATCH_TRANSFORMS_VERSION` 8 → 9, so existing installs read as `stale-config` and repatch.

`scripts/probe-patch-mechanism.mjs` and `scripts/extract-cc-bundles.mjs` read and write the bundle the
same way now. The extractor mattered independently: it is the tool `.claude/skills/pr-verification`
tells everyone to use before making a claim about Claude Code's behaviour, and on 2.1.242+ it was
silently writing out 0.05% of the code.

**Deliberately not done:** no new binary-format code. All container work — Mach-O segment extension,
the ELF `.bun` relocation, PE, code signing — stays in tweakcc. clodex only writes 8 bytes per
patched module into a table it already parses.

## Discriminating tests

New `tests/bun-bundle.test.ts` (14 cases) and a new end-to-end `applyPatch` case in
`tests/patcher.test.ts` driving a **code-split** fake binary — real Bun blob, entry module
deliberately away from table index 0, anchors spread across three chunks, non-JavaScript modules
interleaved between them, and the tweakcc stand-in reproducing the "whole buffer into every
recognized module" behaviour that makes the repoint necessary. The shared fixture's `describe(` now
carries 2.1.242's spelling.

Mutations run, full-file (not `-t`):

| Removed | Turns red |
| --- | --- |
| multi-module read (`readClaudeBundle` → null) | 7 (all of `bun-bundle.test.ts` + the e2e) |
| the JavaScript-loader filter | 7 — `PATCH 1` becomes an ambiguous anchor and the patch refuses |
| join/split boundary count check | `refuses a patched document that lost a module boundary` |
| the write plan's slice layout (order, NUL, changed-only filter) | 4, 1 and 2 respectively |
| the module-table repoint (`applyBundleWritePlan` → no-op) | 3, incl. the e2e: chunk 0 still holds the pristine enum |
| the "bytes are not what I planned around" refusal | `refuses to repoint when the bytes…` |
| the "more than one recognized module" refusal | `refuses when the blob has more than one module…` |
| the read-back verification loop | `refuses when a repointed module does not read back…` |
| the payload bounds check | `reports no bundle when a payload range runs past the end…` |
| the UTF-8 round-trip check | `reports no bundle when a module is not valid UTF-8` |
| the boundary-already-present check | `reports no bundle when a module already contains…` |
| computing the writable module before the shim instead of after | 2 `applyPatch` cases |
| the separator's punctuation (back to a plain marker) | `keeps the module boundary out of reach…` |
| the "more than one recognized module" refusal for a zero-repoint plan | `refuses more than one module … even when nothing needs repointing` |
| the replacement-character half of the UTF-8 check | `reports no bundle when a module is not valid UTF-8` |
| re-signing after the repoint instead of before it | the e2e: the bytes captured at `codesign` time still hold the pristine enum |
| the single-module fallback warning | `says so when it can only read the one module tweakcc names` |
| PATCH 4 anchor fix | 12 across `patcher.test.ts` and `probe-patch-sites.test.ts` |
| PATCH 4 postcondition proof fix | `captures every successful built-in postcondition…` |

A first pass of this table had **eleven** NONE rows. They are gone because the blob fixture can now
express a non-JavaScript module (`loader`), which is what lets a test tell a table position from a
bundle position — and because the vendored asset in the code-split fixture deliberately carries a
copy of the enum anchor, so removing the loader filter makes `PATCH 1` ambiguous instead of silently
patching a module Bun never runs.

The `PATCH_TRANSFORMS_VERSION` digest pin is **not** the discriminating test for any of these; each
has a behavioural test that fails on its own.

Two mutations deserve calling out because the obvious test for them does NOT discriminate. The
UTF-8 check needs a **truncated** four-byte sequence (`f0 90 80`), which decodes to one replacement
character that re-encodes to the same three bytes — `ff fe` is caught by the byte-length half and
leaves the other half unpinned. And "exactly one `codesign` call" is not an ordering assertion: the
e2e now captures the file's bytes at the moment `codesign` runs and asserts they already carry the
repointed modules, because signing before the pointer edit leaves the count unchanged and the
signature invalid.

`pnpm typecheck && pnpm test && pnpm build` green (103 files, 1946 tests), and green again under
`CLODEX_HOME="$(mktemp -d)"`. Node v24.14.1, `CLAUDE_CODE_ENTRYPOINT=cli`.

## Runtime evidence, on real binaries

All eight published 2.1.243 builds, through the canary's own reproduction harness, against a pristine
copy of each release:

| Platform | Leg | Result |
| --- | --- | --- |
| darwin-arm64 | real `clodex patch` on this Mac | 11 applied, 0 skipped, 0 failed |
| linux-arm64, linux-arm64-musl | real `clodex patch` in a native-arch container | 11 applied, 0 failed; **patched binary starts and reports 2.1.243** |
| darwin-x64, linux-x64, linux-x64-musl, win32-x64, win32-arm64 | bundle probe | every check green, including byte-for-byte readback of ~36 MB across ~1,385 modules, `modules-intact`, and a valid Mach-O signature |

Before this change all eight failed at `PATCH 1`.

Three things I checked rather than assumed, because the whole approach depends on them:

- **Bun runs the module source, not the bytecode beside it.** Overwriting eleven bytes of one
  chunk's payload in place on a real 2.1.243 darwin-arm64 build (`Your prompt` → `YOUR_PROMPT`),
  re-signing, and running `claude --help` printed the edited string.
- **A chunk-level patch survives the whole pipeline into the running binary.** A local patch that
  rewrites a string living in a chunk — read, joined, transformed, split, one repack, repointed,
  re-signed — shows up in `claude --help` output on a real patched 2.1.243.
- **Re-patching does not accumulate.** Patched a real 2.1.243, changed the alias set, patched again:
  11 applied, identical file size, binary still starts.
- **Local patches still work, on a chunk.** A local patch rewriting a string that lives in a chunk —
  read, joined, transformed, split, one repack, repointed, re-signed — shows up in real
  `claude --help` output; a second one injecting a startup `console.error` into the entry prints
  ahead of `--version`.

## Deliberately not done

One reviewer proposed having `readClaudeBundle` join only the entry module when the entry is not a
stub, restoring the exact pre-2.1.242 local-patch contract on older releases. I did not: it means a
"is this a stub" heuristic and two reader modes to keep honest forever, to protect a local patch
that edits by position rather than by matching an anchor — which is trusted, opt-in code whose
author is now told, in README, exactly where a positional edit lands. Documenting the contract is
the smaller and more durable answer.

## What I could not verify

- **No authenticated end-to-end run.** The one thing left unproven is that a routed request with a
  patched alias actually reaches a provider on 2.1.243. Everything reachable without credentials is
  identical between this build and a 2.1.241 patched by `main` — including the pre-existing
  `[claude-code:unrecognized_model]` diagnostic, which a known-good patched 2.1.241 prints for its
  own aliases too, so it is not a regression. The smoke test
  (`clodex claude -- --model <alias> -p …`) still wants a human run.
- **x64 ELF is bytes-only by design** — no leg executes one. The x64 reasoning is checked against
  the linux-arm64 container leg, which does start its patched binary.
- **2.1.242 itself was never patched end to end.** Its blob has the same shape and module count as
  2.1.243 (verified by parsing it), but only 2.1.243 was run through the matrix.
- **A build with two tweakcc-recognizable module names has never been seen**, so the refusal that
  covers it is reasoned and unit-tested, not observed. Same for a module that is not valid UTF-8:
  every module of every binary measured (2.1.208–2.1.232 and all of 2.1.243) is pure ASCII.

## Failure behaviour

Every new refusal happens while the work is still on a temporary candidate; the live binary is only
renamed into place at the very end, and the candidate directory is removed on any error. A binary
whose blob cannot be parsed falls back to tweakcc's single-module read — which is the pre-2.1.242
behaviour, and on a split binary that means `PATCH 1` fails loudly rather than a partial patch being
published. `clodex patch --restore` is untouched.

## Land order

PR #104 touches `patcher.ts`, `patch-transforms.ts`, `built-in-patch-proofs.ts` and the same test
files. This one should land first — 2.1.243 is currently unpatchable for every user — and #104 rebase
on top.
