### PR TITLE
fix(proxy): report a broken NODE_EXTRA_CA_CERTS instead of silently ignoring it

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,6 +55,7 @@ import {
 } from './favorites-picker.js';
 import { favoriteProviderDisplayName } from './favorite-provider-display.js';
 import { runProvidersCommand, providersHelpText } from './providers-command.js';
+import { emitParentNotice } from './parent-notice.js';
 import {
   getInferenceSessionLogPath,
   getSessionLogPath,
@@ -1165,7 +1166,13 @@ async function runClaudeHttpProxyCommand(
     return 1;
   }
 
-  const { handle, loaded } = started;
+  const { handle, loaded, caWarning } = started;
+  if (caWarning) {
+    // Background-agent runs hand stdout to the agent protocol, so the notice
+    // channel is the only way this reaches anyone there.
+    if (agentStdout) emitParentNotice(`clodex: ${caWarning}`);
+    else p.log.warn(caWarning);
+  }
   const inheritedProxyPort = (() => {
     const value = process.env['HTTPS_PROXY'] ?? process.env['HTTP_PROXY']
       ?? process.env['https_proxy'] ?? process.env['http_proxy'];

--- a/src/http-proxy/ca.ts
+++ b/src/http-proxy/ca.ts
@@ -129,17 +129,60 @@ export function ensureHttpProxyCertificates(): HttpProxyCertificates {
 export function ensureHttpProxyCaBundle(
   relayCaCertPath: string,
   additionalCaCertPath: string | undefined,
+  // A dropped CA is silent on every layer below this one: the merge used to
+  // swallow the failure, and Node prints only an opaque OpenSSL code for a
+  // NODE_EXTRA_CA_CERTS it cannot load. Someone has to say it out loud.
+  onWarning?: (message: string) => void,
 ): string {
   if (!additionalCaCertPath?.trim()) return relayCaCertPath;
+  const warn = (detail: string): string => {
+    // Say what the child actually gets. NODE_EXTRA_CA_CERTS is ADDITIVE to
+    // node's built-in roots, so a suffix claiming the child "trusts only" the
+    // clodex CA would be false and would send people hunting a second problem.
+    onWarning?.(
+      `${detail} The CA bundle handed to the child is ${relayCaCertPath}; `
+      + "node's built-in roots are unaffected.",
+    );
+    return relayCaCertPath;
+  };
+  let additionalCa: string;
   try {
     if (resolve(additionalCaCertPath) === resolve(relayCaCertPath)) return relayCaCertPath;
+    additionalCa = readFileSync(additionalCaCertPath, 'utf8').trim();
+  } catch (err) {
+    // Node warns for ENOENT/EACCES/ELOOP but is SILENT for EISDIR, and only
+    // once some process actually initializes its TLS roots -- so describe its
+    // warning conditionally, and never as something that always appears.
+    return warn(
+      `NODE_EXTRA_CA_CERTS=${additionalCaCertPath} cannot be read `
+      + `(${err instanceof Error ? err.message : String(err)}), so it is not part of the proxy `
+      + 'CA bundle. Where node reports this itself it says only "Ignoring extra certs ... load '
+      + 'failed", without naming the variable. Clear or correct it.',
+    );
+  }
+  // Deliberately NOT claimed as "carries no certificate": this tests emptiness,
+  // not PEM validity. A non-empty file of junk is merged verbatim and OpenSSL
+  // discards it a layer down, silently -- as it does without clodex. Node is
+  // silent for an empty file too, so its warning is not mentioned here.
+  if (!additionalCa) {
+    return warn(`NODE_EXTRA_CA_CERTS=${additionalCaCertPath} is empty, so it adds nothing.`);
+  }
+  try {
     const relayCa = readFileSync(relayCaCertPath, 'utf8').trimEnd();
-    const additionalCa = readFileSync(additionalCaCertPath, 'utf8').trim();
-    if (!additionalCa) return relayCaCertPath;
     const combinedPath = join(dirname(relayCaCertPath), 'combined-ca.pem');
     writePublic(combinedPath, `${relayCa}\n${additionalCa}\n`);
     return combinedPath;
-  } catch {
-    return relayCaCertPath;
+  } catch (err) {
+    // clodex's own fault -- an unwritable ~/.clodex/http-proxy, a vanished relay
+    // CA, ENOSPC. Do not tell the user to correct their setting. "build" rather
+    // than "write" because this catch also covers reading the relay CA, and
+    // "readable, non-empty" rather than "valid" because that is all that has
+    // actually been established about the configured file.
+    return warn(
+      `clodex could not build the combined CA bundle in ${dirname(relayCaCertPath)} `
+      + `(${err instanceof Error ? err.message : String(err)}), so the readable, non-empty `
+      + `NODE_EXTRA_CA_CERTS=${additionalCaCertPath} was left out of it. Fix the reported `
+      + 'error and restart clodex.',
+    );
   }
 }

--- a/src/http-proxy/index.ts
+++ b/src/http-proxy/index.ts
@@ -164,7 +164,12 @@ export async function startConfiguredHttpProxy(
   inferenceLogPath = getInferenceRequestLogPath(),
   debugLogPath?: string,
   webSocketDiagnosticsLogPath?: string,
-): Promise<{ handle: HttpProxyHandle; loaded: LoadedHttpProxyRoutes }> {
+): Promise<{
+  handle: HttpProxyHandle;
+  loaded: LoadedHttpProxyRoutes;
+  /** Set when an inherited NODE_EXTRA_CA_CERTS had to be dropped; caller reports it. */
+  caWarning?: string;
+}> {
   const loaded = await loadHttpProxyRoutes();
   const handle = await startHttpProxy(buildConfiguredHttpProxyOptions(
     loaded,
@@ -174,11 +179,13 @@ export async function startConfiguredHttpProxy(
     debugLogPath,
     webSocketDiagnosticsLogPath,
   ));
+  let caWarning: string | undefined;
   handle.caCertPath = ensureHttpProxyCaBundle(
     handle.caCertPath,
     process.env['NODE_EXTRA_CA_CERTS'],
+    message => { caWarning = message; },
   );
-  return { handle, loaded };
+  return { handle, loaded, ...(caWarning ? { caWarning } : {}) };
 }
 
 function waitForShutdown(): Promise<void> {
@@ -217,7 +224,7 @@ export async function runHttpProxyServerCommand(
     return 1;
   }
 
-  const { handle, loaded } = started;
+  const { handle, loaded, caWarning } = started;
   writeProxyLifecycleLog(inferenceLogPath, {
     event: 'proxy_started',
     pid: process.pid,
@@ -229,6 +236,10 @@ export async function runHttpProxyServerCommand(
   console.log(pc.bold(pc.green('clodex proxy-mode server running')));
   for (const line of formatHttpProxyEnvironmentLines(handle)) console.log(line);
   console.log(`  Request log: ${handle.inferenceLogPath}`);
+  if (caWarning) {
+    console.log('');
+    console.log(pc.yellow(`  clodex: ${caWarning}`));
+  }
   if (handle.webSocketDiagnosticsLogPath) {
     console.log(`  WebSocket diagnostics: ${handle.webSocketDiagnosticsLogPath}`);
     console.log(pc.yellow('  Diagnostic mode records request headers and metadata; credential headers are redacted.'));

--- a/tests/http-proxy-index.test.ts
+++ b/tests/http-proxy-index.test.ts
@@ -89,6 +89,77 @@ describe('HTTP proxy startup model list', () => {
       rmSync(home, { recursive: true, force: true });
     }
   }, 20_000);
+  it('warns on the running server banner when NODE_EXTRA_CA_CERTS cannot be loaded', async () => {
+    // Drives the real command so the warning is proven to reach the banner the
+    // operator actually reads, not merely to exist in the merge helper.
+    const home = mkdtempSync(join(tmpdir(), 'clodex-proxy-ca-warning-'));
+    const previousHome = process.env['CLODEX_HOME'];
+    const previousExtraCa = process.env['NODE_EXTRA_CA_CERTS'];
+    process.env['CLODEX_HOME'] = home;
+    const missingCaPath = join(home, 'gone', 'clodex-ca.pem');
+    process.env['NODE_EXTRA_CA_CERTS'] = missingCaPath;
+    const printed: string[] = [];
+    const consoleLog = vi.spyOn(console, 'log')
+      .mockImplementation((...args: unknown[]) => { printed.push(args.map(String).join(' ')); });
+    let shutdownRequested = false;
+    const result = runHttpProxyServerCommand(false, false, 0, true);
+
+    try {
+      await vi.waitFor(() => {
+        expect(printed.join('\n')).toContain('clodex proxy-mode server running');
+      });
+      // Assert against the WARNING LINE, not the whole banner: the ordinary env
+      // block already prints the correct CA path, so a banner-wide assertion
+      // stays green even if the warning stops naming it.
+      const warningLine = printed.find(line => line.includes('NODE_EXTRA_CA_CERTS=' + missingCaPath));
+      expect(warningLine).toBeDefined();
+      expect(warningLine!).toContain('not part of the proxy CA bundle');
+      expect(warningLine!).toContain(join(home, 'http-proxy', 'clodex-ca.pem'));
+    } finally {
+      shutdownRequested = true;
+      process.emit('SIGTERM');
+      await result.catch(() => undefined);
+      if (!shutdownRequested) process.emit('SIGTERM');
+      consoleLog.mockRestore();
+      if (previousHome === undefined) delete process.env['CLODEX_HOME'];
+      else process.env['CLODEX_HOME'] = previousHome;
+      if (previousExtraCa === undefined) delete process.env['NODE_EXTRA_CA_CERTS'];
+      else process.env['NODE_EXTRA_CA_CERTS'] = previousExtraCa;
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, 20_000);
+
+  it('leaves the banner clean when no extra CA is configured', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'clodex-proxy-ca-quiet-'));
+    const previousHome = process.env['CLODEX_HOME'];
+    const previousExtraCa = process.env['NODE_EXTRA_CA_CERTS'];
+    process.env['CLODEX_HOME'] = home;
+    delete process.env['NODE_EXTRA_CA_CERTS'];
+    const printed: string[] = [];
+    const consoleLog = vi.spyOn(console, 'log')
+      .mockImplementation((...args: unknown[]) => { printed.push(args.map(String).join(' ')); });
+    const result = runHttpProxyServerCommand(false, false, 0, true);
+
+    try {
+      await vi.waitFor(() => {
+        expect(printed.join('\n')).toContain('clodex proxy-mode server running');
+      });
+      // Assert on the shared warning MARKER, not one branch's sentence. Keyed
+      // on a branch-specific phrase, this stayed green when a mutation emitted
+      // a different branch's warning unconditionally.
+      expect(printed.filter(line => line.includes('clodex: '))).toEqual([]);
+    } finally {
+      process.emit('SIGTERM');
+      await result.catch(() => undefined);
+      consoleLog.mockRestore();
+      if (previousHome === undefined) delete process.env['CLODEX_HOME'];
+      else process.env['CLODEX_HOME'] = previousHome;
+      if (previousExtraCa === undefined) delete process.env['NODE_EXTRA_CA_CERTS'];
+      else process.env['NODE_EXTRA_CA_CERTS'] = previousExtraCa;
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, 20_000);
+
   it('reserves canonical and exact stored names for inactive configured aliases', () => {
     const loaded: LoadedHttpProxyRoutes = {
       routes: [],

--- a/tests/http-proxy-server.test.ts
+++ b/tests/http-proxy-server.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import * as https from 'node:https';
@@ -271,6 +271,114 @@ describe('selective HTTP proxy', () => {
     expect(combinedPath).not.toBe(certificates.caCertPath);
     expect(combined).toContain(certificates.caCert.trim());
     expect(combined).toContain('corporate-test');
+  });
+
+  it('reports the CA it had to drop instead of silently trusting one less', () => {
+    // The old merge swallowed every failure here, so a NODE_EXTRA_CA_CERTS left
+    // over from a moved or deleted file disappeared from the bundle without a
+    // word — and Node's own complaint names an OpenSSL code, not the variable.
+    const certificates = ensureHttpProxyCertificates();
+    const missingPath = join(testHome, 'does-not-exist-ca.pem');
+    const warnings: string[] = [];
+
+    const result = ensureHttpProxyCaBundle(
+      certificates.caCertPath,
+      missingPath,
+      message => warnings.push(message),
+    );
+
+    expect(result).toBe(certificates.caCertPath);
+    expect(warnings).toHaveLength(1);
+    // Actionable means all three: which value is wrong, that it is dropped, and
+    // what the right one is.
+    expect(warnings[0]).toContain(`NODE_EXTRA_CA_CERTS=${missingPath}`);
+    expect(warnings[0]).toContain('not part of the proxy CA bundle');
+    expect(warnings[0]).toContain(certificates.caCertPath);
+    // Conditional, because node stays silent for EISDIR and for any process
+    // that never initializes its TLS roots.
+    expect(warnings[0]).toContain('Where node reports this itself');
+  });
+
+  it('does not promise a Node warning for a directory, which Node ignores silently', () => {
+    const certificates = ensureHttpProxyCertificates();
+    const dirPath = mkdtempSync(join(tmpdir(), 'clodex-ca-dir-'));
+    const warnings: string[] = [];
+    try {
+      expect(ensureHttpProxyCaBundle(certificates.caCertPath, dirPath, m => warnings.push(m)))
+        .toBe(certificates.caCertPath);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('cannot be read');
+      expect(warnings[0]).not.toContain('Ignoring extra certs ... load failed".');
+    } finally {
+      rmSync(dirPath, { recursive: true, force: true });
+    }
+  });
+
+  it('reports a configured CA file that is empty', () => {
+    const certificates = ensureHttpProxyCertificates();
+    const emptyPath = join(testHome, 'empty-ca.pem');
+    writeFileSync(emptyPath, '   \n');
+    const warnings: string[] = [];
+
+    expect(ensureHttpProxyCaBundle(certificates.caCertPath, emptyPath, m => warnings.push(m)))
+      .toBe(certificates.caCertPath);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('is empty');
+    // NODE_EXTRA_CA_CERTS is additive, so no warning may imply the built-in
+    // roots went away -- that would send the reader after a second problem.
+    expect(warnings[0]).toContain("node's built-in roots are unaffected");
+    expect(warnings[0]).not.toContain('trust only');
+    // Node prints nothing at all for an empty file, so this branch must not
+    // claim it does. Only the unreadable branch may cite that warning.
+    expect(warnings[0]).not.toContain('Ignoring extra certs');
+  });
+
+  it('blames clodex, not the configured value, when clodex cannot write the bundle', () => {
+    // An unwritable ~/.clodex/http-proxy is a clodex-side fault. Telling the
+    // user to "clear or correct" a perfectly good NODE_EXTRA_CA_CERTS sends
+    // them to fix the one thing that is not broken.
+    const certificates = ensureHttpProxyCertificates();
+    // Readable and non-empty is all the code establishes, and all the message
+    // may claim -- this fixture is deliberately NOT a parseable certificate.
+    const readableCaPath = join(testHome, 'readable-corporate-ca.pem');
+    writeFileSync(readableCaPath, '-----BEGIN CERTIFICATE-----\nreadable\n-----END CERTIFICATE-----\n');
+    const unwritableDir = mkdtempSync(join(tmpdir(), 'clodex-unwritable-'));
+    const relayCaInUnwritableDir = join(unwritableDir, 'clodex-ca.pem');
+    writeFileSync(relayCaInUnwritableDir, certificates.caCert);
+    // Pre-create the destination as a DIRECTORY so the write fails as EISDIR.
+    mkdirSync(join(unwritableDir, 'combined-ca.pem'));
+    const warnings: string[] = [];
+
+    try {
+      expect(ensureHttpProxyCaBundle(relayCaInUnwritableDir, readableCaPath, m => warnings.push(m)))
+        .toBe(relayCaInUnwritableDir);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('clodex could not build the combined CA bundle');
+      expect(warnings[0]).toContain('readable, non-empty');
+      expect(warnings[0]).not.toContain('Clear or correct it');
+      expect(warnings[0]).not.toContain('cannot be read');
+    } finally {
+      rmSync(unwritableDir, { recursive: true, force: true });
+    }
+  });
+
+  it('stays quiet when there is nothing wrong to report', () => {
+    const certificates = ensureHttpProxyCertificates();
+    const extraPath = join(testHome, 'quiet-corporate-ca.pem');
+    writeFileSync(extraPath, '-----BEGIN CERTIFICATE-----\nquiet-test\n-----END CERTIFICATE-----\n');
+    const warnings: string[] = [];
+
+    // A successful merge, an unset variable, and a variable already pointing at
+    // the clodex CA are all normal; none of them may produce a scary line.
+    expect(ensureHttpProxyCaBundle(certificates.caCertPath, extraPath, m => warnings.push(m)))
+      .not.toBe(certificates.caCertPath);
+    expect(ensureHttpProxyCaBundle(certificates.caCertPath, undefined, m => warnings.push(m)))
+      .toBe(certificates.caCertPath);
+    expect(ensureHttpProxyCaBundle(certificates.caCertPath, '  ', m => warnings.push(m)))
+      .toBe(certificates.caCertPath);
+    expect(ensureHttpProxyCaBundle(certificates.caCertPath, certificates.caCertPath, m => warnings.push(m)))
+      .toBe(certificates.caCertPath);
+    expect(warnings).toEqual([]);
   });
 
   it('intercepts only api.anthropic.com on port 443', () => {


### PR DESCRIPTION
Proxy mode merges any certificate you already have in `NODE_EXTRA_CA_CERTS` into the trust bundle it hands Claude Code. If that path no longer resolves — the file moved, was deleted, or the variable was set to a path that never existed — clodex used to drop it and carry on without a word. You would then be running with one fewer trusted CA than you thought, and the only clue was a line from Node itself that names an OpenSSL error code rather than the setting, printed by *every* Node process that inherits the variable. clodex now names the broken value, says it was left out, and prints the path you probably meant.

Reported in #157.

## User-visible failure

The reporter had a stale `NODE_EXTRA_CA_CERTS` in their Windows user environment. Every Node process on the machine printed:

```
Warning: Ignoring extra certs from C:\Users\<me>\.clodex\ca\clodex-ca.pem,
load failed: error:80000003:system library::No such process
```

That message names neither the variable nor a remedy, so it is easy to read as noise. clodex was silent about it even though clodex is the process that reads the variable and decides what to do with it.

## Root cause and reachability

`ensureHttpProxyCaBundle` wrapped the whole merge in a single `try`/`catch` that returned the clodex CA on any failure (`src/http-proxy/ca.ts`, `catch { return relayCaCertPath; }`). A missing file, an unreadable file, and a file containing no certificate all took that path silently.

Reachable by any proxy-mode user with `NODE_EXTRA_CA_CERTS` set to a path that does not resolve — no special configuration, and the variable is one users are told to set by clodex's own startup banner. `ensureHttpProxyCaBundle` is called from exactly one place, `startConfiguredHttpProxy`, always with `process.env['NODE_EXTRA_CA_CERTS']`, so it is a single choke point.

## Change

- `ensureHttpProxyCaBundle` takes an optional `onWarning` callback and reports three cases it previously swallowed, each naming the right culprit. Return values are unchanged for every input.

  | Case | Message says | Tells the user to fix their value? |
  | --- | --- | --- |
  | value cannot be read | names the variable; describes Node's own `Ignoring extra certs ... load failed` **conditionally** | yes |
  | value points at an empty file | "is empty, so it adds nothing" | no |
  | clodex cannot build the combined bundle | "clodex could not build the combined CA bundle in `<dir>` … the readable, non-empty `NODE_EXTRA_CA_CERTS=<v>` was left out of it" | no — the configured value is fine |

  Every message ends with the same accurate suffix: the bundle actually handed to the child, plus *"node's built-in roots are unaffected."*

  Three wording decisions worth calling out, each of which an earlier revision of this PR got wrong:

  - **The blame split.** An unwritable `~/.clodex/http-proxy`, a vanished clodex CA, or ENOSPC are clodex's faults. The first revision blamed the user's setting for all three and sent them to correct the one thing that was not broken. It also said "write" for a catch that also covers reading the clodex CA — now "build".
  - **"readable, non-empty", not "valid".** That is all the code establishes about the configured file. Nothing here parses PEM.
  - **The suffix must not claim the built-in roots went away.** `NODE_EXTRA_CA_CERTS` is *additive*: with one extra CA, Node 24.14.1 reports 144 bundled roots and 145 default. An earlier revision said the child would "trust only" the clodex CA, which is false and would send the reader hunting a second, non-existent problem.
- `startConfiguredHttpProxy` returns the message as `caWarning`.
- `clodex server --proxy` prints it on the running-server banner; `clodex claude` prints it with `p.log.warn`, or through the parent-notice channel when the run is in machine-readable output mode and stdout belongs to the agent protocol.

## Two things in the report that are not true, and are therefore not implemented

The reporter suggested migrating an older `~/.clodex/ca/` layout and asked whether clodex had persisted the variable into the Windows user environment. Both were checked and neither holds:

- **No released clodex used `~/.clodex/ca/`.** `src/http-proxy/ca.ts` has had `CERT_DIR = 'http-proxy'` for its whole history; every release from `v0.1.0` to `v2.8.3` uses `~/.clodex/http-proxy/clodex-ca.pem`. There is nothing to migrate from, so no migration or symlink is included.
- **No released clodex writes persistent environment variables** — no `setx`, no registry write, no shell-profile edit. One nuance worth stating rather than glossing: the pre-fork **relay-ai** releases (`v0.2.8`, `v0.4.5`) *did* call `setx` and append to shell profiles, for `OPENCODE_API_KEY` — not for `NODE_EXTRA_CA_CERTS` — and that code was removed before clodex `v0.1.0`. So if the reporter ever ran relay-ai there is a route by which persistent variables entered their user environment, though not this one. Released tags also contain test-only harness fixtures mentioning `/home/u/.clodex/ca.pem`; those perform no file operation and ship in no package.

Their third suggestion — that proxy mode should fail fast if *its own* CA cannot be loaded — is already covered: `ensureHttpProxyCertificates()` regenerates the clodex CA when it is missing or expired.

One further caution for the reporter, not addressed here: a missing CA does not produce the `bad record mac` errors they also described. A missing CA yields `SELF_SIGNED_CERT_IN_CHAIN` or `UNABLE_TO_VERIFY_LEAF_SIGNATURE`; `bad record mac` is TLS payload corruption. Their long-running-subagent failures may be a separate problem that this change will not resolve.

## Tests and the mutations they survive

Unit, in `tests/http-proxy-server.test.ts`:
- missing file → warns, names the bad value, says it was dropped, names the clodex CA, and returns the clodex CA path
- file present but empty → warns `is empty`, and asserts no message ever claims the built-in roots were dropped
- value points at a **directory** → real `EISDIR`, still reported, without promising Node printed anything
- clodex cannot build the bundle (staged as a real `EISDIR` by pre-creating `combined-ca.pem` as a directory) → blames clodex, does not say "clear or correct it", and says "readable, non-empty" rather than "valid". The fixture is deliberately *not* a parseable certificate, so the test cannot drift into claiming validity.
- over-scope negative: successful merge, unset value, whitespace value, and a value already pointing at the clodex CA all warn **nothing**

End-to-end, in `tests/http-proxy-index.test.ts`, driving the real `runHttpProxyServerCommand` rather than the helper:
- broken `NODE_EXTRA_CA_CERTS` → the warning appears on the banner an operator actually reads
- nothing configured → the banner stays clean

Mutations run, each as a full-file run, each caught:

| Mutation | Result |
| --- | --- |
| `onWarning` never invoked (feature deleted) | 3 tests fail |
| banner never prints `caWarning` | 1 test fails |
| `startConfiguredHttpProxy` stops passing the callback | 1 test fails |
| warn unconditionally (over-scope) | 5 tests fail |
| merge-failure branch restored to a silent return | 1 test fails |
| emit a *different* branch's warning unconditionally | 2 tests fail |
| suffix changed back to "will trust only that CA" | 1 test fails |

## Runtime evidence

Real command, real bytes on fd 1, macOS 15.6 / Node 24.14.1, isolated `CLODEX_HOME`, no ambient proxy vars:

```
$ CLODEX_HOME=$(mktemp -d) NODE_EXTRA_CA_CERTS=/tmp/definitely-not-here/clodex-ca.pem \
    node dist/cli.js server --proxy --port 17699 --no-discovery

clodex proxy-mode server running
  HTTPS_PROXY=http://127.0.0.1:17699
  HTTP_PROXY=http://127.0.0.1:17699
  NODE_EXTRA_CA_CERTS=/var/folders/.../http-proxy/clodex-ca.pem
  Request log: /var/folders/.../logs/inference-requests.jsonl

  clodex: NODE_EXTRA_CA_CERTS=/tmp/definitely-not-here/clodex-ca.pem cannot be read
  (ENOENT: no such file or directory, open '/tmp/definitely-not-here/clodex-ca.pem'),
  so it is not part of the proxy CA bundle. Where node reports this itself it says
  only "Ignoring extra certs ... load failed", without naming the variable. Clear or
  correct it. The CA bundle handed to the child is
  /var/folders/.../http-proxy/clodex-ca.pem; node's built-in roots are unaffected.
```

A directory-valued variable was exercised the same way and produced the `EISDIR` message.

Why the Node sentence is conditional: a review measured `NODE_EXTRA_CA_CERTS=<dir> node -e 'require("tls").createSecureContext({})'` printing nothing, while a real `clodex server --proxy` run against a directory *did* produce Node's warning. Node's behaviour here depends on whether and when TLS roots get initialised, so the message asserts neither that it always appears nor that it never does.

Node's own opaque warning appeared on fd 2 in the same run, which is the pairing this change exists to fix.

Product smoke test, real Claude Code on the default proxy path against my own `~/.clodex`:

| Leg | Result |
| --- | --- |
| `--model haiku` (Anthropic passthrough) | `HAIKU-OK` |
| `--model luna` (OpenAI OAuth, translated) | `MODEL-OK` |
| `--model haiku` with a broken `NODE_EXTRA_CA_CERTS` | warning printed, `HAIKU-OK` — Claude Code still works |
| `--output-format stream-json` with a broken value | stdout stayed pure protocol JSON; warning went to fd 2 |

## What I did not verify, and what this does not close

- **The `clodex claude` wiring in `src/cli.ts` has no automated test.** Interactive launch is manually verified in this repo by convention; I exercised both branches by hand as shown above, but a mutation to those five lines would not turn the suite red.
- **This covers the two proxy startup commands, not the wrapper.** `clodex-claude` replaces an inherited `NODE_EXTRA_CA_CERTS` with the live server's own post-merge CA path, so a stale caller value does not survive to hurt anyone there. There is a separate pre-existing limitation at `src/wrapper-env.ts:73` — if server and wrapper run under different environments, a valid CA known only to the wrapper's caller is replaced silently. That is a distinct cross-process composition issue, not part of this fix, and this PR does not claim the wrapper validates or preserves caller CAs.
- **Endpoint mode is unaffected** — it does not call `startConfiguredHttpProxy`. Not smoke tested.
- **Windows was not tested.** The reporter's platform is Windows 10; I have no Windows host. Nothing in the change is platform-specific — no path parsing, no separators — but I did not run it there.
- **The check is emptiness, not PEM validity.** A non-empty file of junk or a DER-encoded certificate is still merged verbatim and discarded by OpenSSL a layer down, silently. That is unchanged from `main` and is exactly what Node does with the same file — `NODE_EXTRA_CA_CERTS` pointing at garbage produces no Node warning either. Adding a PEM-content check is a reasonable follow-up, not part of this change, and the wording here is scoped so as not to promise it.
- **Control characters in the configured path reach the banner raw** on the `console.log` and `p.log.warn` branches; only the background-agent branch sanitises, via `emitParentNotice`. Whoever sets that variable already controls the clodex process environment, and Node prints the same path raw in its own warning, so this is hardening with no severity — noted rather than fixed.
- No doc updates: nothing in `README.md`, `docs/`, or `.claude/docs/` describes the merge behaviour, so nothing went stale.

## Failure behavior

The warning is best-effort and additive. `onWarning` is optional; every existing caller and return value is unchanged, so a failure to report cannot change which CA bundle is used or prevent the proxy from starting.

## Land order

`pnpm typecheck && pnpm test && pnpm build` all pass (1976 tests). Clean against current `main` and against #158 by `git merge-tree`. #102 also touches `src/http-proxy/index.ts` and `src/cli.ts`; no ordering constraint either way, but expect a trivial context conflict if it lands first.

Refs #157
