### PR TITLE
fix(auth): stop blaming another sign-in when a busy port blocks browser sign-in

### DIFF
--- a/src/oauth/callback-server.ts
+++ b/src/oauth/callback-server.ts
@@ -1,6 +1,10 @@
-// src/oauth/callback-server.ts — CLI fallback local callback server for PKCE OAuth flows.
-// Primary path: the GUI server handles /oauth/callback when the UI is open.
-// This is only used when running `clodex providers auth <provider>` without the GUI.
+// src/oauth/callback-server.ts — loopback callback server for PKCE OAuth flows.
+// It serves the callback path the caller registered with the provider, on the loopback port the
+// caller supplies, and hands the authorization code back to the flow. Today its only caller is
+// browser sign-in (`clodex providers auth openai --browser`, or the Browser option in the
+// interactive picker), and nothing else in src/ receives an OAuth callback. The UI server that
+// used to own this module's job, for the since-removed Antigravity flow, went with the strip to
+// the Claude-to-OpenAI bridge (d01d0eb).
 
 import http from 'node:http';
 import { listenTcpServer, waitForTcpListener } from '../listener-ready.js';

--- a/src/oauth/openai.ts
+++ b/src/oauth/openai.ts
@@ -191,8 +191,9 @@ export async function runOpenAiBrowserFlow(
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'EADDRINUSE') {
       throw new Error(
-        `Ports ${ports.join(' and ')} are in use — close any other OpenAI sign-in `
-        + '(e.g. codex login) and try again.',
+        `Ports ${ports.join(' and ')} are in use — browser sign-in needs one free. `
+        + 'Check for another OpenAI sign-in (e.g. `codex login`), or any other process '
+        + 'holding them, then try again.',
       );
     }
     throw new Error(
@@ -206,7 +207,10 @@ export async function runOpenAiBrowserFlow(
     const params = await server.waitForCallback(opts?.timeoutMs);
     if (params.error) throw new Error(`OpenAI sign-in failed: ${params.error}`);
     if (!params.code) throw new Error('OpenAI sign-in returned no authorization code');
-    // Defense in depth: the callback server already filters on expectedState.
+    // Unreachable as written: this flow always passes expectedState, so the callback server
+    // answers 400 and keeps waiting rather than delivering a mismatched state here. Kept as a
+    // backstop in case this flow ever stops passing it — but it is not what protects the flow
+    // today, so do not weaken the server-side check on the strength of this one.
     if (params.state !== state) {
       throw new Error('OpenAI sign-in returned a mismatched state — try again');
     }

--- a/tests/oauth-openai.test.ts
+++ b/tests/oauth-openai.test.ts
@@ -239,8 +239,15 @@ describe('oauth/openai', () => {
           }),
         ));
         const busyPorts = blockers.map(srv => (srv.address() as { port: number }).port);
+        // Pin the message exactly, not as a substring: it must state the observed fact (the
+        // ports are busy) and never assert a cause we did not observe. toThrow(string) matches a
+        // substring, so appended copy would slip through — compare the Error for equality.
         await expect(runOpenAiBrowserFlow(vi.fn(), { ports: busyPorts, timeoutMs: 200 }))
-          .rejects.toThrow(new RegExp(`${busyPorts[0]} and ${busyPorts[1]} are in use`));
+          .rejects.toThrowError(new Error(
+            `Ports ${busyPorts[0]} and ${busyPorts[1]} are in use — browser sign-in needs one free. `
+            + 'Check for another OpenAI sign-in (e.g. `codex login`), or any other process '
+            + 'holding them, then try again.',
+          ));
       } finally {
         for (const srv of blockers) srv.close();
         dns.setDefaultResultOrder(previousOrder);


### PR DESCRIPTION
## Summary

When browser sign-in can't start because its ports are already taken, clodex used to tell you to
"close any other OpenAI sign-in (e.g. `codex login`)" — even though all it had actually observed was
that the ports were busy. Any program holding port 1455 or 1457 causes the same failure, so that
advice could send you hunting for a `codex login` that was never running. The error now leads with
what was actually observed, offers another OpenAI sign-in as the first thing to *check* rather than
the cause, and says plainly that any other process holding those ports will do it.

This is the same defect as #142 — an error message asserting a cause it never observed — on a
neighbouring path. It was found while reviewing the fix for #142 in #146.

## Changes

**`src/oauth/openai.ts` — the busy-port message.** Before / after, as the real CLI prints them with
both ports held:

```
Ports 1455 and 1457 are in use — close any other OpenAI sign-in (e.g. codex login) and try again.

Ports 1455 and 1457 are in use — browser sign-in needs one free. Check for another OpenAI sign-in
(e.g. `codex login`), or any other process holding them, then try again.
```

The remedy is now correct whoever holds the port. It renders at 170 columns, down from an
intermediate 218-column draft.

**Two comments that made false claims.** Neither changes behaviour; both were actively misleading.

- `src/oauth/callback-server.ts` opened by describing itself as a "CLI fallback" whose "primary
  path" is a GUI server handling `/oauth/callback`. There is no GUI server, and no `/oauth/callback`
  route exists anywhere — this server serves the callback path its caller registers, and since #141
  it is the only thing that receives a browser sign-in callback. At the parent commit, the only
  occurrences of "GUI" and "/oauth/callback" under `src/` were inside that comment describing them.
  A reviewer following it would conclude the code they were changing was a secondary path.
- `src/oauth/openai.ts`'s post-callback state check was labelled "defense in depth", which
  understates it: this flow always passes `expectedState`, so the callback server answers 400 and
  keeps waiting rather than ever delivering a mismatched state to that branch. **The guard is
  deliberately kept** — removing a redundant check in auth code trades a real safety margin for a
  cosmetic cleanup — but the comment no longer implies it is what protects the flow today.

## Tests

`tests/oauth-openai.test.ts` asserted only a loose regex on the port numbers, so it passed unchanged
against the new wording. It now compares the `Error` for equality.

That distinction is the substantive test change here. `expect(...).rejects.toThrow('<string>')` is a
**substring** match in Vitest, so an assertion written that way lets appended copy through
unasserted. Verified by appending `ARBITRARY UNPINNED SUFFIX` to the production message: under
`toThrow(string)` the file stayed green at 22/22; under `toThrowError(new Error(...))` it fails.

Mutations run, full-file (not `-t` isolation):

| Mutation | Result |
| --- | --- |
| Revert the message to the old wording | new assertion red |
| Append arbitrary prose to the message | red (was **green** before this change) |
| Unmutated | 22/22 green |

## Verification

- `pnpm typecheck && pnpm test && pnpm build` green under an isolated `CLODEX_HOME` —
  103 files / 1950 tests. Re-run 5× consecutively for stability.
- Real CLI, not just assertions: drove `clodex providers auth openai --browser` with both ports held
  by a bare TCP server and read the bytes on fd 1 (exit 1). Also drove it holding **only** 1455 and
  confirmed the flow binds 1457 and completes — so "needs one free" is accurate, not a guess.

## Notes and limits

- The one-element case still reads "Ports 52362 are in use", and a busy port followed by an invalid
  one falls through to the generic listener error. Both need the internal `ports` option; the
  supported CLI always supplies the two fixed ports. Hygiene, not fixed here.
- `callback-server.ts`'s own timeout message says the browser "closed" without observing that. It is
  the same class again, but #146 addressed the reachable case and this PR does not reopen it.
