### PR TITLE
fix(oauth): report ignored callbacks in sign-in timeout

### DIFF
--- a/src/oauth/callback-server.ts
+++ b/src/oauth/callback-server.ts
@@ -60,6 +60,7 @@ export async function startCallbackServer(options: CallbackServerOptions): Promi
   let codeReject: ((e: Error) => void) | undefined;
   // The browser can hit the callback before waitForCallback arms the promise.
   let buffered: CallbackParams | undefined;
+  let ignoredStateMismatchCount = 0;
 
   const { path, redirectHost } = options;
   const server = http.createServer((req, res) => {
@@ -71,6 +72,7 @@ export async function startCallbackServer(options: CallbackServerOptions): Promi
     const state = u.searchParams.get('state') ?? '';
     const error = u.searchParams.get('error') ?? '';
     if (options.expectedState !== undefined && state !== options.expectedState) {
+      ignoredStateMismatchCount++;
       res.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' });
       res.end('Invalid OAuth state');
       return;
@@ -116,7 +118,12 @@ export async function startCallbackServer(options: CallbackServerOptions): Promi
           return;
         }
         const timer = setTimeout(
-          () => reject(new Error('OAuth timeout — browser closed without completing sign-in')),
+          () => reject(new Error(
+            ignoredStateMismatchCount > 0
+              ? `OAuth timeout — ignored ${ignoredStateMismatchCount} callback(s) carrying a different sign-in state; `
+                + 'you probably completed an older browser tab. Run the command again and use the newest tab.'
+              : 'OAuth timeout — browser closed without completing sign-in',
+          )),
           timeoutMs,
         );
         codeResolve = params => { clearTimeout(timer); resolve(params); };

--- a/tests/oauth-openai.test.ts
+++ b/tests/oauth-openai.test.ts
@@ -168,6 +168,25 @@ describe('oauth/openai', () => {
       expect(body.get('code')).toBe('auth_code_1');
     });
 
+    it('reports ignored stale callbacks when sign-in times out', async () => {
+      let resolveCallback!: (status: number) => void;
+      let rejectCallback!: (error: unknown) => void;
+      const callbackResponse = new Promise<number>((resolve, reject) => {
+        resolveCallback = resolve;
+        rejectCallback = reject;
+      });
+      const flow = runOpenAiBrowserFlow(({ url }) => {
+        void hitCallback(url, () => 'code=stale&state=stale').then(resolveCallback, rejectCallback);
+      }, { ports: [0], timeoutMs: 50 });
+
+      expect(await callbackResponse).toBe(400);
+      await expect(flow).rejects.toThrow(
+        'OAuth timeout — ignored 1 callback(s) carrying a different sign-in state; '
+        + 'you probably completed an older browser tab. Run the command again and use the newest tab.',
+      );
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
     it('rejects when the provider returns an error instead of a code', async () => {
       await expect(runOpenAiBrowserFlow(({ url }) => {
         void hitCallback(url, state => `error=access_denied&state=${encodeURIComponent(state)}`);
@@ -266,7 +285,7 @@ describe('oauth/openai', () => {
 
     it('times out when the browser never completes sign-in', async () => {
       await expect(runOpenAiBrowserFlow(vi.fn(), { ports: [0], timeoutMs: 50 }))
-        .rejects.toThrow(/OAuth timeout/);
+        .rejects.toThrow('OAuth timeout — browser closed without completing sign-in');
       expect(global.fetch).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## Summary
When a user starts the OpenAI browser sign-in flow twice — completing an older, stale browser tab
instead of the newest one — the callback server silently rejected the stale callback (its OAuth
`state` no longer matches) and the user was left staring at a generic `OAuth timeout — browser
closed without completing sign-in` message with no indication of what actually happened.

## Changes
- `src/oauth/callback-server.ts`: count callbacks whose `state` parameter doesn't match the
  expected value (previously discarded silently). If the sign-in flow times out and at least one
  such callback was seen, the timeout error now reads:
  `OAuth timeout — ignored N callback(s) carrying a different sign-in state; you probably
  completed an older browser tab. Run the command again and use the newest tab.`
  The original generic message is unchanged when no mismatched callback occurred.
- `tests/oauth-openai.test.ts`: added a test that fires a stale-state callback (confirms the
  server still responds `400`) and asserts the timeout rejects with the new count-aware message;
  tightened the existing plain-timeout test to assert the exact original message so the two paths
  stay distinguishable.

## Additional Notes
- Verified with a feature-deletion mutation: reverting only the `callback-server.ts` change turns
  the new test red (`OAuth timeout — browser closed without completing sign-in` instead of the
  count-aware message) while the rest of the suite still passes — the test is discriminating, not
  theatre.
- `pnpm typecheck`, `pnpm build`, and the full `pnpm test` suite pass under an isolated
  `CLODEX_HOME`; the only failure seen (`credential-helper.test.ts` > *force-kills a helper that
  exceeds the runtime limit*) is a pre-existing flake unrelated to this change and passes in
  isolation.
- No README/docs reference the old error string, so no documentation updates were needed.
- This affects only the browser-based OpenAI sign-in flow (used, for example, by workspaces that
  block device-code auth); the device-code flow is untouched.
  
  Closes #142 