### PR TITLE
fix(patch): restore Claude Code patching on 2.1.257, broken on every platform

### DIFF
--- a/.claude/docs/patcher.md
+++ b/.claude/docs/patcher.md
@@ -171,6 +171,46 @@ So the blob is published, not rebuilt:
   emits four. Do NOT use `--version` or `--help` (byte-identical between the two) or the model id on
   the wire (passed through unvalidated by both).
 
+## The Bun blob-pointer stand-in (`bun-compiled-pointer.ts`)
+
+ELF only, and a no-op on every release where tweakcc works unaided.
+
+A Bun standalone ELF keeps the virtual address of its `.bun` section in an 8-byte little-endian
+global; Bun reads it at startup to find the blob. `repackELFSection` moves `.bun` to a fresh page
+past the end of the file, so it has to rewrite that global — and it finds it by scanning the first
+writable `PT_LOAD` for eight bytes equal to `.bun`'s current address, **only at addresses that are
+multiples of 16384**. tweakcc 4.3.0 and 4.3.3 both do this, so bumping the pin does not help.
+
+Through Claude Code 2.1.252 the global happened to land on a 16 KiB boundary on every ELF build
+(measured on 2.1.246 and 2.1.252, x64 and arm64, glibc and musl — all at `vaddr % 16384 == 0`).
+2.1.257 moved it off one on all four: `0x534f758` linux-x64, `0x4d9af08` linux-x64-musl,
+`0x5310758` linux-arm64, `0x4c46d10` linux-arm64-musl. The strided scan steps over it and
+`repackELFSection` throws `Could not find original BUN_COMPILED location in binary`. **Alignment is
+not something Bun promises; it was luck, and it ran out.**
+
+So clodex plants a copy of the value the scan is looking for at an address the scan does visit,
+remembers the eight bytes it displaced, and after the repack copies the address tweakcc wrote onto
+the global's real home and puts the displaced bytes back. The published binary differs from an
+unaided repack in exactly one place: the global, holding the value it was always meant to hold.
+
+- **It never runs where tweakcc already works.** The module reproduces tweakcc's own scan first and
+  returns null if that finds anything, so an older release — or a future one that goes back to
+  being aligned — takes the path it always took, byte for byte.
+- **The real global is identified, not guessed:** the ONE 8-byte occurrence of `.bun`'s address
+  inside the writable segment and outside `.bun`'s own payload. Occurrences inside the payload are
+  coincidences in compressed JavaScript (dozens on some builds) and are excluded by range. Anything
+  other than exactly one candidate is refused rather than patched, because publishing a binary whose
+  Bun global still points at the old blob is a `claude` that dies inside Bun before it prints
+  anything.
+- **The restore verifies rather than assumes:** the stand-in must have changed, must agree with
+  where `.bun` actually ended up, and both writes must read back.
+- Mach-O and PE never reach this code — they assign the section in place and rewrite no pointer.
+  That asymmetry is why the failure was ELF-only, and why the probe must be run per format.
+
+`tests/bun-compiled-pointer.test.ts` covers the rules on hand-built ELF64 files. Only
+`scripts/probe-patch-mechanism.mjs` and the canary's container leg cover a real 300 MB build, and
+only the container leg starts the result.
+
 ## The entry-module shim (`bun-entry-module.ts`)
 
 tweakcc finds the module holding the bundle **by name**, and Claude Code 2.1.229 renamed it from

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,12 @@ ELF build of Claude Code across two releases while macOS stayed green. Before ch
 `scripts/probe-patch-mechanism.mjs` against a build for each format — Mach-O, ELF and PE. It needs
 no Linux or Windows host, because it never executes the binary. See `.claude/docs/patcher.md`.
 
+**A green macOS/Windows run says nothing about ELF.** Claude Code 2.1.257 moved the global Bun
+reads its blob's address from off the 16 KiB boundary tweakcc's ELF repack scans for it, and
+`clodex patch` failed on all four ELF builds while Mach-O and PE stayed green — Mach-O and PE
+assign the section in place and rewrite no pointer. `src/bun-compiled-pointer.ts` works around it;
+see `.claude/docs/patcher.md`.
+
 **Patch anchors are not platform-independent either.** Claude Code 2.1.238 minified one helper's
 parameter differently on its arm64 builds, so `PATCH 5: model picker options` matched five builds
 and missed `linux-arm64`, `linux-arm64-musl` and `win32-arm64`. The probe now applies every patch

--- a/scripts/probe-patch-mechanism.mjs
+++ b/scripts/probe-patch-mechanism.mjs
@@ -66,6 +66,11 @@ import {
   restoreEntryModuleName,
   shimEntryModuleName,
 } from '../src/bun-entry-module.ts';
+// bun-compiled-pointer.ts imports nothing relative either, so a static import is safe here.
+import {
+  restoreBunCompiledPointer,
+  shimBunCompiledPointer,
+} from '../src/bun-compiled-pointer.ts';
 
 // `src/` spells its own imports the TypeScript way — `./model-aliases.js` for a file that is
 // really `./model-aliases.ts`. tsup and vitest both understand that; bare `node` does not, and
@@ -399,12 +404,19 @@ try {
     const writable = writableModuleIndex(scratch);
     if (writable === null) throw new Error('no module of this build carries a name tweakcc can write to');
     const plan = planBundleWrite(scratch, bundle, splitBundleSource(bundle, written), writable);
+    // Mirrors patcher.ts: without this the ELF repack cannot find the global Bun reads its blob's
+    // address from on Claude Code 2.1.257, and the probe reports a repack failure that has nothing
+    // to do with this build's anchors. See src/bun-compiled-pointer.ts.
+    const bunPointerShim = shimBunCompiledPointer(scratch);
     await writeContent(installation, plan.content);
+    if (bunPointerShim) restoreBunCompiledPointer(scratch, bunPointerShim);
     publishedPlan = plan;
     applyBundleWritePlan(scratch, plan);
     publishedBlob = true;
   } else {
+    const bunPointerShim = shimBunCompiledPointer(scratch);
     await writeContent(installation, written);
+    if (bunPointerShim) restoreBunCompiledPointer(scratch, bunPointerShim);
   }
   let restoreError = null;
   if (writeShim) {

--- a/src/bun-compiled-pointer.ts
+++ b/src/bun-compiled-pointer.ts
@@ -1,0 +1,327 @@
+// Keeps tweakcc's ELF repack able to find the pointer Bun uses to locate its embedded blob.
+//
+// Read `.claude/docs/patcher.md` first. This file exists for the same reason `bun-entry-module.ts`
+// does: tweakcc identifies something in the binary by a rule that a Claude Code release quietly
+// stopped satisfying, and the cheapest correct answer is a reversible byte-level stand-in around
+// the repack rather than a fork of tweakcc.
+//
+// THE RULE. A Bun standalone ELF stores the virtual address of its `.bun` section in an 8-byte
+// little-endian global — Bun reads it at startup to find the blob. `repackELFSection` moves `.bun`
+// to a fresh page past the end of the file, so it has to rewrite that global. It finds it by
+// scanning the first writable `PT_LOAD` segment for 8 bytes equal to `.bun`'s CURRENT virtual
+// address — but only at addresses that are multiples of 16384. tweakcc 4.3.0 and 4.3.3 both do
+// this; bumping the pin does not help.
+//
+// WHAT BROKE. Through Claude Code 2.1.252 that global happened to land on a 16 KiB boundary on
+// every ELF build (measured: 2.1.246 and 2.1.252, x64 and arm64, glibc and musl — all at
+// `vaddr % 16384 === 0`). Claude Code 2.1.257 moved it off one: 0x534f758 on linux-x64,
+// 0x4d9af08 on linux-x64-musl, 0x5310758 on linux-arm64, 0x4c46d10 on linux-arm64-musl. The
+// strided scan steps straight over it, `repackELFSection` throws "Could not find original
+// BUN_COMPILED location in binary", and `clodex patch` fails on all four ELF builds. Nothing about
+// clodex's own patches changed; the alignment the scan assumes is not a property Bun promises.
+//
+// THE STAND-IN. Before the repack, plant a copy of the value the scan is looking for at an address
+// the scan DOES visit, and remember the eight bytes displaced. tweakcc then finds that copy and
+// rewrites it to the new `.bun` address. Afterwards, copy the new address to where the real global
+// actually lives and put the displaced bytes back, so the published binary differs from a
+// pristine repack in exactly one place: the global, holding the value it was always meant to hold.
+//
+// Two things make that safe rather than clever, and both are checked rather than assumed:
+//   * it is a NO-OP wherever tweakcc already works. `bunCompiledPointerScan` runs tweakcc's own
+//     scan first; if that finds anything, this module returns null and stays out of the way. So an
+//     older release, and any future release that goes back to being aligned, takes the path it
+//     always took.
+//   * the real global is identified, not guessed: the ONE 8-byte occurrence of `.bun`'s address
+//     inside the writable segment and outside `.bun`'s own payload. Matches inside the payload are
+//     coincidences in compressed JavaScript (there are dozens on some builds) and are excluded by
+//     range. Anything other than exactly one candidate is refused, loudly, instead of patched.
+// The restore reads back both addresses and refuses a binary where either did not take.
+
+import { closeSync, openSync, readSync, writeSync } from 'node:fs';
+
+/** tweakcc's `repackELFSection` only inspects addresses at this stride. Mirrored, not chosen. */
+const TWEAKCC_SCAN_STRIDE = 16384n;
+
+/** Chunk used to sweep the writable segment for the pointer. Any size ≥ 8 is correct. */
+const SCAN_CHUNK = 1 << 20;
+
+const ELF_MAGIC = 0x464c457f;
+const ELFCLASS64 = 2;
+const ELFDATA2LSB = 1;
+const PT_LOAD = 1;
+const PF_W = 2;
+
+interface ElfSection {
+  name: string;
+  addr: bigint;
+  offset: bigint;
+  size: bigint;
+}
+
+interface ElfSegment {
+  type: number;
+  flags: number;
+  offset: bigint;
+  vaddr: bigint;
+  filesz: bigint;
+}
+
+interface ElfLayout {
+  sections: ElfSection[];
+  segments: ElfSegment[];
+}
+
+/** What `shimBunCompiledPointer` has to hand back for the restore to finish the job. */
+export interface BunCompiledPointerShim {
+  /** Address of the real Bun global. Its FILE offset is re-derived from the repacked binary. */
+  pointerVaddr: bigint;
+  /** Address of the aligned slot tweakcc will find and rewrite instead. */
+  standInVaddr: bigint;
+  /** The eight bytes the stand-in displaced, put back verbatim after the repack. */
+  displaced: Buffer;
+  /** `.bun`'s address before the repack — what the planted copy holds. */
+  bunVaddr: bigint;
+}
+
+function readAt(fd: number, length: number, position: number): Buffer {
+  const buf = Buffer.alloc(length);
+  let read = 0;
+  while (read < length) {
+    const n = readSync(fd, buf, read, length - read, position + read);
+    if (n <= 0) break;
+    read += n;
+  }
+  return read === length ? buf : buf.subarray(0, read);
+}
+
+/**
+ * Section and segment tables of a little-endian ELF64, or null for anything else — a Mach-O, a PE,
+ * an npm `cli.js`, or a truncated file. Null means "not our case", never "assume it is fine".
+ */
+function readElfLayout(fd: number): ElfLayout | null {
+  const ident = readAt(fd, 64, 0);
+  if (ident.length < 64) return null;
+  if (ident.readUInt32LE(0) !== ELF_MAGIC) return null;
+  if (ident[4] !== ELFCLASS64 || ident[5] !== ELFDATA2LSB) return null;
+
+  const phoff = ident.readBigUInt64LE(0x20);
+  const shoff = ident.readBigUInt64LE(0x28);
+  const phentsize = ident.readUInt16LE(0x36);
+  const phnum = ident.readUInt16LE(0x38);
+  const shentsize = ident.readUInt16LE(0x3a);
+  const shnum = ident.readUInt16LE(0x3c);
+  const shstrndx = ident.readUInt16LE(0x3e);
+  if (shnum === 0 || shstrndx >= shnum || shentsize < 64 || phentsize < 56) return null;
+
+  const shTable = readAt(fd, shnum * shentsize, Number(shoff));
+  if (shTable.length !== shnum * shentsize) return null;
+  const raw = [];
+  for (let i = 0; i < shnum; i++) {
+    const at = i * shentsize;
+    raw.push({
+      nameOffset: shTable.readUInt32LE(at),
+      addr: shTable.readBigUInt64LE(at + 16),
+      offset: shTable.readBigUInt64LE(at + 24),
+      size: shTable.readBigUInt64LE(at + 32),
+    });
+  }
+  const strtab = raw[shstrndx]!;
+  const names = readAt(fd, Number(strtab.size), Number(strtab.offset));
+  const sections: ElfSection[] = raw.map(section => {
+    const start = section.nameOffset;
+    let end = start;
+    while (end < names.length && names[end] !== 0) end++;
+    return {
+      name: names.toString('utf8', start, end),
+      addr: section.addr,
+      offset: section.offset,
+      size: section.size,
+    };
+  });
+
+  const phTable = readAt(fd, phnum * phentsize, Number(phoff));
+  if (phTable.length !== phnum * phentsize) return null;
+  const segments: ElfSegment[] = [];
+  for (let i = 0; i < phnum; i++) {
+    const at = i * phentsize;
+    segments.push({
+      type: phTable.readUInt32LE(at),
+      flags: phTable.readUInt32LE(at + 4),
+      offset: phTable.readBigUInt64LE(at + 8),
+      vaddr: phTable.readBigUInt64LE(at + 16),
+      filesz: phTable.readBigUInt64LE(at + 32),
+    });
+  }
+  return { sections, segments };
+}
+
+function alignUp(value: bigint, to: bigint): bigint {
+  return ((value + to - 1n) / to) * to;
+}
+
+/** The segment tweakcc searches: the first writable `PT_LOAD`. Same predicate, same order. */
+function writableLoad(layout: ElfLayout): ElfSegment | undefined {
+  return layout.segments.find(segment => segment.type === PT_LOAD && (segment.flags & PF_W) !== 0);
+}
+
+/** File offset of `vaddr`, or null when it falls in no loaded segment's file image. */
+function fileOffsetOf(layout: ElfLayout, vaddr: bigint, length: bigint): number | null {
+  for (const segment of layout.segments) {
+    if (segment.type !== PT_LOAD) continue;
+    if (vaddr < segment.vaddr) continue;
+    if (vaddr + length > segment.vaddr + segment.filesz) continue;
+    return Number(segment.offset + (vaddr - segment.vaddr));
+  }
+  return null;
+}
+
+/**
+ * tweakcc's own strided scan, reproduced exactly, over the given `needle`. Returns the address it
+ * would settle on, or null when it would throw. Running it is what keeps this module a no-op on
+ * every build where tweakcc needs no help.
+ */
+function tweakccWouldFind(fd: number, segment: ElfSegment, needle: Buffer): bigint | null {
+  const first = alignUp(segment.vaddr, TWEAKCC_SCAN_STRIDE);
+  const last = segment.vaddr + segment.filesz - 8n;
+  for (let vaddr = first; vaddr <= last; vaddr += TWEAKCC_SCAN_STRIDE) {
+    const at = Number(segment.offset + (vaddr - segment.vaddr));
+    if (readAt(fd, 8, at).equals(needle)) return vaddr;
+  }
+  return null;
+}
+
+/** Every offset in `[from, to)` holding `needle`, excluding those inside `[skipFrom, skipTo)`. */
+function scanForNeedle(
+  fd: number,
+  from: number,
+  to: number,
+  needle: Buffer,
+  skipFrom: number,
+  skipTo: number,
+): number[] {
+  const hits: number[] = [];
+  // Overlap by 7 so a match straddling a chunk boundary is not missed.
+  for (let start = from; start < to; start += SCAN_CHUNK - 7) {
+    const length = Math.min(SCAN_CHUNK, to - start);
+    if (length < 8) break;
+    const chunk = readAt(fd, length, start);
+    let at = 0;
+    for (;;) {
+      const found = chunk.indexOf(needle, at);
+      if (found < 0 || found + 8 > chunk.length) break;
+      const offset = start + found;
+      if (offset < skipFrom || offset >= skipTo) hits.push(offset);
+      at = found + 1;
+    }
+  }
+  return hits;
+}
+
+/**
+ * Plant the stand-in tweakcc's ELF repack needs, or return null when it needs none.
+ *
+ * Null covers every case this does not apply to: a Mach-O or PE binary, a non-native install, a
+ * binary with no `.bun` section or no writable segment, and — the important one — any ELF where
+ * tweakcc's own scan already finds the pointer. Throws only when the binary IS one that needs help
+ * and the pointer cannot be identified unambiguously, because publishing a binary whose Bun global
+ * still points at the old blob would produce a `claude` that does not start.
+ */
+export function shimBunCompiledPointer(path: string): BunCompiledPointerShim | null {
+  const fd = openSync(path, 'r+');
+  try {
+    const layout = readElfLayout(fd);
+    if (!layout) return null;
+    const bun = layout.sections.find(section => section.name === '.bun');
+    if (!bun || bun.size === 0n) return null;
+    const segment = writableLoad(layout);
+    if (!segment) return null;
+
+    const needle = Buffer.alloc(8);
+    needle.writeBigUInt64LE(bun.addr);
+    if (tweakccWouldFind(fd, segment, needle) !== null) return null;
+
+    const segmentStart = Number(segment.offset);
+    const segmentEnd = Number(segment.offset + segment.filesz);
+    const bunStart = Number(bun.offset);
+    const bunEnd = Number(bun.offset + bun.size);
+    const candidates = scanForNeedle(fd, segmentStart, segmentEnd, needle, bunStart, bunEnd);
+    if (candidates.length !== 1) {
+      throw new Error(
+        `cannot locate Bun's blob pointer: ${candidates.length} candidates in the writable segment `
+        + `(expected 1). Refusing to repack a binary whose Bun global would be left stale.`,
+      );
+    }
+    const pointerOffset = candidates[0]!;
+    const pointerVaddr = segment.vaddr + BigInt(pointerOffset) - segment.offset;
+
+    // The slot tweakcc will land on: the lowest address its scan visits that overlaps neither the
+    // blob it is about to move nor the global we are about to correct. Its previous contents are
+    // restored below, so "free" is not required of it — only "not something the repack rereads".
+    const first = alignUp(segment.vaddr, TWEAKCC_SCAN_STRIDE);
+    const last = segment.vaddr + segment.filesz - 8n;
+    let standInVaddr: bigint | null = null;
+    for (let vaddr = first; vaddr <= last; vaddr += TWEAKCC_SCAN_STRIDE) {
+      const at = Number(segment.offset + (vaddr - segment.vaddr));
+      if (at + 8 > bunStart && at < bunEnd) continue;
+      if (at + 8 > pointerOffset && at < pointerOffset + 8) continue;
+      standInVaddr = vaddr;
+      break;
+    }
+    if (standInVaddr === null) {
+      throw new Error("no address tweakcc's ELF repack scans is usable for Bun's blob pointer");
+    }
+
+    const standInOffset = Number(segment.offset + (standInVaddr - segment.vaddr));
+    const displaced = readAt(fd, 8, standInOffset);
+    if (displaced.length !== 8) throw new Error("could not read the bytes Bun's blob pointer displaces");
+    writeSync(fd, needle, 0, 8, standInOffset);
+    return { pointerVaddr, standInVaddr, displaced, bunVaddr: bun.addr };
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/**
+ * Move the address tweakcc wrote into the stand-in over to the real Bun global, and put the
+ * displaced bytes back. Throws if the repack did not rewrite the stand-in, if it disagrees with
+ * where `.bun` actually ended up, or if either write does not read back — all of which would leave
+ * a `claude` that fails inside Bun before it prints anything.
+ */
+export function restoreBunCompiledPointer(path: string, shim: BunCompiledPointerShim): void {
+  const fd = openSync(path, 'r+');
+  try {
+    const layout = readElfLayout(fd);
+    if (!layout) throw new Error('the repacked binary is no longer a 64-bit little-endian ELF');
+    const bun = layout.sections.find(section => section.name === '.bun');
+    if (!bun) throw new Error('the repacked binary has no .bun section');
+
+    const standInOffset = fileOffsetOf(layout, shim.standInVaddr, 8n);
+    const pointerOffset = fileOffsetOf(layout, shim.pointerVaddr, 8n);
+    if (standInOffset === null || pointerOffset === null) {
+      throw new Error("the repack moved Bun's blob pointer out of the loaded image");
+    }
+    const written = readAt(fd, 8, standInOffset).readBigUInt64LE(0);
+    if (written === shim.bunVaddr) {
+      throw new Error("the repack did not rewrite Bun's blob pointer — the stand-in was not used");
+    }
+    if (written !== bun.addr) {
+      throw new Error(
+        `the repack pointed Bun at 0x${written.toString(16)} but put .bun at 0x${bun.addr.toString(16)}`,
+      );
+    }
+
+    const value = Buffer.alloc(8);
+    value.writeBigUInt64LE(written);
+    writeSync(fd, value, 0, 8, pointerOffset);
+    writeSync(fd, shim.displaced, 0, 8, standInOffset);
+
+    if (!readAt(fd, 8, pointerOffset).equals(value)) {
+      throw new Error("Bun's blob pointer did not take the repacked address");
+    }
+    if (!readAt(fd, 8, standInOffset).equals(shim.displaced)) {
+      throw new Error('the bytes the stand-in displaced were not restored');
+    }
+  } finally {
+    closeSync(fd);
+  }
+}

--- a/src/bun-compiled-pointer.ts
+++ b/src/bun-compiled-pointer.ts
@@ -111,7 +111,12 @@ function readElfLayout(fd: number): ElfLayout | null {
   const shentsize = ident.readUInt16LE(0x3a);
   const shnum = ident.readUInt16LE(0x3c);
   const shstrndx = ident.readUInt16LE(0x3e);
-  if (shnum === 0 || shstrndx >= shnum || shentsize < 64 || phentsize < 56) return null;
+  // `e_shnum === 0` is SHN_XINDEX and `e_phnum === 0xffff` is PN_XNUM: both say the real count
+  // lives elsewhere. Neither occurs on any Claude Code build (measured: 10 program headers, 38-42
+  // sections on all eight), and reading 0xffff headers of arbitrary file bytes as segments is how
+  // a stand-in gets planted at a garbage offset.
+  if (shnum === 0 || phnum === 0xffff) return null;
+  if (shstrndx >= shnum || shentsize < 64 || phentsize < 56) return null;
 
   const shTable = readAt(fd, shnum * shentsize, Number(shoff));
   if (shTable.length !== shnum * shentsize) return null;
@@ -164,15 +169,24 @@ function writableLoad(layout: ElfLayout): ElfSegment | undefined {
   return layout.segments.find(segment => segment.type === PT_LOAD && (segment.flags & PF_W) !== 0);
 }
 
-/** File offset of `vaddr`, or null when it falls in no loaded segment's file image. */
+/**
+ * File offset of `vaddr`, or null when no loaded segment's file image holds it — or when MORE than
+ * one does. Taking the first match would be a silent wrong answer rather than a safe one: the
+ * restore's readback reads the offset it just wrote, so it proves the write landed, not that the
+ * offset was right, and Bun would be left pointed at the old blob. No real build has overlapping
+ * PT_LOADs (checked on all eight 2.1.257/2.1.252/2.1.246 builds and on a repacked one), so this
+ * refuses a shape that does not occur rather than resolving one that does.
+ */
 function fileOffsetOf(layout: ElfLayout, vaddr: bigint, length: bigint): number | null {
+  let found: number | null = null;
   for (const segment of layout.segments) {
     if (segment.type !== PT_LOAD) continue;
     if (vaddr < segment.vaddr) continue;
     if (vaddr + length > segment.vaddr + segment.filesz) continue;
-    return Number(segment.offset + (vaddr - segment.vaddr));
+    if (found !== null) return null;
+    found = Number(segment.offset + (vaddr - segment.vaddr));
   }
-  return null;
+  return found;
 }
 
 /**
@@ -208,7 +222,7 @@ function scanForNeedle(
     let at = 0;
     for (;;) {
       const found = chunk.indexOf(needle, at);
-      if (found < 0 || found + 8 > chunk.length) break;
+      if (found < 0) break;
       const offset = start + found;
       if (offset < skipFrom || offset >= skipTo) hits.push(offset);
       at = found + 1;
@@ -283,9 +297,11 @@ export function shimBunCompiledPointer(path: string): BunCompiledPointerShim | n
 
 /**
  * Move the address tweakcc wrote into the stand-in over to the real Bun global, and put the
- * displaced bytes back. Throws if the repack did not rewrite the stand-in, if it disagrees with
- * where `.bun` actually ended up, or if either write does not read back — all of which would leave
- * a `claude` that fails inside Bun before it prints anything.
+ * displaced bytes back. Throws if either address no longer resolves to exactly one place in the
+ * repacked image, if the repack did not rewrite the stand-in, or if it disagrees with where `.bun`
+ * actually ended up — all of which would leave a `claude` that fails inside Bun before it prints
+ * anything. (The readbacks below confirm the writes landed. They read the offsets they just wrote,
+ * so they cannot vouch for the offsets themselves; `fileOffsetOf` is what does that.)
  */
 export function restoreBunCompiledPointer(path: string, shim: BunCompiledPointerShim): void {
   const fd = openSync(path, 'r+');
@@ -298,7 +314,9 @@ export function restoreBunCompiledPointer(path: string, shim: BunCompiledPointer
     const standInOffset = fileOffsetOf(layout, shim.standInVaddr, 8n);
     const pointerOffset = fileOffsetOf(layout, shim.pointerVaddr, 8n);
     if (standInOffset === null || pointerOffset === null) {
-      throw new Error("the repack moved Bun's blob pointer out of the loaded image");
+      throw new Error(
+        "the repack left Bun's blob pointer outside the loaded image, or in more than one segment of it",
+      );
     }
     const written = readAt(fd, 8, standInOffset).readBigUInt64LE(0);
     if (written === shim.bunVaddr) {

--- a/src/patch-transforms.ts
+++ b/src/patch-transforms.ts
@@ -709,28 +709,34 @@ export function applyClodexPatches(source: string, config: PatchScriptModelConfi
     const marker = '/*ccpatch:child-network-env*/';
     const contractVar = q(NETWORK_ENV_CONTRACT_VAR);
     const networkVars = JSON.stringify(CHILD_NETWORK_ENV_VARS);
-    // What the REWRITE depends on. `{...process.env` is the merged copy every
-    // `process.env` read is redirected away from; the CLAUDE_CODE_REMOTE ternary
-    // is the head the anchor bound to. Both are structural, not incidental.
-    const requiredBodyLiterals = [
-      '{...process.env',
-      'CLAUDE_CODE_REMOTE',
-    ];
-    // A smell test, NOT the identity proof — identity is the whole-bundle count
-    // of the passthrough early-out below, plus the brace walk proving the match
-    // spans exactly the function it started in.
+    // What the REWRITE depends on: `{...process.env` is the merged copy every
+    // `process.env` read is redirected away from. (The `CLAUDE_CODE_REMOTE`
+    // ternary is load-bearing too, but the anchor already requires it inside the
+    // captured body, so restating it here could never fail.)
+    const requiredBodyLiterals = ['{...process.env'];
+    // A smell test, NOT the identity proof. Identity is the whole-bundle count of
+    // the passthrough early-out below, the head's CLAUDE_CODE_REMOTE ternary, and
+    // the brace walk proving the match spans exactly the function it started in.
+    // Measured on both real bundles: with these names ignored entirely, the full
+    // anchor still has exactly ONE candidate. They never choose among candidates,
+    // so all they can do is reject one already identified.
     //
-    // These are names Claude Code scrubs out of a child's environment, and each
-    // one is only as durable as the line that happens to spell it. 2.1.252 wrote
-    // `process.env.CLAUDE_BG_PTY_AUTH!==void 0` inline; 2.1.257 replaced that
+    // Which is what makes an aggressive threshold the wrong trade. These are names
+    // Claude Code happens to scrub out of a child's environment, each only as
+    // durable as the line that spells it: 2.1.252 wrote
+    // `process.env.CLAUDE_BG_PTY_AUTH!==void 0` inline, and 2.1.257 replaced that
     // whole run of per-name reads with a set-membership test and stopped spelling
-    // the name at all. Requiring EVERY name turned that refactor — which changed
-    // nothing about what clodex patches — into `clodex patch` refusing 2.1.257 on
-    // all eight published builds. So require a quorum instead: a body that still
-    // scrubs at least two of them is the builder, and a body that scrubs none is
-    // something else and must not be rewritten. Both real bundles clear it with
-    // room (2.1.252 matches 5, 2.1.257 matches 4), which is the margin one more
-    // refactor of this kind is supposed to land in.
+    // the name anywhere. Requiring EVERY name turned that refactor — which changed
+    // nothing about what clodex rewrites — into `clodex patch` refusing 2.1.257 on
+    // all eight published builds at once, and the same move on any other group
+    // would do it again. Nor is a higher floor worth much: two of the five are the
+    // OTEL pair, so "at least two" can be satisfied from a single category and
+    // buys little over one.
+    //
+    // So the floor is ONE. It still refuses a body that scrubs nothing — which is
+    // the only case where these names say something the anchor does not — while
+    // taking four independent refactors, not one, to produce a false refusal.
+    // 2.1.252 matches five and 2.1.257 matches four.
     const scrubbedEnvNames = [
       'CLAUDE_CODE_OAUTH_TOKEN',
       'CLAUDE_CODE_SUBSCRIPTION_TYPE',
@@ -738,7 +744,7 @@ export function applyClodexPatches(source: string, config: PatchScriptModelConfi
       '"OTEL_"',
       'CLAUDE_CODE_OTEL_DIAG_STDERR',
     ];
-    const MIN_SCRUBBED_ENV_NAMES = 2;
+    const MIN_SCRUBBED_ENV_NAMES = 1;
     /**
      * Index of the `}` closing the block opened at `open`, or -1 if the scan runs
      * off the end. Braces inside strings, template literals and comments do not
@@ -838,9 +844,13 @@ export function applyClodexPatches(source: string, config: PatchScriptModelConfi
         // Walking the real block from the function's own `{` rules out both:
         // the anchor's end must BE the function's end.
         const at = js.indexOf(match);
-        const bound = at < 0
-          ? -1
-          : blockEndIndex(js, at + head!.length - 1) - at - (match.length - 1);
+        const closingBrace = at < 0 ? -1 : blockEndIndex(js, at + head!.length - 1);
+        // Distinct from "ended in the wrong place": -1 means the walk ran off the
+        // end of the source without ever closing the block. Folding it into the
+        // arithmetic below reports it as a bundle-sized negative distance, which
+        // names nothing.
+        const braceScanFailed = at < 0 || closingBrace < 0;
+        const bound = braceScanFailed ? 0 : closingBrace - at - (match.length - 1);
         // Name the check that rejected it. "target validation failed" alone sends
         // the next person triaging a canary failure off to extract a 32 MB bundle
         // by hand to learn which of four unrelated conditions was the one.
@@ -854,9 +864,11 @@ export function applyClodexPatches(source: string, config: PatchScriptModelConfi
               + MIN_SCRUBBED_ENV_NAMES + ')'
             : /\bfunction\s*[\w$]*\(/.test(body!)
               ? 'body declares a nested function'
-              : bound !== 0
-                ? 'match ends ' + bound + ' characters from the function it started in'
-                : undefined;
+              : braceScanFailed
+                ? "the brace walk never reached the function's closing brace"
+                : bound !== 0
+                  ? 'match ends ' + bound + ' characters from the function it started in'
+                  : undefined;
         if (why !== undefined) {
           log('FAIL', patchName, 'target validation failed: ' + why);
           fail('clodex patch: child network environment target validation failed: ' + why);

--- a/src/patch-transforms.ts
+++ b/src/patch-transforms.ts
@@ -56,8 +56,18 @@ import {
  * 2.8.1-patched Windows binary does is not measured. The bump is for every install
  * that still starts: a patch written the old way carries stale bytecode beside
  * patched source, and on 2.1.246 that stale bytecode runs.
+ *
+ * 11 — two sites stopped recognising Claude Code 2.1.257, each on all eight
+ * published builds. PATCH 7's anchor hardcoded the context-window resolver's
+ * parameter NAMES, and 2.1.257 minified the same function as `(e,n)` instead of
+ * `(e,t)`. PATCH 10 required the child-env builder to spell every one of five
+ * scrubbed environment variable names, and 2.1.257 replaced a run of per-name
+ * reads with a set-membership test that spells `CLAUDE_BG_PTY_AUTH` nowhere.
+ * An install patched by an older clodex is not wrong, but it was produced by a
+ * transform set whose anchors are narrower, so it re-reads as stale rather than
+ * current.
  */
-export const PATCH_TRANSFORMS_VERSION = 10;
+export const PATCH_TRANSFORMS_VERSION = 11;
 
 export interface PatchScriptModelEntry {
   alias?: string;
@@ -500,28 +510,39 @@ export function applyClodexPatches(source: string, config: PatchScriptModelConfi
   // lowercased model string — alias and id are both in the table, so it hits
   // pre- or post-alias-resolution.
   //
-  // Anchor: the resolver's exact body shape. Identifiers are wildcarded (they
-  // churn per build); the (e,t) arity + 3-statement shape matches once.
+  // Anchor: the resolver's exact body shape. EVERY identifier is wildcarded,
+  // including the two PARAMETER names — the minifier renames those per build
+  // too. Claude Code 2.1.252 spelled the resolver `(e,t)` and 2.1.257 spelled
+  // the same function `(e,n)`, which is exactly how a hardcoded `(e,t)` came to
+  // fail on all eight published builds at once. What still pins the site is the
+  // shape, not the spelling: two parameters, both threaded unchanged into the
+  // two calls, around a 3-statement body. That matches once per bundle.
+  //
+  // The injected lookup reads the model string out of the FIRST parameter, so
+  // the snippet has to be built around whatever this build named it.
   // ---------------------------------------------------------------------------
   if (Object.keys(CONTEXT_BY_KEY).length) {
     const MARKER = '/*ccpatch:ctx*/';
-    const SNIPPET =
-      MARKER + 'var _ccw=(' + JSON.stringify(CONTEXT_BY_KEY) + ')[String(e||"").trim().toLowerCase()];if(_ccw!==void 0)return _ccw;';
+    const snippetFor = (modelParam: string) =>
+      MARKER + 'var _ccw=(' + JSON.stringify(CONTEXT_BY_KEY) + ')[String(' + modelParam + '||"").trim().toLowerCase()];if(_ccw!==void 0)return _ccw;';
 
     if (js.includes(MARKER)) {
       // Re-patching an already-patched binary: refresh the baked table in place
-      // so a MODEL_CONFIG edit takes effect without a restore first.
+      // so a MODEL_CONFIG edit takes effect without a restore first. The name in
+      // the snippet already there is the one this binary's resolver declares —
+      // reusing it is what keeps a refresh from rewriting `n` back to `e` and
+      // leaving a lookup on an identifier that is not in scope.
       applyOnce(
         'PATCH 7: per-model context window (refresh)',
-        /\/\*ccpatch:ctx\*\/var _ccw=\(\{[^{}]*\}\)\[[^\]]*\];if\(_ccw!==void 0\)return _ccw;/,
-        () => SNIPPET,
+        /\/\*ccpatch:ctx\*\/var _ccw=\(\{[^{}]*\}\)\[String\(([\w$]+)\|\|""\)\.trim\(\)\.toLowerCase\(\)\];if\(_ccw!==void 0\)return _ccw;/,
+        (_m, modelParam) => snippetFor(modelParam!),
         { required: true, noopIsSkip: true }
       );
     } else {
       applyOnce(
         'PATCH 7: per-model context window',
-        /(function [\w$]+\(e,t\)\{)(let [\w$]+=[\w$]+\(\);if\([\w$]+!==void 0\)return [\w$]+;if\([\w$]+\(e,t\)\)return [\w$]+;return [\w$]+\(e,t\)\})/,
-        (_m, head, body) => head! + SNIPPET + body!,
+        /(function [\w$]+\(([\w$]+),([\w$]+)\)\{)(let [\w$]+=[\w$]+\(\);if\([\w$]+!==void 0\)return [\w$]+;if\([\w$]+\(\2,\3\)\)return [\w$]+;return [\w$]+\(\2,\3\)\})/,
+        (_m, head, modelParam, _windowParam, body) => head! + snippetFor(modelParam!) + body!,
         { required: true }
       );
     }
@@ -677,24 +698,47 @@ export function applyClodexPatches(source: string, config: PatchScriptModelConfi
   // and exactly one `<fn>(process.env.CLAUDE_CODE_REMOTE)?` ternary precedes it.
   // Those two facts together are what pin the head to the real builder.
   //
-  // The literal, nested-function and brace-balance checks below are the last
-  // line: they reject a match that ends at a nested `return <copy>}` (which
-  // would truncate the function) or that swallowed a neighbour.
+  // The nested-function and brace-balance checks below are the last line: they
+  // reject a match that ends at a nested `return <copy>}` (which would truncate
+  // the function) or that swallowed a neighbour. The literal checks are split by
+  // what they are FOR — two the rewrite structurally depends on, and a quorum
+  // over names Claude Code happens to scrub, which churn. See below.
   // ---------------------------------------------------------------------------
   {
     const patchName = 'PATCH 10: child network environment';
     const marker = '/*ccpatch:child-network-env*/';
     const contractVar = q(NETWORK_ENV_CONTRACT_VAR);
     const networkVars = JSON.stringify(CHILD_NETWORK_ENV_VARS);
+    // What the REWRITE depends on. `{...process.env` is the merged copy every
+    // `process.env` read is redirected away from; the CLAUDE_CODE_REMOTE ternary
+    // is the head the anchor bound to. Both are structural, not incidental.
     const requiredBodyLiterals = [
       '{...process.env',
       'CLAUDE_CODE_REMOTE',
+    ];
+    // A smell test, NOT the identity proof — identity is the whole-bundle count
+    // of the passthrough early-out below, plus the brace walk proving the match
+    // spans exactly the function it started in.
+    //
+    // These are names Claude Code scrubs out of a child's environment, and each
+    // one is only as durable as the line that happens to spell it. 2.1.252 wrote
+    // `process.env.CLAUDE_BG_PTY_AUTH!==void 0` inline; 2.1.257 replaced that
+    // whole run of per-name reads with a set-membership test and stopped spelling
+    // the name at all. Requiring EVERY name turned that refactor — which changed
+    // nothing about what clodex patches — into `clodex patch` refusing 2.1.257 on
+    // all eight published builds. So require a quorum instead: a body that still
+    // scrubs at least two of them is the builder, and a body that scrubs none is
+    // something else and must not be rewritten. Both real bundles clear it with
+    // room (2.1.252 matches 5, 2.1.257 matches 4), which is the margin one more
+    // refactor of this kind is supposed to land in.
+    const scrubbedEnvNames = [
       'CLAUDE_CODE_OAUTH_TOKEN',
       'CLAUDE_CODE_SUBSCRIPTION_TYPE',
       'CLAUDE_BG_PTY_AUTH',
       '"OTEL_"',
       'CLAUDE_CODE_OTEL_DIAG_STDERR',
     ];
+    const MIN_SCRUBBED_ENV_NAMES = 2;
     /**
      * Index of the `}` closing the block opened at `open`, or -1 if the scan runs
      * off the end. Braces inside strings, template literals and comments do not
@@ -797,12 +841,25 @@ export function applyClodexPatches(source: string, config: PatchScriptModelConfi
         const bound = at < 0
           ? -1
           : blockEndIndex(js, at + head!.length - 1) - at - (match.length - 1);
-        const targetIsValid = requiredBodyLiterals.every(literal => body!.includes(literal))
-          && !/\bfunction\s*[\w$]*\(/.test(body!)
-          && bound === 0;
-        if (!targetIsValid) {
-          log('FAIL', patchName, 'target validation failed');
-          fail('clodex patch: child network environment target validation failed');
+        // Name the check that rejected it. "target validation failed" alone sends
+        // the next person triaging a canary failure off to extract a 32 MB bundle
+        // by hand to learn which of four unrelated conditions was the one.
+        const missingLiteral = requiredBodyLiterals.find(literal => !body!.includes(literal));
+        const scrubbedSeen = scrubbedEnvNames.filter(name => body!.includes(name));
+        const why = missingLiteral !== undefined
+          ? 'body does not contain ' + missingLiteral
+          : scrubbedSeen.length < MIN_SCRUBBED_ENV_NAMES
+            ? 'body scrubs only ' + scrubbedSeen.length + ' of the '
+              + scrubbedEnvNames.length + ' known child-env names (expected at least '
+              + MIN_SCRUBBED_ENV_NAMES + ')'
+            : /\bfunction\s*[\w$]*\(/.test(body!)
+              ? 'body declares a nested function'
+              : bound !== 0
+                ? 'match ends ' + bound + ' characters from the function it started in'
+                : undefined;
+        if (why !== undefined) {
+          log('FAIL', patchName, 'target validation failed: ' + why);
+          fail('clodex patch: child network environment target validation failed: ' + why);
         }
         const restoredBody = body!.replace(/process\.env/g, '_clodexChildEnv');
         const restore = marker

--- a/src/patcher.ts
+++ b/src/patcher.ts
@@ -69,6 +69,10 @@ import {
   shimEntryModuleName,
 } from './bun-entry-module.js';
 import {
+  restoreBunCompiledPointer,
+  shimBunCompiledPointer,
+} from './bun-compiled-pointer.js';
+import {
   applyBundleWritePlan,
   planBundleWrite,
   readClaudeBundle,
@@ -915,11 +919,18 @@ export async function applyPatch(
         splitBundleSource(loaded.bundle, local.content),
         writable,
       );
+      // Claude Code 2.1.257 moved the global Bun reads its blob's address from off the 16 KiB
+      // boundary tweakcc's ELF repack scans, so the repack could not find it and threw on all
+      // four ELF builds. A no-op everywhere else. See `bun-compiled-pointer.ts`.
+      const bunPointerShim = shimBunCompiledPointer(candidatePath);
       await writeContent(loaded.installation, plan.content);
+      if (bunPointerShim) restoreBunCompiledPointer(candidatePath, bunPointerShim);
       applyBundleWritePlan(candidatePath, plan);
       publishedBlob = true;
     } else {
+      const bunPointerShim = shimBunCompiledPointer(candidatePath);
       await writeContent(loaded.installation, local.content);
+      if (bunPointerShim) restoreBunCompiledPointer(candidatePath, bunPointerShim);
     }
     if (writeShim) restoreEntryModuleName(candidatePath, writeShim, { resign: true });
     // The repack signs on its way out, so publishing the blob after it leaves an invalid signature.

--- a/tests/bun-blob-fixture.ts
+++ b/tests/bun-blob-fixture.ts
@@ -278,3 +278,141 @@ export function rebuildFakeNativeClaude(
     { entryPointId: parsed.entryPointId, flags: parsed.flags, structBytes: parsed.structBytes },
   );
 }
+
+// ---------------------------------------------------------------------------------------------
+// An ELF64 wrapper for the blob above, so the `clodex patch` write path can be driven end to end
+// on the one executable format that needs the Bun blob-pointer stand-in.
+//
+// A Mach-O or PE candidate never reaches `src/bun-compiled-pointer.ts` — only ELF relocates the
+// blob and rewrites the global that points at it. Every other fake install here starts with a
+// `#!/bin/sh` shim, so `readElfLayout` returns null and the stand-in is a silent no-op; a fixture
+// that cannot produce ELF bytes cannot see the production wiring get deleted.
+// ---------------------------------------------------------------------------------------------
+
+/** Where the writable PT_LOAD starts, at a deliberately un-16K-aligned address, as real builds do. */
+const ELF_SEG_OFFSET = 0x1000;
+/** The lowest address tweakcc's 16 KiB-strided scan visits inside that segment. */
+export const ELF_FIRST_SCANNED = 0x4000;
+/** Where the Bun blob-pointer global sits — off the boundary, as on every 2.1.257 ELF build. */
+export const ELF_POINTER_VADDR = ELF_FIRST_SCANNED + 0x758;
+const ELF_BUN_AT = 0x8000;
+const ELF_SECTION_NAMES = ['', '.shstrtab', '.bun'];
+
+function elfSectionHeaders(bunAddr: number, bunOffset: number, bunSize: number, shoff: number): Buffer {
+  const shstrtab = Buffer.from(`${ELF_SECTION_NAMES.join('\0')}\0`, 'utf8');
+  const nameOffsets = new Map<string, number>();
+  let cursor = 0;
+  for (const name of ELF_SECTION_NAMES) {
+    nameOffsets.set(name, cursor);
+    cursor += name.length + 1;
+  }
+  const table = Buffer.alloc(3 * 64 + shstrtab.length);
+  const write = (index: number, name: string, addr: number, offset: number, size: number) => {
+    const at = index * 64;
+    table.writeUInt32LE(nameOffsets.get(name)!, at);
+    table.writeBigUInt64LE(BigInt(addr), at + 16);
+    table.writeBigUInt64LE(BigInt(offset), at + 24);
+    table.writeBigUInt64LE(BigInt(size), at + 32);
+  };
+  write(1, '.shstrtab', 0, shoff + 3 * 64, shstrtab.length);
+  write(2, '.bun', bunAddr, bunOffset, bunSize);
+  shstrtab.copy(table, 3 * 64);
+  return table;
+}
+
+/**
+ * A native install shaped like a Linux Claude Code build: an ELF64 whose writable segment holds
+ * the Bun blob-pointer global at an address tweakcc's scan never visits, followed by the blob
+ * itself in a `.bun` section.
+ */
+export function buildFakeElfClaude(modules: BunModuleFixture[], options: BunBlobOptions = {}): Buffer {
+  const blob = buildBunBlob(modules, options);
+  const bunOffset = ELF_BUN_AT;
+  const segmentSize = bunOffset - ELF_SEG_OFFSET + blob.length;
+  const shoff = bunOffset + blob.length;
+  const buf = Buffer.alloc(shoff + 3 * 64 + 64);
+
+  buf.writeUInt32LE(0x464c457f, 0);
+  buf[4] = 2; // ELFCLASS64
+  buf[5] = 1; // ELFDATA2LSB
+  buf.writeBigUInt64LE(0x40n, 0x20); // e_phoff
+  buf.writeBigUInt64LE(BigInt(shoff), 0x28); // e_shoff
+  buf.writeUInt16LE(56, 0x36);
+  buf.writeUInt16LE(1, 0x38); // one program header
+  buf.writeUInt16LE(64, 0x3a);
+  buf.writeUInt16LE(3, 0x3c); // three section headers
+  buf.writeUInt16LE(1, 0x3e); // .shstrtab index
+
+  buf.writeUInt32LE(1, 0x40); // PT_LOAD
+  buf.writeUInt32LE(6, 0x44); // R|W
+  buf.writeBigUInt64LE(BigInt(ELF_SEG_OFFSET), 0x48);
+  buf.writeBigUInt64LE(BigInt(ELF_SEG_OFFSET), 0x50); // vaddr == offset
+  buf.writeBigUInt64LE(BigInt(segmentSize), 0x60);
+
+  // Filler that can never be read as an address, then the global, then the blob.
+  buf.fill(0xaa, ELF_SEG_OFFSET, bunOffset);
+  buf.writeBigUInt64LE(BigInt(ELF_BUN_AT), ELF_POINTER_VADDR);
+  blob.copy(buf, bunOffset);
+  elfSectionHeaders(ELF_BUN_AT, bunOffset, blob.length, shoff).copy(buf, shoff);
+  return buf;
+}
+
+/**
+ * What tweakcc's `repackELFSection` does to that binary: scan the writable segment at a 16384-byte
+ * stride for the address `.bun` currently has, rewrite the eight bytes it finds to `.bun`'s new
+ * address, and record the section there. It never looks anywhere else — which is the whole reason
+ * `shimBunCompiledPointer` exists.
+ *
+ * Throws the way tweakcc throws when the scan comes up empty, so a fixture that stops reproducing
+ * the 2.1.257 failure fails loudly instead of passing for the wrong reason.
+ */
+export function repackFakeElfClaude(
+  binary: Buffer,
+  contentsByIndex: (index: number, previous: string) => string,
+  newBunAddr: number,
+): Buffer {
+  const segmentOffset = Number(binary.readBigUInt64LE(0x48));
+  const segmentVaddr = Number(binary.readBigUInt64LE(0x50));
+  const segmentSize = Number(binary.readBigUInt64LE(0x60));
+  const shoff = Number(binary.readBigUInt64LE(0x28));
+  const bunAddr = Number(binary.readBigUInt64LE(shoff + 2 * 64 + 16));
+
+  const needle = Buffer.alloc(8);
+  needle.writeBigUInt64LE(BigInt(bunAddr));
+  let foundAt = -1;
+  const first = Math.ceil(segmentVaddr / 16384) * 16384;
+  for (let vaddr = first; vaddr <= segmentVaddr + segmentSize - 8; vaddr += 16384) {
+    const at = segmentOffset + (vaddr - segmentVaddr);
+    if (binary.subarray(at, at + 8).equals(needle)) { foundAt = at; break; }
+  }
+  if (foundAt < 0) {
+    throw new Error(`Could not find original BUN_COMPILED location in binary (searched for 0x${bunAddr.toString(16)})`);
+  }
+
+  const parsed = parseBunBlob(binary);
+  const blob = buildBunBlob(
+    parsed.names.map((name, index) => ({
+      name,
+      contents: contentsByIndex(index, parsed.contents[index]!),
+      sourcemap: parsed.sourcemap[index]!,
+      bytecode: parsed.bytecode[index]!,
+      moduleInfo: parsed.moduleInfo[index]!,
+      bytecodeOriginPath: parsed.bytecodeOriginPath[index]!,
+      loader: parsed.loaders[index]!,
+    })),
+    { entryPointId: parsed.entryPointId, flags: parsed.flags, structBytes: parsed.structBytes },
+  );
+
+  // The blob keeps its file position; only its recorded address moves, which is all the restore
+  // reads. Growing the file where the real repack does would add nothing this test can observe.
+  const bunOffset = Number(binary.readBigUInt64LE(shoff + 2 * 64 + 24));
+  const grown = bunOffset + blob.length;
+  const out = Buffer.alloc(grown + 3 * 64 + 64);
+  binary.subarray(0, bunOffset).copy(out, 0);
+  blob.copy(out, bunOffset);
+  out.writeBigUInt64LE(BigInt(grown), 0x28);
+  out.writeBigUInt64LE(BigInt(bunOffset - segmentOffset + blob.length), 0x60);
+  out.writeBigUInt64LE(BigInt(newBunAddr), foundAt);
+  elfSectionHeaders(newBunAddr, bunOffset, blob.length, grown).copy(out, grown);
+  return out;
+}

--- a/tests/bun-blob-fixture.ts
+++ b/tests/bun-blob-fixture.ts
@@ -289,13 +289,28 @@ export function rebuildFakeNativeClaude(
 // that cannot produce ELF bytes cannot see the production wiring get deleted.
 // ---------------------------------------------------------------------------------------------
 
-/** Where the writable PT_LOAD starts, at a deliberately un-16K-aligned address, as real builds do. */
+/** Where the writable PT_LOAD starts in the FILE, at a deliberately un-16K-aligned offset. */
 const ELF_SEG_OFFSET = 0x1000;
+/**
+ * How far the segment's virtual address runs ahead of its file offset — 0x202000 on the real
+ * linux-x64 build, 0x220000 on arm64. Never zero, and that matters: a fixture mapped at
+ * `vaddr === offset` cannot tell a virtual address from a file offset, so an implementation that
+ * confuses the two reads and writes the same wrong place, passes its own readback, and leaves Bun
+ * pointed at the old blob on every real Linux build.
+ */
+const ELF_LOAD_BIAS = 0x202000;
+const ELF_SEG_VADDR = ELF_SEG_OFFSET + ELF_LOAD_BIAS;
 /** The lowest address tweakcc's 16 KiB-strided scan visits inside that segment. */
-export const ELF_FIRST_SCANNED = 0x4000;
+const ELF_FIRST_SCANNED = Math.ceil(ELF_SEG_VADDR / 0x4000) * 0x4000;
 /** Where the Bun blob-pointer global sits — off the boundary, as on every 2.1.257 ELF build. */
-export const ELF_POINTER_VADDR = ELF_FIRST_SCANNED + 0x758;
-const ELF_BUN_AT = 0x8000;
+const ELF_POINTER_VADDR = ELF_FIRST_SCANNED + 0x758;
+const elfOffsetOf = (vaddr: number) => ELF_SEG_OFFSET + (vaddr - ELF_SEG_VADDR);
+/** File offset of the Bun blob-pointer global — what a test reads out of the published bytes. */
+export const ELF_POINTER_OFFSET = elfOffsetOf(ELF_POINTER_VADDR);
+/** File offset of the slot the stand-in borrows, which must come back byte-identical. */
+export const ELF_STAND_IN_OFFSET = elfOffsetOf(ELF_FIRST_SCANNED);
+const ELF_BUN_OFFSET = 0x8000;
+const ELF_BUN_VADDR = ELF_BUN_OFFSET + ELF_LOAD_BIAS;
 const ELF_SECTION_NAMES = ['', '.shstrtab', '.bun'];
 
 function elfSectionHeaders(bunAddr: number, bunOffset: number, bunSize: number, shoff: number): Buffer {
@@ -327,7 +342,7 @@ function elfSectionHeaders(bunAddr: number, bunOffset: number, bunSize: number, 
  */
 export function buildFakeElfClaude(modules: BunModuleFixture[], options: BunBlobOptions = {}): Buffer {
   const blob = buildBunBlob(modules, options);
-  const bunOffset = ELF_BUN_AT;
+  const bunOffset = ELF_BUN_OFFSET;
   const segmentSize = bunOffset - ELF_SEG_OFFSET + blob.length;
   const shoff = bunOffset + blob.length;
   const buf = Buffer.alloc(shoff + 3 * 64 + 64);
@@ -346,14 +361,14 @@ export function buildFakeElfClaude(modules: BunModuleFixture[], options: BunBlob
   buf.writeUInt32LE(1, 0x40); // PT_LOAD
   buf.writeUInt32LE(6, 0x44); // R|W
   buf.writeBigUInt64LE(BigInt(ELF_SEG_OFFSET), 0x48);
-  buf.writeBigUInt64LE(BigInt(ELF_SEG_OFFSET), 0x50); // vaddr == offset
+  buf.writeBigUInt64LE(BigInt(ELF_SEG_VADDR), 0x50);
   buf.writeBigUInt64LE(BigInt(segmentSize), 0x60);
 
   // Filler that can never be read as an address, then the global, then the blob.
   buf.fill(0xaa, ELF_SEG_OFFSET, bunOffset);
-  buf.writeBigUInt64LE(BigInt(ELF_BUN_AT), ELF_POINTER_VADDR);
+  buf.writeBigUInt64LE(BigInt(ELF_BUN_VADDR), ELF_POINTER_OFFSET);
   blob.copy(buf, bunOffset);
-  elfSectionHeaders(ELF_BUN_AT, bunOffset, blob.length, shoff).copy(buf, shoff);
+  elfSectionHeaders(ELF_BUN_VADDR, bunOffset, blob.length, shoff).copy(buf, shoff);
   return buf;
 }
 

--- a/tests/bun-compiled-pointer.test.ts
+++ b/tests/bun-compiled-pointer.test.ts
@@ -40,6 +40,14 @@ function buildElf(
   pointerVaddr: number,
   extraPointerVaddrs: number[] = [],
   bun: { offset: number; size: number } = { offset: BUN_OFFSET, size: BUN_SIZE },
+  { segSize = SEG_SIZE, decoySegment = false, phnum = 1 }: {
+    /** Grow the writable segment past one `SCAN_CHUNK`, so the sweep's chunking loop runs twice. */
+    segSize?: number;
+    /** Add an earlier PT_LOAD whose vaddr range also covers the pointer but not the stand-in. */
+    decoySegment?: boolean;
+    /** `e_phnum`. 0xffff is PN_XNUM, which says the real count lives in the section table. */
+    phnum?: number;
+  } = {},
 ): Buffer {
   const shstrtab = Buffer.from(SECTION_NAMES.join('\0') + '\0', 'utf8');
   const nameOffsets = new Map<string, number>();
@@ -48,16 +56,17 @@ function buildElf(
     nameOffsets.set(name, at);
     at += name.length + 1;
   }
-  const shstrOffset = SHOFF + 4 * 64;
+  const shoff = SEG_OFFSET + segSize;
+  const shstrOffset = shoff + 4 * 64;
   const buf = Buffer.alloc(shstrOffset + shstrtab.length, 0);
 
   buf.writeUInt32LE(0x464c457f, 0);
   buf[4] = 2; // ELFCLASS64
   buf[5] = 1; // ELFDATA2LSB
   buf.writeBigUInt64LE(BigInt(0x40), 0x20); // e_phoff
-  buf.writeBigUInt64LE(BigInt(SHOFF), 0x28); // e_shoff
+  buf.writeBigUInt64LE(BigInt(shoff), 0x28); // e_shoff
   buf.writeUInt16LE(56, 0x36); // e_phentsize
-  buf.writeUInt16LE(1, 0x38); // e_phnum
+  buf.writeUInt16LE(phnum, 0x38); // e_phnum
   buf.writeUInt16LE(64, 0x3a); // e_shentsize
   buf.writeUInt16LE(4, 0x3c); // e_shnum
   buf.writeUInt16LE(1, 0x3e); // e_shstrndx
@@ -67,22 +76,34 @@ function buildElf(
   buf.writeUInt32LE(6, 0x44); // p_flags = R|W
   buf.writeBigUInt64LE(BigInt(SEG_OFFSET), 0x48);
   buf.writeBigUInt64LE(BigInt(SEG_VADDR), 0x50);
-  buf.writeBigUInt64LE(BigInt(SEG_SIZE), 0x60); // p_filesz
+  buf.writeBigUInt64LE(BigInt(segSize), 0x60); // p_filesz
+
+  if (decoySegment) {
+    // A second PT_LOAD, EARLIER in the table, mapping the same file bytes at the same address but
+    // stopping short of the stand-in. Nothing real does this; the point is that resolving an
+    // address through "the first segment that contains it" would be a silent wrong answer.
+    buf.writeUInt16LE(2, 0x38);
+    buf.writeUInt32LE(1, 0x78);
+    buf.writeUInt32LE(6, 0x7c);
+    buf.writeBigUInt64LE(BigInt(SEG_OFFSET), 0x80);
+    buf.writeBigUInt64LE(BigInt(SEG_VADDR), 0x88);
+    buf.writeBigUInt64LE(BigInt(FIRST_SCANNED - SEG_VADDR + 0x1000), 0x98);
+  }
 
   const section = (index: number, name: string, addr: number, offset: number, size: number) => {
-    const base = SHOFF + index * 64;
+    const base = shoff + index * 64;
     buf.writeUInt32LE(nameOffsets.get(name)!, base);
     buf.writeBigUInt64LE(BigInt(addr), base + 16);
     buf.writeBigUInt64LE(BigInt(offset), base + 24);
     buf.writeBigUInt64LE(BigInt(size), base + 32);
   };
   section(1, '.shstrtab', 0, shstrOffset, shstrtab.length);
-  section(2, '.data', SEG_VADDR, SEG_OFFSET, BUN_OFFSET - SEG_OFFSET);
+  section(2, '.data', SEG_VADDR, SEG_OFFSET, bun.offset - SEG_OFFSET);
   section(3, '.bun', SEG_VADDR + (bun.offset - SEG_OFFSET), bun.offset, bun.size);
   shstrtab.copy(buf, shstrOffset);
 
   // A filler that can never be mistaken for an address.
-  buf.fill(0xaa, SEG_OFFSET, SEG_OFFSET + SEG_SIZE);
+  buf.fill(0xaa, SEG_OFFSET, SEG_OFFSET + segSize);
   const bunVaddr = SEG_VADDR + (bun.offset - SEG_OFFSET);
   for (const vaddr of [pointerVaddr, ...extraPointerVaddrs]) {
     buf.writeBigUInt64LE(BigInt(bunVaddr), SEG_OFFSET + (vaddr - SEG_VADDR));
@@ -234,6 +255,63 @@ describe('the Bun blob pointer stand-in', () => {
 
     expect(() => shimBunCompiledPointer(file))
       .toThrow("no address tweakcc's ELF repack scans is usable");
+  });
+
+  // Mirrors SCAN_CHUNK in src/bun-compiled-pointer.ts. The other fixtures here are smaller than one
+  // chunk, so the sweep's loop body runs once and the overlap that stitches chunks together is
+  // unobservable — a pointer that straddles a boundary would be missed, or found twice and refused
+  // as ambiguous, with every other test still green.
+  const SCAN_CHUNK = 1 << 20;
+  const BIG_SEG = 3 * SCAN_CHUNK;
+
+  it.each([
+    { where: 'wholly inside the first chunk', delta: SCAN_CHUNK - 8 },
+    { where: 'straddling the first boundary', delta: SCAN_CHUNK - 4 },
+    { where: 'first byte past the first boundary', delta: SCAN_CHUNK - 7 },
+    { where: 'straddling the second boundary', delta: 2 * (SCAN_CHUNK - 7) - 3 },
+    { where: 'in the last chunk', delta: 2 * SCAN_CHUNK + 0x40 },
+  ])('finds a pointer $where of the segment sweep', ({ delta }) => {
+    const pointer = SEG_VADDR + delta;
+    const bun = { offset: SEG_OFFSET + BIG_SEG - 0x8000, size: 0x8000 };
+    writeFileSync(file, buildElf(pointer, [], bun, { segSize: BIG_SEG }));
+
+    const shim = shimBunCompiledPointer(file);
+
+    // Found once: a miss throws "0 candidates", a double-report throws "2 candidates".
+    expect(shim).not.toBeNull();
+    expect(shim!.pointerVaddr).toBe(BigInt(pointer));
+  });
+
+  // `fileOffsetOf` resolves the two addresses in the REPACKED image. Taking the first PT_LOAD that
+  // contains an address would put the repacked value at the wrong file offset, and every check in
+  // the restore would still pass, because the readback reads the offset it just wrote.
+  it('refuses to resolve an address that more than one segment claims', () => {
+    const pointer = FIRST_SCANNED + 0x758;
+    writeFileSync(file, buildElf(pointer, [], { offset: BUN_OFFSET, size: BUN_SIZE }));
+    const shim = shimBunCompiledPointer(file)!;
+    // Re-lay the same bytes with the overlapping decoy segment, keeping the stand-in tweakcc wrote.
+    const withDecoy = buildElf(pointer, [], { offset: BUN_OFFSET, size: BUN_SIZE }, { decoySegment: true });
+    withDecoy.writeBigUInt64LE(BigInt(0x90000), SEG_OFFSET + (Number(shim.standInVaddr) - SEG_VADDR));
+    withDecoy.writeBigUInt64LE(BigInt(0x90000), SHOFF + 3 * 64 + 16);
+    writeFileSync(file, withDecoy);
+
+    expect(() => restoreBunCompiledPointer(file, shim)).toThrow('in more than one segment');
+  });
+
+  // PN_XNUM says the real program-header count lives in the section table. Reading 0xffff headers
+  // of arbitrary file bytes as segments is how a stand-in gets planted at a garbage offset.
+  it('leaves an ELF alone when its program-header count is PN_XNUM', () => {
+    // Big enough that 0xffff * 56 bytes of "program headers" can actually be read out of it —
+    // otherwise the short read rejects the file anyway and this passes without testing the guard.
+    const bun = { offset: SEG_OFFSET + 4 * SCAN_CHUNK - 0x8000, size: 0x8000 };
+    writeFileSync(
+      file,
+      buildElf(FIRST_SCANNED + 0x758, [], bun, { segSize: 4 * SCAN_CHUNK, phnum: 0xffff }),
+    );
+    const before = readFileSync(file);
+
+    expect(shimBunCompiledPointer(file)).toBeNull();
+    expect(readFileSync(file).equals(before)).toBe(true);
   });
 
   it('ignores candidates inside the blob itself', () => {

--- a/tests/bun-compiled-pointer.test.ts
+++ b/tests/bun-compiled-pointer.test.ts
@@ -1,0 +1,248 @@
+// The stand-in that keeps tweakcc's ELF repack able to find the global Bun reads its blob's
+// address from. Claude Code 2.1.257 moved that global off the 16 KiB boundary tweakcc scans, and
+// `clodex patch` failed on all four ELF builds with "Could not find original BUN_COMPILED
+// location in binary". See src/bun-compiled-pointer.ts.
+//
+// The binaries here are synthetic: a real one is 300 MB and cannot be committed, and every rule
+// this module applies is about ELF structure, which a small hand-built ELF64 carries exactly.
+// The real builds are covered by scripts/probe-patch-mechanism.mjs and the canary's container leg.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, openSync, readSync, closeSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  restoreBunCompiledPointer,
+  shimBunCompiledPointer,
+} from '../src/bun-compiled-pointer.js';
+
+const STRIDE = 16384;
+// The writable segment starts on an ODD address, as it does on every real build (0x532c490 on
+// linux-x64 2.1.257). A 16 KiB-aligned segment would make the first scanned address the segment's
+// own start and hide the arithmetic this module has to get right.
+const SEG_OFFSET = 0x10490;
+const SEG_VADDR = 0x10490;
+const SEG_SIZE = 0x20000;
+/** The lowest address tweakcc's scan visits inside that segment. */
+const FIRST_SCANNED = 0x14000;
+const BUN_OFFSET = 0x20000;
+const BUN_VADDR = 0x20000;
+const BUN_SIZE = 0x8000;
+const SHOFF = SEG_OFFSET + SEG_SIZE;
+
+const SECTION_NAMES = ['', '.shstrtab', '.data', '.bun'];
+
+/**
+ * A 64-bit little-endian ELF with one writable PT_LOAD and a `.bun` section inside it, carrying
+ * the blob pointer at `pointerVaddr`. Everything the module reads — and nothing else.
+ */
+function buildElf(
+  pointerVaddr: number,
+  extraPointerVaddrs: number[] = [],
+  bun: { offset: number; size: number } = { offset: BUN_OFFSET, size: BUN_SIZE },
+): Buffer {
+  const shstrtab = Buffer.from(SECTION_NAMES.join('\0') + '\0', 'utf8');
+  const nameOffsets = new Map<string, number>();
+  let at = 0;
+  for (const name of SECTION_NAMES) {
+    nameOffsets.set(name, at);
+    at += name.length + 1;
+  }
+  const shstrOffset = SHOFF + 4 * 64;
+  const buf = Buffer.alloc(shstrOffset + shstrtab.length, 0);
+
+  buf.writeUInt32LE(0x464c457f, 0);
+  buf[4] = 2; // ELFCLASS64
+  buf[5] = 1; // ELFDATA2LSB
+  buf.writeBigUInt64LE(BigInt(0x40), 0x20); // e_phoff
+  buf.writeBigUInt64LE(BigInt(SHOFF), 0x28); // e_shoff
+  buf.writeUInt16LE(56, 0x36); // e_phentsize
+  buf.writeUInt16LE(1, 0x38); // e_phnum
+  buf.writeUInt16LE(64, 0x3a); // e_shentsize
+  buf.writeUInt16LE(4, 0x3c); // e_shnum
+  buf.writeUInt16LE(1, 0x3e); // e_shstrndx
+
+  // The one PT_LOAD, writable.
+  buf.writeUInt32LE(1, 0x40); // p_type = PT_LOAD
+  buf.writeUInt32LE(6, 0x44); // p_flags = R|W
+  buf.writeBigUInt64LE(BigInt(SEG_OFFSET), 0x48);
+  buf.writeBigUInt64LE(BigInt(SEG_VADDR), 0x50);
+  buf.writeBigUInt64LE(BigInt(SEG_SIZE), 0x60); // p_filesz
+
+  const section = (index: number, name: string, addr: number, offset: number, size: number) => {
+    const base = SHOFF + index * 64;
+    buf.writeUInt32LE(nameOffsets.get(name)!, base);
+    buf.writeBigUInt64LE(BigInt(addr), base + 16);
+    buf.writeBigUInt64LE(BigInt(offset), base + 24);
+    buf.writeBigUInt64LE(BigInt(size), base + 32);
+  };
+  section(1, '.shstrtab', 0, shstrOffset, shstrtab.length);
+  section(2, '.data', SEG_VADDR, SEG_OFFSET, BUN_OFFSET - SEG_OFFSET);
+  section(3, '.bun', SEG_VADDR + (bun.offset - SEG_OFFSET), bun.offset, bun.size);
+  shstrtab.copy(buf, shstrOffset);
+
+  // A filler that can never be mistaken for an address.
+  buf.fill(0xaa, SEG_OFFSET, SEG_OFFSET + SEG_SIZE);
+  const bunVaddr = SEG_VADDR + (bun.offset - SEG_OFFSET);
+  for (const vaddr of [pointerVaddr, ...extraPointerVaddrs]) {
+    buf.writeBigUInt64LE(BigInt(bunVaddr), SEG_OFFSET + (vaddr - SEG_VADDR));
+  }
+  return buf;
+}
+
+function read8(file: string, vaddr: number): bigint {
+  const fd = openSync(file, 'r');
+  try {
+    const out = Buffer.alloc(8);
+    readSync(fd, out, 0, 8, SEG_OFFSET + (vaddr - SEG_VADDR));
+    return out.readBigUInt64LE(0);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/**
+ * What tweakcc's `repackELFSection` does once its scan succeeds: rewrite the eight bytes it found
+ * to `.bun`'s new address, and move the section there. `foundAt` is the address it settled on.
+ */
+function simulateRepack(file: string, foundAt: number, newBunVaddr: number): void {
+  const buf = readFileSync(file);
+  buf.writeBigUInt64LE(BigInt(newBunVaddr), SEG_OFFSET + (foundAt - SEG_VADDR));
+  // .bun stays inside the segment's file image here — only its recorded address changes, which is
+  // all the restore reads.
+  buf.writeBigUInt64LE(BigInt(newBunVaddr), SHOFF + 3 * 64 + 16);
+  writeFileSync(file, buf);
+}
+
+/** tweakcc's own strided scan, so a test can assert the stand-in actually lands where it looks. */
+function tweakccScan(file: string, needle: bigint): number | null {
+  const buf = readFileSync(file);
+  for (let vaddr = FIRST_SCANNED; vaddr <= SEG_VADDR + SEG_SIZE - 8; vaddr += STRIDE) {
+    if (buf.readBigUInt64LE(SEG_OFFSET + (vaddr - SEG_VADDR)) === needle) return vaddr;
+  }
+  return null;
+}
+
+describe('the Bun blob pointer stand-in', () => {
+  let dir: string;
+  let file: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), 'clodex-bun-pointer-'));
+    file = path.join(dir, 'claude');
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  // The releases through 2.1.252 that tweakcc repacks unaided. Planting anything there would be a
+  // change to a path that works, on every ELF build, for no reason.
+  it('does nothing when the pointer already sits where tweakcc scans', () => {
+    writeFileSync(file, buildElf(FIRST_SCANNED));
+    const before = readFileSync(file);
+
+    expect(shimBunCompiledPointer(file)).toBeNull();
+    expect(readFileSync(file).equals(before)).toBe(true);
+  });
+
+  it.each([
+    ['Mach-O', Buffer.from([0xcf, 0xfa, 0xed, 0xfe, 0, 0, 0, 0])],
+    ['PE', Buffer.from('MZ\0\0\0\0\0\0', 'latin1')],
+    ['too short to be an ELF', Buffer.from([0x7f, 0x45, 0x4c, 0x46])],
+  ])('leaves a %s binary alone', (_name, bytes) => {
+    writeFileSync(file, bytes);
+    const before = readFileSync(file);
+
+    expect(shimBunCompiledPointer(file)).toBeNull();
+    expect(readFileSync(file).equals(before)).toBe(true);
+  });
+
+  // The 2.1.257 shape. Every ELF build moved the pointer off the boundary: 0x534f758 on
+  // linux-x64, 0x4d9af08 on linux-x64-musl, 0x5310758 on linux-arm64, 0x4c46d10 on
+  // linux-arm64-musl — none of them a multiple of 16384.
+  describe('when the pointer sits where tweakcc never looks', () => {
+    const POINTER = FIRST_SCANNED + 0x758;
+    const NEW_BUN_VADDR = 0x90000;
+
+    beforeEach(() => writeFileSync(file, buildElf(POINTER)));
+
+    it('makes tweakcc find something, without disturbing the real pointer', () => {
+      expect(tweakccScan(file, BigInt(BUN_VADDR)), 'the fixture must reproduce the failure')
+        .toBeNull();
+
+      const shim = shimBunCompiledPointer(file);
+
+      expect(shim).not.toBeNull();
+      expect(shim!.pointerVaddr).toBe(BigInt(POINTER));
+      expect(tweakccScan(file, BigInt(BUN_VADDR))).toBe(Number(shim!.standInVaddr));
+      expect(read8(file, POINTER)).toBe(BigInt(BUN_VADDR));
+    });
+
+    it('moves the repacked address onto the real pointer and puts the displaced bytes back', () => {
+      const shim = shimBunCompiledPointer(file)!;
+      const displacedAt = Number(shim.standInVaddr);
+      const before = read8(file, displacedAt);
+
+      simulateRepack(file, displacedAt, NEW_BUN_VADDR);
+      restoreBunCompiledPointer(file, shim);
+
+      expect(read8(file, POINTER)).toBe(BigInt(NEW_BUN_VADDR));
+      expect(read8(file, displacedAt)).toBe(shim.displaced.readBigUInt64LE(0));
+      expect(before, 'the stand-in really did displace something').toBe(BigInt(BUN_VADDR));
+    });
+
+    // A repack that silently did not use the stand-in would leave Bun pointed at a blob that is no
+    // longer there — a claude that dies before it prints anything. Refuse instead of publishing.
+    it('refuses when the repack never rewrote the stand-in', () => {
+      const shim = shimBunCompiledPointer(file)!;
+
+      expect(() => restoreBunCompiledPointer(file, shim))
+        .toThrow('the stand-in was not used');
+      expect(read8(file, POINTER), 'and it left the binary as it found it').toBe(BigInt(BUN_VADDR));
+    });
+
+    it('refuses when the repack disagrees with where .bun ended up', () => {
+      const shim = shimBunCompiledPointer(file)!;
+      const buf = readFileSync(file);
+      // The stand-in says one address, the section header says another.
+      buf.writeBigUInt64LE(BigInt(NEW_BUN_VADDR), SEG_OFFSET + (Number(shim.standInVaddr) - SEG_VADDR));
+      buf.writeBigUInt64LE(BigInt(NEW_BUN_VADDR + 0x1000), SHOFF + 3 * 64 + 16);
+      writeFileSync(file, buf);
+
+      expect(() => restoreBunCompiledPointer(file, shim))
+        .toThrow(/pointed Bun at 0x90000 but put \.bun at 0x91000/);
+    });
+  });
+
+  // Matches inside the blob are coincidences in compressed JavaScript — real builds carry dozens.
+  // A second match OUTSIDE it is not something this module is entitled to guess about.
+  it('refuses to guess when more than one pointer candidate is outside the blob', () => {
+    writeFileSync(file, buildElf(FIRST_SCANNED + 0x758, [FIRST_SCANNED + 0x900]));
+
+    expect(() => shimBunCompiledPointer(file))
+      .toThrow("cannot locate Bun's blob pointer: 2 candidates");
+  });
+
+  // The remaining refusal: nowhere the scan visits is usable, because the blob covers every one of
+  // them. Nothing observed does this, but the alternative to refusing is planting the stand-in into
+  // the blob tweakcc is about to reparse.
+  it('refuses when every address tweakcc scans is inside the blob', () => {
+    // `.bun` starts below the first scanned address and runs to the end of the segment, so every
+    // address the scan visits is inside the blob the repack is about to move. The real pointer sits
+    // in the sliver below it. Nothing observed does this; the alternative to refusing would be
+    // planting the stand-in into the blob tweakcc is about to reparse.
+    const bun = { offset: SEG_OFFSET + 0x1000, size: SEG_SIZE - 0x1000 };
+    writeFileSync(file, buildElf(SEG_VADDR + 0x40, [], bun));
+
+    expect(() => shimBunCompiledPointer(file))
+      .toThrow("no address tweakcc's ELF repack scans is usable");
+  });
+
+  it('ignores candidates inside the blob itself', () => {
+    // Two more occurrences, both inside `.bun`, exactly as a real bundle carries them.
+    writeFileSync(file, buildElf(FIRST_SCANNED + 0x758, [BUN_VADDR + 0x40, BUN_VADDR + 0x2000]));
+
+    const shim = shimBunCompiledPointer(file);
+
+    expect(shim).not.toBeNull();
+    expect(shim!.pointerVaddr).toBe(BigInt(FIRST_SCANNED + 0x758));
+  });
+});

--- a/tests/bun-compiled-pointer.test.ts
+++ b/tests/bun-compiled-pointer.test.ts
@@ -17,16 +17,24 @@ import {
 } from '../src/bun-compiled-pointer.js';
 
 const STRIDE = 16384;
-// The writable segment starts on an ODD address, as it does on every real build (0x532c490 on
-// linux-x64 2.1.257). A 16 KiB-aligned segment would make the first scanned address the segment's
-// own start and hide the arithmetic this module has to get right.
+// The writable segment starts on an ODD address, as it does on every real build (file offset
+// 0x512a490 at virtual address 0x532c490 on linux-x64 2.1.257). A 16 KiB-aligned segment would make
+// the first scanned address the segment's own start and hide the arithmetic this module has to get
+// right.
 const SEG_OFFSET = 0x10490;
-const SEG_VADDR = 0x10490;
+/**
+ * How far virtual addresses run ahead of file offsets: 0x202000 on the real linux-x64 build,
+ * 0x220000 on arm64. Never zero, and that is the point — mapped at `vaddr === offset`, an
+ * implementation that confuses the two reads and writes the same wrong place, passes its own
+ * readback, and leaves Bun pointed at the old blob on every real Linux build.
+ */
+const LOAD_BIAS = 0x202000;
+const SEG_VADDR = SEG_OFFSET + LOAD_BIAS;
 const SEG_SIZE = 0x20000;
 /** The lowest address tweakcc's scan visits inside that segment. */
-const FIRST_SCANNED = 0x14000;
+const FIRST_SCANNED = Math.ceil(SEG_VADDR / STRIDE) * STRIDE;
 const BUN_OFFSET = 0x20000;
-const BUN_VADDR = 0x20000;
+const BUN_VADDR = BUN_OFFSET + LOAD_BIAS;
 const BUN_SIZE = 0x8000;
 const SHOFF = SEG_OFFSET + SEG_SIZE;
 
@@ -181,7 +189,7 @@ describe('the Bun blob pointer stand-in', () => {
   // linux-arm64-musl — none of them a multiple of 16384.
   describe('when the pointer sits where tweakcc never looks', () => {
     const POINTER = FIRST_SCANNED + 0x758;
-    const NEW_BUN_VADDR = 0x90000;
+    const NEW_BUN_VADDR = 0x900000;
 
     beforeEach(() => writeFileSync(file, buildElf(POINTER)));
 
@@ -229,7 +237,7 @@ describe('the Bun blob pointer stand-in', () => {
       writeFileSync(file, buf);
 
       expect(() => restoreBunCompiledPointer(file, shim))
-        .toThrow(/pointed Bun at 0x90000 but put \.bun at 0x91000/);
+        .toThrow(/pointed Bun at 0x900000 but put \.bun at 0x901000/);
     });
   });
 
@@ -315,8 +323,12 @@ describe('the Bun blob pointer stand-in', () => {
   });
 
   it('ignores candidates inside the blob itself', () => {
-    // Two more occurrences, both inside `.bun`, exactly as a real bundle carries them.
-    writeFileSync(file, buildElf(FIRST_SCANNED + 0x758, [BUN_VADDR + 0x40, BUN_VADDR + 0x2000]));
+    // Two more occurrences, both inside `.bun`, exactly as a real bundle carries them (5 of them on
+    // linux-arm64 2.1.257). Neither may land on a 16 KiB boundary, or tweakcc's own scan finds one
+    // and this stops testing the exclusion at all.
+    const inBlob = [BUN_VADDR + 0x40, BUN_VADDR + 0x2100];
+    for (const vaddr of inBlob) expect(vaddr % STRIDE, 'decoy must be off the scan stride').not.toBe(0);
+    writeFileSync(file, buildElf(FIRST_SCANNED + 0x758, inBlob));
 
     const shim = shimBunCompiledPointer(file);
 

--- a/tests/fixtures/claude-bundle.ts
+++ b/tests/fixtures/claude-bundle.ts
@@ -16,12 +16,27 @@ const ENUM_AND_DESCRIPTION =
   '.enum(["sonnet","opus","haiku","fable"]).optional().describe(`Optional model override for this '
   + 'agent. Defaults to inherit.`+(hint()?" Prefer the session model.":""))';
 
+/**
+ * The context-window resolver PATCH 7 keys on, as Claude Code 2.1.252 minified it. Its two
+ * PARAMETER names are as minified — and as churn-prone — as every other identifier here:
+ * 2.1.257 spelled the very same function `(e,n)`, and an anchor that required `(e,t)` failed on
+ * all eight published builds at once. `contextResolver` re-spells it so a test can pin that.
+ */
+export const CONTEXT_RESOLVER =
+  'function RS(e,t){let r=FAc();if(r!==void 0)return r;if(EHi(e,t))return Dve;return $Ac(e,t)}';
+
+/** The same resolver with the two parameters renamed, as a later build's minifier may spell it. */
+export function contextResolver(modelParam: string, windowParam: string): string {
+  return `function RS(${modelParam},${windowParam}){let r=FAc();if(r!==void 0)return r;`
+    + `if(EHi(${modelParam},${windowParam}))return Dve;return $Ac(${modelParam},${windowParam})}`;
+}
+
 export const CLAUDE_CORE_FIXTURE = [
   ENUM_AND_DESCRIPTION,
   'var KNOWN=["sonnet","opus","haiku","fable","opusplan"];',
   'function rz(x){switch(x){case"best":{return "opus"}default:return null}}',
   'function opts(e,t,r){let n=cur(),o=(n==="opus"||n==="sonnet")&&n!==r?[n,r]:[r];for(let i of o)Dlh(e,i,t);return e}',
-  'function RS(e,t){let r=FAc();if(r!==void 0)return r;if(EHi(e,t))return Dve;return $Ac(e,t)}',
+  CONTEXT_RESOLVER,
   'function cwdOf(){let p=process.env.PWD;return p}',
   'function childEnv(){let e=extra(),t=Object.keys(e).length>0,n=Object.keys(e).length>0,s=flag(process.env.CLAUDE_CODE_REMOTE)?remote():{};let o=[process.env.CLAUDE_CODE_OAUTH_TOKEN,process.env.CLAUDE_CODE_SUBSCRIPTION_TYPE,process.env.CLAUDE_BG_PTY_AUTH,"OTEL_",process.env.CLAUDE_CODE_OTEL_DIAG_STDERR],u=["CLAUDE_CODE_OAUTH_TOKEN"];if(!t&&!n&&!o[0])return process.env;let v={...process.env,...e,...s};for(let k of u)delete v[k],delete v[`INPUT_${k}`];return v}function mcpAllow(){let e=process.env.CLAUDE_CODE_MCP_ALLOWLIST_ENV;return e}',
 ].join('\n');

--- a/tests/patcher.test.ts
+++ b/tests/patcher.test.ts
@@ -12,8 +12,8 @@ import {
 import {
   buildFakeElfClaude,
   buildFakeNativeClaude,
-  ELF_FIRST_SCANNED,
-  ELF_POINTER_VADDR,
+  ELF_POINTER_OFFSET,
+  ELF_STAND_IN_OFFSET,
   MACHO_MAGIC,
   parseBunBlob,
   rebuildFakeNativeClaude,
@@ -1398,14 +1398,94 @@ describe('applyPatch', () => {
       expect(outcome.ok ? 'ok' : outcome.message).toBe('ok');
 
       const published = readFileSync(binaryPath);
-      // The real global holds the relocated address...
-      expect(published.readBigUInt64LE(ELF_POINTER_VADDR)).toBe(BigInt(RELOCATED_BUN_ADDR));
+      // The real global holds the relocated address. Read at its FILE OFFSET, which the fixture
+      // keeps distinct from its virtual address — the two are 0x202000 apart on a real linux-x64.
+      expect(published.readBigUInt64LE(ELF_POINTER_OFFSET)).toBe(BigInt(RELOCATED_BUN_ADDR));
       // ...and the slot the stand-in borrowed holds what it held before, byte for byte.
-      expect(published.readBigUInt64LE(ELF_FIRST_SCANNED))
-        .toBe(pristine.readBigUInt64LE(ELF_FIRST_SCANNED));
+      expect(published.readBigUInt64LE(ELF_STAND_IN_OFFSET))
+        .toBe(pristine.readBigUInt64LE(ELF_STAND_IN_OFFSET));
       // The patch itself still landed, so this is not passing on a binary nothing was done to.
       expect(parseBunBlob(published).contents[0]).toContain('"extended"');
       expect(parseBunBlob(published).contents[6]).toContain('/*ccpatch:ctx*/');
+    } finally {
+      Object.defineProperty(process, 'platform', platform);
+      if (previousAppHome === undefined) delete process.env.CLODEX_HOME;
+      else process.env.CLODEX_HOME = previousAppHome;
+      if (previousTweakccHome === undefined) delete process.env.TWEAKCC_CONFIG_DIR;
+      else process.env.TWEAKCC_CONFIG_DIR = previousTweakccHome;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  /**
+   * The same thing on the OTHER write path. `applyPatch` falls back to tweakcc's single-module
+   * write whenever `readClaudeBundle` returns null — an npm `cli.js` install, or a blob whose
+   * modules do not round-trip. An npm install is not an ELF, so the stand-in is a no-op there and
+   * that call site could be deleted with everything else still green; this is the case where the
+   * fallback and a native ELF meet, which is what makes it a second call site rather than a
+   * decoration.
+   */
+  it('repoints the ELF blob pointer on the single-module write path too', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'clodex-elf-fallback-'));
+    const binaryPath = join(dir, 'claude');
+    const tweakccHome = join(dir, 'tweakcc-home');
+    const previousAppHome = process.env.CLODEX_HOME;
+    const previousTweakccHome = process.env.TWEAKCC_CONFIG_DIR;
+    // Loader 5 is a vendored asset, not JavaScript Bun executes, so `readClaudeBundle` finds no
+    // bundle at all and returns null — which is what selects the fallback write.
+    const modules = [{ name: '/$bunfs/root/src/entrypoints/cli.js', contents: CLAUDE_FIXTURE, loader: 5 }];
+    const pristine = buildFakeElfClaude(modules);
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+    vi.mocked(execFileSync).mockReset();
+    vi.mocked(execFileSync).mockImplementation((() => '') as unknown as typeof execFileSync);
+    mkdirSync(tweakccHome, { recursive: true });
+    writeFileSync(binaryPath, pristine, { mode: 0o755 });
+    process.env.CLODEX_HOME = dir;
+    process.env.TWEAKCC_CONFIG_DIR = tweakccHome;
+
+    const RELOCATED_BUN_ADDR = 0x900000;
+
+    tweakccMocks.tryDetectInstallation.mockReset();
+    tweakccMocks.readContent.mockReset();
+    tweakccMocks.writeContent.mockReset();
+    tweakccMocks.tryDetectInstallation.mockImplementation(
+      async ({ path }: { path: string }) => ({ path, version: 'test-version', kind: 'native' }),
+    );
+    tweakccMocks.readContent.mockImplementation(
+      async ({ path }: { path: string }) => parseBunBlob(readFileSync(path)).contents[0]!,
+    );
+    tweakccMocks.writeContent.mockImplementation(
+      async ({ path }: { path: string }, content: string) => {
+        writeFileSync(
+          path,
+          repackFakeElfClaude(readFileSync(path), () => content, RELOCATED_BUN_ADDR),
+          { mode: 0o755 },
+        );
+      },
+    );
+
+    try {
+      const outcome = await applyPatch(
+        binaryPath,
+        'test-version',
+        {
+          config: { 'clodex:test:extended': { alias: 'extended', context: 272_000, display: 'Extended (test)' } },
+          unknownWindows: [],
+        },
+        'desired-config-hash',
+        { trace: false, manifest: null },
+      );
+
+      expect(outcome.ok ? 'ok' : outcome.message).toBe('ok');
+
+      const published = readFileSync(binaryPath);
+      expect(published.readBigUInt64LE(ELF_POINTER_OFFSET)).toBe(BigInt(RELOCATED_BUN_ADDR));
+      expect(published.readBigUInt64LE(ELF_STAND_IN_OFFSET))
+        .toBe(pristine.readBigUInt64LE(ELF_STAND_IN_OFFSET));
+      // Went through the fallback, and the patch landed in the one module tweakcc names.
+      expect(parseBunBlob(published).contents[0]).toContain('"extended"');
+      expect(parseBunBlob(published).contents[0]).toContain('/*ccpatch:ctx*/');
     } finally {
       Object.defineProperty(process, 'platform', platform);
       if (previousAppHome === undefined) delete process.env.CLODEX_HOME;
@@ -2167,6 +2247,24 @@ describe('patch script identity naming', () => {
 
     expect(() => runPatchScript(config, source)).toThrow(
       'clodex patch: child network environment target validation failed',
+    );
+  });
+
+  // `CLAUDE_CODE_REMOTE` is not in the literal list, because the ANCHOR already requires it inside
+  // the captured body — that is why removing it from the list was safe. Nothing else pins the
+  // anchor's copy of it, so widen it to any environment variable and the site would silently stop
+  // proving it bound to the builder that consults the remote flag.
+  it('rejects a child builder whose head consults a different environment variable', () => {
+    const source = CLAUDE_FIXTURE.replace(
+      'flag(process.env.CLAUDE_CODE_REMOTE)?remote():{}',
+      'flag(process.env.CLAUDE_CODE_ELSEWHERE)?remote():{}',
+    );
+
+    expect(source, 'fixture drifted from the shape this test mutates').not.toBe(CLAUDE_FIXTURE);
+    expect(source).not.toContain('CLAUDE_CODE_REMOTE');
+
+    expect(() => runPatchScript(config, source)).toThrow(
+      'clodex patch: required patch failed: PATCH 10: child network environment',
     );
   });
 

--- a/tests/patcher.test.ts
+++ b/tests/patcher.test.ts
@@ -6,6 +6,8 @@ import {
   CLAUDE_PROXY_EFFORT_FIXTURE,
   CLAUDE_SPLIT_ENTRY_ID,
   CLAUDE_SPLIT_MODULES,
+  CONTEXT_RESOLVER,
+  contextResolver,
 } from './fixtures/claude-bundle.js';
 import {
   buildFakeNativeClaude,
@@ -582,8 +584,8 @@ describe('PATCH_TRANSFORMS_VERSION', () => {
       .join('\n');
     const digest = createHash('sha256').update(source).digest('hex');
     expect({ version: PATCH_TRANSFORMS_VERSION, digest }).toEqual({
-      version: 10,
-      digest: 'b7897568a924dfa98b828d6cf4f136638777e5d11216e38a8e7408b9b5639b16',
+      version: 11,
+      digest: '87fec3418582a3be6839917e63ae71ac4a6d3ed71aa4b86c7e220d310c2fa00c',
     });
   });
 });
@@ -1939,26 +1941,78 @@ describe('patch script identity naming', () => {
     expect(result.content).toContain('if(o[0]){delete v.CLAUDE_CODE_OAUTH_TOKEN;return e}');
   });
 
-  // Each literal is an independent statement about what the target function does.
-  // The anchor alone cannot tell the child-env builder from another function that
-  // merges process.env, so dropping any one of these must refuse rather than
-  // patch a lookalike.
-  it.each([
+  // The names the builder scrubs are a smell test, not the identity proof, and
+  // each one is only as durable as the line that happens to spell it. Claude Code
+  // 2.1.257 replaced a run of per-name `process.env.CLAUDE_BG_*!==void 0` reads
+  // with a set-membership test and stopped spelling those names at all — a
+  // refactor that changed nothing about what clodex rewrites. Requiring every
+  // name made `clodex patch` refuse that release on all eight published builds.
+  const SCRUBBED_ENV_NAMES: [string, string, string][] = [
     ['the OAuth credential it scrubs', 'CLAUDE_CODE_OAUTH_TOKEN', 'SOMETHING_ELSE_TOKEN'],
     ['the subscription type it scrubs', 'CLAUDE_CODE_SUBSCRIPTION_TYPE', 'SOMETHING_ELSE_TYPE'],
     ['the background PTY token it scrubs', 'CLAUDE_BG_PTY_AUTH', 'SOMETHING_ELSE_AUTH'],
     ['the OTEL prefix it strips', '"OTEL_"', '"UNRELATED_"'],
     ['the OTEL diagnostic flag it strips', 'CLAUDE_CODE_OTEL_DIAG_STDERR', 'SOMETHING_ELSE_DIAG'],
-  ])('refuses a child builder that no longer references %s', (_name, literal, replacement) => {
-    // Replace EVERY occurrence: the check is `body.includes(literal)`, so one
-    // surviving mention anywhere in the body keeps the guard satisfied and the
-    // test passes without testing anything.
-    const source = CLAUDE_FIXTURE_239.split(literal).join(replacement);
+  ];
+
+  /** Every occurrence, so one surviving mention cannot keep the guard satisfied. */
+  function withoutScrubbedNames(source: string, names: [string, string, string][]): string {
+    return names.reduce((acc, [, literal, replacement]) => acc.split(literal).join(replacement), source);
+  }
+
+  it.each(SCRUBBED_ENV_NAMES)(
+    'still patches a child builder that stopped spelling %s',
+    (_name, literal, replacement) => {
+      const source = withoutScrubbedNames(CLAUDE_FIXTURE_239, [['', literal, replacement]]);
+
+      expect(source, 'fixture drifted from the shape this test mutates').not.toBe(CLAUDE_FIXTURE_239);
+      expect(source, 'no occurrence of the literal may survive').not.toContain(literal);
+
+      const result = applyClodexPatches(source, config);
+
+      expect(result.results.at(-1)).toEqual({
+        status: 'OK',
+        name: 'PATCH 10: child network environment',
+      });
+      expect(result.content).toContain('function childEnv(){/*ccpatch:child-network-env*/');
+    },
+  );
+
+  // The quorum still has to mean something: a body that scrubs almost none of
+  // them is not the child-env builder and must be refused, not rewritten.
+  it.each([
+    { left: 'one', drop: SCRUBBED_ENV_NAMES.slice(0, 4) },
+    { left: 'none', drop: SCRUBBED_ENV_NAMES },
+  ])('refuses a child builder that scrubs $left of the known names', ({ drop }) => {
+    const source = withoutScrubbedNames(CLAUDE_FIXTURE_239, drop);
 
     expect(source, 'fixture drifted from the shape this test mutates').not.toBe(CLAUDE_FIXTURE_239);
-    expect(source, 'no occurrence of the literal may survive').not.toContain(literal);
+    for (const [, literal] of drop) expect(source).not.toContain(literal);
+
     expect(() => runPatchScript(config, source)).toThrow(
-      'clodex patch: child network environment target validation failed',
+      'clodex patch: child network environment target validation failed: '
+      + 'body scrubs only ' + (SCRUBBED_ENV_NAMES.length - drop.length)
+      + ' of the 5 known child-env names (expected at least 2)',
+    );
+  });
+
+  // Every refusal names the check that produced it. A bare "target validation
+  // failed" covers four unrelated conditions, and telling them apart from a
+  // canary report meant extracting a 32 MB bundle by hand.
+  it('says which check refused the target', () => {
+    const nested = CLAUDE_FIXTURE.replace(
+      's=flag(process.env.CLAUDE_CODE_REMOTE)?remote():{};let o=',
+      's=flag(process.env.CLAUDE_CODE_REMOTE)?remote():{};function nested(){}let o=',
+    );
+    expect(() => runPatchScript(config, nested)).toThrow(
+      'clodex patch: child network environment target validation failed: '
+      + 'body declares a nested function',
+    );
+
+    const noMerge = CLAUDE_FIXTURE.replace('let v={...process.env,...e,...s}', 'let v={...te,...e,...s}');
+    expect(() => runPatchScript(config, noMerge)).toThrow(
+      'clodex patch: child network environment target validation failed: '
+      + 'body does not contain {...process.env',
     );
   });
 
@@ -2494,6 +2548,94 @@ describe('patch script identity naming', () => {
     const parsed = JSON.parse(table!) as Record<string, number>;
     expect(parsed['clodex:openai:mystery']).toBe(131_072);
     expect(parsed['sol']).toBe(272_000);
+  });
+
+  // ---------------------------------------------------------------------------
+  // PATCH 7's anchor and the parameter names Claude Code's minifier picks.
+  //
+  // 2.1.252 minified the context-window resolver as `(e,t)` and 2.1.257 minified
+  // the same function as `(e,n)`. The anchor required the literal `(e,t)`, so the
+  // site reported "anchor not found" on all eight published 2.1.257 builds and
+  // `clodex patch` aborted — no context windows, no auto-compaction, on every
+  // platform at once. Nothing below is 2.1.257-specific: the resolver is spelled
+  // through a helper so a name the minifier has not chosen yet is covered too.
+  // ---------------------------------------------------------------------------
+  describe('PATCH 7 against a resolver whose parameters the minifier renamed', () => {
+    /** The patched resolver, pulled back out of the bundle so it can be RUN. */
+    function resolverFrom(patched: string): (model: unknown, opts?: unknown) => unknown {
+      const declaration = patched
+        .split('\n')
+        .find(line => line.startsWith('function RS(') && line.includes('/*ccpatch:ctx*/'));
+      expect(declaration).toBeDefined();
+      // The resolver's own callees are stubbed to the shape the real ones have:
+      // no env override, no 1M gate, and a native window for anything unbaked.
+      const make = new Function(
+        'FAc',
+        'EHi',
+        'Dve',
+        '$Ac',
+        `${declaration}; return RS;`,
+      ) as (
+        FAc: () => undefined,
+        EHi: () => boolean,
+        Dve: number,
+        $Ac: () => number,
+      ) => (model: unknown, opts?: unknown) => unknown;
+      return make(() => undefined, () => false, 200_000, () => 200_000);
+    }
+
+    it.each([
+      { spelling: '(e,t)', model: 'e', window: 't' },
+      { spelling: '(e,n)', model: 'e', window: 'n' },
+      { spelling: '(a,i)', model: 'a', window: 'i' },
+    ])('applies to a resolver minified as $spelling', ({ model, window }) => {
+      const source = CLAUDE_FIXTURE.replace(CONTEXT_RESOLVER, contextResolver(model, window));
+      // Guards the substitution itself: a fixture edit that stopped this from
+      // landing would leave every case below testing the same `(e,t)` spelling.
+      expect(source).toContain(contextResolver(model, window));
+
+      const patched = applyClodexPatches(source, config);
+
+      expect(patched.results).toContainEqual({ status: 'OK', name: 'PATCH 7: per-model context window' });
+      // The lookup has to read the parameter THIS build declares. Reading a name
+      // that is not in scope would either throw or silently pick up an unrelated
+      // binding from the module around it, and every model would fall through to
+      // the 200k clamp with nothing reported as failed.
+      expect(patched.content).toContain(`[String(${model}||"").trim().toLowerCase()]`);
+
+      const resolve = resolverFrom(patched.content);
+      expect(resolve('sol')).toBe(272_000);
+      expect(resolve('  SOL  ')).toBe(272_000);
+      expect(resolve('clodex:openai:mystery')).toBe(128_000);
+      expect(resolve('sonnet')).toBe(200_000);
+    });
+
+    it('keeps the build\'s own parameter name when a later run refreshes the table', () => {
+      const source = CLAUDE_FIXTURE.replace(CONTEXT_RESOLVER, contextResolver('a', 'i'));
+      const once = applyClodexPatches(source, config).content;
+
+      const updated = applyClodexPatches(once, {
+        ...config,
+        'clodex:openai:mystery': { context: 131_072, display: 'Mystery (OpenAI)' },
+      });
+
+      expect(updated.results).toContainEqual({
+        status: 'OK',
+        name: 'PATCH 7: per-model context window (refresh)',
+      });
+      // Scoped to the context snippet: the effort patches legitimately read `e`,
+      // because THEIR anchors are single-parameter functions of that name.
+      expect(updated.content).toMatch(
+        /\/\*ccpatch:ctx\*\/var _ccw=\(\{[^{}]*\}\)\[String\(a\|\|""\)\.trim\(\)\.toLowerCase\(\)\]/,
+      );
+      expect(updated.content).not.toMatch(
+        /\/\*ccpatch:ctx\*\/var _ccw=\(\{[^{}]*\}\)\[String\(e\|\|""\)/,
+      );
+
+      const resolve = resolverFrom(updated.content);
+      expect(resolve('clodex:openai:mystery')).toBe(131_072);
+      expect(resolve('sol')).toBe(272_000);
+    });
   });
 
   it('keeps identity and context patches when every effort anchor drifts', () => {

--- a/tests/patcher.test.ts
+++ b/tests/patcher.test.ts
@@ -10,10 +10,14 @@ import {
   contextResolver,
 } from './fixtures/claude-bundle.js';
 import {
+  buildFakeElfClaude,
   buildFakeNativeClaude,
+  ELF_FIRST_SCANNED,
+  ELF_POINTER_VADDR,
   MACHO_MAGIC,
   parseBunBlob,
   rebuildFakeNativeClaude,
+  repackFakeElfClaude,
 } from './bun-blob-fixture.js';
 import { execFileSync } from 'node:child_process';
 import * as p from '@clack/prompts';
@@ -585,7 +589,7 @@ describe('PATCH_TRANSFORMS_VERSION', () => {
     const digest = createHash('sha256').update(source).digest('hex');
     expect({ version: PATCH_TRANSFORMS_VERSION, digest }).toEqual({
       version: 11,
-      digest: '87fec3418582a3be6839917e63ae71ac4a6d3ed71aa4b86c7e220d310c2fa00c',
+      digest: 'de2d7eed932eccae7f6a59b4334c95f15ea580e540f41e166efb2120a2b9556e',
     });
   });
 });
@@ -1318,6 +1322,99 @@ describe('applyPatch', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  /**
+   * The ELF half of the same write path. A Bun standalone ELF keeps its blob's address in an
+   * 8-byte global; tweakcc's repack moves the blob and rewrites that global, but finds it by
+   * scanning only 16384-aligned addresses. Claude Code 2.1.257 moved it off a boundary on all four
+   * ELF builds and the repack threw, so `clodex patch` failed there while macOS and Windows — which
+   * assign the section in place and rewrite no pointer — stayed green.
+   *
+   * `src/bun-compiled-pointer.ts` has its own tests. This one exists because those call it
+   * directly: every other fake install in this file starts with a `#!/bin/sh` shim, so the module
+   * is a silent no-op and BOTH production call sites could be deleted with the suite green.
+   */
+  it('repoints the ELF blob pointer that tweakcc cannot find on its own', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'clodex-elf-pointer-'));
+    const binaryPath = join(dir, 'claude');
+    const tweakccHome = join(dir, 'tweakcc-home');
+    const previousAppHome = process.env.CLODEX_HOME;
+    const previousTweakccHome = process.env.TWEAKCC_CONFIG_DIR;
+    const pristine = buildFakeElfClaude(CLAUDE_SPLIT_MODULES, { entryPointId: CLAUDE_SPLIT_ENTRY_ID });
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+    vi.mocked(execFileSync).mockReset();
+    vi.mocked(execFileSync).mockImplementation((() => '') as unknown as typeof execFileSync);
+    mkdirSync(tweakccHome, { recursive: true });
+    writeFileSync(binaryPath, pristine, { mode: 0o755 });
+    process.env.CLODEX_HOME = dir;
+    process.env.TWEAKCC_CONFIG_DIR = tweakccHome;
+
+    // Where the fixture's repack relocates the blob to. Any address the pristine binary does not
+    // already carry will do; the point is that the published global must end up holding THIS.
+    const RELOCATED_BUN_ADDR = 0x900000;
+
+    tweakccMocks.tryDetectInstallation.mockReset();
+    tweakccMocks.readContent.mockReset();
+    tweakccMocks.writeContent.mockReset();
+    tweakccMocks.tryDetectInstallation.mockImplementation(
+      async ({ path }: { path: string }) => ({ path, version: 'test-version', kind: 'native' }),
+    );
+    tweakccMocks.readContent.mockImplementation(async ({ path }: { path: string }) => {
+      const parsed = parseBunBlob(readFileSync(path));
+      const index = parsed.names.findIndex(tweakccRecognizesModuleName);
+      if (index < 0) throw new Error(`Failed to extract JavaScript from native installation: ${path}`);
+      return parsed.contents[index]!;
+    });
+    // Throws exactly as `repackELFSection` throws when its strided scan finds nothing, so a fixture
+    // that stopped reproducing 2.1.257 fails loudly instead of passing for the wrong reason.
+    tweakccMocks.writeContent.mockImplementation(
+      async ({ path }: { path: string }, content: string) => {
+        const parsed = parseBunBlob(readFileSync(path));
+        writeFileSync(
+          path,
+          repackFakeElfClaude(
+            readFileSync(path),
+            (index, previous) => (tweakccRecognizesModuleName(parsed.names[index]!) ? content : previous),
+            RELOCATED_BUN_ADDR,
+          ),
+          { mode: 0o755 },
+        );
+      },
+    );
+
+    try {
+      const outcome = await applyPatch(
+        binaryPath,
+        'test-version',
+        {
+          config: { 'clodex:test:extended': { alias: 'extended', context: 272_000, display: 'Extended (test)' } },
+          unknownWindows: [],
+        },
+        'desired-config-hash',
+        { trace: false, manifest: null },
+      );
+
+      expect(outcome.ok ? 'ok' : outcome.message).toBe('ok');
+
+      const published = readFileSync(binaryPath);
+      // The real global holds the relocated address...
+      expect(published.readBigUInt64LE(ELF_POINTER_VADDR)).toBe(BigInt(RELOCATED_BUN_ADDR));
+      // ...and the slot the stand-in borrowed holds what it held before, byte for byte.
+      expect(published.readBigUInt64LE(ELF_FIRST_SCANNED))
+        .toBe(pristine.readBigUInt64LE(ELF_FIRST_SCANNED));
+      // The patch itself still landed, so this is not passing on a binary nothing was done to.
+      expect(parseBunBlob(published).contents[0]).toContain('"extended"');
+      expect(parseBunBlob(published).contents[6]).toContain('/*ccpatch:ctx*/');
+    } finally {
+      Object.defineProperty(process, 'platform', platform);
+      if (previousAppHome === undefined) delete process.env.CLODEX_HOME;
+      else process.env.CLODEX_HOME = previousAppHome;
+      if (previousTweakccHome === undefined) delete process.env.TWEAKCC_CONFIG_DIR;
+      else process.env.TWEAKCC_CONFIG_DIR = previousTweakccHome;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 
@@ -1978,21 +2075,37 @@ describe('patch script identity naming', () => {
     },
   );
 
-  // The quorum still has to mean something: a body that scrubs almost none of
-  // them is not the child-env builder and must be refused, not rewritten.
-  it.each([
-    { left: 'one', drop: SCRUBBED_ENV_NAMES.slice(0, 4) },
-    { left: 'none', drop: SCRUBBED_ENV_NAMES },
-  ])('refuses a child builder that scrubs $left of the known names', ({ drop }) => {
-    const source = withoutScrubbedNames(CLAUDE_FIXTURE_239, drop);
+  // Exactly ON the floor, which is the case neither the five positives above nor
+  // the negative below can see: they leave four names and none. Without this, an
+  // off-by-one — `<=` instead of `<` — refuses a builder clodex can patch, on
+  // every platform, with every other assertion here still green.
+  it('still patches a child builder down to a single known name', () => {
+    const source = withoutScrubbedNames(CLAUDE_FIXTURE_239, SCRUBBED_ENV_NAMES.slice(0, 4));
 
     expect(source, 'fixture drifted from the shape this test mutates').not.toBe(CLAUDE_FIXTURE_239);
-    for (const [, literal] of drop) expect(source).not.toContain(literal);
+    const survivors = SCRUBBED_ENV_NAMES.filter(([, literal]) => source.includes(literal));
+    expect(survivors, 'exactly one name may survive, or this is not the boundary').toHaveLength(1);
+
+    const result = applyClodexPatches(source, config);
+
+    expect(result.results.at(-1)).toEqual({
+      status: 'OK',
+      name: 'PATCH 10: child network environment',
+    });
+    expect(result.content).toContain('function childEnv(){/*ccpatch:child-network-env*/');
+  });
+
+  // The floor still has to mean something: a body that scrubs none of them is not
+  // the child-env builder and must be refused, not rewritten.
+  it('refuses a child builder that scrubs none of the known names', () => {
+    const source = withoutScrubbedNames(CLAUDE_FIXTURE_239, SCRUBBED_ENV_NAMES);
+
+    expect(source, 'fixture drifted from the shape this test mutates').not.toBe(CLAUDE_FIXTURE_239);
+    for (const [, literal] of SCRUBBED_ENV_NAMES) expect(source).not.toContain(literal);
 
     expect(() => runPatchScript(config, source)).toThrow(
       'clodex patch: child network environment target validation failed: '
-      + 'body scrubs only ' + (SCRUBBED_ENV_NAMES.length - drop.length)
-      + ' of the 5 known child-env names (expected at least 2)',
+      + 'body scrubs only 0 of the 5 known child-env names (expected at least 1)',
     );
   });
 
@@ -2013,6 +2126,19 @@ describe('patch script identity naming', () => {
     expect(() => runPatchScript(config, noMerge)).toThrow(
       'clodex patch: child network environment target validation failed: '
       + 'body does not contain {...process.env',
+    );
+
+    // The brace walk reads `/` as division, never as the start of a regex literal — telling those
+    // apart needs the grammar. An unmatched `{` inside one therefore runs the walk off the end of
+    // the source. Reported as a distance, that is a bundle-sized negative number naming nothing.
+    const runawayBrace = CLAUDE_FIXTURE_239.replace(
+      'for(let k of u)delete v[k];return v}',
+      'var re=/{/;for(let k of u)delete v[k];return v}',
+    );
+    expect(runawayBrace, 'fixture drifted from the shape this test mutates').not.toBe(CLAUDE_FIXTURE_239);
+    expect(() => runPatchScript(config, runawayBrace)).toThrow(
+      'clodex patch: child network environment target validation failed: '
+      + "the brace walk never reached the function's closing brace",
     );
   });
 
@@ -2608,6 +2734,25 @@ describe('patch script identity naming', () => {
       expect(resolve('  SOL  ')).toBe(272_000);
       expect(resolve('clodex:openai:mystery')).toBe(128_000);
       expect(resolve('sonnet')).toBe(200_000);
+    });
+
+    // What still pins the site once the names are wildcarded is that BOTH parameters are threaded
+    // unchanged into both calls. Drop that and the anchor is "any two-parameter function with this
+    // statement shape", which a minifier can produce more than once — so the decoy below has the
+    // resolver's exact shape and differs only in what it passes.
+    it('does not bind a lookalike that threads different arguments', () => {
+      const decoy = 'function Dcy(p,q){let z=Q1();if(z!==void 0)return z;'
+        + 'if(R1(p,9))return S1;return T1(p,q)}';
+      const source = `${CLAUDE_FIXTURE}\n${decoy}`;
+
+      const patched = applyClodexPatches(source, config);
+
+      expect(patched.results).toContainEqual({ status: 'OK', name: 'PATCH 7: per-model context window' });
+      // The marker went into the resolver, and the lookalike came through untouched. An anchor that
+      // stopped proving the threading would match both and refuse the whole patch as ambiguous.
+      expect(patched.content).toContain(`function RS(e,t){${'/*ccpatch:ctx*/'}`);
+      expect(patched.content).toContain(decoy);
+      expect(patched.content.match(/\/\*ccpatch:ctx\*\//g)).toHaveLength(1);
     });
 
     it('keeps the build\'s own parameter name when a later run refreshes the table', () => {


### PR DESCRIPTION
Claude Code 2.1.257 could not be patched at all. `clodex patch` failed on every published build —
macOS, Linux and Windows, Intel and ARM — so anyone who upgraded lost their custom model aliases,
their per-model context windows and their effort settings until they went back to an older Claude
Code. This restores patching on 2.1.257, verified against a pristine copy of all eight builds.

It was three separate breaks stacked on top of each other; each one had to be fixed before the next
became visible.

## 1. PATCH 7 — the context-window anchor hardcoded minified parameter names

**Symptom.** `clodex patch: required patch failed: PATCH 7: per-model context window`, "anchor not
found", on all eight builds. Every other site reported OK; PATCH 7 is required, so the patch aborted
there and PATCH 8–10 never ran.

**Cause.** The anchor wildcards every identifier in the resolver's body *except* the two parameter
names, which it spelled `(e,t)`:

```
2.1.252  function Lp(e,t){let r=Vw();if(r!==void 0)return r;if(KSn(e,t))return g$;return Gw(e,t)}
2.1.257  function Np(e,n){let r=AL();if(r!==void 0)return r;if(nAn(e,n))return XN;return bL(e,n)}
```

Same function, and the minifier named the second parameter `n` instead of `t`. Parameter names churn
exactly like the rest of the identifiers; the anchor treated them as if they did not.

**Change.** The anchor binds on shape — two parameters, both threaded unchanged into the two calls,
around the same three-statement body — with both names wildcarded and back-referenced. Measured on
the real extracted bundles, it matches exactly once on 2.1.252 and exactly once on 2.1.257, and
binds to the same function tweakcc-independent inspection identifies as the resolver.

The injected lookup is now built around whichever name the build gave the *model* parameter. That
also closes a latent bug on the refresh path: it rewrote the snippet with a hardcoded `e`, so
re-patching a 2.1.257 binary in place would have left a lookup on an identifier not in scope.

## 2. PATCH 10 — the child-env fingerprint required a name upstream stopped spelling

**Symptom.** Only reachable once PATCH 7 applied: `clodex patch: child network environment target
validation failed`, again on all eight builds.

**Cause.** The anchor bound to the right function; validation rejected it. The check required the
matched body to contain all five of `CLAUDE_CODE_OAUTH_TOKEN`, `CLAUDE_CODE_SUBSCRIPTION_TYPE`,
`CLAUDE_BG_PTY_AUTH`, `"OTEL_"` and `CLAUDE_CODE_OTEL_DIAG_STDERR`. 2.1.257 replaced a run of
per-name `process.env.CLAUDE_BG_*!==void 0` reads with a set-membership test and stopped spelling
`CLAUDE_BG_PTY_AUTH` anywhere in the builder.

**Change.** Those names were never the identity proof — the whole-bundle uniqueness of the
`)return process.env;let X={` passthrough early-out, the `CLAUDE_CODE_REMOTE` ternary in the head,
and the brace walk that proves the match ends at the function's own closing brace are. Review
measured that directly: with the five names ignored entirely, the full anchor still has exactly one
candidate on both real bundles, so they never choose among candidates and all a high floor can do is
refuse a target that was already correctly identified — which is this outage. They are now a floor
of one: a body that scrubs nothing is not the builder and is refused, but it takes four independent
upstream refactors rather than one to trip. 2.1.252 matches five, 2.1.257 matches four.
`{...process.env` stays required outright, because the rewrite depends on it structurally.

Every refusal now names the check that produced it. Diagnosing the bare "target validation failed"
from a canary report meant extracting a 32 MB bundle by hand to learn which of four conditions fired.

## 3. tweakcc's ELF repack could no longer find Bun's blob pointer

**Symptom.** Only reachable once both patch-site failures were fixed and the patch got as far as the
repack: `Could not find original BUN_COMPILED location in binary (searched for 0x5541000)` on all
four ELF builds. macOS and Windows were unaffected throughout.

**Cause.** A Bun standalone ELF keeps its `.bun` section's virtual address in an 8-byte global.
`repackELFSection` moves the section, so it has to rewrite that global — and it finds it by scanning
the first writable `PT_LOAD` **only at 16384-aligned addresses**. Measured: on 2.1.246 and 2.1.252,
x64 and arm64, glibc and musl, that global sat at `vaddr % 16384 == 0`. On 2.1.257 it does not, on
any of the four: `0x534f758` linux-x64, `0x4d9af08` linux-x64-musl, `0x5310758` linux-arm64,
`0x4c46d10` linux-arm64-musl. The alignment was luck, not a promise. tweakcc 4.3.3 (latest) carries
the identical scan, so bumping the pin does not fix it — worth knowing for #45.

**Change.** New `src/bun-compiled-pointer.ts`, in the same shape as the existing entry-module shim:
plant a copy of the value the scan looks for at an address it does visit, let the repack rewrite that
copy, then move the address it wrote onto the real global and restore the eight bytes the copy
displaced. It is a strict no-op wherever tweakcc already works — it reproduces tweakcc's own scan
first and stands aside if that succeeds — and it identifies the real global rather than guessing it:
the one 8-byte occurrence of `.bun`'s address inside the writable segment and outside `.bun`'s own
payload. Matches inside the payload are coincidences in compressed JavaScript (dozens on some
builds). Anything other than exactly one candidate is refused, and the restore verifies that the
repack rewrote the stand-in, that it agrees with where `.bun` actually ended up, and that both writes
read back.

## Deliberately not done

- **No tweakcc bump.** 4.3.3 has the same scan; the workaround is needed either way. #45 stays
  independent.
- **No rewrite of the ELF repack in clodex.** Doing the section move ourselves would replace a
  narrow, verifiable stand-in with ownership of the whole relocation, on the path that has already
  broken twice on ELF alone.
- **`PATCH_TRANSFORMS_VERSION` 10 → 11**, so installs patched by an older clodex read as stale and
  repatch rather than keeping narrower anchors forever.

## Verification

Everything below ran against a pristine 2.1.257 downloaded per platform from the npm registry, in a
throwaway sandbox with `HOME`, `CLODEX_HOME`, `TWEAKCC_CONFIG_DIR` and
`TWEAKCC_CC_INSTALLATION_PATH` redirected. Node 24.14.1, macOS 15 host, Docker Desktop for the
container legs.

| Platform | Leg | Result |
| --- | --- | --- |
| darwin-arm64 | real `clodex patch` on the host | 11 applied, 0 failed |
| linux-arm64 | real `clodex patch`, native arm64 container | 11 applied; patched binary starts and reports 2.1.257 |
| linux-arm64-musl | real `clodex patch`, native arm64 container | 11 applied; patched binary starts and reports 2.1.257 |
| darwin-x64 | `scripts/probe-patch-mechanism.mjs` | 18 checks pass |
| linux-x64 | probe | 17 checks pass |
| linux-x64-musl | probe | 17 checks pass |
| win32-x64 | probe | 16 checks pass |
| win32-arm64 | probe | 16 checks pass |

**What that does and does not prove.** The two container legs are the only ones that START the
patched binary, and they cover ELF arm64 only. The probe legs prove the anchors matched, the repack
round-tripped and the published bytes read back byte-for-byte carrying all six clodex patch markers —
they never execute the result. **No leg executes an x64 ELF or a Windows binary**; that coverage is
bytes-only by design, and the x64 ELF reasoning is checked against the arm64 container leg, which
exercises the identical code path on the identical executable format.

`pnpm typecheck && pnpm test && pnpm build` green (1999 tests), and green again under an isolated
`CLODEX_HOME="$(mktemp -d)"`.

**Mutation testing.** Every behaviour here was deleted or broken and the full affected test file
re-run. The `PATCH_TRANSFORMS_VERSION` source-digest pin reddens alongside some of these; it is a
tripwire, and in every row below behavioural tests are red beside it.

| Mutation | Behavioural tests red |
| --- | --- |
| PATCH 7 anchor back to the literal `(e,t)` | 3, with the exact production error |
| PATCH 7 snippet hardcodes `e` again | 2 (one a `ReferenceError` from executing the emitted resolver) |
| PATCH 7 anchor stops proving both arguments are threaded | 1 — the lookalike makes it ambiguous |
| Scrubbed-name floor raised to 5 (the old rule) | 7 |
| Floor lowered to 0 | 1 |
| Floor comparison `<=` instead of `<` | 1 — the boundary case |
| Brace-scan failure folded back into a distance | 1 |
| Anchor accepts any env var in the head ternary | 1 |
| `shimBunCompiledPointer` forced to return null | 7 |
| `restoreBunCompiledPointer` made a no-op | 3 |
| Either production call site deleted individually | 1 each |
| `fileOffsetOf` treats a virtual address as a file offset | 4 |
| Chunk sweep overlap `SCAN_CHUNK` instead of `SCAN_CHUNK - 7` | 2 |
| Two-segment refusal removed | 1 |
| `PN_XNUM` rejection removed | 1 |

**Three adversarial review rounds ran before this was pushed**, one per subsystem plus one on test
discrimination, and a fourth over the changes those produced. They found no wrong bind on either
real bundle and no production defect, and they found five things the tests could not see — the last
four rows above, plus the two individual call sites. All are fixed here. Two review notes are
recorded rather than acted on: PATCH 7's anchor is structural, so a future release could in
principle bind a lookalike silently (true of the anchor before this change too, and an ambiguous
match is refused), and the scrubbed-name floor cannot be made to discriminate anything on today's
bytes because the anchor already has exactly one candidate without it.

## Not verified

- No launch-path smoke test: nothing in `launch.ts`, `env.ts`, `claude-wrapper.ts` or the gateway is
  touched, and running one would have meant patching a real install.
- The "no address tweakcc scans is usable" refusal in the new module is covered by a synthetic ELF
  only. No observed build produces that layout.
- Whether Claude Code 2.1.258+ keeps either the resolver shape or the pointer alignment. Neither is
  a contract; the canary is what catches the next one.

**Unrelated, observed while verifying, not caused by this change:** one probe run in 24 against
linux-arm64-musl published a binary carrying no `ccpatch:` markers at all — the run fell to
tweakcc's single-module path, which on a code-split release patches a stub. The probe caught it and
failed. It did not reproduce in 24 further runs and the input binary was byte-stable, so the cause
is unproven; a plausible one is that `readBunModuleNames` treats a short `readSync` as "no module
table". Through `clodex patch` that same event is a loud failure at the first required patch site,
not a corrupt install, but the message would blame an anchor. Worth its own issue and its own
evidence rather than a speculative fix here.
