### PR TITLE
fix(patch): refuse an unfamiliar Claude Code build instead of rewriting the wrong bytes

### DIFF
--- a/.claude/docs/patcher.md
+++ b/.claude/docs/patcher.md
@@ -176,8 +176,8 @@ So the blob is published, not rebuilt:
 ELF only, and a no-op on every release where tweakcc works unaided.
 
 A Bun standalone ELF keeps the virtual address of its `.bun` section in an 8-byte little-endian
-global; Bun reads it at startup to find the blob. `repackELFSection` moves `.bun` to a fresh page
-past the end of the file, so it has to rewrite that global — and it finds it by scanning the first
+global. `repackELFSection` moves `.bun` to a fresh page past the end of the file and rewrites that
+global to match — and it finds it by scanning the first
 writable `PT_LOAD` for eight bytes equal to `.bun`'s current address, **only at addresses that are
 multiples of 16384**. tweakcc 4.3.0 and 4.3.3 both do this, so bumping the pin does not help.
 
@@ -193,17 +193,29 @@ remembers the eight bytes it displaced, and after the repack copies the address 
 the global's real home and puts the displaced bytes back. The published binary differs from an
 unaided repack in exactly one place: the global, holding the value it was always meant to hold.
 
-- **It never runs where tweakcc already works.** The module reproduces tweakcc's own scan first and
-  returns null if that finds anything, so an older release — or a future one that goes back to
-  being aligned — takes the path it always took, byte for byte.
 - **The real global is identified, not guessed:** the ONE 8-byte occurrence of `.bun`'s address
   inside the writable segment and outside `.bun`'s own payload. Occurrences inside the payload are
-  coincidences in compressed JavaScript (dozens on some builds) and are excluded by range. Anything
-  other than exactly one candidate is refused rather than patched, because publishing a binary whose
-  Bun global still points at the old blob is a `claude` that dies inside Bun before it prints
-  anything.
+  coincidences in compressed JavaScript — up to five on the arm64 builds measured (0, 0, 5 and 3
+  across the four 2.1.257 ELF builds) — and are excluded by range. Anything other than exactly one
+  candidate is refused rather than patched.
+- **It never runs where tweakcc already lands on that same address**, so an older release — or a
+  future one that goes back to being aligned — takes the path it always took, byte for byte. The
+  order matters: the census above runs **first** and the no-op check defers to it. Reversed, a
+  build carrying a coincidental copy of the blob address at a 16384-aligned offset would make
+  clodex stand aside while the repack rewrote that copy, and `clodex patch` would report success.
+  No shipped build does — on all four 2.1.257 ELF builds every occurrence is unaligned, and on
+  2.1.252 the single aligned hit *is* the global — and the ordering is what keeps that a measured
+  fact rather than an assumption.
 - **The restore verifies rather than assumes:** the stand-in must have changed, must agree with
   where `.bun` actually ended up, and both writes must read back.
+
+**What a wrong answer actually costs.** Not a binary that fails to start. That was this section's
+original claim and it is wrong: on published 2.1.257 linux-x64 and linux-x64-musl, reverting *only*
+the global to its pre-repack value still yields a `claude` that starts and prints its version, so
+Bun locates the blob another way — the end-of-file trailer scan described above. The cost is eight
+bytes of **live data** rewritten and never put back. Nothing in range is spare: the stand-in slot
+lands in `.data` on the glibc builds and in `.tdata`, the TLS initialisation image, on the musl
+ones. Refusing beats guessing for that reason, not the other one.
 - Mach-O and PE never reach this code — they assign the section in place and rewrite no pointer.
   That asymmetry is why the failure was ELF-only, and why the probe must be run per format.
 

--- a/src/bun-compiled-pointer.ts
+++ b/src/bun-compiled-pointer.ts
@@ -1,4 +1,5 @@
-// Keeps tweakcc's ELF repack able to find the pointer Bun uses to locate its embedded blob.
+// Keeps tweakcc's ELF repack able to find the address it expects to rewrite when it moves Bun's
+// embedded blob.
 //
 // Read `.claude/docs/patcher.md` first. This file exists for the same reason `bun-entry-module.ts`
 // does: tweakcc identifies something in the binary by a rule that a Claude Code release quietly
@@ -6,8 +7,10 @@
 // the repack rather than a fork of tweakcc.
 //
 // THE RULE. A Bun standalone ELF stores the virtual address of its `.bun` section in an 8-byte
-// little-endian global — Bun reads it at startup to find the blob. `repackELFSection` moves `.bun`
-// to a fresh page past the end of the file, so it has to rewrite that global. It finds it by
+// little-endian global. `repackELFSection` moves `.bun` to a fresh page past the end of the file
+// and rewrites that global to match. (It is tweakcc that insists on finding it — startup itself
+// still locates the blob from the end-of-file trailer, which is why a stale value is wrong
+// rather than fatal. See WHAT A WRONG ANSWER COSTS below.) It finds it by
 // scanning the first writable `PT_LOAD` segment for 8 bytes equal to `.bun`'s CURRENT virtual
 // address — but only at addresses that are multiples of 16384. tweakcc 4.3.0 and 4.3.3 both do
 // this; bumping the pin does not help.
@@ -27,17 +30,26 @@
 // pristine repack in exactly one place: the global, holding the value it was always meant to hold.
 //
 // Two things make that safe rather than clever, and both are checked rather than assumed:
-//   * it is a NO-OP wherever tweakcc already works. `bunCompiledPointerScan` runs tweakcc's own
-//     scan first; if that finds anything, this module returns null and stays out of the way. So an
-//     older release, and any future release that goes back to being aligned, takes the path it
-//     always took.
 //   * the real global is identified, not guessed: the ONE 8-byte occurrence of `.bun`'s address
 //     inside the writable segment and outside `.bun`'s own payload. Matches inside the payload are
-//     coincidences in compressed JavaScript (there are dozens on some builds) and are excluded by
-//     range. Anything other than exactly one candidate is refused, loudly, instead of patched.
+//     coincidences in compressed JavaScript — up to five on the arm64 builds measured — and are
+//     excluded by range. Anything other than exactly one candidate is refused, loudly, instead of
+//     patched.
+//   * it is a NO-OP wherever tweakcc already lands on that same address. So an older release, and
+//     any future release that goes back to being aligned, takes the path it always took. Note the
+//     order: the census above runs FIRST and the no-op defers to it, so tweakcc settling on some
+//     OTHER aligned copy is refused rather than waved through.
 // The restore reads back both addresses and refuses a binary where either did not take.
+//
+// WHAT A WRONG ANSWER COSTS. Not a binary that fails to start — that was this file's original
+// claim and it is wrong. Measured on published 2.1.257 linux-x64 and linux-x64-musl: revert only
+// the global to its pre-repack value and `claude --version` still works, so Bun locates the blob
+// another way (the end-of-file trailer `bun-bundle.ts` describes). What a wrong answer costs is
+// eight bytes of live data rewritten and never restored. The addresses in play are not spare: the
+// stand-in slot lands in `.data` on the glibc builds and in `.tdata`, the TLS initialisation
+// image, on the musl ones. That is why this refuses instead of guessing.
 
-import { closeSync, openSync, readSync, writeSync } from 'node:fs';
+import { closeSync, fstatSync, openSync, readSync, writeSync } from 'node:fs';
 
 /** tweakcc's `repackELFSection` only inspects addresses at this stride. Mirrored, not chosen. */
 const TWEAKCC_SCAN_STRIDE = 16384n;
@@ -118,6 +130,15 @@ function readElfLayout(fd: number): ElfLayout | null {
   if (shnum === 0 || phnum === 0xffff) return null;
   if (shstrndx >= shnum || shentsize < 64 || phentsize < 56) return null;
 
+  // Every length below comes out of the file's own header, so size the reads against the file
+  // before allocating rather than after. `shnum * shentsize` alone reaches ~4.3 GB from a file that
+  // carries nothing but the ELF magic, and `sh_size` is a full u64. A real build is checked, not
+  // trusted: this is the same posture as the SHN_XINDEX/PN_XNUM refusal above.
+  const fileSize = fstatSync(fd).size;
+  const fits = (offset: number, length: number) =>
+    Number.isSafeInteger(offset) && offset >= 0 && length >= 0 && offset + length <= fileSize;
+
+  if (!fits(Number(shoff), shnum * shentsize)) return null;
   const shTable = readAt(fd, shnum * shentsize, Number(shoff));
   if (shTable.length !== shnum * shentsize) return null;
   const raw = [];
@@ -131,6 +152,7 @@ function readElfLayout(fd: number): ElfLayout | null {
     });
   }
   const strtab = raw[shstrndx]!;
+  if (!fits(Number(strtab.offset), Number(strtab.size))) return null;
   const names = readAt(fd, Number(strtab.size), Number(strtab.offset));
   const sections: ElfSection[] = raw.map(section => {
     const start = section.nameOffset;
@@ -144,6 +166,7 @@ function readElfLayout(fd: number): ElfLayout | null {
     };
   });
 
+  if (!fits(Number(phoff), phnum * phentsize)) return null;
   const phTable = readAt(fd, phnum * phentsize, Number(phoff));
   if (phTable.length !== phnum * phentsize) return null;
   const segments: ElfSegment[] = [];
@@ -173,7 +196,8 @@ function writableLoad(layout: ElfLayout): ElfSegment | undefined {
  * File offset of `vaddr`, or null when no loaded segment's file image holds it — or when MORE than
  * one does. Taking the first match would be a silent wrong answer rather than a safe one: the
  * restore's readback reads the offset it just wrote, so it proves the write landed, not that the
- * offset was right, and Bun would be left pointed at the old blob. No real build has overlapping
+ * offset was right — the eight bytes would go somewhere other than the global, leaving that stale
+ * and overwriting whatever was really there. No real build has overlapping
  * PT_LOADs (checked on all eight 2.1.257/2.1.252/2.1.246 builds and on a repacked one), so this
  * refuses a shape that does not occur rather than resolving one that does.
  */
@@ -236,9 +260,15 @@ function scanForNeedle(
  *
  * Null covers every case this does not apply to: a Mach-O or PE binary, a non-native install, a
  * binary with no `.bun` section or no writable segment, and — the important one — any ELF where
- * tweakcc's own scan already finds the pointer. Throws only when the binary IS one that needs help
- * and the pointer cannot be identified unambiguously, because publishing a binary whose Bun global
- * still points at the old blob would produce a `claude` that does not start.
+ * tweakcc's own scan already lands on the real global.
+ *
+ * Throws when the binary IS an ELF carrying a blob and the global cannot be identified
+ * unambiguously. Not because a stale global is known to be fatal — measured on 2.1.257 linux-x64
+ * and linux-x64-musl, a published binary whose global was reverted to the pre-repack address still
+ * starts and prints its version, so Bun finds the blob another way. It throws because the
+ * alternative is guessing WHICH eight bytes to rewrite, and every address in range is live data:
+ * the stand-in slot alone lands in `.data` on the glibc builds and in `.tdata`, the TLS
+ * initialisation image, on the musl ones.
  */
 export function shimBunCompiledPointer(path: string): BunCompiledPointerShim | null {
   const fd = openSync(path, 'r+');
@@ -252,12 +282,19 @@ export function shimBunCompiledPointer(path: string): BunCompiledPointerShim | n
 
     const needle = Buffer.alloc(8);
     needle.writeBigUInt64LE(bun.addr);
-    if (tweakccWouldFind(fd, segment, needle) !== null) return null;
 
     const segmentStart = Number(segment.offset);
     const segmentEnd = Number(segment.offset + segment.filesz);
     const bunStart = Number(bun.offset);
     const bunEnd = Number(bun.offset + bun.size);
+    // The census runs BEFORE the no-op check, so the "exactly one candidate" rule governs both
+    // paths. Ordering it the other way let tweakcc's strided scan settle on any aligned 8 bytes
+    // that happened to equal `.bun`'s address: clodex would stand aside, the repack would rewrite
+    // that coincidence — live `.data`/`.tdata` bytes nothing then restores — and `clodex patch`
+    // would report success. No shipped build reaches it (every occurrence on the four 2.1.257 ELF
+    // builds is unaligned; on 2.1.252 the one aligned hit IS the global, which is why standing
+    // aside was right there), and this is what keeps that a measured fact rather than an
+    // assumption.
     const candidates = scanForNeedle(fd, segmentStart, segmentEnd, needle, bunStart, bunEnd);
     if (candidates.length !== 1) {
       throw new Error(
@@ -267,6 +304,18 @@ export function shimBunCompiledPointer(path: string): BunCompiledPointerShim | n
     }
     const pointerOffset = candidates[0]!;
     const pointerVaddr = segment.vaddr + BigInt(pointerOffset) - segment.offset;
+
+    const wouldFind = tweakccWouldFind(fd, segment, needle);
+    if (wouldFind !== null) {
+      if (wouldFind !== pointerVaddr) {
+        throw new Error(
+          `tweakcc's ELF repack would rewrite 0x${wouldFind.toString(16)}, which is not Bun's blob `
+          + `pointer at 0x${pointerVaddr.toString(16)}. Refusing to repack a binary whose Bun global `
+          + 'would be left stale.',
+        );
+      }
+      return null;
+    }
 
     // The slot tweakcc will land on: the lowest address its scan visits that overlaps neither the
     // blob it is about to move nor the global we are about to correct. Its previous contents are
@@ -299,9 +348,10 @@ export function shimBunCompiledPointer(path: string): BunCompiledPointerShim | n
  * Move the address tweakcc wrote into the stand-in over to the real Bun global, and put the
  * displaced bytes back. Throws if either address no longer resolves to exactly one place in the
  * repacked image, if the repack did not rewrite the stand-in, or if it disagrees with where `.bun`
- * actually ended up — all of which would leave a `claude` that fails inside Bun before it prints
- * anything. (The readbacks below confirm the writes landed. They read the offsets they just wrote,
- * so they cannot vouch for the offsets themselves; `fileOffsetOf` is what does that.)
+ * actually ended up — each of which means the eight bytes about to be written are not the eight
+ * this run identified, and the displaced live data would not go back where it came from. (The
+ * readbacks below confirm the writes landed. They read the offsets they just wrote, so they cannot
+ * vouch for the offsets themselves; `fileOffsetOf` is what does that.)
  */
 export function restoreBunCompiledPointer(path: string, shim: BunCompiledPointerShim): void {
   const fd = openSync(path, 'r+');
@@ -318,7 +368,15 @@ export function restoreBunCompiledPointer(path: string, shim: BunCompiledPointer
         "the repack left Bun's blob pointer outside the loaded image, or in more than one segment of it",
       );
     }
-    const written = readAt(fd, 8, standInOffset).readBigUInt64LE(0);
+    // `readAt` hands back a SHORT buffer rather than throwing, and this is the one consumer that
+    // would then index past its end — a raw `RangeError: Attempt to access memory outside buffer
+    // bounds` in place of a diagnostic naming the binary. Every other caller length-checks or
+    // compares with `.equals`, which is false on a short buffer and lands on the right message.
+    const standIn = readAt(fd, 8, standInOffset);
+    if (standIn.length !== 8) {
+      throw new Error('the repacked binary ends before the stand-in for Bun\'s blob pointer');
+    }
+    const written = standIn.readBigUInt64LE(0);
     if (written === shim.bunVaddr) {
       throw new Error("the repack did not rewrite Bun's blob pointer — the stand-in was not used");
     }

--- a/src/patch-transforms.ts
+++ b/src/patch-transforms.ts
@@ -733,10 +733,19 @@ export function applyClodexPatches(source: string, config: PatchScriptModelConfi
     // OTEL pair, so "at least two" can be satisfied from a single category and
     // buys little over one.
     //
-    // So the floor is ONE. It still refuses a body that scrubs nothing — which is
-    // the only case where these names say something the anchor does not — while
-    // taking four independent refactors, not one, to produce a false refusal.
-    // 2.1.252 matches five and 2.1.257 matches four.
+    // So the floor is ONE. It still refuses a body that spells none of them —
+    // which is the only case where these names say something the anchor does not.
+    // 2.1.252 spells five and 2.1.257 spells four. Note what the floor does NOT
+    // buy: one refactor can still take it to zero, because "extract the remaining
+    // literals into a shared table" is a single ordinary move and is exactly what
+    // 2.1.257 already did to one of the five. The floor is cheap insurance
+    // against a body that spells none of these names, not a durable identity signal.
+    //
+    // These are matched as SUBSTRINGS of the body. A builder that scrubs the same
+    // names through a table declared elsewhere spells none of them here and is
+    // refused; that is the conservative direction, and the message below says
+    // "spells" rather than "scrubs" so the next reader is not sent looking for
+    // deletion logic that is not there.
     const scrubbedEnvNames = [
       'CLAUDE_CODE_OAUTH_TOKEN',
       'CLAUDE_CODE_SUBSCRIPTION_TYPE',
@@ -859,7 +868,7 @@ export function applyClodexPatches(source: string, config: PatchScriptModelConfi
         const why = missingLiteral !== undefined
           ? 'body does not contain ' + missingLiteral
           : scrubbedSeen.length < MIN_SCRUBBED_ENV_NAMES
-            ? 'body scrubs only ' + scrubbedSeen.length + ' of the '
+            ? 'body spells only ' + scrubbedSeen.length + ' of the '
               + scrubbedEnvNames.length + ' known child-env names (expected at least '
               + MIN_SCRUBBED_ENV_NAMES + ')'
             : /\bfunction\s*[\w$]*\(/.test(body!)
@@ -867,7 +876,15 @@ export function applyClodexPatches(source: string, config: PatchScriptModelConfi
               : braceScanFailed
                 ? "the brace walk never reached the function's closing brace"
                 : bound !== 0
-                  ? 'match ends ' + bound + ' characters from the function it started in'
+                  // Say which way it went. `bound` is the function's closing brace minus the
+                  // match's last character, so a positive value means the match stopped SHORT
+                  // (a nested `return <copy>}` ended it early, leaving live `process.env` reads
+                  // unrewritten) and a negative one means it RAN PAST the function into a
+                  // neighbour. Those are different bugs; a signed number in front of the word
+                  // "from" reads as neither.
+                  ? 'match ends ' + Math.abs(bound) + ' characters '
+                    + (bound > 0 ? 'before' : 'after')
+                    + ' the end of the function it started in'
                   : undefined;
         if (why !== undefined) {
           log('FAIL', patchName, 'target validation failed: ' + why);

--- a/tests/bun-blob-fixture.ts
+++ b/tests/bun-blob-fixture.ts
@@ -295,8 +295,8 @@ const ELF_SEG_OFFSET = 0x1000;
  * How far the segment's virtual address runs ahead of its file offset — 0x202000 on the real
  * linux-x64 build, 0x220000 on arm64. Never zero, and that matters: a fixture mapped at
  * `vaddr === offset` cannot tell a virtual address from a file offset, so an implementation that
- * confuses the two reads and writes the same wrong place, passes its own readback, and leaves Bun
- * pointed at the old blob on every real Linux build.
+ * confuses the two reads and writes the same wrong place, passes its own readback, and rewrites
+ * eight bytes that are not the global on every real Linux build.
  */
 const ELF_LOAD_BIAS = 0x202000;
 const ELF_SEG_VADDR = ELF_SEG_OFFSET + ELF_LOAD_BIAS;

--- a/tests/bun-compiled-pointer.test.ts
+++ b/tests/bun-compiled-pointer.test.ts
@@ -1,5 +1,5 @@
-// The stand-in that keeps tweakcc's ELF repack able to find the global Bun reads its blob's
-// address from. Claude Code 2.1.257 moved that global off the 16 KiB boundary tweakcc scans, and
+// The stand-in that keeps tweakcc's ELF repack able to find the global holding the address of
+// Bun's blob. Claude Code 2.1.257 moved that global off the 16 KiB boundary tweakcc scans, and
 // `clodex patch` failed on all four ELF builds with "Could not find original BUN_COMPILED
 // location in binary". See src/bun-compiled-pointer.ts.
 //
@@ -7,8 +7,27 @@
 // this module applies is about ELF structure, which a small hand-built ELF64 carries exactly.
 // The real builds are covered by scripts/probe-patch-mechanism.mjs and the canary's container leg.
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, readFileSync, rmSync, writeFileSync, openSync, readSync, closeSync } from 'node:fs';
+
+/**
+ * The restore's two readbacks exist to catch a write that was issued and did not land. Nothing in
+ * the production path can produce that, and substituting an impossible shim does not test it: a
+ * mutant that inspects the impossible field instead of reading the file passes such a test. So the
+ * write itself is faulted — `writeSync` reports success for one position and writes nothing — with
+ * an ordinary shim from `shimBunCompiledPointer` and an ordinary repack either side of it.
+ */
+const droppedWrite: { atPosition: number | null } = { atPosition: null };
+vi.mock('node:fs', async importOriginal => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    writeSync: (fd: number, buffer: never, offset: number, length: number, position: number) =>
+      (droppedWrite.atPosition !== null && position === droppedWrite.atPosition
+        ? length
+        : actual.writeSync(fd, buffer, offset, length, position)),
+  };
+});
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import {
@@ -26,7 +45,7 @@ const SEG_OFFSET = 0x10490;
  * How far virtual addresses run ahead of file offsets: 0x202000 on the real linux-x64 build,
  * 0x220000 on arm64. Never zero, and that is the point — mapped at `vaddr === offset`, an
  * implementation that confuses the two reads and writes the same wrong place, passes its own
- * readback, and leaves Bun pointed at the old blob on every real Linux build.
+ * readback, and rewrites eight bytes that are not the global on every real Linux build.
  */
 const LOAD_BIAS = 0x202000;
 const SEG_VADDR = SEG_OFFSET + LOAD_BIAS;
@@ -48,13 +67,18 @@ function buildElf(
   pointerVaddr: number,
   extraPointerVaddrs: number[] = [],
   bun: { offset: number; size: number } = { offset: BUN_OFFSET, size: BUN_SIZE },
-  { segSize = SEG_SIZE, decoySegment = false, phnum = 1 }: {
+  { segSize = SEG_SIZE, decoySegment = false, phnum = 1, trailingWritableSegment = false }: {
     /** Grow the writable segment past one `SCAN_CHUNK`, so the sweep's chunking loop runs twice. */
     segSize?: number;
     /** Add an earlier PT_LOAD whose vaddr range also covers the pointer but not the stand-in. */
     decoySegment?: boolean;
     /** `e_phnum`. 0xffff is PN_XNUM, which says the real count lives in the section table. */
     phnum?: number;
+    /**
+     * Add a LATER writable PT_LOAD holding none of the pointer occurrences. tweakcc takes the
+     * FIRST writable `PT_LOAD`; a mirror that took the last would scan this one instead.
+     */
+    trailingWritableSegment?: boolean;
   } = {},
 ): Buffer {
   const shstrtab = Buffer.from(SECTION_NAMES.join('\0') + '\0', 'utf8');
@@ -96,6 +120,17 @@ function buildElf(
     buf.writeBigUInt64LE(BigInt(SEG_OFFSET), 0x80);
     buf.writeBigUInt64LE(BigInt(SEG_VADDR), 0x88);
     buf.writeBigUInt64LE(BigInt(FIRST_SCANNED - SEG_VADDR + 0x1000), 0x98);
+  }
+
+  if (trailingWritableSegment) {
+    // Mapped past everything else, and left as filler, so it carries no occurrence of `.bun`'s
+    // address. Picking it instead of the real one makes the census come up empty.
+    buf.writeUInt16LE(2, 0x38);
+    buf.writeUInt32LE(1, 0x78);
+    buf.writeUInt32LE(6, 0x7c);
+    buf.writeBigUInt64LE(BigInt(SEG_OFFSET), 0x80);
+    buf.writeBigUInt64LE(BigInt(SEG_VADDR + segSize + 0x100000), 0x88);
+    buf.writeBigUInt64LE(BigInt(0x1000), 0x98);
   }
 
   const section = (index: number, name: string, addr: number, offset: number, size: number) => {
@@ -160,7 +195,10 @@ describe('the Bun blob pointer stand-in', () => {
     dir = mkdtempSync(path.join(tmpdir(), 'clodex-bun-pointer-'));
     file = path.join(dir, 'claude');
   });
-  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+  afterEach(() => {
+    droppedWrite.atPosition = null;
+    rmSync(dir, { recursive: true, force: true });
+  });
 
   // The releases through 2.1.252 that tweakcc repacks unaided. Planting anything there would be a
   // change to a path that works, on every ELF build, for no reason.
@@ -218,8 +256,8 @@ describe('the Bun blob pointer stand-in', () => {
       expect(before, 'the stand-in really did displace something').toBe(BigInt(BUN_VADDR));
     });
 
-    // A repack that silently did not use the stand-in would leave Bun pointed at a blob that is no
-    // longer there — a claude that dies before it prints anything. Refuse instead of publishing.
+    // A repack that silently did not use the stand-in means the address clodex is about to copy
+    // over the real global was never written. Refuse instead of publishing a guess.
     it('refuses when the repack never rewrote the stand-in', () => {
       const shim = shimBunCompiledPointer(file)!;
 
@@ -248,6 +286,47 @@ describe('the Bun blob pointer stand-in', () => {
 
     expect(() => shimBunCompiledPointer(file))
       .toThrow("cannot locate Bun's blob pointer: 2 candidates");
+  });
+
+  // The "exactly one candidate" rule has to govern the NO-OP path too, and for a while it did not:
+  // the module ran tweakcc's scan first and returned null the moment it found anything. So a build
+  // carrying a coincidental copy of `.bun`'s address at an address the scan visits made clodex
+  // stand aside while the repack rewrote that copy — eight bytes of live `.data`/`.tdata` that
+  // nothing then restores — and `clodex patch` reported success. Both shapes below took that path.
+  //
+  // No shipped build reaches either (every occurrence on the four 2.1.257 ELF builds is unaligned,
+  // and on 2.1.252 the single aligned hit IS the global), which is exactly why it needs a test:
+  // there is no real binary that would notice the regression.
+  describe('when tweakcc would settle on something that is not the real pointer', () => {
+    it('refuses when the aligned decoy is inside the blob, where the census cannot see it', () => {
+      // Inside `.bun`, so the census excludes it by range and still finds exactly one candidate —
+      // and on a 16 KiB boundary, so tweakcc's scan stops there instead. This is the realistic
+      // shape: the coincidental copies a real build carries live in the compressed payload.
+      const decoy = Math.ceil(BUN_VADDR / STRIDE) * STRIDE;
+      expect(decoy, 'decoy must be inside the blob').toBeLessThan(BUN_VADDR + BUN_SIZE);
+      const pointer = FIRST_SCANNED + 0x758;
+      writeFileSync(file, buildElf(pointer, [decoy]));
+
+      expect(tweakccScan(file, BigInt(BUN_VADDR)), 'tweakcc must land on the decoy, or this proves nothing')
+        .toBe(decoy);
+
+      const before = readFileSync(file);
+      expect(() => shimBunCompiledPointer(file)).toThrow(
+        `tweakcc's ELF repack would rewrite 0x${decoy.toString(16)}, which is not Bun's blob pointer `
+        + `at 0x${pointer.toString(16)}`,
+      );
+      expect(readFileSync(file).equals(before), 'a refusal must not have written anything').toBe(true);
+    });
+
+    it('refuses when the aligned decoy is outside the blob, as a second candidate', () => {
+      // Same failure, caught one check earlier: two candidates outside the payload is ambiguous
+      // before tweakcc's preference between them matters.
+      writeFileSync(file, buildElf(FIRST_SCANNED + 0x758, [FIRST_SCANNED]));
+
+      expect(tweakccScan(file, BigInt(BUN_VADDR))).toBe(FIRST_SCANNED);
+      expect(() => shimBunCompiledPointer(file))
+        .toThrow("cannot locate Bun's blob pointer: 2 candidates");
+    });
   });
 
   // The remaining refusal: nowhere the scan visits is usable, because the blob covers every one of
@@ -308,6 +387,56 @@ describe('the Bun blob pointer stand-in', () => {
 
   // PN_XNUM says the real program-header count lives in the section table. Reading 0xffff headers
   // of arbitrary file bytes as segments is how a stand-in gets planted at a garbage offset.
+  // Every length below is read out of the file's own header, so the reads are sized against the
+  // file before allocating. Each fixture is the shape that makes ONE of the three call sites throw
+  // a raw RangeError without its guard — verified by deleting that guard alone. The distinction
+  // matters: `e_shoff` and `e_shnum * e_shentsize` both land on the section-table read, so they
+  // cannot stand in for the program-header one.
+  describe('refuses a header that claims more than the file holds', () => {
+    // `Buffer.alloc(0xfffe * 0xffff)` is ~4.3 GB, the shape the code comment cites. Unguarded this
+    // is `RangeError: The value of "length" is out of range ... Received -196606` — readSync
+    // coerces the length to int32.
+    it('when the section table would run past the end', () => {
+      const buf = buildElf(FIRST_SCANNED + 0x758);
+      buf.writeUInt16LE(0xfffe, 0x3c); // e_shnum
+      buf.writeUInt16LE(0xffff, 0x3a); // e_shentsize
+      writeFileSync(file, buf);
+
+      expect(shimBunCompiledPointer(file)).toBeNull();
+    });
+
+    // The other half of `fits`: a position past 2^53 converts to a double that cannot address a
+    // byte. Unguarded, `RangeError: The value of "position" is out of range`.
+    it('when a table offset is not a safe integer', () => {
+      const buf = buildElf(FIRST_SCANNED + 0x758);
+      buf.writeBigUInt64LE(BigInt(Number.MAX_SAFE_INTEGER) + 8n, 0x28); // e_shoff
+      writeFileSync(file, buf);
+
+      expect(shimBunCompiledPointer(file)).toBeNull();
+    });
+
+    // The program-header read has its own guard and its own fixture; neither of the two above
+    // reaches it, because both are refused at the section table first.
+    it('when the program-header table would run past the end', () => {
+      const buf = buildElf(FIRST_SCANNED + 0x758);
+      buf.writeBigUInt64LE(BigInt(Number.MAX_SAFE_INTEGER) + 8n, 0x20); // e_phoff
+      writeFileSync(file, buf);
+
+      expect(shimBunCompiledPointer(file)).toBeNull();
+    });
+
+    // 2^53 exactly, NOT 2^40: unguarded, a 1 TB `Buffer.alloc` succeeds lazily and the function
+    // still returns null, so a smaller fixture would pass with the guard deleted and prove nothing.
+    it('when the section-name table claims an impossible size', () => {
+      const buf = buildElf(FIRST_SCANNED + 0x758);
+      const shoff = SEG_OFFSET + SEG_SIZE;
+      buf.writeBigUInt64LE(2n ** 53n, shoff + 1 * 64 + 32); // .shstrtab sh_size
+      writeFileSync(file, buf);
+
+      expect(shimBunCompiledPointer(file)).toBeNull();
+    });
+  });
+
   it('leaves an ELF alone when its program-header count is PN_XNUM', () => {
     // Big enough that 0xffff * 56 bytes of "program headers" can actually be read out of it —
     // otherwise the short read rejects the file anyway and this passes without testing the guard.
@@ -320,6 +449,108 @@ describe('the Bun blob pointer stand-in', () => {
 
     expect(shimBunCompiledPointer(file)).toBeNull();
     expect(readFileSync(file).equals(before)).toBe(true);
+  });
+
+  // The restore advertises that both of its writes are read back before it reports success. The
+  // production path cannot make a write fail, so these drive `restoreBunCompiledPointer` with a
+  // hand-built shim — the only way to reach either branch. Without them both `if (!readAt(...))`
+  // blocks can be deleted with the whole file green, and `bun-compiled-pointer.ts` is not covered
+  // by the transform source digest either, so nothing at all would notice.
+  describe('the restore refuses when a write did not land', () => {
+    const POINTER = FIRST_SCANNED + 0x758;
+    const NEW_BUN_VADDR = 0x900000;
+
+    it('refuses when the blob pointer does not read back', () => {
+      writeFileSync(file, buildElf(POINTER));
+      const shim = shimBunCompiledPointer(file)!;
+      simulateRepack(file, Number(shim.standInVaddr), NEW_BUN_VADDR);
+
+      // Drop only the write to the real global. Everything else — the shim, the repack, the
+      // displaced-bytes write — is exactly what production does.
+      droppedWrite.atPosition = SEG_OFFSET + (POINTER - SEG_VADDR);
+
+      expect(() => restoreBunCompiledPointer(file, shim))
+        .toThrow("Bun's blob pointer did not take the repacked address");
+    });
+
+    // `readAt` returns a SHORT buffer instead of throwing, and the stand-in readback is the one
+    // consumer that indexes into it. Unguarded it raises `RangeError: Attempt to access memory
+    // outside buffer bounds`, which names neither the binary nor the check.
+    it('names the binary when the repacked file ends before the stand-in', () => {
+      writeFileSync(file, buildElf(POINTER));
+      const shim = shimBunCompiledPointer(file)!;
+      simulateRepack(file, Number(shim.standInVaddr), NEW_BUN_VADDR);
+
+      // Only NOW inflate `p_filesz`, so the census above ran against a sane file: the segment
+      // claims bytes the file does not have, which is what a truncated binary looks like.
+      const poked = readFileSync(file);
+      poked.writeBigUInt64LE(BigInt(SEG_SIZE + 0x10000), 0x60);
+      writeFileSync(file, poked);
+
+      const beyond = BigInt(SEG_VADDR + SEG_SIZE + 0x8000);
+      expect(() => restoreBunCompiledPointer(file, { ...shim, standInVaddr: beyond }))
+        .toThrow("the repacked binary ends before the stand-in for Bun's blob pointer");
+    });
+
+    it('refuses when the displaced bytes do not read back', () => {
+      writeFileSync(file, buildElf(POINTER));
+      const shim = shimBunCompiledPointer(file)!;
+      simulateRepack(file, Number(shim.standInVaddr), NEW_BUN_VADDR);
+
+      // Drop only the write that puts the borrowed bytes back. The pointer write lands, so this
+      // cannot pass by tripping the first guard instead.
+      droppedWrite.atPosition = SEG_OFFSET + (Number(shim.standInVaddr) - SEG_VADDR);
+
+      expect(() => restoreBunCompiledPointer(file, shim))
+        .toThrow('the bytes the stand-in displaced were not restored');
+    });
+  });
+
+  // Three details that are pure MIRROR FIDELITY: they make no difference on any build published so
+  // far, so nothing real would notice them drifting away from what tweakcc actually does. Drifting
+  // away from what tweakcc actually does is the whole reason `clodex patch` broke on 2.1.257, which
+  // is why they are pinned here rather than left to a comment.
+  describe('mirrors tweakcc exactly, in ways no shipped build exercises', () => {
+    it('scans the FIRST writable PT_LOAD, as tweakcc does', () => {
+      // A later writable segment carrying no occurrence of the address. tweakcc takes the first
+      // one; taking the last would sweep an empty range and refuse with "0 candidates".
+      const pointer = FIRST_SCANNED + 0x758;
+      writeFileSync(file, buildElf(pointer, [], undefined, { trailingWritableSegment: true }));
+
+      const shim = shimBunCompiledPointer(file);
+
+      expect(shim).not.toBeNull();
+      expect(shim!.pointerVaddr).toBe(BigInt(pointer));
+    });
+
+    it('visits the last address tweakcc visits, not one short of it', () => {
+      // tweakcc's loop is `for (e = m; e <= h; e += 16384)` with `h = vaddr + len - 8`. Sized so
+      // that `h` lands exactly ON the stride, which is the only geometry where `<` and `<=`
+      // disagree — and where `<` would make clodex plant a stand-in tweakcc did not need.
+      const segSize = 0x21b78;
+      const last = SEG_VADDR + segSize - 8;
+      expect(last % STRIDE, 'the fixture must put the final slot exactly on the stride').toBe(0);
+      expect(last, 'the final slot must be outside .bun').toBeGreaterThan(BUN_VADDR + BUN_SIZE);
+
+      writeFileSync(file, buildElf(last, [], undefined, { segSize }));
+      const before = readFileSync(file);
+
+      expect(shimBunCompiledPointer(file), 'tweakcc can reach this one unaided').toBeNull();
+      expect(readFileSync(file).equals(before)).toBe(true);
+    });
+
+    it('does not borrow a slot that overlaps the real pointer', () => {
+      // The global 4 bytes past a boundary: the first slot the stand-in would pick overlaps it, so
+      // planting there would corrupt the very address the restore then reads.
+      const pointer = FIRST_SCANNED + 4;
+      writeFileSync(file, buildElf(pointer));
+
+      const shim = shimBunCompiledPointer(file)!;
+
+      expect(shim.standInVaddr).not.toBe(BigInt(FIRST_SCANNED));
+      expect(shim.standInVaddr).toBe(BigInt(FIRST_SCANNED + STRIDE));
+      expect(read8(file, pointer), 'the real pointer must survive planting').toBe(BigInt(BUN_VADDR));
+    });
   });
 
   it('ignores candidates inside the blob itself', () => {

--- a/tests/patcher.test.ts
+++ b/tests/patcher.test.ts
@@ -589,7 +589,7 @@ describe('PATCH_TRANSFORMS_VERSION', () => {
     const digest = createHash('sha256').update(source).digest('hex');
     expect({ version: PATCH_TRANSFORMS_VERSION, digest }).toEqual({
       version: 11,
-      digest: 'de2d7eed932eccae7f6a59b4334c95f15ea580e540f41e166efb2120a2b9556e',
+      digest: '347109442fbf14a785671325aad7e1ac120be496019d832c013f3dab502f7036',
     });
   });
 });
@@ -2004,8 +2004,11 @@ describe('patch script identity naming', () => {
     expect(source, 'the neighbour must not be introduced by `function`, or the anchor guard hides the case')
       .toContain('};var zzNext=()=>{');
 
+    // Pin the DIRECTION, not just the refusal. Overrunning and truncating are
+    // different bugs with different fixes, and the message is the only place a
+    // canary report says which one happened.
     expect(() => runPatchScript(config, source)).toThrow(
-      'clodex patch: child network environment target validation failed',
+      /target validation failed: match ends \d+ characters after the end of the function it started in/,
     );
   });
 
@@ -2073,8 +2076,10 @@ describe('patch script identity naming', () => {
     );
     expect([...truncated].reduce((d, c) => d + (c === '{' ? 1 : c === '}' ? -1 : 0), 0)).toBe(0);
 
+    // The mirror of the overrun case above: this one stops SHORT, and the message
+    // has to say so.
     expect(() => runPatchScript(config, source)).toThrow(
-      'clodex patch: child network environment target validation failed',
+      /target validation failed: match ends \d+ characters before the end of the function it started in/,
     );
   });
 
@@ -2175,9 +2180,14 @@ describe('patch script identity naming', () => {
     expect(result.content).toContain('function childEnv(){/*ccpatch:child-network-env*/');
   });
 
-  // The floor still has to mean something: a body that scrubs none of them is not
+  // The floor still has to mean something: a body that spells none of them is not
   // the child-env builder and must be refused, not rewritten.
-  it('refuses a child builder that scrubs none of the known names', () => {
+  //
+  // "spells", not "scrubs": the check is a substring test over the matched body,
+  // so a builder that scrubs the same names through a table declared elsewhere
+  // reads as zero here. Saying "scrubs" sent the next reader looking for deletion
+  // logic the check never inspects.
+  it('refuses a child builder that spells none of the known names', () => {
     const source = withoutScrubbedNames(CLAUDE_FIXTURE_239, SCRUBBED_ENV_NAMES);
 
     expect(source, 'fixture drifted from the shape this test mutates').not.toBe(CLAUDE_FIXTURE_239);
@@ -2185,7 +2195,7 @@ describe('patch script identity naming', () => {
 
     expect(() => runPatchScript(config, source)).toThrow(
       'clodex patch: child network environment target validation failed: '
-      + 'body scrubs only 0 of the 5 known child-env names (expected at least 1)',
+      + 'body spells only 0 of the 5 known child-env names (expected at least 1)',
     );
   });
 


### PR DESCRIPTION
Closes #163 — the follow-ups the adversarial review of #159 produced. Nothing here changes what happens on any Claude Code build that ships today; it closes a hole that only a future one could walk into, corrects a rationale that turned out to be false, and makes the refusal messages describe the checks they actually perform.

## 1. The "exactly one candidate" rule now governs both paths

`src/bun-compiled-pointer.ts` ran `tweakccWouldFind` **before** the candidate census, so the rule the file states — the one 8-byte occurrence of `.bun`'s address inside the writable segment and outside its payload, anything else refused — only held when the stand-in engaged. If tweakcc's 16 KiB-strided scan landed on any coincidental copy of that address, clodex stood aside, the repack rewrote the coincidence, and `clodex patch` reported success. The census runs first now and the no-op defers to it.

**Unreachable on every shipped build, measured.** On all four 2.1.257 ELF builds every occurrence is unaligned (offsets within the stride: 14168, 12040, 1880, 11536); on 2.1.252 the single aligned hit *is* the global, which is why standing aside was right there. The ordering is what keeps that a measured fact rather than an assumption.

**Cost**, since this sweeps ~130 MB on releases tweakcc handles unaided — 12 alternating warm trials on pristine 2.1.252 linux-x64: median **0.142 ms → 90.9 ms**. About 1.6% of a patch run that already spends 3.45 s in the repack and 5.56 s in total.

## 2. A rationale this repo had wrong in six places

The module comments and `patcher.md` justified that refusal by saying a stale Bun global means a `claude` that will not start. It does not. Single-variable disproof, run under both libcs: take the correctly-published binary, change **only** the eight bytes at the global back to the pre-repack `.bun` address, and it still starts.

```
linux-x64      global 0x10000000 -> 0x5541000   debian:bookworm-slim  2.1.257 (Claude Code)
linux-x64-musl global 0x10000000 -> 0x4f8c000   alpine:3              2.1.257 (Claude Code)
```

Bun locates the blob another way — the end-of-file trailer `bun-bundle.ts` already documents. The real cost of a wrong answer is eight bytes of **live data** rewritten and never restored: the stand-in slot lands in `.data` on the glibc builds and in `.tdata`, the TLS initialisation image, on the musl ones. That is a stronger argument than the one the comments gave, and it is now the one they give. `"dozens on some builds"` is corrected to the measured 0, 0, 5 and 3.

## 3. PATCH 10 diagnostics that described the wrong check

- `scrubbedSeen` counts substring **spellings**, so a builder that scrubs every name through a table declared elsewhere scores zero. `body scrubs only N` sent readers looking for deletion logic the check never inspects — it now says `spells`.
- An overrun read `match ends -49 characters from the function it started in`, hiding the direction behind a sign. Stopping short and running past are different bugs with different fixes; the message now names **before** or **after**.
- The comment's "takes four independent upstream refactors rather than one" was unsupported — extracting the remaining literals into one shared table is a single ordinary refactor, and is what 2.1.257 already did to one of the five. Dropped.

## 4. Tests

Every behaviour above is pinned, plus the four #163 found unpinned: both readback guards in the restore, `writableLoad` taking the first writable `PT_LOAD`, the `<=` bound mirroring tweakcc's final slot, and the stand-in/pointer overlap guard. Each reddens exactly one behavioural test under mutation; none is digest-only.

The two readback tests **fault the write** — `writeSync` reports success for one position and writes nothing — around an ordinary shim and an ordinary repack. They previously handed the restore an impossible shim, which the review showed was a weak oracle: replacing either readback with a predicate over the impossible field left the file green. Both of those mutants now redden, and plain deletion is still caught.

## 5. Header-derived reads bounded

The three table reads are sized against the file before allocating — `e_shnum * e_shentsize` alone reaches ~4.3 GB from a file carrying nothing but the ELF magic. Each bound has its own fixture, because two of the obvious three land on the same call site and would leave the program-header guard untested. The one `readAt` consumer that indexed into a short buffer names the binary now instead of raising a bare `RangeError`.

**Deliberately not done:** `p_offset` and `p_filesz` are still trusted, so a corrupt segment header can still produce a slow refusal or a raw `RangeError`. Unchanged from 2.8.4, reachable only from a corrupt binary, and a refusal either way.

`PATCH_TRANSFORMS_VERSION` stays **11**: no anchor moved and no emitted byte changed, so installs patched by 2.8.4 remain current and are not forced to re-patch.

## Verification

- `pnpm typecheck` clean, `pnpm test` **2033 passed (104 files)**, `pnpm build` green, under an isolated `CLODEX_HOME` and an unreachable `HTTPS_PROXY`.
- `scripts/probe-patch-mechanism.mjs` **PASS on all eight pristine 2.1.257 builds and both 2.1.252 ELF builds** (16–18 checks each). The 2.1.252 legs are the ones that matter here — they are what exercises the newly-validated no-op on a real 300 MB binary.
- Shim output byte-identical to 2.8.4 on every real build; still a strict no-op on 2.1.252 x64 and arm64.
- Three independent review agents reproduced the probe matrix; one also confirmed via an independent ELF census that the new cross-check compares like with like (2.1.252 x64 file offset `0x511c000` → vaddr `0x531c000`, arm64 `0x50c0000` → `0x52e0000`, both agreeing with tweakcc).
- Re-patching cannot reach the new throw from `clodex patch`: `current` returns before `applyPatch`, `reuse`/`restore` seed from the pristine backup, `snapshot` keeps live bytes only when marker-free, `--restore` copies directly. An externally repacked marker-free binary can reach `snapshot`, and failing closed there is the intent — the old ordering would have rewritten an unidentified live word instead.

## Not verified

No `claude -p` round trip through a provider. Windows PE and darwin-x64 remain bytes-only. The change was reviewed by a three-lens adversarial panel before the first push; the fixes it required were made after that panel reported, and I mutation-verified the delta myself — including re-running the exact oracle mutants the review used — rather than convening a second panel.