### PR TITLE
docs(releasing): record the two checks a patcher release needs

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -44,6 +44,28 @@ Publishing happens inside the release-please job deliberately: a tag created by 
   (`src/constants.ts::VERSION` reads `pkg.version`).
 - **Never commit `dist/`.** It is gitignored; `prepublishOnly` and release CI rebuild it.
 
+## Before releasing a patcher change
+
+`clodex patch` rewrites the user's own Claude Code binary, so a bad patcher release is the most
+expensive thing this project can ship. Two checks belong in every patcher release. Neither is
+covered by CI, and both exist because the obvious signal lied.
+
+- **A green probe is not evidence that a patched binary runs.** `scripts/probe-patch-mechanism.mjs`
+  reads, patches and repacks, but it never *executes* what it produced — that is by design, and it
+  is what lets one Mac cover the ELF and PE builds. It reports only what it can see. On Claude Code
+  2.1.246 the probe reported a clean pass against the real ELF build whose patched form segfaulted
+  before it could print its version.
+
+- **`claude --version` cannot tell a working patch from a silent no-op.** Run the patched binary
+  against a **pristine control** and diff something only the patch changes. The Agent-tool model
+  enum does it: patched offers the clodex aliases (`...,"luna","sol","terra"`), pristine offers only
+  Claude's own. That the binary starts, and that it reports the expected version, prove neither — a
+  2.1.246 binary patched by clodex 2.8.1 did both while running entirely unpatched code, because
+  Bun 1.4.1 runs a module's cached bytecode rather than the patched source beside it.
+
+Both are the same failure shape, and it is the dangerous one: the patch appears to apply and does
+nothing. `.claude/docs/patcher.md` covers why 2.1.246 made it reachable and what the fix relies on.
+
 ## Version bumping
 
 Normal conventional-commit bumping applies (the repo is past 1.0). To force a specific

--- a/src/oauth/callback-server.ts
+++ b/src/oauth/callback-server.ts
@@ -1,6 +1,10 @@
-// src/oauth/callback-server.ts — CLI fallback local callback server for PKCE OAuth flows.
-// Primary path: the GUI server handles /oauth/callback when the UI is open.
-// This is only used when running `clodex providers auth <provider>` without the GUI.
+// src/oauth/callback-server.ts — loopback callback server for PKCE OAuth flows.
+// It serves the callback path the caller registered with the provider, on the loopback port the
+// caller supplies, and hands the authorization code back to the flow. Today its only caller is
+// browser sign-in (`clodex providers auth openai --browser`, or the Browser option in the
+// interactive picker), and nothing else in src/ receives an OAuth callback. The UI server that
+// used to own this module's job, for the since-removed Antigravity flow, went with the strip to
+// the Claude-to-OpenAI bridge (d01d0eb).
 
 import http from 'node:http';
 import { listenTcpServer, waitForTcpListener } from '../listener-ready.js';

--- a/src/oauth/openai.ts
+++ b/src/oauth/openai.ts
@@ -191,8 +191,9 @@ export async function runOpenAiBrowserFlow(
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'EADDRINUSE') {
       throw new Error(
-        `Ports ${ports.join(' and ')} are in use — close any other OpenAI sign-in `
-        + '(e.g. codex login) and try again.',
+        `Ports ${ports.join(' and ')} are in use — browser sign-in needs one free. `
+        + 'Check for another OpenAI sign-in (e.g. `codex login`), or any other process '
+        + 'holding them, then try again.',
       );
     }
     throw new Error(
@@ -206,7 +207,10 @@ export async function runOpenAiBrowserFlow(
     const params = await server.waitForCallback(opts?.timeoutMs);
     if (params.error) throw new Error(`OpenAI sign-in failed: ${params.error}`);
     if (!params.code) throw new Error('OpenAI sign-in returned no authorization code');
-    // Defense in depth: the callback server already filters on expectedState.
+    // Unreachable as written: this flow always passes expectedState, so the callback server
+    // answers 400 and keeps waiting rather than delivering a mismatched state here. Kept as a
+    // backstop in case this flow ever stops passing it — but it is not what protects the flow
+    // today, so do not weaken the server-side check on the strength of this one.
     if (params.state !== state) {
       throw new Error('OpenAI sign-in returned a mismatched state — try again');
     }

--- a/tests/oauth-openai.test.ts
+++ b/tests/oauth-openai.test.ts
@@ -239,8 +239,15 @@ describe('oauth/openai', () => {
           }),
         ));
         const busyPorts = blockers.map(srv => (srv.address() as { port: number }).port);
+        // Pin the message exactly, not as a substring: it must state the observed fact (the
+        // ports are busy) and never assert a cause we did not observe. toThrow(string) matches a
+        // substring, so appended copy would slip through — compare the Error for equality.
         await expect(runOpenAiBrowserFlow(vi.fn(), { ports: busyPorts, timeoutMs: 200 }))
-          .rejects.toThrow(new RegExp(`${busyPorts[0]} and ${busyPorts[1]} are in use`));
+          .rejects.toThrowError(new Error(
+            `Ports ${busyPorts[0]} and ${busyPorts[1]} are in use — browser sign-in needs one free. `
+            + 'Check for another OpenAI sign-in (e.g. `codex login`), or any other process '
+            + 'holding them, then try again.',
+          ));
       } finally {
         for (const srv of blockers) srv.close();
         dns.setDefaultResultOrder(previousOrder);


### PR DESCRIPTION
## Summary

`clodex patch` rewrites the user's own Claude Code binary, so a bad patcher release is the most
expensive thing this project can ship. Releasing 2.8.2 turned up that **both signals a maintainer
would naturally trust can report success over a patch that is broken or does nothing.** This adds a
short section to `RELEASING.md` naming them and the control that actually discriminates.

## The two checks

- **A green probe is not evidence that a patched binary runs.** `scripts/probe-patch-mechanism.mjs`
  reads, patches and repacks but never executes what it produced — deliberately, since that is what
  lets one host cover the ELF and PE builds. It reported a clean pass on the real ELF 2.1.246 build
  whose patched form segfaulted before printing its version.
- **`claude --version` cannot separate a working patch from a silent no-op.** A 2.1.246 binary
  patched by clodex 2.8.1 started *and* reported the right version while running entirely unpatched
  code, because Bun 1.4.1 runs a module's cached bytecode rather than the patched source beside it.

The control that does work, and is now written down: diff the Agent-tool model enum of the patched
binary against a pristine one — patched offers the clodex aliases, pristine offers only Claude's own.

## Verification

Docs-only; no code path changes.

- The claim that the probe never executes the binary was checked against the source rather than
  assumed: the sole `execFileSync` in `scripts/probe-patch-mechanism.mjs` is `codesign --verify`
  (line 457), and the script states it itself at lines 326 and 445. `CLAUDE.md:198` agrees.
- The stale-bytecode mechanism was reproduced independently on a pristine 2.1.246 darwin-arm64
  binary: 1,659 same-length edits to the version string with bytecode left intact produced a binary
  that prints `2.1.246` while containing **zero** occurrences of that string in its JavaScript
  source; the same edits with bytecode, module info and source hash cleared print the edited value.
  A pristine re-signed control also prints `2.1.246`, ruling out a signing artifact.
- An earlier draft cited a precise probe check count. I had not measured that number myself, so it
  was replaced with "a clean pass" rather than carried on someone else's authority.