### PR TITLE
fix(openai): let a garbled tool call be retried instead of run with invented arguments

### DIFF
--- a/src/oauth/responses-websocket.ts
+++ b/src/oauth/responses-websocket.ts
@@ -568,7 +568,7 @@ function toolArgumentNormalizationGap(
       // `arguments` cannot be reported as the filler-strip rule having forked.
       return canonicalJson({
         ...(normalizeToolCallJson(item) as JsonObject),
-        arguments: canonicalJson(sanitizeToolInput(parsed as Record<string, unknown>, required)),
+        arguments: canonicalJson(sanitizeToolInput(parsed, required)),
       });
     } catch { return undefined; }
   };
@@ -1234,7 +1234,7 @@ function sanitizedCallArguments(item: JsonObject, requiredProps: Map<string, Set
   const required = requiredProps.get(typeof item.name === 'string' ? item.name : '');
   return {
     ...item,
-    arguments: JSON.stringify(sanitizeToolInput(parsed as Record<string, unknown>, required)),
+    arguments: JSON.stringify(sanitizeToolInput(parsed, required)),
   };
 }
 

--- a/src/sdk-adapter.ts
+++ b/src/sdk-adapter.ts
@@ -409,6 +409,31 @@ export function translateMessages(
   return out;
 }
 
+/** True for a JSON object — the only shape the tool-input strip rule applies to. */
+function isPlainObject(value: unknown): boolean {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/** True when `text` is parseable JSON, so forwarding it verbatim would not surface an error. */
+function parsesAsJson(text: string): boolean {
+  if (text.trim() === '') return true;
+  try { JSON.parse(text); return true; } catch { return false; }
+}
+
+/**
+ * Claude Code's non-streaming fallback rejects a `tool_use` whose `input` is
+ * neither a string nor an object (lodash `isObject`, so arrays pass but numbers
+ * and booleans do not) by throwing rather than answering with a tool_result the
+ * model can retry. A scalar is never valid Anthropic tool input, so send the
+ * empty object it used to collapse to and let validation reject it the ordinary
+ * way. A string is kept: that path re-parses it, and an unparseable one becomes
+ * the same retryable JSON-parse error the streamed path now produces.
+ */
+function representableToolInput(input: unknown): unknown {
+  if (typeof input === 'string') return input;
+  return isPlainObject(input) || Array.isArray(input) ? input : {};
+}
+
 /** Per-tool `required` property sets, read back out of the translated tool schemas. */
 function toolRequiredProps(tools?: SdkCallParams['tools']): Map<string, ReadonlySet<string>> {
   const map = new Map<string, ReadonlySet<string>>();
@@ -854,10 +879,20 @@ export async function writeAnthropicStream(
         if (idToBlock.has(id)) {
           // Streamed input: emit the sanitized complete input as one delta,
           // falling back to the buffered raw JSON if the SDK gave no parsed input.
+          //
+          // Arguments that do not parse at all are forwarded as the model's own
+          // bytes. Claude Code re-parses this text, so anything derived from a
+          // failed parse — the SDK's raw-string passthrough, JSON-quoted — parses
+          // cleanly on its side and is spread into a character-index map that it
+          // then acts on. Sending the bytes makes its parse fail as ours did, and
+          // it answers the model with a retryable "could not be parsed as JSON".
           if (!flushedTools.has(id)) {
-            const json = part.input !== undefined && part.input !== null
-              ? JSON.stringify(sanitizeToolInput(part.input as Record<string, unknown>, requiredProps.get(part.toolName ?? '')))
-              : (toolJsonBuffer.get(id) ?? '');
+            const buffered = toolJsonBuffer.get(id);
+            const json = buffered !== undefined && !isPlainObject(part.input) && !parsesAsJson(buffered)
+              ? buffered
+              : part.input !== undefined && part.input !== null
+                ? JSON.stringify(sanitizeToolInput(part.input, requiredProps.get(part.toolName ?? '')))
+                : (buffered ?? '');
             if (json) {
               emit('content_block_delta', {
                 type: 'content_block_delta', index: idToBlock.get(id) ?? blockIndex,
@@ -874,7 +909,7 @@ export async function writeAnthropicStream(
           });
           emit('content_block_delta', {
             type: 'content_block_delta', index: blockIndex,
-            delta: { type: 'input_json_delta', partial_json: JSON.stringify(sanitizeToolInput(part.input as Record<string, unknown> ?? {}, requiredProps.get(part.toolName ?? ''))) },
+            delta: { type: 'input_json_delta', partial_json: JSON.stringify(sanitizeToolInput(part.input ?? {}, requiredProps.get(part.toolName ?? ''))) },
           });
           flushedTools.add(id);
         }
@@ -1105,7 +1140,7 @@ export async function generateAnthropicResponse(
         type: 'tool_use',
         id: encodeToolUseId(tc.toolCallId, grabRoundTripSignature(tc as FullStreamPart)),
         name: tc.toolName,
-        input: sanitizeToolInput(tc.input as Record<string, unknown> ?? {}, requiredProps.get(tc.toolName)),
+        input: representableToolInput(sanitizeToolInput(tc.input ?? {}, requiredProps.get(tc.toolName))),
       })),
     ],
     stop_reason: finishReason === 'tool-calls' ? 'tool_use' : 'end_turn',

--- a/src/tool-input-sanitize.ts
+++ b/src/tool-input-sanitize.ts
@@ -23,13 +23,22 @@
  * The returned object is prototype-less so model-controlled keys like
  * `__proto__` are stored as ordinary own properties instead of silently
  * invoking the plain-object setter.
+ *
+ * Anything that is not a plain object is returned unchanged. A model can emit
+ * arguments that parse to an array or a scalar, or that do not parse at all —
+ * in which case the SDK hands the raw string through as the input. Iterating
+ * those with `Object.entries` invents a character-index map
+ * (`'{"path":'` -> `{"0":"{","1":"\""...}`), which is not what the model said
+ * and is not what `sanitizedCallArguments` in oauth/responses-websocket.ts
+ * records for the same call — it returns those shapes untouched.
  */
 export function sanitizeToolInput(
-  input: Record<string, unknown>,
+  input: unknown,
   requiredProps?: ReadonlySet<string>,
-): Record<string, unknown> {
+): unknown {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return input;
   const out: Record<string, unknown> = Object.create(null);
-  for (const [k, v] of Object.entries(input)) {
+  for (const [k, v] of Object.entries(input as Record<string, unknown>)) {
     if (v === null) continue;
     if (Array.isArray(v) && v.length === 0 && !requiredProps?.has(k)) continue;
     out[k] = v;

--- a/tests/sdk-adapter.test.ts
+++ b/tests/sdk-adapter.test.ts
@@ -1400,6 +1400,68 @@ describe('writeAnthropicStream', () => {
     expect(toolInputFromEvents(events)).toEqual({ query: 'who won' });
   });
 
+  // Unparseable arguments must reach the client as the model's own bytes: it
+  // re-parses this text, and anything that parses cleanly gets spread into a
+  // character-index map it will act on. A failed parse instead becomes a
+  // retryable "could not be parsed as JSON" tool_result.
+  it('forwards unparseable streamed arguments as the raw bytes the model sent', async () => {
+    const readTools = translateTools([{
+      name: 'Read', description: 'Read a file',
+      input_schema: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] },
+    }]);
+    const raw = '{"path":';
+    const { events } = await collect([
+      { type: 'start' },
+      { type: 'tool-input-start', id: 'c1', toolName: 'Read' },
+      { type: 'tool-input-delta', id: 'c1', delta: raw },
+      // the SDK hands the unparsed text back as the input when it cannot parse it
+      { type: 'tool-call', toolCallId: 'c1', toolName: 'Read', input: raw },
+      { type: 'finish', finishReason: 'tool-calls' },
+    ], 'm', undefined, readTools);
+    const json = events
+      .filter(e => e.event === 'content_block_delta' && e.data.delta.type === 'input_json_delta')
+      .map(e => e.data.delta.partial_json).join('');
+    expect(json).toBe(raw);
+    expect(() => JSON.parse(json)).toThrow();
+  });
+
+  it('still sends parseable streamed arguments as sanitized JSON', async () => {
+    const { events } = await collect([
+      { type: 'start' },
+      { type: 'tool-input-start', id: 'c1', toolName: 'WebSearch' },
+      { type: 'tool-input-delta', id: 'c1', delta: '{"query":"q","blocked_domains":[]}' },
+      { type: 'tool-call', toolCallId: 'c1', toolName: 'WebSearch', input: { query: 'q', blocked_domains: [] } },
+      { type: 'finish', finishReason: 'tool-calls' },
+    ], 'm', undefined, webSearchTools);
+    expect(toolInputFromEvents(events)).toEqual({ query: 'q' });
+  });
+
+  it.each([
+    ['a JSON array', ['a', 'b'], ['a', 'b']],
+    ['a bare string', 'just a string', 'just a string'],
+    // Claude Code's non-streaming fallback throws on input that is neither a
+    // string nor an object, instead of answering with a retryable tool_result.
+    ['a number', 42, {}],
+    ['a boolean', true, {}],
+  ])('sends %s in a shape the client can represent, on the non-streamed path', async (_label, raw, expected) => {
+    const provider = createOpenAI({
+      apiKey: 'synthetic-test-key',
+      fetch: async () => new Response(JSON.stringify({
+        id: 'resp_synthetic', model: 'm',
+        output: [{ type: 'function_call', id: 'fc1', call_id: 'call_1', name: 'WebSearch', arguments: JSON.stringify(raw) }],
+        usage: { input_tokens: 1, input_tokens_details: { cached_tokens: 0 }, output_tokens: 1, output_tokens_details: { reasoning_tokens: 0 } },
+      }), { status: 200, headers: { 'content-type': 'application/json' } }),
+    });
+    const params = translateRequest({
+      model: 'm', messages: [{ role: 'user', content: 'go' }],
+      tools: [{ name: 'WebSearch', description: 'Search the web',
+        input_schema: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] } }],
+    }, '@ai-sdk/openai');
+    const out = await generateAnthropicResponse(provider.responses('m'), params, 'm');
+    const toolUse = out.content.find((c: { type: string }) => c.type === 'tool_use') as { input: unknown } | undefined;
+    expect(toolUse?.input).toEqual(expected);
+  });
+
   it('preserves an intentional empty array for a schema-required property', async () => {
     const todoTools = translateTools([{
       name: 'TodoWrite',


### PR DESCRIPTION
Replaces #155, which was closed after a live smoke test invalidated its premise.

## The defect

When a model emits tool arguments that are not valid JSON, the filler-strip rule in
`src/tool-input-sanitize.ts` iterated the value with `Object.entries`, rewriting it into a
character-index map of the raw text:

```
model sent:          {"path":
client received:     {"0":"{","1":"\"","2":"p","3":"a","4":"t","5":"h","6":"\"","7":":"}
```

That is a valid object, so a tool whose schema has **no required properties** — MCP tools, which all
inherit `z.object({}).passthrough()` — accepts it and **runs on arguments the model never sent**.
Tools with required properties reject it, so the visible symptom is confined to permissive schemas.

## The fix

Forward unparseable arguments as the model's own bytes. This is the load-bearing detail: Claude Code
re-parses the text it receives, so anything *derived* from a failed parse — including the raw string
JSON-quoted — parses cleanly on its side and gets spread into an index map it will act on. Only the
original bytes make its parse fail the way ours did, which routes it to the `__unparsedToolInput`
path: no hook, no permission check, no execution, and a `tool_result` telling the model its input
could not be parsed, with the bytes quoted back so it can retry.

Two supporting pieces:

- `sanitizeToolInput` returns non-object input unchanged instead of rewriting it. Arrays and strings
  reach the client as themselves.
- `representableToolInput` sends `{}` for a number or boolean on the non-streaming path, where the
  client throws on input that is neither a string nor an object rather than answering with a
  retryable result. A string is kept there, because that path re-parses it and lands on the same
  JSON-parse error.

The parameter type widens to `unknown`, which lets five `as Record<string, unknown>` casts come out
of the call sites — those casts were what let a non-object reach the loop to begin with.

## Live verification

A malformed argument forced through a real MCP tool with an all-optional schema, `main` vs this
branch, same prompt and model (`gpt-5.6-luna`, ChatGPT/Codex OAuth route):

| | `main` | this branch |
| --- | --- | --- |
| MCP tool invoked | **yes**, with `{"0":"{","1":"\"",...}` | **never dispatched** (0 dispatches) |
| what the model was told | nothing — it received a fabricated result | `You sent (first 8 of 8 bytes): {"city":` |

Ordinary tool use is unaffected, checked on both branches: WebSearch, an all-optional MCP tool, and
Read/Bash/Edit/Glob, across `luna` and `sol`, zero tool errors on either.

## Tests

Five regressions, each mutation-checked in isolation:

- unparseable streamed arguments arrive as the raw bytes, and `JSON.parse` on them throws —
  removing the forwarding reddens exactly this one
- parseable streamed arguments are still sanitized normally (pins that the new branch is scoped)
- arrays and strings pass through on the non-streamed path — removing the sanitizer guard reddens
  exactly these two
- numbers and booleans become `{}` there — removing `representableToolInput` reddens exactly these two

`pnpm typecheck && pnpm test && pnpm build`: 103 files, 1970 tests, green. Re-run with an
unreachable proxy (`HTTPS_PROXY=http://127.0.0.1:9`) to rule out ambient bridge dependence: same.

## Not closed here

`sanitizeToolInput` and `sanitizedCallArguments` are documented as one shared rule. This narrows the
gap but does not close it, and I would rather name what remains than imply otherwise:

- `tc.input ?? {}` collapses a missing input and an upstream `arguments: "null"` into the same `{}`,
  while the snapshot preserves `"null"`. Pre-existing; note that the streamed emit site excludes
  `null` before the sanitizer runs, so the fix is subtler than it looks.
- For an unparseable payload the snapshot keeps the original bytes while the echo differs, so OAuth
  continuation can still diverge for that shape. Pre-existing.

Both are #84-class echo mismatches and want their own change.
