### PR TITLE
fix(openai): prevent nested agents from being forced into worktrees

### DIFF
--- a/src/sdk-adapter.ts
+++ b/src/sdk-adapter.ts
@@ -420,12 +420,16 @@ function toolRequiredProps(tools?: SdkCallParams['tools']): Map<string, Readonly
   return map;
 }
 
-export function translateTools(anthropicTools?: AnthropicTool[]): Record<string, ReturnType<typeof tool>> | undefined {
+export function translateTools(anthropicTools?: AnthropicTool[], npm?: string): Record<string, ReturnType<typeof tool>> | undefined {
   if (!anthropicTools?.length) return undefined;
   const tools: Record<string, ReturnType<typeof tool>> = {};
   for (const t of anthropicTools) {
     if (!t.name || !t.input_schema) continue;
-    tools[t.name] = tool({ description: t.description ?? '', inputSchema: jsonSchema(t.input_schema) });
+    tools[t.name] = tool({
+      description: t.description ?? '',
+      inputSchema: jsonSchema(t.input_schema),
+      strict: npm === '@ai-sdk/openai' ? false : undefined,
+    });
   }
   return Object.keys(tools).length ? tools : undefined;
 }
@@ -546,7 +550,7 @@ export function translateRequest(
       ...translateMessages(messages, npm, supportsExplicitOpenAiCaching),
     ],
     allowSystemInMessages: true,
-    tools: translateTools(upstreamTools.length ? upstreamTools : undefined),
+    tools: translateTools(upstreamTools.length ? upstreamTools : undefined, npm),
     toolChoice: compactRequest ? 'none' : translateToolChoice(body.tool_choice),
     maxOutputTokens: options?.openAiOAuth ? undefined : body.max_tokens,
     temperature: body.temperature,

--- a/tests/sdk-adapter.test.ts
+++ b/tests/sdk-adapter.test.ts
@@ -43,10 +43,72 @@ describe('translateTools', () => {
   it('builds client-side tools (no execute) keyed by name', () => {
     const tools = translateTools([
       { name: 'Read', description: 'read a file', input_schema: { type: 'object', properties: { path: { type: 'string' } } } },
-    ]);
+    ], '@ai-sdk/openai-compatible');
     expect(tools && Object.keys(tools)).toEqual(['Read']);
     expect(tools!.Read.execute).toBeUndefined();
+    expect(tools?.Read.strict).toBeUndefined();
   });
+  it('serializes optional properties as optional OpenAI function arguments', async () => {
+    const requestBodies: unknown[] = [];
+    const provider = createOpenAI({
+      apiKey: 'synthetic-test-key',
+      fetch: async (_input, init) => {
+        requestBodies.push(JSON.parse(String(init?.body)));
+        return new Response(JSON.stringify({
+          id: 'resp_synthetic',
+          model: 'gpt-5.6-sol',
+          output: [],
+          usage: {
+            input_tokens: 1,
+            input_tokens_details: { cached_tokens: 0 },
+            output_tokens: 0,
+            output_tokens_details: { reasoning_tokens: 0 },
+          },
+        }), { status: 200, headers: { 'content-type': 'application/json' } });
+      },
+    });
+    const params = translateRequest({
+      model: 'gpt-5.6-sol',
+      messages: [{ role: 'user', content: 'delegate this task' }],
+      tools: [{
+        name: 'Agent',
+        description: 'Launch an agent',
+        input_schema: {
+          type: 'object',
+          properties: {
+            description: { type: 'string' },
+            prompt: { type: 'string' },
+            isolation: { type: 'string', enum: ['worktree', 'remote'] },
+          },
+          required: ['description', 'prompt'],
+        },
+      }],
+    }, '@ai-sdk/openai', { openAiOAuth: true });
+
+    await generateAnthropicResponse(
+      provider.responses('gpt-5.6-sol'), params, 'gpt-5.6-sol');
+
+    expect(requestBodies).toEqual([
+      expect.objectContaining({
+        tools: [{
+          type: 'function',
+          name: 'Agent',
+          description: 'Launch an agent',
+          strict: false,
+          parameters: {
+            type: 'object',
+            properties: {
+              description: { type: 'string' },
+              prompt: { type: 'string' },
+              isolation: { type: 'string', enum: ['worktree', 'remote'] },
+            },
+            required: ['description', 'prompt'],
+          },
+        }],
+      }),
+    ]);
+  });
+
   it('returns undefined for empty/missing tools', () => {
     expect(translateTools(undefined)).toBeUndefined();
     expect(translateTools([])).toBeUndefined();


### PR DESCRIPTION
Nested Claude Code agents routed through OpenAI could be forced into temporary Git worktrees even when their Agent input did not request isolation. This change preserves optional tool arguments so those agents stay in the caller's checkout unless isolation is explicitly selected.

## Root cause

Clodex passed the original Anthropic tool JSON Schema to the AI SDK without setting the function tool's `strict` flag. OpenAI Responses may normalize a tool with an omitted `strict` value toward strict mode, where every property must be required. For Claude Code's Agent schema, that made optional properties such as `isolation` mandatory and forced the model to choose `worktree` or `remote`.

The official OpenAI Codex serializer explicitly sends `strict: false` for Responses function tools: https://github.com/openai/codex/blob/21ff2e802cd74eee8b25db6b17d9bd4891a42e38/codex-rs/tools/src/responses_api.rs

## Change

- Set `strict: false` only for tools translated through `@ai-sdk/openai`.
- Preserve the original schema and its `required` list unchanged.
- Leave the strict setting unset for other providers.
- Keep the existing tool-input sanitization and OAuth continuation normalization unchanged.

This deliberately avoids converting optional properties into nullable required properties. Such a conversion would alter Claude Code's tool contract and would require recursive handling of nested objects, unions, references, `additionalProperties`, and unsupported schema keywords.

## Verification

- Added a wire-level Responses request test proving the Agent tool is serialized with `strict: false`, while `description` and `prompt` remain required and `isolation` remains optional.
- Added a provider-scope assertion proving OpenAI-compatible tools remain unchanged.
- Mutation check: replacing the scoped `strict: false` assignment with `undefined` makes the full adapter test file fail exactly the new regression test; restoring it passes all 73 adapter tests.
- `corepack pnpm typecheck`
- `corepack pnpm test`: 103 files and 1,964 tests passed.
- `corepack pnpm build`
- `git diff --check`

A runtime reproduction used a fresh temporary Git repository, a clean Claude configuration, endpoint bridge mode, the ChatGPT OAuth `sol` route, and no session persistence. Official v2.8.2 placed the nested Explore agent under `<fixture>/.claude/worktrees/agent-*`; the patched build reported `<fixture>` itself. Both runs exited successfully, and automatic cleanup left the fixture's Git worktree list unchanged.

Environment: Darwin arm64, Node.js 24.16.0, repository-pinned pnpm 10.34.5.

## Boundaries

`strict: false` prevents the Responses backend from making optional fields mandatory. It does not prevent a model from voluntarily requesting isolation when that behavior is appropriate. Native Claude Code background-session isolation is separate from this translation path.
