### PR TITLE
fix(proxy): retry a dropped Anthropic connection instead of failing the request

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,14 @@ clodex --version    # version
   retry cannot complete before the translated streaming paths' 120-second
   no-data timeout. Unset, empty, or malformed values preserve the default. A
   stream that fails after output begins cannot be replayed safely and still
-  terminates the request.
+  terminates the request. The same setting covers requests passed straight
+  through to Anthropic, which replay once by default. Only a request that went
+  out on a pooled connection the far end had already closed, and that received
+  no part of a response, is replayed there; anything else is reported as it
+  happens. Setting Claude Code's own `CLAUDE_CODE_MAX_RETRIES=0` also disables
+  the passthrough replay, so telling the client never to resend a request is
+  not quietly undone one layer down. Recovered requests appear in the inference
+  log as `response_retried`.
 
 ## Known limitations
 

--- a/src/http-proxy/server.ts
+++ b/src/http-proxy/server.ts
@@ -12,6 +12,7 @@ import { ensureHttpProxyCertificates } from './ca.js';
 import { normalizeRouteLookupId } from '../context-model-id.js';
 import { listenTcpServer } from '../listener-ready.js';
 import { routeUnavailableMessage } from '../route-unavailable.js';
+import { passthroughUpstreamRetries } from '../upstream-retry.js';
 import {
   outboundHttpProxyAgent,
   outboundProxyUrlForTarget,
@@ -37,6 +38,37 @@ const ANTHROPIC_HOST = 'api.anthropic.com';
 const MAX_BODY_BYTES = 50 * 1024 * 1024;
 const MAX_ERROR_BODY_BYTES = 64 * 1024;
 const MAX_USAGE_SSE_BLOCK_BYTES = 64 * 1024;
+
+/**
+ * The reset a pooled socket produces when the peer closed it while it sat idle.
+ * EPIPE is arguably as safe to replay and is deliberately NOT included: no test
+ * here can stage one, and an untested replay path on a billable POST is not
+ * worth the reach. `errorType` on response_failed records it if it shows up.
+ */
+const RETRYABLE_PASSTHROUGH_CODE = 'ECONNRESET';
+
+/**
+ * The passthrough's own connection pool. `timeout` must not be dropped: it is
+ * what evicts an IDLE pooled socket, and https.globalAgent -- which this
+ * replaces -- carries one. Without it dead sockets accumulate in the pool and
+ * the stale-socket reset this module absorbs becomes MORE likely, not less.
+ */
+/**
+ * Identify an upstream failure for the 502 body. Observed live: an ETIMEDOUT
+ * whose `message` was empty, rendering as "Anthropic upstream unreachable: ."
+ * -- exactly the unactionable error this path exists to stop producing. Fall
+ * back to whatever does identify it.
+ */
+export function upstreamUnreachableDetail(err: Error): string {
+  return err.message || (err as NodeJS.ErrnoException).code || err.name || 'connection failed';
+}
+
+export function createPassthroughAgent(): https.Agent {
+  return new https.Agent({
+    keepAlive: true,
+    timeout: https.globalAgent.options.timeout ?? 5_000,
+  });
+}
 
 type ResponseUsage = {
   usageStage: 'message_start' | 'message_delta';
@@ -290,6 +322,7 @@ function forwardRawAnthropicRequest(
 ): Promise<void> {
   return new Promise(resolve => {
     const startedAt = Date.now();
+    const retryBudget = passthroughUpstreamRetries();
     let lastActivityAt = startedAt;
     let headersReceived = false;
     let firstByteAt: number | undefined;
@@ -344,42 +377,115 @@ function forwardRawAnthropicRequest(
       resolve();
     };
     const errorType = (err: Error): string => (err as NodeJS.ErrnoException).code ?? err.name;
-    const upstream = https.request({
-      protocol: 'https:',
-      hostname: origin.hostname,
-      port: origin.port || 443,
-      method: req.method,
-      path: req.url,
-      headers: requestHeadersWithoutProxyHeaders(req),
-      servername: net.isIP(origin.hostname) ? undefined : origin.hostname,
-      rejectUnauthorized,
-      agent,
-    }, upstreamRes => {
-      headersReceived = true;
-      statusCode = upstreamRes.statusCode ?? 502;
-      lastActivityAt = Date.now();
-      upstreamRes.on('data', (chunk: Buffer) => {
-        const now = Date.now();
-        if (firstByteAt === undefined) {
-          firstByteAt = now;
-          writeLifecycle('response_started', {
-            statusCode,
-            durationMs: now - startedAt,
-            timeToFirstByteMs: now - startedAt,
-          });
-        }
-        lastActivityAt = now;
-        bytes += chunk.length;
-        chunks += 1;
-      });
-      copyResponse(upstreamRes, res, onErrorResponse, onResponseUsage);
-      upstreamRes.once('end', () => {
-        responseEnded = true;
+    let upstream: http.ClientRequest | undefined;
+    let attempt = 0;
+
+    // A keep-alive pool hands out sockets the far end may already have closed
+    // while they sat idle; the write then fails with a reset before anything is
+    // read back. Retrying is safe precisely in that case and only in that case:
+    // the socket was reused, so this attempt never reached a fresh connection,
+    // and no response has arrived, so the request cannot have been served. A
+    // reset on a socket we opened ourselves is a real network fault and is
+    // reported as before.
+    //
+    // `!headersReceived` is load-bearing and reachable. A clean premature close
+    // is reported on the response object, but a genuine TCP RST is a socket
+    // ERROR, and node's socketErrorListener calls emitErrorEvent(req, err)
+    // WITHOUT checking `req.res` -- so it lands here even with half a response
+    // already written downstream. Without this term that half-delivered request
+    // is replayed into the same stream (pinned by the after-headers test, which
+    // resets the raw TCP socket to produce exactly that arrival).
+    const isRetryableUpstreamFailure = (err: Error, request: http.ClientRequest): boolean =>
+      attempt <= retryBudget
+      && !headersReceived
+      && !failed
+      && !clientDisconnected
+      && !isLocalShutdown()
+      && request.reusedSocket === true
+      && (err as NodeJS.ErrnoException).code === RETRYABLE_PASSTHROUGH_CODE;
+
+    const sendAttempt = (): void => {
+      attempt += 1;
+      const request = https.request({
+        protocol: 'https:',
+        hostname: origin.hostname,
+        port: origin.port || 443,
+        method: req.method,
+        path: req.url,
+        headers: requestHeadersWithoutProxyHeaders(req),
+        servername: net.isIP(origin.hostname) ? undefined : origin.hostname,
+        rejectUnauthorized,
+        agent,
+      }, upstreamRes => {
+        headersReceived = true;
+        statusCode = upstreamRes.statusCode ?? 502;
         lastActivityAt = Date.now();
-        done();
+        upstreamRes.on('data', (chunk: Buffer) => {
+          const now = Date.now();
+          if (firstByteAt === undefined) {
+            firstByteAt = now;
+            writeLifecycle('response_started', {
+              statusCode,
+              durationMs: now - startedAt,
+              timeToFirstByteMs: now - startedAt,
+              ...(attempt > 1 ? { attempt } : {}),
+            });
+          }
+          lastActivityAt = now;
+          bytes += chunk.length;
+          chunks += 1;
+        });
+        copyResponse(upstreamRes, res, onErrorResponse, onResponseUsage);
+        upstreamRes.once('end', () => {
+          responseEnded = true;
+          lastActivityAt = Date.now();
+          done();
+        });
+        upstreamRes.once('error', err => {
+          if (clientDisconnected || failed) {
+            done();
+            return;
+          }
+          failed = true;
+          stopProgress();
+          const now = Date.now();
+          writeLifecycle('response_failed', {
+            statusCode,
+            phase: responsePhase(),
+            durationMs: now - startedAt,
+            ...(firstByteAt !== undefined ? { timeToFirstByteMs: firstByteAt - startedAt } : {}),
+            idleMs: now - lastActivityAt,
+            bytes,
+            chunks,
+            errorType: errorType(err),
+            terminationSource: 'upstream_failure',
+            attempt,
+          });
+          done();
+        });
       });
-      upstreamRes.once('error', err => {
-        if (clientDisconnected || failed) {
+      upstream = request;
+      request.once('error', err => {
+        if (clientDisconnected) {
+          done();
+          return;
+        }
+        if (isRetryableUpstreamFailure(err, request)) {
+          const retriedAt = Date.now();
+          writeLifecycle('response_retried', {
+            phase: responsePhase(),
+            durationMs: retriedAt - startedAt,
+            idleMs: retriedAt - lastActivityAt,
+            errorType: errorType(err),
+            terminationSource: 'upstream_failure',
+            attempt,
+            reusedSocket: true,
+          });
+          lastActivityAt = retriedAt;
+          sendAttempt();
+          return;
+        }
+        if (failed) {
           done();
           return;
         }
@@ -387,19 +493,26 @@ function forwardRawAnthropicRequest(
         stopProgress();
         const now = Date.now();
         writeLifecycle('response_failed', {
-          statusCode,
+          statusCode: 502,
           phase: responsePhase(),
           durationMs: now - startedAt,
-          ...(firstByteAt !== undefined ? { timeToFirstByteMs: firstByteAt - startedAt } : {}),
           idleMs: now - lastActivityAt,
           bytes,
           chunks,
           errorType: errorType(err),
-          terminationSource: 'upstream_failure',
+          terminationSource: isLocalShutdown() ? 'local_shutdown' : 'upstream_failure',
+          attempt,
+          reusedSocket: request.reusedSocket === true,
         });
+        const detail = upstreamUnreachableDetail(err);
+        onErrorResponse?.(502, `Anthropic upstream unreachable: ${detail}`);
+        if (!res.headersSent) res.writeHead(502, { 'Content-Type': 'text/plain' });
+        res.end(`Anthropic upstream unreachable: ${detail}`);
         done();
       });
-    });
+      request.end(rawBody);
+    };
+
     res.once('finish', () => {
       stopProgress();
       if (failed || clientDisconnected) return;
@@ -410,6 +523,7 @@ function forwardRawAnthropicRequest(
         ...(firstByteAt !== undefined ? { timeToFirstByteMs: firstByteAt - startedAt } : {}),
         bytes,
         chunks,
+        ...(attempt > 1 ? { attempt } : {}),
       });
     });
     res.once('close', () => {
@@ -427,33 +541,11 @@ function forwardRawAnthropicRequest(
         chunks,
         terminationSource: isLocalShutdown() ? 'local_shutdown' : 'downstream_client',
       });
-      upstream.destroy(new Error('Client disconnected'));
+      upstream?.destroy(new Error('Client disconnected'));
       done();
     });
-    upstream.once('error', err => {
-      if (clientDisconnected) {
-        done();
-        return;
-      }
-      failed = true;
-      stopProgress();
-      const now = Date.now();
-      writeLifecycle('response_failed', {
-        statusCode: 502,
-        phase: responsePhase(),
-        durationMs: now - startedAt,
-        idleMs: now - lastActivityAt,
-        bytes,
-        chunks,
-        errorType: errorType(err),
-        terminationSource: 'upstream_failure',
-      });
-      onErrorResponse?.(502, `Anthropic upstream unreachable: ${err.message}`);
-      if (!res.headersSent) res.writeHead(502, { 'Content-Type': 'text/plain' });
-      res.end(`Anthropic upstream unreachable: ${err.message}`);
-      done();
-    });
-    upstream.end(rawBody);
+
+    sendAttempt();
   });
 }
 
@@ -733,7 +825,7 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
   }
   const anthropicOrigin = new URL(options.anthropicOrigin ?? 'https://api.anthropic.com');
   const anthropicProxyUrl = outboundProxyUrlForTarget(anthropicOrigin.href);
-  let anthropicAgent: ReturnType<typeof outboundHttpProxyAgent>;
+  let anthropicAgent: https.Agent | undefined;
   let adapter: ProxyHandle | null = options.adapterHandle ?? null;
   if (options.routes.length > 0) {
     adapter ??= await startProxyCatalog(
@@ -1010,6 +1102,9 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
   } else {
     anthropicAgent = outboundHttpProxyAgent(anthropicOrigin.href);
   }
+  // Without this the passthrough falls back to https.globalAgent, whose pool is
+  // shared with every other https client in the process and outlives close().
+  anthropicAgent ??= createPassthroughAgent();
 
   return {
     host: options.host ?? '127.0.0.1',

--- a/src/trace-log.ts
+++ b/src/trace-log.ts
@@ -229,6 +229,7 @@ export type InferenceResponseLifecycleEvent =
   | 'response_progress'
   | 'response_completed'
   | 'response_failed'
+  | 'response_retried'
   | 'response_client_disconnected'
   | 'response_usage';
 
@@ -283,6 +284,10 @@ export interface InferenceResponseLifecycleLogEntry {
   errorSignature?: string;
   failureSource?: InferenceFailureSource;
   terminationSource?: InferenceTerminationSource;
+  /** 1-based upstream attempt this record describes. Absent when only one was made. */
+  attempt?: number;
+  /** Whether the failed attempt went out on a pooled keep-alive socket. */
+  reusedSocket?: boolean;
 }
 
 export type ProxyLifecycleEvent =
@@ -455,6 +460,7 @@ export function writeInferenceResponseLifecycleLog(
   const outputTokens = nonNegativeInteger(entry.outputTokens);
   const cacheCreationInputTokens = nonNegativeInteger(entry.cacheCreationInputTokens);
   const cacheReadInputTokens = nonNegativeInteger(entry.cacheReadInputTokens);
+  const attempt = nonNegativeInteger(entry.attempt);
   writeSecureLogLine(path, JSON.stringify({
     timestamp: new Date().toISOString(),
     event: entry.event,
@@ -486,6 +492,8 @@ export function writeInferenceResponseLifecycleLog(
     ...(entry.errorSignature ? { errorSignature: compactLogValue(entry.errorSignature, 100) } : {}),
     ...(entry.failureSource ? { failureSource: entry.failureSource } : {}),
     ...(entry.terminationSource ? { terminationSource: entry.terminationSource } : {}),
+    ...(attempt !== undefined ? { attempt } : {}),
+    ...(entry.reusedSocket !== undefined ? { reusedSocket: entry.reusedSocket } : {}),
   }));
 }
 

--- a/src/upstream-retry.ts
+++ b/src/upstream-retry.ts
@@ -48,3 +48,34 @@ export function upstreamMaxRetries(
   }
   return value;
 }
+
+/**
+ * Claude Code's own retry budget. Read, never written: if the operator has told
+ * the client never to resend a request, clodex must not resend on its behalf.
+ */
+const CLIENT_MAX_RETRIES_ENV = 'CLAUDE_CODE_MAX_RETRIES';
+
+/**
+ * Retry budget for raw Anthropic passthrough requests. These are not SDK
+ * generations, but they share the knob so that turning retries off turns them
+ * off everywhere. One retry is enough for the failure this exists to absorb: a
+ * pooled keep-alive socket the far end closed while it sat idle, which the
+ * agent evicts as soon as it resets.
+ */
+export const DEFAULT_PASSTHROUGH_RETRIES = 1;
+
+export function passthroughUpstreamRetries(env: NodeJS.ProcessEnv = process.env): number {
+  const explicit = upstreamMaxRetries(env);
+  if (explicit !== undefined) return explicit;
+  // Replaying here is safe to default on because Claude Code already resends a
+  // 502 itself, so the ambiguous "upstream may have served it" window is one
+  // the client already accepts. `CLAUDE_CODE_MAX_RETRIES=0` withdraws exactly
+  // that, and reinstating it one layer down would be a duplicate send the
+  // operator explicitly opted out of.
+  const raw = env[CLIENT_MAX_RETRIES_ENV]?.trim();
+  if (raw !== undefined && raw !== '') {
+    const clientRetries = Number(raw);
+    if (Number.isFinite(clientRetries) && clientRetries === 0) return 0;
+  }
+  return DEFAULT_PASSTHROUGH_RETRIES;
+}

--- a/tests/http-proxy-server.test.ts
+++ b/tests/http-proxy-server.test.ts
@@ -11,7 +11,12 @@ import { PassThrough } from 'node:stream';
 import { gzipSync } from 'node:zlib';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { ensureHttpProxyCaBundle, ensureHttpProxyCertificates } from '../src/http-proxy/ca.js';
-import { shouldInterceptConnect, startHttpProxy } from '../src/http-proxy/server.js';
+import {
+  createPassthroughAgent,
+  shouldInterceptConnect,
+  startHttpProxy,
+  upstreamUnreachableDetail,
+} from '../src/http-proxy/server.js';
 
 const testHome = mkdtempSync(join(tmpdir(), 'clodex-http-proxy-'));
 const previousRelayHome = process.env['CLODEX_HOME'];
@@ -1945,6 +1950,501 @@ describe('selective HTTP proxy', () => {
       if (previous === undefined) delete process.env['CLODEX_SERVICE_TIER'];
       else process.env['CLODEX_SERVICE_TIER'] = previous;
     }
+  });
+
+
+  // A keep-alive pool can hand out a socket the far end closed while it was
+  // idle. Every request in this group drives that shape through the real MITM
+  // path against a real origin rather than by emitting a synthetic error.
+  describe('Anthropic passthrough retry', () => {
+    const ORIGIN_BODY = JSON.stringify({ type: 'message', content: [] });
+    const POST_HEADER_MARKER = 'event: message_start\n\n';
+    /**
+     * Origin that serves every connection normally except for the Nth request
+     * it sees on that same connection, which it kills without replying. With
+     * `killOnConnectionRequest: 2` a socket is only reset once it has been
+     * pooled and reused, which is the production failure; with `1` the reset
+     * lands on a freshly opened socket, which must never be replayed.
+     */
+    function resettingOrigin(killOnConnectionRequest: number): {
+      server: https.Server;
+      requestCount: () => number;
+    } {
+      const certificates = ensureHttpProxyCertificates();
+      let requests = 0;
+      const bodies: string[] = [];
+      const perConnection = new WeakMap<net.Socket, number>();
+      const server = https.createServer({
+        key: certificates.serverKey,
+        cert: certificates.serverCert,
+      }, (req, res) => {
+        const chunks: Buffer[] = [];
+        req.on('data', (chunk: Buffer) => chunks.push(chunk));
+        req.once('end', () => bodies.push(Buffer.concat(chunks).toString()));
+        const seen = (perConnection.get(req.socket) ?? 0) + 1;
+        perConnection.set(req.socket, seen);
+        requests += 1;
+        if (seen === killOnConnectionRequest) {
+          req.socket.destroy();
+          return;
+        }
+        res.writeHead(200, {
+          'Content-Type': 'application/json',
+          'Content-Length': String(Buffer.byteLength(ORIGIN_BODY)),
+        });
+        res.end(ORIGIN_BODY);
+      });
+      return { server, requestCount: () => requests, bodies };
+    }
+
+    function messagesRequest(body: string): string {
+      return [
+        'POST /v1/messages HTTP/1.1',
+        'Host: api.anthropic.com',
+        'Content-Type: application/json',
+        `Content-Length: ${Buffer.byteLength(body)}`,
+        'Connection: keep-alive',
+        '',
+        '',
+      ].join('\r\n') + body;
+    }
+
+    /**
+     * Resolve once `count` responses have been fully DELIVERED, keyed on the
+     * origin's terminating body rather than the status line. Waiting on the
+     * status line only would let the next request go out while the upstream
+     * socket is still busy: it would then open a fresh socket, and the reuse
+     * these tests exist to exercise would silently never happen.
+     */
+    async function awaitResponses(
+      socket: tls.TLSSocket,
+      read: () => string,
+      count: number,
+      terminator = ORIGIN_BODY,
+    ): Promise<void> {
+      await awaitUntil(socket, () => read().split(terminator).length - 1 >= count,
+        () => `expected ${count} x ${JSON.stringify(terminator)}, got: ${read().slice(0, 400)}`);
+    }
+
+    /**
+     * Poll until `done`, then THROW on expiry. Silently returning on timeout
+     * let a test that could never see its terminator burn the full deadline and
+     * still pass. One `data` listener for the whole wait, not one per poll.
+     */
+    async function awaitUntil(
+      socket: tls.TLSSocket,
+      done: () => boolean,
+      describe: () => string,
+      timeoutMs = 10_000,
+    ): Promise<void> {
+      if (done()) return;
+      await new Promise<void>((resolve, reject) => {
+        const finish = (err?: Error): void => {
+          clearInterval(poll);
+          clearTimeout(timer);
+          socket.off('data', onData);
+          if (err) reject(err); else resolve();
+        };
+        const check = (): void => { if (done()) finish(); };
+        const onData = (): void => check();
+        const poll = setInterval(check, 25);
+        const timer = setTimeout(() => finish(new Error(`timed out: ${describe()}`)), timeoutMs);
+        socket.on('data', onData);
+        check();
+      });
+    }
+
+    /** Wait for a 502, which no ORIGIN_BODY terminator can ever match. */
+    async function awaitStatus502(socket: tls.TLSSocket, read: () => string): Promise<void> {
+      await awaitUntil(socket, () => read().includes('Anthropic upstream unreachable'),
+        () => `expected a 502 body, got: ${read().slice(0, 400)}`);
+    }
+
+    async function readLog(path: string): Promise<Record<string, unknown>[]> {
+      return readFileSync(path, 'utf8').trim().split('\n').map(line => JSON.parse(line));
+    }
+
+    /**
+     * Two keep-alive requests down one client connection. The second reuses the
+     * proxy's pooled upstream socket, which the origin then resets.
+     */
+    async function twoRequestsOverOneConnection(logName: string, secondIs502 = false): Promise<{
+      response: string;
+      entries: Record<string, unknown>[];
+      originRequests: number;
+      bodies: string[];
+    }> {
+      const certificates = ensureHttpProxyCertificates();
+      const inferenceLogPath = join(testHome, logName);
+      const { server, requestCount, bodies } = resettingOrigin(2);
+      const originPort = await listen(server);
+      const proxy = await startHttpProxy({
+        routes: [],
+        inferenceLogPath,
+        anthropicOrigin: `https://127.0.0.1:${originPort}`,
+        anthropicRejectUnauthorized: false,
+      });
+      try {
+        const secure = await connectMitm(proxy.port, certificates.caCert);
+        let response = '';
+        secure.on('data', chunk => { response += chunk.toString(); });
+
+        secure.write(messagesRequest(JSON.stringify({
+          model: 'claude-opus-4-8',
+          messages: [{ role: 'user', content: 'first' }],
+        })));
+        await awaitResponses(secure, () => response, 1);
+        expect(response).toContain('200 OK');
+
+        secure.write(messagesRequest(JSON.stringify({
+          model: 'claude-opus-4-8',
+          messages: [{ role: 'user', content: 'second' }],
+        })));
+        if (secondIs502) await awaitStatus502(secure, () => response);
+        else await awaitResponses(secure, () => response, 2);
+        secure.destroy();
+
+        return {
+          response,
+          entries: await readLog(inferenceLogPath),
+          originRequests: requestCount(),
+          bodies,
+        };
+      } finally {
+        await proxy.close();
+        await new Promise<void>(resolve => server.close(() => resolve()));
+      }
+    }
+
+    it('replays a request whose pooled upstream socket was reset before any reply', async () => {
+      const { response, entries, originRequests, bodies } = await twoRequestsOverOneConnection(
+        'passthrough-retry-reused.jsonl',
+      );
+
+      // Both client requests were answered; the reset never reached the client.
+      expect(response.split('HTTP/1.1 200 OK').length - 1).toBe(2);
+      expect(response).not.toContain('502');
+      expect(response).not.toContain('Anthropic upstream unreachable');
+      // First request, the reset second request, and its replay.
+      expect(originRequests).toBe(3);
+      // The replay must carry the ORIGINAL body byte for byte. Truncating or
+      // re-encoding it would still produce a 200 and leave every other
+      // assertion green, so pin it here.
+      const second = JSON.stringify({ model: 'claude-opus-4-8', messages: [{ role: 'user', content: 'second' }] });
+      expect(bodies).toHaveLength(3);
+      expect(bodies[2]).toBe(second);
+      expect(bodies[2]).toBe(bodies[1]);
+
+      const retried = entries.filter(entry => entry['event'] === 'response_retried');
+      expect(retried).toEqual([
+        expect.objectContaining({
+          event: 'response_retried',
+          route: 'passthrough',
+          phase: 'waiting_for_headers',
+          errorType: 'ECONNRESET',
+          terminationSource: 'upstream_failure',
+          attempt: 1,
+          reusedSocket: true,
+        }),
+      ]);
+      expect(entries.some(entry => entry['event'] === 'response_failed')).toBe(false);
+      // The replay's success is attributed to attempt 2, so a log reader can
+      // tell a recovered request from one that never needed recovering.
+      expect(entries).toContainEqual(expect.objectContaining({
+        event: 'response_completed',
+        requestId: retried[0]!['requestId'],
+        attempt: 2,
+      }));
+    }, 20_000);
+
+    it('does not replay a reset on a socket it opened itself', async () => {
+      const certificates = ensureHttpProxyCertificates();
+      const inferenceLogPath = join(testHome, 'passthrough-retry-fresh.jsonl');
+      const { server, requestCount } = resettingOrigin(1);
+      const originPort = await listen(server);
+      const proxy = await startHttpProxy({
+        routes: [],
+        inferenceLogPath,
+        anthropicOrigin: `https://127.0.0.1:${originPort}`,
+        anthropicRejectUnauthorized: false,
+      });
+      try {
+        const secure = await connectMitm(proxy.port, certificates.caCert);
+        let response = '';
+        secure.on('data', chunk => { response += chunk.toString(); });
+        secure.write(messagesRequest(JSON.stringify({
+          model: 'claude-opus-4-8',
+          messages: [{ role: 'user', content: 'fresh socket reset' }],
+        })));
+        await awaitStatus502(secure, () => response);
+        secure.destroy();
+
+        expect(response).toContain('502');
+        expect(response).toContain('Anthropic upstream unreachable');
+        // Exactly one upstream attempt: a fresh connection may have delivered
+        // the request before dying, so replaying it could duplicate the turn.
+        expect(requestCount()).toBe(1);
+
+        const entries = await readLog(inferenceLogPath);
+        expect(entries.some(entry => entry['event'] === 'response_retried')).toBe(false);
+        expect(entries).toContainEqual(expect.objectContaining({
+          event: 'response_failed',
+          route: 'passthrough',
+          statusCode: 502,
+          phase: 'waiting_for_headers',
+          errorType: 'ECONNRESET',
+          attempt: 1,
+          reusedSocket: false,
+        }));
+      } finally {
+        await proxy.close();
+        await new Promise<void>(resolve => server.close(() => resolve()));
+      }
+    }, 20_000);
+
+    it('does not replay a reused socket that already sent response headers', async () => {
+      // Pins the behaviour AND the guard. A clean `destroy()` here is reported
+      // on the response object, so the request-level retry decision is never
+      // consulted and the test proves nothing. Resetting the RAW TCP socket
+      // (the TLS socket cannot: resetAndDestroy throws ERR_INVALID_HANDLE_TYPE)
+      // delivers a genuine RST, which node reports on the REQUEST -- the one
+      // arrival point where a post-header replay could occur. Staged on a
+      // REUSED socket so the reuse gate cannot be what produces the result.
+      const certificates = ensureHttpProxyCertificates();
+      const inferenceLogPath = join(testHome, 'passthrough-retry-after-headers.jsonl');
+      let requests = 0;
+      const perConnection = new WeakMap<net.Socket, number>();
+      const rawByPort = new Map<number, net.Socket>();
+      const origin = https.createServer({
+        key: certificates.serverKey,
+        cert: certificates.serverCert,
+      }, (req, res) => {
+        req.resume();
+        const seen = (perConnection.get(req.socket) ?? 0) + 1;
+        perConnection.set(req.socket, seen);
+        requests += 1;
+        if (seen === 2) {
+          res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+          res.write(POST_HEADER_MARKER);
+          const raw = rawByPort.get(req.socket.remotePort ?? -1);
+          setTimeout(() => raw?.resetAndDestroy(), 30);
+          return;
+        }
+        res.writeHead(200, {
+          'Content-Type': 'application/json',
+          'Content-Length': String(Buffer.byteLength(ORIGIN_BODY)),
+        });
+        res.end(ORIGIN_BODY);
+      });
+      origin.on('connection', raw => {
+        const port = raw.remotePort;
+        if (port !== undefined) rawByPort.set(port, raw);
+      });
+      const originPort = await listen(origin);
+      const proxy = await startHttpProxy({
+        routes: [],
+        inferenceLogPath,
+        anthropicOrigin: `https://127.0.0.1:${originPort}`,
+        anthropicRejectUnauthorized: false,
+      });
+      try {
+        const secure = await connectMitm(proxy.port, certificates.caCert);
+        let response = '';
+        secure.on('data', chunk => { response += chunk.toString(); });
+
+        secure.write(messagesRequest(JSON.stringify({
+          model: 'claude-opus-4-8',
+          messages: [{ role: 'user', content: 'first' }],
+        })));
+        await awaitResponses(secure, () => response, 1);
+
+        secure.write(messagesRequest(JSON.stringify({
+          model: 'claude-opus-4-8',
+          messages: [{ role: 'user', content: 'reset after headers' }],
+          stream: true,
+        })));
+        await awaitUntil(secure, () => response.includes(POST_HEADER_MARKER),
+          () => `expected the partial stream, got: ${response.slice(0, 400)}`);
+        await new Promise(resolve => setTimeout(resolve, 250));
+        secure.destroy();
+
+        // The client really did receive part of a response before the reset.
+        expect(response).toContain(POST_HEADER_MARKER);
+        // Two client requests, two upstream attempts. A third would mean the
+        // half-delivered response was replayed.
+        expect(requests).toBe(2);
+        const entries = await readLog(inferenceLogPath);
+        expect(entries.some(entry => entry['event'] === 'response_retried')).toBe(false);
+      } finally {
+        await proxy.close();
+        await new Promise<void>(resolve => origin.close(() => resolve()));
+      }
+    }, 20_000);
+
+    it('identifies a failure whose error carries no message', () => {
+      // Observed live on this branch: ETIMEDOUT with an empty message rendered
+      // as "Anthropic upstream unreachable: ." and told the reader nothing.
+      expect(upstreamUnreachableDetail(Object.assign(new Error(''), { code: 'ETIMEDOUT' })))
+        .toBe('ETIMEDOUT');
+      // A real message still wins -- it says more than the code does.
+      expect(upstreamUnreachableDetail(Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' })))
+        .toBe('socket hang up');
+      // And something is always produced, however bare the error.
+      expect(upstreamUnreachableDetail(new Error(''))).toBe('Error');
+      expect(upstreamUnreachableDetail(Object.assign(new Error(''), { name: '' })))
+        .toBe('connection failed');
+    });
+
+    it('keeps the idle-eviction the global pool it replaces already had', () => {
+      // Expressed as parity, not a magic 5000: the invariant is "no worse than
+      // https.globalAgent at dropping idle sockets". Dropping `timeout` leaves
+      // dead sockets pooled forever and makes the stale reset MORE likely.
+      const agent = createPassthroughAgent();
+      try {
+        expect(agent.keepAlive).toBe(true);
+        expect(agent.options.timeout).toBeDefined();
+        expect(agent.options.timeout).toBe(https.globalAgent.options.timeout);
+      } finally {
+        agent.destroy();
+      }
+    });
+
+    it('pools passthrough connections in its own agent, not the process-wide one', async () => {
+      // Falling back to https.globalAgent shares a pool with every other https
+      // client in the process and survives close(). Reuse alone cannot detect
+      // that -- globalAgent is keep-alive too -- so assert the pool identity.
+      const certificates = ensureHttpProxyCertificates();
+      const { server } = resettingOrigin(0);
+      const originPort = await listen(server);
+      // Agent pool keys carry TLS options too, so match on the origin's port
+      // rather than reconstructing the whole key.
+      const globalPoolHasOrigin = (): boolean =>
+        [...Object.keys(https.globalAgent.freeSockets), ...Object.keys(https.globalAgent.sockets)]
+          .some(key => key.startsWith(`127.0.0.1:${originPort}:`));
+      expect(globalPoolHasOrigin()).toBe(false);
+      const proxy = await startHttpProxy({
+        routes: [],
+        anthropicOrigin: `https://127.0.0.1:${originPort}`,
+        anthropicRejectUnauthorized: false,
+      });
+      try {
+        const secure = await connectMitm(proxy.port, certificates.caCert);
+        let response = '';
+        secure.on('data', chunk => { response += chunk.toString(); });
+        secure.write(messagesRequest(JSON.stringify({
+          model: 'claude-opus-4-8',
+          messages: [{ role: 'user', content: 'pool identity' }],
+        })));
+        await awaitResponses(secure, () => response, 1);
+        secure.destroy();
+
+        expect(response).toContain('200 OK');
+        // The kept-alive upstream socket must be parked in the proxy's own pool.
+        expect(globalPoolHasOrigin()).toBe(false);
+      } finally {
+        await proxy.close();
+        await new Promise<void>(resolve => server.close(() => resolve()));
+      }
+    }, 20_000);
+
+    it('does not replay, or blame upstream, when the proxy itself is shutting down', async () => {
+      // close() destroys the passthrough pool, which surfaces on an in-flight
+      // request as a socket error indistinguishable from an upstream fault.
+      // Replaying then is pointless work against a dying proxy, and recording
+      // it as `upstream_failure` sends a log reader after Anthropic.
+      const certificates = ensureHttpProxyCertificates();
+      const inferenceLogPath = join(testHome, 'passthrough-retry-shutdown.jsonl');
+      let sawSecond: () => void = () => {};
+      const secondSeen = new Promise<void>(resolve => { sawSecond = resolve; });
+      let requests = 0;
+      const perConnection = new WeakMap<net.Socket, number>();
+      const origin = https.createServer({
+        key: certificates.serverKey,
+        cert: certificates.serverCert,
+      }, (req, res) => {
+        req.resume();
+        const seen = (perConnection.get(req.socket) ?? 0) + 1;
+        perConnection.set(req.socket, seen);
+        requests += 1;
+        // Answer the first so the upstream socket is POOLED, then hold the
+        // second open across the shutdown. Staged on a reused socket so the
+        // reuse gate is not what suppresses the replay.
+        if (seen === 1) {
+          res.writeHead(200, {
+            'Content-Type': 'application/json',
+            'Content-Length': String(Buffer.byteLength(ORIGIN_BODY)),
+          });
+          res.end(ORIGIN_BODY);
+          return;
+        }
+        req.once('end', () => sawSecond());
+      });
+      const originPort = await listen(origin);
+      const proxy = await startHttpProxy({
+        routes: [],
+        inferenceLogPath,
+        anthropicOrigin: `https://127.0.0.1:${originPort}`,
+        anthropicRejectUnauthorized: false,
+      });
+      let closed = false;
+      try {
+        const secure = await connectMitm(proxy.port, certificates.caCert);
+        let response = '';
+        secure.on('data', chunk => { response += chunk.toString(); });
+        secure.on('error', () => {});
+        secure.write(messagesRequest(JSON.stringify({
+          model: 'claude-opus-4-8',
+          messages: [{ role: 'user', content: 'first' }],
+        })));
+        await awaitResponses(secure, () => response, 1);
+        secure.write(messagesRequest(JSON.stringify({
+          model: 'claude-opus-4-8',
+          messages: [{ role: 'user', content: 'in flight at shutdown' }],
+        })));
+        await secondSeen;
+
+        await proxy.close();
+        closed = true;
+        secure.destroy();
+        await new Promise(resolve => setTimeout(resolve, 200));
+
+        const entries = await readLog(inferenceLogPath);
+        expect(entries.some(entry => entry['event'] === 'response_retried')).toBe(false);
+        const upstreamBlamed = entries.filter(entry =>
+          entry['event'] === 'response_failed'
+          && entry['terminationSource'] === 'upstream_failure');
+        expect(upstreamBlamed).toEqual([]);
+        // A third upstream request would mean the dying proxy replayed.
+        expect(requests).toBe(2);
+      } finally {
+        if (!closed) await proxy.close();
+        await new Promise<void>(resolve => origin.close(() => resolve()));
+      }
+    }, 20_000);
+
+    it('honours CLODEX_UPSTREAM_MAX_RETRIES=0 by surfacing the reset', async () => {
+      const previous = process.env['CLODEX_UPSTREAM_MAX_RETRIES'];
+      process.env['CLODEX_UPSTREAM_MAX_RETRIES'] = '0';
+      try {
+        const { response, entries, originRequests } = await twoRequestsOverOneConnection(
+          'passthrough-retry-disabled.jsonl',
+          true,
+        );
+        expect(response).toContain('502');
+        expect(originRequests).toBe(2);
+        expect(entries.some(entry => entry['event'] === 'response_retried')).toBe(false);
+        expect(entries).toContainEqual(expect.objectContaining({
+          event: 'response_failed',
+          statusCode: 502,
+          errorType: 'ECONNRESET',
+          attempt: 1,
+          reusedSocket: true,
+        }));
+      } finally {
+        if (previous === undefined) delete process.env['CLODEX_UPSTREAM_MAX_RETRIES'];
+        else process.env['CLODEX_UPSTREAM_MAX_RETRIES'] = previous;
+      }
+    }, 20_000);
   });
 
 });

--- a/tests/upstream-retry.test.ts
+++ b/tests/upstream-retry.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  DEFAULT_PASSTHROUGH_RETRIES,
   MAX_UPSTREAM_MAX_RETRIES,
   UPSTREAM_MAX_RETRIES_ENV,
+  passthroughUpstreamRetries,
   upstreamMaxRetries,
 } from '../src/upstream-retry.js';
 import { installParentNoticeSink } from '../src/parent-notice.js';
@@ -90,6 +92,72 @@ describe('upstreamMaxRetries', () => {
       expect(stderr.join('')).toBe('');
     } finally {
       release();
+      spy.mockRestore();
+    }
+  });
+});
+
+describe('passthroughUpstreamRetries', () => {
+  it('replays a dropped keep-alive socket once when nothing is configured', () => {
+    // Unlike the SDK paths there is no library default to defer to, so an
+    // absent setting has to resolve to a real number here.
+    expect(passthroughUpstreamRetries({})).toBe(DEFAULT_PASSTHROUGH_RETRIES);
+    expect(DEFAULT_PASSTHROUGH_RETRIES).toBe(1);
+  });
+
+  it('lets the shared setting turn passthrough replays off', () => {
+    expect(passthroughUpstreamRetries({ [UPSTREAM_MAX_RETRIES_ENV]: '0' })).toBe(0);
+  });
+
+  it('follows the shared setting upward and honours its ceiling', () => {
+    expect(passthroughUpstreamRetries({ [UPSTREAM_MAX_RETRIES_ENV]: '3' })).toBe(3);
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      expect(passthroughUpstreamRetries({ [UPSTREAM_MAX_RETRIES_ENV]: '99' }))
+        .toBe(MAX_UPSTREAM_MAX_RETRIES);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('does not resend when the client itself was told never to resend', () => {
+    // Replaying here is defensible only because Claude Code resends a 502 on
+    // its own, so the ambiguous window is one the client already accepts.
+    // CLAUDE_CODE_MAX_RETRIES=0 withdraws that; reinstating it a layer down
+    // would be a duplicate billed send the operator opted out of.
+    expect(passthroughUpstreamRetries({ CLAUDE_CODE_MAX_RETRIES: '0' })).toBe(0);
+    expect(passthroughUpstreamRetries({ CLAUDE_CODE_MAX_RETRIES: ' 0 ' })).toBe(0);
+  });
+
+  it('keeps replaying when the client retains a retry budget of its own', () => {
+    expect(passthroughUpstreamRetries({ CLAUDE_CODE_MAX_RETRIES: '1' }))
+      .toBe(DEFAULT_PASSTHROUGH_RETRIES);
+    expect(passthroughUpstreamRetries({ CLAUDE_CODE_MAX_RETRIES: '10' }))
+      .toBe(DEFAULT_PASSTHROUGH_RETRIES);
+    // Unusable values are the client's business, not a reason to change ours.
+    expect(passthroughUpstreamRetries({ CLAUDE_CODE_MAX_RETRIES: '' }))
+      .toBe(DEFAULT_PASSTHROUGH_RETRIES);
+    expect(passthroughUpstreamRetries({ CLAUDE_CODE_MAX_RETRIES: 'none' }))
+      .toBe(DEFAULT_PASSTHROUGH_RETRIES);
+  });
+
+  it('lets the clodex setting win over the client budget in both directions', () => {
+    expect(passthroughUpstreamRetries({
+      CLODEX_UPSTREAM_MAX_RETRIES: '2',
+      CLAUDE_CODE_MAX_RETRIES: '0',
+    })).toBe(2);
+    expect(passthroughUpstreamRetries({
+      CLODEX_UPSTREAM_MAX_RETRIES: '0',
+      CLAUDE_CODE_MAX_RETRIES: '10',
+    })).toBe(0);
+  });
+
+  it('falls back to the default when the setting is unusable', () => {
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      expect(passthroughUpstreamRetries({ [UPSTREAM_MAX_RETRIES_ENV]: 'lots' }))
+        .toBe(DEFAULT_PASSTHROUGH_RETRIES);
+    } finally {
       spy.mockRestore();
     }
   });


### PR DESCRIPTION
When clodex passes a request straight through to Anthropic and the connection it happens to use has just been closed by the other end, the request failed outright with `502 Anthropic upstream unreachable: read ECONNRESET`. Nothing had been sent or received, so it could simply have been sent again — and now it is. The failure showed up in confusing places: an agent doing web research would report the page as unreachable when the page was fine and only the connection had dropped. One reporter logged roughly 300 of these in a week.

Reported in #158.

## User-visible failure

`502 Anthropic upstream unreachable: read ECONNRESET`, at a rate of ~300/week on one machine and 12 in a 10-minute window on another, with local network faults ruled out by the reporter (`netstat -e` clean over 4GB, no TLS-inspecting AV).

The reporter attributed it to non-Anthropic traffic being forwarded unreliably and asked for a `--proxy-anthropic-only` flag. That diagnosis does not hold, and the flag would not have helped: this string is produced at exactly one place in the tree, reachable only from the Anthropic passthrough. `shouldInterceptConnect` (`src/http-proxy/server.ts`) intercepts only `api.anthropic.com:443`; every other CONNECT is a blind tunnel whose failures produce a bare `502 Bad Gateway` with no body, and plain-HTTP forwards produce `Proxy upstream unreachable:`. The requests hitting this error were already Anthropic requests.

## Root cause and reachability

Two facts combine:

1. **The passthrough had no connection retry.** Every SDK generation path resolves `CLODEX_UPSTREAM_MAX_RETRIES` through `src/upstream-retry.ts` (a documented invariant in `CLAUDE.md`). `forwardRawAnthropicRequest` did not; a single `upstream.once('error')` turned any error straight into a 502.
2. **It ran on Node's process-wide connection pool.** `agent` was `undefined` unless an outbound corporate proxy was configured, so `https.request` fell back to `https.globalAgent`, which has had `keepAlive: true` since Node 19. Verified on this machine, Node 24.14.1:

   ```
   globalAgent keepAlive: true
   globalAgent options: {"keepAlive":true,"scheduling":"lifo","timeout":5000,...}
   keepAliveMsecs: 1000
   ```

A pooled socket the far end closed while it sat idle fails on its next use with `read ECONNRESET`, before any response byte. Reachable by every proxy-mode user on any request clodex forwards to Anthropic — which, on a patched binary, is every request for a real Anthropic model. No special configuration required.

Reproduced directly (`/tmp/probe-req-error.mjs`, keep-alive agent against a local HTTPS origin that kills the second request on a connection):

```
req1 HEADERS 200 reusedSocket= false
req1 RES end
req2 HEADERS 200 reusedSocket= true
req2 RES aborted
req2 RES error ECONNRESET
```

Alternatives ruled out: it is not the blind CONNECT tunnel (different error text, verified by reading both emit sites); it is not the adapter path (that destroys the response rather than emitting this string); it is not a client disconnect (`terminationSource` would be `downstream_client`).

## Change

`forwardRawAnthropicRequest` resends the request when **all** of these hold:

- the socket came from the pool (`request.reusedSocket === true`), so this was not a fresh connection
- no response headers have arrived, so the request cannot have been served
- the error is `ECONNRESET` — the reset a pooled socket gives when the peer closed it while idle
- the retry budget allows it

`EPIPE` is arguably as safe and is deliberately **excluded**: no test here can stage one, and an untested replay path on a billable POST is not worth the reach. If it occurs it now shows up as `errorType` on `response_failed`, which makes adding it a one-line follow-up with evidence.

A reset on a connection clodex opened itself is **not** replayed. That one may have reached the server before dying, and a duplicated `/v1/messages` POST is a duplicated billed generation.

The budget is `passthroughUpstreamRetries()` in `src/upstream-retry.ts`: `CLODEX_UPSTREAM_MAX_RETRIES` when set (so `0` turns it off everywhere, and the existing clamp and warning apply), otherwise 1. One is enough for the failure this absorbs — the pool evicts a socket as soon as it resets — and keeping the default low makes the logs answer whether it was enough.

Passthrough also gets its own `https.Agent({ keepAlive: true, timeout: 5_000 })` instead of `https.globalAgent`. Its pool is no longer shared with every other HTTPS client in the process, and `close()` destroys it. The existing guard that deliberately leaves the agent unset when `HTTP(S)_PROXY` points at this same proxy is preserved — that branch still avoids routing through itself, it just gets a plain direct pool now.

The `timeout` is not decoration. `https.globalAgent` carries `timeout: 5000`, which evicts an **idle** pooled socket; a bare `new https.Agent({ keepAlive: true })` has none and would hold dead sockets indefinitely, making the exact race this PR absorbs *more* likely rather than less. Measured on Node 24.14.1: after 6s idle, the bare agent still held 1 free socket and the timed agent held 0. It does not cut an in-flight response short — a request against an origin that stalled 8s before responding, and one that stalled 8s mid-stream, both completed; Node raises `timeout` on the request and destroys nothing without a listener.

### Logging, so the next report is answerable

- Recovered requests append `response_retried` with `errorType`, `phase`, `attempt`, and `reusedSocket`.
- A `response_failed` that was **not** retried now carries `attempt` and `reusedSocket`, which separates "a fresh connection failed" (a real network fault) from "we replayed and it failed again".
- A success that needed a replay carries `attempt: 2`; a first-attempt success carries no `attempt` at all, so existing log readers see no change on the happy path.

If #158's reporter upgrades and still sees 502s, `reusedSocket: false` on the failures says the cause is elsewhere.

## Tests and the mutations they survive

All in `tests/http-proxy-server.test.ts`, driven through the real MITM path against a real local HTTPS origin. No synthetic error injection — the origin resets a genuinely reused socket.

- **replays a request whose pooled upstream socket was reset before any reply** — two keep-alive requests down one client connection; the second reuses the pooled upstream socket, which the origin resets. Asserts two `200 OK`s downstream, no `502`, three origin requests, one `response_retried` with `reusedSocket: true`, and `response_completed` at `attempt: 2`.
- **does not replay a reset on a socket it opened itself** — under-scope negative. Asserts exactly one origin request and `reusedSocket: false` on the failure.
- **does not replay a reused socket that already sent response headers** — over-scope negative, staged on a reused socket so the reuse gate is not what produces the result. Asserts the client actually received the partial SSE marker, so deleting the origin's reset branch fails it.
- **pools passthrough connections in its own agent, not the process-wide one** — asserts no key for the origin's port appears in `https.globalAgent.freeSockets`/`sockets`. Reuse alone cannot detect this, since `globalAgent` is keep-alive too.
- **honours `CLODEX_UPSTREAM_MAX_RETRIES=0`** — 502 surfaced, two origin requests, no `response_retried`.

Synchronisation matters here and got it wrong first: the tests originally waited on a status line, which let request 2 go out while the upstream socket was still busy — it would then open a fresh socket and the reuse under test would silently never happen. A reviewer reproduced a failure by splitting the first response into two chunks 100 ms apart. They now wait on the response body.

Plus four unit tests for `passthroughUpstreamRetries` in `tests/upstream-retry.test.ts`.

Mutations, each run as a full-file run:

| Mutation | Result |
| --- | --- |
| retry predicate always false (feature deleted) | **fails** — the replay test drops to one `200 OK` |
| drop `request.reusedSocket === true` | **fails** — the fresh-socket test sees 2 origin requests |
| `attempt <= retryBudget` → `attempt <= 99` | **fails** — the `=0` test retries anyway |
| remove the dedicated agent (fall back to `globalAgent`) | **fails** — pool-identity test |
| drop the agent's idle-eviction `timeout` | **fails** — parity test |
| drop `!headersReceived` | **fails** — raw-RST after-headers test |
| truncate the replayed body | **fails** — body-fidelity assertion |
| ignore `CLAUDE_CODE_MAX_RETRIES=0` | **fails** — retry-budget unit test |
| replay while the proxy is shutting down | **fails** — shutdown test |
| record a shutdown as `upstream_failure` | **fails** — shutdown test |
| widen the error predicate to retry *any* error | **survives** — see below |

## The replay is a heuristic, not a proof — and what bounds it

`reusedSocket === true` does **not** prove the request went undelivered. It proves only that the socket came from the free pool. An adversarial review staged the gap: an origin that consumes the full request body before resetting still gets replayed. So a duplicated `/v1/messages` POST — a duplicated billed generation — is possible in the window where upstream accepted and processed a request but reset before any response header reached clodex.

**By default that window is one the client already accepts,** because Claude Code resends a 502 itself. From the 2.1.247 bundle, its retry-count resolver is:

```js
function qRt(){ let e=dA(), t=V.CLAUDE_CODE_MAX_RETRIES;
  if(t!==void 0 && Number.isFinite(t) && t>=0){ ...clamp at 15...; return t }
  return e ? 300 : 10 }
```

so a 502 is retried up to 10 times out of the box.

**But that is a default, not an invariant — and an earlier revision of this PR wrongly argued it as one.** A first review pointed at the Anthropic SDK's `shouldRetry` gate (`status >= 500 → retry`); a second review showed that is *not* the path streaming `/v1/messages` takes. Verified in the bundle: the streaming query client is built with `maxRetries: 0` (`RWe(()=>Ak({maxRetries:0, ...}))`), and streaming is retried by Claude Code's own outer loop, which is what `qRt()` feeds. That loop honours `CLAUDE_CODE_MAX_RETRIES=0` and really does return zero.

So with `CLAUDE_CODE_MAX_RETRIES=0`, `main` surfaces the first 502 and this change would have silently replayed a billable POST — a genuinely new risk for that configuration.

**The fix reads that setting.** `passthroughUpstreamRetries()` returns 0 when `CLAUDE_CODE_MAX_RETRIES=0`, so an operator who told the client never to resend a request does not get it reinstated a layer down. Precedence: an explicit `CLODEX_UPSTREAM_MAX_RETRIES` wins in either direction; otherwise the client's zero wins; otherwise the default is 1.

That leaves the replay defensible in every configuration I can name: where the client would retry the 502 anyway, doing it here removes a spurious failure at no new risk; where the client would not, neither do we. It remains a heuristic — I am not claiming `reusedSocket` proves non-delivery — and `CLODEX_UPSTREAM_MAX_RETRIES=0` disables it outright.

## The guard that took three rounds to pin

## Two guards that are defensive and not independently pinned

`!headersReceived` stops a half-delivered response from being replayed into the same stream. I twice reported it as unpinnable and was twice wrong in a different way — first claiming it was unreachable (it is not: `socketErrorListener` calls `emitErrorEvent(req, err)` with no `req.res` check), then claiming no test could reach it.

The technique, from the second review: a clean `destroy()` is reported on the response object, and `resetAndDestroy()` throws `ERR_INVALID_HANDLE_TYPE` on a **TLS** socket — but capturing the **raw TCP** socket from the origin's `connection` event and resetting *that* delivers a genuine RST, which Node reports on the request. With it, removing `!headersReceived` fails with a replay of the half-delivered request and `ERR_HTTP_HEADERS_SENT`.

The guard is now reachable, pinned, and documented as load-bearing rather than defensive.

### The one mutation that still survives

Widening the predicate from `code === 'ECONNRESET'` to any error is not detected. I could not build a test that distinguishes them, and I do not think one exists: on a **pooled, pre-header** failure the reachable error codes are `ECONNRESET` and `EPIPE`, so no origin can produce a third code at that point for a test to reject. The narrow comparison is kept because it is the correct expression of intent, not because a test defends it. Recording it rather than pretending otherwise.

## Sibling shape I checked and deliberately did not fix

The same mechanism exists on the **local adapter hop** used by translated models: `adapterAgent` (`src/http-proxy/server.ts`) is `new http.Agent({ keepAlive: true })` with no idle-eviction timeout, while the adapter server sets `keepAliveTimeout = 60_000` (`src/proxy.ts`). A translated request arriving after >60s idle can therefore reuse a socket the adapter has just closed.

I did not reproduce it and did not change it. It is a different failure surface (`res.destroy()`, not a 502), it does not produce the string in this report, and extending the change there would put every translated request in the blast radius of a PR whose purpose is the passthrough. Recording it here so it is a known gap rather than a silent one.

## Runtime evidence

Environment: macOS 15.6, Node 24.14.1, pnpm 10.34.5. Suite runs used an isolated `CLODEX_HOME` and `CLAUDE_CODE_ENTRYPOINT=cli`.

- `pnpm typecheck && pnpm test && pnpm build` — 1984 tests pass, build succeeds.
- `CLODEX_HOME="$(mktemp -d)" pnpm test` — 1984 pass.

Product smoke test, real Claude Code on the default proxy path against my own `~/.clodex`:

| Leg | Result |
| --- | --- |
| `--model haiku` (Anthropic passthrough — the changed path) | `HAIKU-OK` |
| `--model luna` (OpenAI OAuth, translated) | `MODEL-OK` |

The passthrough leg's inference log confirms the shape in production: `response_started` → `response_usage` → `response_completed`, with no `attempt` field on the first-attempt success and no spurious retries.

## Field data from a real install, including what it says against this fix

A six-week `inference-requests.jsonl` from my own daily-driver install (proxy mode, ~860 MB of records) contains these passthrough failure classes:

| `errorType` | count |
| --- | --- |
| `CERT_HAS_EXPIRED` | 871 |
| `AI_RetryError` (translated routes) | 618 |
| `ENOTFOUND` | 471 |
| `ETIMEDOUT` | 263 |
| **`ECONNRESET`** | **29** |
| `EPIPE` | 2 |

So the reported failure shape is real here too, but it is not the dominant one, and the 29 do not all fall to this change:

- **21 of 29 failed at `phase: "streaming"`** with a partly delivered body (523 to 122350 bytes). Those are explicitly **out of scope** — a half-delivered stream must never be replayed, and this change does not.
- **8 failed at `waiting_for_headers` with `bytes: 0`**, the shape the retry targets. Their durations were 129, 541, 1116, 1140, 8342, 8644, 34084 and 82492 ms.

Of those 8, only the four sub-1.2s ones carry the stale-pooled-socket signature — a reset that arrives inside a round trip. The 8.3s, 8.6s, 34s and 82s failures are something else (an upstream that accepted the connection and reset much later), and the `reusedSocket` gate will most likely exclude them.

**Read honestly, that is roughly 4 recovered requests in six weeks on this machine, not 29.** I am putting that in the PR rather than the headline number because it is the number that survives scrutiny. Two things keep it worth doing anyway: the reporter's install sees ~300/week where mine sees 29 total, and their machine is the one that ruled out network faults; and this log predates the change, so it has **no `reusedSocket` field** — which is precisely why the field is being added. After this ships, that column answers the question instead of me inferring it from a duration.

The 2 `EPIPE` records are also why EPIPE is excluded rather than guessed at: it is real but rare enough that shipping an untested replay path for it is not justified.

## What I did not verify

- **I have not reproduced the reporter's 502s myself**, and cannot confirm their resets are the stale-pooled-socket kind. Their `reusedSocket` field will settle it after they upgrade. The mechanism is proven; that this is *their* mechanism is inference.
- **Windows was not tested** — the reporter's platform. Nothing in the change is platform-specific.
- **Requests to Anthropic endpoints other than `/v1/messages` are retried but not logged.** Lifecycle logging is gated on `messagesEndpoint === 'messages'`, a pre-existing deliberate choice I did not change; `count_tokens`, OAuth, and telemetry calls therefore get the fix without leaving a record.
- No provider credentials beyond Anthropic and OpenAI OAuth, so other providers' passthrough behaviour is untested — though passthrough is provider-independent by construction.

## Failure behavior and rollback

With `CLODEX_UPSTREAM_MAX_RETRIES=0` the behaviour is exactly as before this change: the first reset becomes a 502. Reverting the commit restores `https.globalAgent` and the single-attempt path; nothing is persisted and no stored format changes.

## Land order

Clean against current `main` and against #157 by `git merge-tree`. #102 also touches `src/http-proxy/server.ts`; no ordering constraint, but expect a context conflict if it lands first.

Refs #158 — note this does **not** implement the requested `--proxy-anthropic-only` flag; see the root-cause section for why that flag would not have addressed the reported error.
