### PR TITLE
chore(canary): stop inventing dropped checks when a baseline predates leg modes

### DIFF
--- a/canary/clodex-patch-canary-selftest.sh
+++ b/canary/clodex-patch-canary-selftest.sh
@@ -577,6 +577,25 @@ fp_case "same config compares"        '{"configFingerprint":"aaa"}' aaa compare
 fp_case "changed config skips"        '{"configFingerprint":"aaa"}' bbb skip
 fp_case "a pre-fingerprint entry falls back" '{}'                   bbb compare
 
+# 21b. A baseline entry recorded before the leg-mode field existed cannot be compared at all. The
+#      two modes' check names are disjoint sets — patch sites for host/container, probe check names
+#      for a probe — so an entry whose mode is unknown cannot be placed in either. Comparing one
+#      anyway reports every name in the other set as dropped: it invented 16 lost probe checks on a
+#      container leg that had never run as a probe, on two consecutive runs. A missing
+#      configFingerprint only leaves the config unknown and can fall back to comparing; a missing
+#      mode makes the comparison itself meaningless, so it re-takes the baseline instead.
+mode_case() { # mode_case <name> <base-entry-json> <current-mode> <expect: compare|skip>
+  local name="$1" base_mode cur="$3" want="$4" got
+  base_mode="$(printf '%s' "$2" | jq -r '.mode // ""')"
+  if [ -z "$base_mode" ]; then got=skip
+  elif [ "$base_mode" != "$cur" ]; then got=skip
+  else got=compare; fi
+  matrix_check "$name" "$want" "$got"
+}
+mode_case "same mode compares"        '{"mode":"container"}' container compare
+mode_case "changed mode skips"        '{"mode":"probe"}'     container skip
+mode_case "a pre-mode entry is re-taken, not compared" '{}'  container skip
+
 # 22. The container leg must tell a patch that HUNG from a container that never got that far —
 #     one is a broken release, the other is the canary's own infrastructure.
 hang_case() { # hang_case <name> <started-marker-exists> <expect>

--- a/canary/clodex-patch-canary.sh
+++ b/canary/clodex-patch-canary.sh
@@ -1186,8 +1186,17 @@ if [ "$BASE_PLATFORMS" != "{}" ]; then
     # A leg's checks are named per mode — patch sites for host/container, probe check names for a
     # probe. Comparing across modes reports every name in the other set as a lost site, so a single
     # Docker outage would produce a page of invented regressions on the run after it.
+    # An entry recorded before this field existed carries no mode, so its names cannot be placed in
+    # either set. Comparing it anyway does the exact damage the mode check exists to prevent — it
+    # reported all 16 probe names as dropped on two consecutive container runs — so an entry with no
+    # mode is re-taken rather than compared. Unlike a missing configFingerprint, which only leaves
+    # the config unknown, a missing mode makes the comparison itself meaningless.
     BASE_MODE="$(printf '%s' "$BASE_PLATFORMS" | jq -r --arg p "$PLATFORM" '.[$p].mode // ""')"
-    if [ -n "$BASE_MODE" ] && [ "$BASE_MODE" != "$(matrix_mode_of "$PLATFORM")" ]; then
+    if [ -z "$BASE_MODE" ]; then
+      add_soft "$PLATFORM's baseline predates the leg-mode record, so its checks were not compared; its baseline is re-taken from $VERSION"
+      continue
+    fi
+    if [ "$BASE_MODE" != "$(matrix_mode_of "$PLATFORM")" ]; then
       add_soft "$PLATFORM was tested as a $(matrix_mode_of "$PLATFORM") leg this time and a $BASE_MODE leg on $BASE_VERSION, so its checks were not compared"
       continue
     fi


### PR DESCRIPTION
## Summary

The patch canary compares each platform's checks against the last release that passed, so it can
say "this check used to run and now doesn't." Twice in a row it said that about checks that had
never run on those platforms — reporting the same 16 phantom regressions on `linux-arm64` and
`linux-arm64-musl` for both 2.1.246 and 2.1.243.

This is worth fixing beyond tidiness: the canary's entire value is trustworthy signal, and this
repo's history already includes it going green through a real break. Notes that cry wolf are how a
real one gets skimmed past.

## Root cause

Check names are namespaced by leg mode — patch-site names for `host`/`container` legs, probe check
names for a `probe` — and the two sets are disjoint. The comparison already knows this and refuses
to compare across modes; its own comment says doing so "would produce a page of invented
regressions on the run after it."

That refusal reads the baseline's recorded mode and only fires when it is non-empty:

```sh
BASE_MODE="$(... jq -r '.[$p].mode // ""')"
if [ -n "$BASE_MODE" ] && [ "$BASE_MODE" != "$(matrix_mode_of "$PLATFORM")" ]; then
```

So a baseline entry written before the `mode` field existed carries no mode, skips the guard, and
gets compared anyway — producing exactly the page of invented regressions the guard exists to
prevent. An unknown mode makes the comparison *meaningless*, not merely unverified, so it now
re-takes the baseline instead. That is deliberately the opposite of the `configFingerprint` check
immediately above, where an absent field leaves only the config unknown and comparing is still the
better default.

## Tests

Adds three cases to the selftest mirroring the existing `fp_case` block: same mode compares,
changed mode skips, and a pre-mode entry is re-taken rather than compared.

Discrimination proved by running both implementations over the same three inputs:

```
CASE                                     EXPECT   OLD      NEW
same mode compares                       compare  compare  compare
changed mode skips                       skip     skip     skip
a pre-mode entry is re-taken             skip     compare  skip
```

Only the third case changes, so the fix is scoped to the defect.

## Verification

- Selftest with the change: **104 passed, 0 failed**, four consecutive clean runs.
- Selftest on unmodified `main`: **101 passed, 0 failed**, four consecutive clean runs.
- `bash -n` clean on both scripts.
- The live canary runs from `~/.local/bin` symlinks into this folder, so merging deploys it.

## What I could not verify

I could not get the feature-deletion mutation to report in situ: with the helper reverted to the old
logic, the selftest stalled and hit its timeout on four attempts, always *before* reaching the new
section. `matrix_check` only prints on failure and never exits, so a failing assertion cannot be the
cause, and the pristine and fixed scripts each ran cleanly four times under the same conditions. The
most likely explanation is leftover child processes from earlier runs I had killed, since the clean
batches followed an explicit `pkill` and the stalling ones did not. I did not root-cause it, so the
discrimination evidence above is the isolated two-implementation comparison rather than an in-situ
red test. Flagging it rather than presenting the isolated run as equivalent.

## Related, not in this PR

The ledger's `lastCompleteVersion` had regressed to 2.1.243 because I retriaged an older release
after a newer one; it has been corrected to 2.1.246 directly in the state file. Ordering retriages
oldest-first avoids it. Not worth code, but worth knowing.