### PR TITLE
fix(openai): stop scrambling a malformed tool call into unreadable arguments

### DIFF
--- a/src/oauth/responses-websocket.ts
+++ b/src/oauth/responses-websocket.ts
@@ -568,7 +568,7 @@ function toolArgumentNormalizationGap(
       // `arguments` cannot be reported as the filler-strip rule having forked.
       return canonicalJson({
         ...(normalizeToolCallJson(item) as JsonObject),
-        arguments: canonicalJson(sanitizeToolInput(parsed as Record<string, unknown>, required)),
+        arguments: canonicalJson(sanitizeToolInput(parsed, required)),
       });
     } catch { return undefined; }
   };
@@ -1234,7 +1234,7 @@ function sanitizedCallArguments(item: JsonObject, requiredProps: Map<string, Set
   const required = requiredProps.get(typeof item.name === 'string' ? item.name : '');
   return {
     ...item,
-    arguments: JSON.stringify(sanitizeToolInput(parsed as Record<string, unknown>, required)),
+    arguments: JSON.stringify(sanitizeToolInput(parsed, required)),
   };
 }
 

--- a/src/sdk-adapter.ts
+++ b/src/sdk-adapter.ts
@@ -856,7 +856,7 @@ export async function writeAnthropicStream(
           // falling back to the buffered raw JSON if the SDK gave no parsed input.
           if (!flushedTools.has(id)) {
             const json = part.input !== undefined && part.input !== null
-              ? JSON.stringify(sanitizeToolInput(part.input as Record<string, unknown>, requiredProps.get(part.toolName ?? '')))
+              ? JSON.stringify(sanitizeToolInput(part.input, requiredProps.get(part.toolName ?? '')))
               : (toolJsonBuffer.get(id) ?? '');
             if (json) {
               emit('content_block_delta', {
@@ -874,7 +874,7 @@ export async function writeAnthropicStream(
           });
           emit('content_block_delta', {
             type: 'content_block_delta', index: blockIndex,
-            delta: { type: 'input_json_delta', partial_json: JSON.stringify(sanitizeToolInput(part.input as Record<string, unknown> ?? {}, requiredProps.get(part.toolName ?? ''))) },
+            delta: { type: 'input_json_delta', partial_json: JSON.stringify(sanitizeToolInput(part.input ?? {}, requiredProps.get(part.toolName ?? ''))) },
           });
           flushedTools.add(id);
         }
@@ -1105,7 +1105,7 @@ export async function generateAnthropicResponse(
         type: 'tool_use',
         id: encodeToolUseId(tc.toolCallId, grabRoundTripSignature(tc as FullStreamPart)),
         name: tc.toolName,
-        input: sanitizeToolInput(tc.input as Record<string, unknown> ?? {}, requiredProps.get(tc.toolName)),
+        input: sanitizeToolInput(tc.input ?? {}, requiredProps.get(tc.toolName)),
       })),
     ],
     stop_reason: finishReason === 'tool-calls' ? 'tool_use' : 'end_turn',

--- a/src/sdk-adapter.ts
+++ b/src/sdk-adapter.ts
@@ -409,6 +409,19 @@ export function translateMessages(
   return out;
 }
 
+/**
+ * Claude Code's non-streaming fallback rejects a `tool_use` whose `input` is
+ * neither a string nor an object (lodash `isObject`, so arrays pass but numbers
+ * and booleans do not) by throwing rather than answering with a tool_result the
+ * model can retry. A scalar is never valid Anthropic tool input anyway, so send
+ * the empty object it used to collapse to and let schema validation reject it
+ * the ordinary, retryable way. Strings and arrays reach the client unchanged.
+ */
+function representableToolInput(input: unknown): unknown {
+  if (typeof input === 'string') return input;
+  return input !== null && typeof input === 'object' ? input : {};
+}
+
 /** Per-tool `required` property sets, read back out of the translated tool schemas. */
 function toolRequiredProps(tools?: SdkCallParams['tools']): Map<string, ReadonlySet<string>> {
   const map = new Map<string, ReadonlySet<string>>();
@@ -1105,7 +1118,7 @@ export async function generateAnthropicResponse(
         type: 'tool_use',
         id: encodeToolUseId(tc.toolCallId, grabRoundTripSignature(tc as FullStreamPart)),
         name: tc.toolName,
-        input: sanitizeToolInput(tc.input ?? {}, requiredProps.get(tc.toolName)),
+        input: representableToolInput(sanitizeToolInput(tc.input ?? {}, requiredProps.get(tc.toolName))),
       })),
     ],
     stop_reason: finishReason === 'tool-calls' ? 'tool_use' : 'end_turn',

--- a/src/tool-input-sanitize.ts
+++ b/src/tool-input-sanitize.ts
@@ -23,13 +23,24 @@
  * The returned object is prototype-less so model-controlled keys like
  * `__proto__` are stored as ordinary own properties instead of silently
  * invoking the plain-object setter.
+ *
+ * Anything that is not a plain object is returned unchanged. A model can emit
+ * arguments that parse to an array or a scalar, or that do not parse at all —
+ * in which case the SDK hands the raw string through as the input. Iterating
+ * those with `Object.entries` invents a character-index map
+ * (`'{"path":'` -> `{"0":"{","1":"\""...}`), which is not what the model said
+ * and is not what `sanitizedCallArguments` in oauth/responses-websocket.ts
+ * records for the same call — it returns those shapes untouched. Passing them
+ * through keeps the one shared rule single-valued, and lets the malformed
+ * input reach the client as itself so it can be rejected honestly.
  */
 export function sanitizeToolInput(
-  input: Record<string, unknown>,
+  input: unknown,
   requiredProps?: ReadonlySet<string>,
-): Record<string, unknown> {
+): unknown {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return input;
   const out: Record<string, unknown> = Object.create(null);
-  for (const [k, v] of Object.entries(input)) {
+  for (const [k, v] of Object.entries(input as Record<string, unknown>)) {
     if (v === null) continue;
     if (Array.isArray(v) && v.length === 0 && !requiredProps?.has(k)) continue;
     out[k] = v;

--- a/tests/sdk-adapter.test.ts
+++ b/tests/sdk-adapter.test.ts
@@ -48,7 +48,7 @@ describe('translateTools', () => {
     expect(tools!.Read.execute).toBeUndefined();
     expect(tools?.Read.strict).toBeUndefined();
   });
-  it('serializes optional properties as optional OpenAI function arguments', async () => {
+  it('sends strict: false so OpenAI does not make optional tool properties mandatory', async () => {
     const requestBodies: unknown[] = [];
     const provider = createOpenAI({
       apiKey: 'synthetic-test-key',
@@ -90,10 +90,9 @@ describe('translateTools', () => {
 
     expect(requestBodies).toEqual([
       expect.objectContaining({
-        tools: [{
+        tools: [expect.objectContaining({
           type: 'function',
           name: 'Agent',
-          description: 'Launch an agent',
           strict: false,
           parameters: {
             type: 'object',
@@ -104,7 +103,7 @@ describe('translateTools', () => {
             },
             required: ['description', 'prompt'],
           },
-        }],
+        })],
       }),
     ]);
   });

--- a/tests/sdk-adapter.test.ts
+++ b/tests/sdk-adapter.test.ts
@@ -1400,6 +1400,49 @@ describe('writeAnthropicStream', () => {
     expect(toolInputFromEvents(events)).toEqual({ query: 'who won' });
   });
 
+  // A model can emit arguments that parse to an array or a scalar, or that do
+  // not parse at all — the SDK then hands the raw string through as the input.
+  // Iterating those with Object.entries invented a character-index map, which
+  // is neither what the model said nor what the OAuth head snapshot records for
+  // the same call (sanitizedCallArguments returns those shapes untouched).
+  it.each([
+    ['a malformed JSON string', '{"query":'],
+    ['a JSON array', ['a', 'b']],
+    ['a bare string', 'just a string'],
+  ])('passes %s through instead of inventing a character-index map', async (_label, raw) => {
+    const requestBodies: unknown[] = [];
+    const provider = createOpenAI({
+      apiKey: 'synthetic-test-key',
+      fetch: async () => {
+        requestBodies.push(null);
+        return new Response(JSON.stringify({
+          id: 'resp_synthetic',
+          model: 'm',
+          output: [{ type: 'function_call', id: 'fc1', call_id: 'call_1', name: 'WebSearch', arguments: typeof raw === 'string' ? raw : JSON.stringify(raw) }],
+          usage: {
+            input_tokens: 1,
+            input_tokens_details: { cached_tokens: 0 },
+            output_tokens: 1,
+            output_tokens_details: { reasoning_tokens: 0 },
+          },
+        }), { status: 200, headers: { 'content-type': 'application/json' } });
+      },
+    });
+    const params = translateRequest({
+      model: 'm',
+      messages: [{ role: 'user', content: 'go' }],
+      tools: [{
+        name: 'WebSearch',
+        description: 'Search the web',
+        input_schema: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] },
+      }],
+    }, '@ai-sdk/openai');
+
+    const out = await generateAnthropicResponse(provider.responses('m'), params, 'm');
+    const toolUse = out.content.find((c: { type: string }) => c.type === 'tool_use') as { input: unknown } | undefined;
+    expect(toolUse?.input).toEqual(raw);
+  });
+
   it('preserves an intentional empty array for a schema-required property', async () => {
     const todoTools = translateTools([{
       name: 'TodoWrite',

--- a/tests/sdk-adapter.test.ts
+++ b/tests/sdk-adapter.test.ts
@@ -93,6 +93,7 @@ describe('translateTools', () => {
         tools: [expect.objectContaining({
           type: 'function',
           name: 'Agent',
+          description: 'Launch an agent',
           strict: false,
           parameters: {
             type: 'object',
@@ -1408,7 +1409,7 @@ describe('writeAnthropicStream', () => {
     ['a malformed JSON string', '{"query":'],
     ['a JSON array', ['a', 'b']],
     ['a bare string', 'just a string'],
-  ])('passes %s through instead of inventing a character-index map', async (_label, raw) => {
+  ])('passes %s through on the non-streamed path instead of inventing a character-index map', async (_label, raw) => {
     const requestBodies: unknown[] = [];
     const provider = createOpenAI({
       apiKey: 'synthetic-test-key',
@@ -1440,6 +1441,33 @@ describe('writeAnthropicStream', () => {
     const out = await generateAnthropicResponse(provider.responses('m'), params, 'm');
     const toolUse = out.content.find((c: { type: string }) => c.type === 'tool_use') as { input: unknown } | undefined;
     expect(toolUse?.input).toEqual(raw);
+  });
+
+  // The streaming path is the one Claude Code actually uses (and OAuth forces
+  // it), so it needs its own coverage: the raw-JSON buffer only stands in when
+  // the SDK supplies no parsed input, and for an array or an invalid dynamic
+  // tool call it supplies a non-object one instead.
+  it.each([
+    ['a malformed JSON string', '{"path":'],
+    ['a JSON array', ['a', 'b']],
+    ['a bare string', 'hello'],
+  ])('passes %s through on the streamed path too', async (_label, bad) => {
+    const readTools = translateTools([{
+      name: 'Read',
+      description: 'Read a file',
+      input_schema: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] },
+    }]);
+    const { events } = await collect([
+      { type: 'start' },
+      { type: 'tool-input-start', id: 'c1', toolName: 'Read' },
+      { type: 'tool-call', toolCallId: 'c1', toolName: 'Read', input: bad },
+      { type: 'finish', finishReason: 'tool-calls' },
+    ], 'm', undefined, readTools);
+    const json = events
+      .filter(e => e.event === 'content_block_delta' && e.data.delta.type === 'input_json_delta')
+      .map(e => e.data.delta.partial_json)
+      .join('');
+    expect(JSON.parse(json)).toEqual(bad);
   });
 
   it('preserves an intentional empty array for a schema-required property', async () => {

--- a/tests/sdk-adapter.test.ts
+++ b/tests/sdk-adapter.test.ts
@@ -1406,10 +1406,16 @@ describe('writeAnthropicStream', () => {
   // is neither what the model said nor what the OAuth head snapshot records for
   // the same call (sanitizedCallArguments returns those shapes untouched).
   it.each([
-    ['a malformed JSON string', '{"query":'],
-    ['a JSON array', ['a', 'b']],
-    ['a bare string', 'just a string'],
-  ])('passes %s through on the non-streamed path instead of inventing a character-index map', async (_label, raw) => {
+    ['a malformed JSON string', '{"query":', '{"query":'],
+    ['a JSON array', ['a', 'b'], ['a', 'b']],
+    ['a bare string', 'just a string', 'just a string'],
+    // Claude Code's non-streaming fallback throws on a tool_use input that is
+    // neither a string nor an object, instead of answering with a tool_result
+    // the model can retry. A scalar is never valid Anthropic tool input, so it
+    // collapses to {} and gets rejected the ordinary, retryable way.
+    ['a number', 42, {}],
+    ['a boolean', true, {}],
+  ])('sends %s in a shape the client can represent, on the non-streamed path', async (_label, raw, expected) => {
     const requestBodies: unknown[] = [];
     const provider = createOpenAI({
       apiKey: 'synthetic-test-key',
@@ -1440,7 +1446,7 @@ describe('writeAnthropicStream', () => {
 
     const out = await generateAnthropicResponse(provider.responses('m'), params, 'm');
     const toolUse = out.content.find((c: { type: string }) => c.type === 'tool_use') as { input: unknown } | undefined;
-    expect(toolUse?.input).toEqual(raw);
+    expect(toolUse?.input).toEqual(expected);
   });
 
   // The streaming path is the one Claude Code actually uses (and OAuth forces

--- a/tests/sdk-adapter.test.ts
+++ b/tests/sdk-adapter.test.ts
@@ -1457,17 +1457,29 @@ describe('writeAnthropicStream', () => {
       description: 'Read a file',
       input_schema: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] },
     }]);
-    const { events } = await collect([
+    const partialJson = async (parts: unknown[]) => {
+      const { events } = await collect(parts as never[], 'm', undefined, readTools);
+      return events
+        .filter(e => e.event === 'content_block_delta' && e.data.delta.type === 'input_json_delta')
+        .map(e => e.data.delta.partial_json)
+        .join('');
+    };
+    // Emitted after a tool-input-start, so the block is already open.
+    expect(JSON.parse(await partialJson([
       { type: 'start' },
       { type: 'tool-input-start', id: 'c1', toolName: 'Read' },
       { type: 'tool-call', toolCallId: 'c1', toolName: 'Read', input: bad },
       { type: 'finish', finishReason: 'tool-calls' },
-    ], 'm', undefined, readTools);
-    const json = events
-      .filter(e => e.event === 'content_block_delta' && e.data.delta.type === 'input_json_delta')
-      .map(e => e.data.delta.partial_json)
-      .join('');
-    expect(JSON.parse(json)).toEqual(bad);
+    ]))).toEqual(bad);
+    // A bare tool-call with no tool-input-start opens its own block instead, and
+    // has no buffered raw JSON to fall back on. @ai-sdk/openai emits this shape
+    // from response.output_item.done for file_search_call, image_generation_call,
+    // mcp_call, local_shell_call and shell_call.
+    expect(JSON.parse(await partialJson([
+      { type: 'start' },
+      { type: 'tool-call', toolCallId: 'c2', toolName: 'Read', input: bad },
+      { type: 'finish', finishReason: 'tool-calls' },
+    ]))).toEqual(bad);
   });
 
   it('preserves an intentional empty array for a schema-required property', async () => {


### PR DESCRIPTION
> **HOLD — do not merge. A live smoke test invalidated this PR's central claim.**
>
> Forcing a malformed tool argument through a real MCP tool with an all-optional schema, on this
> branch and on `main`, the MCP server received the **identical** value both times:
> `{"0":"{","1":"\"","2":"c","3":"i","4":"t","5":"y","6":"\"","7":":"}`.
>
> Claude Code object-spreads `tool_use.input` itself before validation and execution, so passing a
> non-object through does not stop an index map from reaching the tool — the client rebuilds it. The
> "tool runs on invented arguments" defect described below is therefore **not** closed by this diff.
> For tools with required properties, both versions reject identically.
>
> What remains true: clodex stops fabricating a value the model never sent. That is worth having,
> but it is hygiene in clodex's own output, not a downstream behavior fix.
>
> There may also be a downside: the transcript renderer validates the raw value, so a non-object
> input may render the tool-use row as nothing — same execution, less visibility. Not yet verified
> in a TUI.
>
> The better fix this exposed: emit the **raw bytes** for unparseable arguments, the way the
> `toolJsonBuffer` fallback already does. Then the client's `JSON.parse` fails and the model gets its
> actionable "input could not be parsed as JSON — retry with valid JSON" message. The JSON-quoted
> string this PR emits parses cleanly and degrades right back into the index map.
>
> Smoke tests that DID pass, on both this branch and `main` (no regression): WebSearch, an
> all-optional MCP tool, and Read/Bash/Edit/Glob, across luna and sol.

---

When a model returns tool arguments that are not a JSON object, clodex handed Claude Code a
character-index map of the raw text instead of the arguments themselves:

```
upstream arguments: {"path":
delivered to client: {"0":"{","1":"\"","2":"p","3":"a","4":"t","5":"h","6":"\"","7":":"}
```

The filler-strip rule in `src/tool-input-sanitize.ts` iterates its input with `Object.entries`.
That is correct for the object it was written for, but a model can also emit arguments that parse
to an array or a scalar, or that do not parse at all — in which case the SDK passes the raw string
through as the input. Iterating a string enumerates its characters.

## Change

Non-object input is returned unchanged. The parameter type widens to `unknown`, which lets five
`as Record<string, unknown>` casts come out of the call sites — those casts were what let a
non-object reach the loop in the first place.

## Reachability

**Both the streaming and non-streaming paths were affected, so the OAuth route was too.** Driving
each non-object shape through `writeAnthropicStream` and `generateAnthropicResponse` with the guard
removed produces the same corruption on both:

| shape | before | after |
| --- | --- | --- |
| `{"path":` | `{"0":"{","1":"\"",...}` | `{"path":` |
| `["a","b"]` | `{"0":"a","1":"b"}` | `["a","b"]` |
| `just a string` | `{"0":"j","1":"u",...}` | `just a string` |

An earlier draft of this description claimed streaming was already correct via the
`toolJsonBuffer` fallback. That was wrong, and the review caught it. The fallback only runs when
the SDK supplies *no* parsed input; when it supplies a non-object one — which it does for an array,
and for an invalid dynamic tool call — line 859 and the `else if (openType !== 'tool')` site at
line 877 both scramble it. The fix is worth more than the first draft claimed, not less.

## Where a non-object input comes from

`LanguageModelV4ToolCall.input` is documented as "Stringified JSON object", but the OpenAI Responses
provider does not enforce the object part. For `function_call` — the only tool type clodex
advertises, since `translateTools` always emits `type: 'function'` — the done event's schema
validates `arguments` as `z.string()` only, and the handler passes it through unchanged. So an
array, a scalar, or malformed JSON all reach `part.input` as a non-object. `mcp_call` and
`mcp_approval_request` do the same.

(For completeness: `custom_tool_call` is structurally *always* non-object — its schema requires
`input: z.string()` and the handler `JSON.stringify`s it, so the value round-trips to a JS string
every time. clodex should never see one, because it never advertises a custom tool. Noting it only
because it shows the "stringified JSON object" contract is advisory rather than enforced.)

## What changes for the user, stated carefully

The proven change is that **the model's own value is preserved**. Rejection itself is mostly not
new: against Claude Code 2.1.247 both the pre-fix character map and a passed-through `"hello"`
produce the same `InputValidationError` for `Read`, because both fail the tool's schema. So this is
not "silently executed before, rejected now" in the general case.

The scope is narrower still: for any tool with a required property — essentially every built-in the
model calls — the old character map was rejected too, and only the error text changes. The case where
behavior really differs is a tool whose schema has **no required properties** (`ListMcpResourcesTool`
and many MCP tools): there the character map strips clean to `{}`, validates, and the tool **runs on
invented arguments**. That is the defect this closes.

What it buys:

- The error names what the model actually sent, so the retry is informed rather than confusing.
- Where a permissive schema would have *accepted* the fabricated index map, the call no longer runs
  on invented arguments. That is the narrow case where behavior changes from executing to rejecting.

For reference, the downstream half was traced through the Claude Code 2.1.247 bundle: it accumulates
`input_json_delta` as a string and runs plain `JSON.parse` at `content_block_stop` (the vendored
Anthropic SDK's tolerant partial-JSON accumulator is present but is dead code for the tool loop). A
non-object that parses cleanly reaches Zod and comes back as an ordinary validation error; only a
genuine parse failure produces the "retry with valid JSON" sentinel.

## A regression this fix created, and closed

Passing scalars through turned out to be worse than the old behavior on one path. Claude Code's
non-streaming fallback begins by throwing on a `tool_use` whose `input` is neither a string nor an
object (lodash `isObject`, so arrays pass but a number or boolean does not). It is caught, so nothing
crashes, but the turn ends as an API-style error instead of the `tool_result` the model could have
retried — where previously the scalar collapsed to `{}` and was rejected the ordinary way.

`representableToolInput` at the non-streaming site now sends `{}` for a number or boolean, and leaves
strings, arrays and objects untouched. Streaming is unaffected: there the client accumulates input as
a string and parses at `content_block_stop`, so it never sees a scalar. Pinned by two tests;
mutation-checked in isolation.

## Known divergences NOT closed here

`sanitizeToolInput` and `sanitizedCallArguments` in `src/oauth/responses-websocket.ts` are
documented as one shared rule. This brings them closer but does not make them identical, and I would
rather name the gaps than imply they are gone:

- **Explicit `null`.** `tc.input ?? {}` (line 1108, and line 877) collapses a missing input and an
  upstream `arguments: "null"` into the same `{}`, while the snapshot preserves `"null"`. Reachable
  only if a model emits bare `null` as an entire arguments payload. Pre-existing and untouched by
  this diff — note that line 859 already excludes `null` before reaching the sanitizer, so the fix
  is subtler than it looks and wants its own change.
- **Malformed strings.** The snapshot keeps the original bytes while the client echoes them
  JSON-quoted, so continuation still diverges for that shape. Also pre-existing.

Both are #84-class echo mismatches and deserve their own PR rather than being folded in here.

## Verification

- Eight regression tests: three non-object shapes over each of the streaming and non-streaming
  paths, plus the two scalar shapes above.
  The streaming ones drive BOTH emit sites — one after a `tool-input-start`, and one bare
  `tool-call` with no start and so no buffered raw JSON to fall back on. That second shape is not
  hypothetical: `@ai-sdk/openai` emits it from `response.output_item.done` for `file_search_call`,
  `image_generation_call`, `mcp_call`, `local_shell_call` and `shell_call`, and `ai` never
  synthesizes a missing start — it forwards provider ordering verbatim, and its own
  `simulateStreamingMiddleware` produces the same shape. Mutation-checked in isolation: breaking
  only that site reddens the three streaming tests.
- Mutation, both directions: removing the guard reddens exactly those six in a full-file run;
  restoring it returns 81/81 in `tests/sdk-adapter.test.ts`.
- `pnpm typecheck && pnpm test && pnpm build` — 103 files, 1972 tests, all green. Re-run with an
  unreachable proxy (`HTTPS_PROXY=http://127.0.0.1:9`) to confirm no dependence on ambient bridge
  env: same result.

## Test-only commits

`de14eb3` renames the strict-mode test added in #153 and loosens its wire assertion from an exact
tool object to `objectContaining` — only `strict` is clodex-controlled there, and the AI SDK's
serializer already emits a second conditional field (`defer_loading`) in the same object. The tool
`description` is kept inside the matcher, because dropping it left the file green when
`translateTools` was mutated to send an empty description.

`b5bc987` adds the streaming coverage and renames the original three to say `non-streamed`, since
they sit under `describe('writeAnthropicStream')` and did not exercise it.
