### PR TITLE
feat(timeouts): let you raise the 10-minute limit so long agent runs can finish

### DIFF
--- a/.claude/docs/claude-code-internals.md
+++ b/.claude/docs/claude-code-internals.md
@@ -258,6 +258,20 @@ Background pty hosts are started `detached: true` and resized via
 `process.kill(-process.pid, 'SIGWINCH')` to the process group — which is why the wrapper must `exec`
 rather than spawn.
 
+## Client-side stream deadlines (verified against 2.1.259)
+
+Claude Code applies its own deadlines independently of any server-side clodex timeout. Before
+response headers, proxy-mode requests default to the smaller of roughly 180s plus 1s per 32 KiB of
+request body and the Anthropic SDK's roughly 599s deadline. A foreign `ANTHROPIC_BASE_URL` does not
+use that custom first-byte watchdog, but the SDK still defaults to 600s.
+
+After headers, the byte-idle fallback is 180s for the first-party URL used in proxy mode and 300s
+for a foreign base URL used in endpoint mode. `CLAUDE_BYTE_STREAM_IDLE_TIMEOUT_MS` and
+`CLAUDE_STREAM_FIRST_BYTE_TIMEOUT_MS` are bounded to 10s–30m. The separate event watchdog defaults
+to 300s and `CLAUDE_STREAM_IDLE_TIMEOUT_MS` can raise it beyond 30m, but the byte watchdog remains
+the effective ceiling unless `CLAUDE_ENABLE_BYTE_WATCHDOG=false`. `API_TIMEOUT_MS` controls the SDK
+request deadline. Raising a clodex server timeout alone never raises any of these client limits.
+
 ## Things that looked like clodex bugs and were not (not version-specific)
 
 - **"Concurrent subagents died at turn 2" was not unknown-model classification.** The agents' first

--- a/.claude/docs/launch-and-wrapper.md
+++ b/.claude/docs/launch-and-wrapper.md
@@ -94,6 +94,11 @@ doc: `docs/background-agents.md` (shipped via the `docs` entry in package.json `
   `ANTHROPIC_BASE_URL`/`ANTHROPIC_API_KEY`/`ANTHROPIC_MODEL` **for the child only**. Claude Code may
   persist the model to `~/.claude/settings.json` itself; that is outside clodex's control (reset
   with `claude --model sonnet`).
+- `CLODEX_UPSTREAM_IDLE_TIMEOUT_MS` and `CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS` are resolved by the
+  process serving provider requests. `clodex claude` owns that server in-process. With a standalone
+  `clodex server`, restart that server with the variables set; putting them only on a
+  `clodex-claude` wrapper cannot reconfigure it. Request-time notices are immediate on standalone
+  server stderr, while `clodex claude` queues them as described below.
 
 ## Parent diagnostics while Claude Code runs
 

--- a/.claude/docs/oauth-continuation.md
+++ b/.claude/docs/oauth-continuation.md
@@ -30,24 +30,30 @@ is too small.
 ### Upstream timeouts and retries
 
 Every AI SDK generation entry point, for both Anthropic- and OpenAI-format routes, resolves one
-budget through `src/upstream-retry.ts`. `streamText` consumers enforce the idle and total deadlines;
-true `generateText` consumers enforce only the total because they expose no stream event that could
-reset an idle clock. The idle default is 120s (range 10s–1h), and the total default is 10m (range
-1m–6h). Each provider call gets a fresh total timer, including a new call after an OAuth 401 refresh;
-it is not an end-to-end route deadline. An explicit total wins when the pair conflicts, lowering the
-idle value; when only an idle value exceeds the default total, the total rises to match. Malformed
-values fall back safely, out-of-range values clamp, and each problem emits one parent-terminal
-notice. Raw Anthropic passthrough is not an SDK generation and receives neither timeout.
+budget through `src/upstream-retry.ts`. `streamText` consumers abort their SDK controller at the idle
+and total deadlines; true `generateText` consumers abort at the total deadline only because they
+expose no stream event that could reset an idle clock. Cancellation is cooperative, so a provider
+transport that ignores the signal can settle later. The idle default is 120s (range 10s–1h), and the
+total default is 10m (range 1m–6h). Each provider call gets a fresh total timer, including a new call
+after an OAuth 401 refresh; it is not an end-to-end route deadline. An explicit total wins when the
+pair conflicts, lowering the idle value; when only an idle value exceeds the default total, the total
+rises to match. Malformed values fall back safely, out-of-range values clamp, and each problem emits
+one parent-terminal notice. Raw relays are not SDK generations and receive neither timeout.
 
-SDK generation entry points also resolve `CLODEX_UPSTREAM_MAX_RETRIES` through that budget. Unset or
-malformed values leave the SDK's two-retry default in control; valid non-negative integers are
-bounded using the resolved idle timeout. The default timeout yields a ceiling of five and the
-configured range permits at most ten, estimated from the SDK's fallback exponential backoff.
-Provider-supplied retry hints and failed-attempt time can mean fewer retries begin before a streaming
-idle deadline; that stream's shared abort signal enforces the actual deadline. Raw Anthropic
-passthrough shares the retry setting but retains its independent ceiling of five. **This policy can
-recover only before output begins**; replay after partial output could duplicate content or tool
-calls.
+SDK generation entry points retry transient provider failures up to five times by default and resolve
+`CLODEX_UPSTREAM_MAX_RETRIES` through the same budget. Valid non-negative integers override the
+default; unset or malformed values preserve it. The default and ceiling fall with a shorter idle
+timeout. At the default timeout the ceiling is five, and the configured range permits at most ten,
+estimated from the SDK's fallback exponential backoff. Five retries can add roughly 62s of fallback
+backoff on a dead provider, versus roughly 6s for the SDK's former two-retry default. Provider retry
+hints and failed-attempt time can mean fewer retries begin before a streaming idle deadline; the
+stream's shared signal requests cancellation when that deadline expires. A deadline during retry
+backoff preserves the provider failure that prompted the retry, while a deadline during a silent
+active provider call remains a timeout. Proxy mode's raw HTTP MITM path shares the retry setting but
+retains its independent ceiling of five and one-retry default; other direct raw relays add no
+transport-failure replay, although an OAuth 401 refresh can still start a new authenticated call.
+**This policy can recover only while no model output has been exposed downstream**; replay after
+partial output could duplicate content or tool calls.
 
 ### Mismatch diagnostics
 

--- a/.claude/docs/oauth-continuation.md
+++ b/.claude/docs/oauth-continuation.md
@@ -27,14 +27,25 @@ explicit programmatic option outranks the environment so tests are never perturb
 `evictions` array on every `ws_head_decision` diagnostic — sustained `*_lru_cap` counts mean a cap
 is too small.
 
-### Upstream retries
+### Upstream timeouts and retries
 
-Every SDK generation entry point resolves `CLODEX_UPSTREAM_MAX_RETRIES` through
-`src/upstream-retry.ts`. Unset or malformed values leave the SDK's two-retry default in control;
-valid integers are bounded to 0–5. Five retries complete before the translated streaming paths'
-120-second no-data timeout; larger integers clamp to 5 with a one-time stderr warning. That idle
-deadline — not the separate ten-minute total timeout — is the effective retry ceiling. Keep
-translated and OpenAI-format streaming and non-streaming consumers wired together. **This policy can
+Every AI SDK generation entry point, for both Anthropic- and OpenAI-format routes, resolves one
+budget through `src/upstream-retry.ts`. `streamText` consumers enforce the idle and total deadlines;
+true `generateText` consumers enforce only the total because they expose no stream event that could
+reset an idle clock. The idle default is 120s (range 10s–1h), and the total default is 10m (range
+1m–6h). Each provider call gets a fresh total timer, including a new call after an OAuth 401 refresh;
+it is not an end-to-end route deadline. An explicit total wins when the pair conflicts, lowering the
+idle value; when only an idle value exceeds the default total, the total rises to match. Malformed
+values fall back safely, out-of-range values clamp, and each problem emits one parent-terminal
+notice. Raw Anthropic passthrough is not an SDK generation and receives neither timeout.
+
+SDK generation entry points also resolve `CLODEX_UPSTREAM_MAX_RETRIES` through that budget. Unset or
+malformed values leave the SDK's two-retry default in control; valid non-negative integers are
+bounded using the resolved idle timeout. The default timeout yields a ceiling of five and the
+configured range permits at most ten, estimated from the SDK's fallback exponential backoff.
+Provider-supplied retry hints and failed-attempt time can mean fewer retries begin before a streaming
+idle deadline; that stream's shared abort signal enforces the actual deadline. Raw Anthropic
+passthrough shares the retry setting but retains its independent ceiling of five. **This policy can
 recover only before output begins**; replay after partial output could duplicate content or tool
 calls.
 

--- a/.claude/docs/translation.md
+++ b/.claude/docs/translation.md
@@ -22,7 +22,10 @@ hand-rolled per-provider translation. Preserved hard-won behavior:
   tokenizes at ~1.5 chars/token — 200k+ tokens per screenshot, killing agents with "Prompt is too
   long" while the local bytes/4 estimate showed half the real count.
   `estimateAnthropicInputTokens` likewise counts each image block at a flat vision estimate.
-- `streamAnthropicResponse` maps SDK events to Anthropic SSE, aborting after 120s without an event.
+- Anthropic- and OpenAI-format `streamText` calls abort after the configured idle window without an
+  event (120s by default) or the configured total provider-call window (10m by default). True
+  `generateText` calls enforce only the total window because they expose no event that can reset an
+  idle clock.
 - `modelPrefersResponsesApi()` selects `provider.responses(id)` for models requiring the Responses
   API (GPT-5.4+, GPT-5.5, `*-codex`, o-series); `provider.chat(id)` otherwise. Originator string is
   `clodex`.

--- a/.claude/harnesses/pr82-idle-abort-vs-retry-budget.harness.ts
+++ b/.claude/harnesses/pr82-idle-abort-vs-retry-budget.harness.ts
@@ -17,7 +17,7 @@ describe('PR82: idle abort vs SDK retry budget', () => {
       '@ai-sdk/provider-utils'
     ) as any;
 
-    const IDLE_MS = 120_000; // SDK_STREAM_IDLE_TIMEOUT_MS in src/sdk-adapter.ts
+    const IDLE_MS = 120_000; // DEFAULT_UPSTREAM_IDLE_TIMEOUT_MS in src/upstream-retry.ts
     const controller = new AbortController();
     // Armed BEFORE streamText, exactly as src/sdk-adapter.ts:866 does, and
     // never reset because a failing attempt yields no stream part.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,9 +172,10 @@ These bite from outside the subsystem that owns them, so they live here rather t
   "remove the unused dependency" cleanup breaks fresh installs. Reason in
   `.claude/docs/patcher.md`.
 - **Every AI SDK generation entry point must resolve its timeout and retry budget through
-  `src/upstream-retry.ts`.** Anthropic- and OpenAI-format `streamText` consumers enforce idle and
-  total deadlines; `generateText` consumers enforce total only. Raw Anthropic passthrough is not an
-  SDK generation and uses no shared timeout. Details in `.claude/docs/oauth-continuation.md`.
+  `src/upstream-retry.ts`.** Anthropic- and OpenAI-format `streamText` consumers abort at idle and
+  total deadlines; `generateText` consumers abort at total only. Cancellation remains cooperative
+  with the provider transport. Raw relays are not SDK generations and use no shared timeout. Details
+  in `.claude/docs/oauth-continuation.md`.
 
 ## Tests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,10 +171,10 @@ These bite from outside the subsystem that owns them, so they live here rather t
 - **`node-gyp-build` is a deliberate direct dependency that no clodex source imports.** Routine
   "remove the unused dependency" cleanup breaks fresh installs. Reason in
   `.claude/docs/patcher.md`.
-- **Every SDK generation entry point must resolve `CLODEX_UPSTREAM_MAX_RETRIES` through
-  `src/upstream-retry.ts`.** Adding a new streaming or non-streaming path without wiring it leaves
-  that path on a different retry policy than the rest. Details in
-  `.claude/docs/oauth-continuation.md`.
+- **Every AI SDK generation entry point must resolve its timeout and retry budget through
+  `src/upstream-retry.ts`.** Anthropic- and OpenAI-format `streamText` consumers enforce idle and
+  total deadlines; `generateText` consumers enforce total only. Raw Anthropic passthrough is not an
+  SDK generation and uses no shared timeout. Details in `.claude/docs/oauth-continuation.md`.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -339,22 +339,51 @@ clodex --version    # version
   SDK reports that it omitted the tier for a model, clodex warns once and the
   backend default remains in use.
 - **Outbound proxy:** when `HTTP_PROXY`/`HTTPS_PROXY` (and optionally `NO_PROXY`) are set in clodex's environment, all clodex-originated network calls honor them — OAuth sign-in and token refresh, model-list and models.dev refreshes, upstream OpenAI API calls, and the ChatGPT/Codex OAuth WebSocket transport (tunneled via HTTP CONNECT).
-- **Upstream retries:** set `CLODEX_UPSTREAM_MAX_RETRIES` to an integer from
-  `0` through `5` to override the SDK's default of two retries for retryable
-  provider failures. `0` disables retries. The SDK honors valid
-  `retry-after`/`retry-after-ms` headers and otherwise uses exponential
-  backoff. Larger integers clamp to `5` with a one-time warning because a sixth
-  retry cannot complete before the translated streaming paths' 120-second
-  no-data timeout. Unset, empty, or malformed values preserve the default. A
-  stream that fails after output begins cannot be replayed safely and still
-  terminates the request. The same setting covers requests passed straight
-  through to Anthropic, which replay once by default. Only a request that went
-  out on a pooled connection the far end had already closed, and that received
-  no part of a response, is replayed there; anything else is reported as it
-  happens. Setting Claude Code's own `CLAUDE_CODE_MAX_RETRIES=0` also disables
-  the passthrough replay, so telling the client never to resend a request is
-  not quietly undone one layer down. Recovered requests appear in the inference
-  log as `response_retried`.
+- **Provider timeouts:** `CLODEX_UPSTREAM_IDLE_TIMEOUT_MS` controls how long an
+  SDK-backed translated stream may produce no event (default `120000`; range
+  `10000`–`3600000` ms). `CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS` limits each call
+  clodex makes to a configured provider, including non-streaming calls (default
+  `600000`; range `60000`–`21600000` ms). An authentication refresh can start a
+  new call with a fresh timer, so this is not an end-to-end route deadline. Set
+  both variables on the process serving the request: the embedded server
+  started by `clodex claude`, or a standalone `clodex server`. `clodex-claude`
+  only connects to an existing server, so setting them on that wrapper does not
+  reconfigure the server. Empty values use the defaults, malformed values are
+  ignored, and integers outside the supported ranges clamp to the nearest
+  bound. Clodex warns once for each malformed, clamped, or inconsistent setting
+  when a request first resolves it; `clodex claude` displays that parent notice
+  after Claude Code exits. The total timeout can never be shorter than the idle
+  timeout: increasing only the idle timeout raises the default total to match,
+  while an explicit shorter total lowers the idle timeout. The 10s/1m floors
+  avoid near-immediate termination; the 1h/6h ceilings allow deliberately long
+  calls without leaving stalls attached indefinitely. These are server-side
+  limits, and callers may stop sooner. Claude Code currently defaults to about
+  180s of downstream byte silence in proxy mode and 300s in endpoint mode, with
+  a 30m byte-watchdog ceiling. In Claude Code's environment, `API_TIMEOUT_MS`
+  controls the pre-header deadline; `CLAUDE_STREAM_IDLE_TIMEOUT_MS` and
+  `CLAUDE_BYTE_STREAM_IDLE_TIMEOUT_MS` control stream silence. Waits beyond 30m
+  also require `CLAUDE_ENABLE_BYTE_WATCHDOG=false`. With a standalone server,
+  set those client variables on the Claude Code process, not the server.
+- **Upstream retries:** set `CLODEX_UPSTREAM_MAX_RETRIES` to a non-negative
+  integer to override the SDK's default of two retries for retryable provider
+  failures. `0` disables retries. Clodex estimates the configuration ceiling
+  from the resolved idle timeout and the SDK's fallback 2s, 4s, 8s, … backoff:
+  the ceiling is `5` at the default timeout and can rise to `10` at the maximum.
+  Larger integers clamp with a one-time warning that names the active idle
+  timeout. Provider `retry-after` hints and time spent in failed attempts can
+  mean fewer retries start before a streaming idle deadline; the shared abort
+  signal still interrupts backoff when that deadline fires. Unset, empty, or
+  malformed values preserve the SDK default. A stream that fails after output
+  begins cannot be replayed safely and still terminates the request. The same
+  retry setting covers requests passed straight through to Anthropic, which
+  replay once by default and retain an independent ceiling of `5`; the timeout
+  settings neither add timers nor change retry limits on that raw relay. Only a
+  request sent on a pooled connection the far end had already closed, with no
+  response received, is replayed there;
+  anything else is reported as it happens. Setting Claude Code's own
+  `CLAUDE_CODE_MAX_RETRIES=0` also disables the passthrough replay, so telling
+  the client never to resend a request is not quietly undone one layer down.
+  Recovered requests appear in the inference log as `response_retried`.
 
 ## Known limitations
 

--- a/README.md
+++ b/README.md
@@ -356,33 +356,47 @@ clodex --version    # version
   timeout: increasing only the idle timeout raises the default total to match,
   while an explicit shorter total lowers the idle timeout. The 10s/1m floors
   avoid near-immediate termination; the 1h/6h ceilings allow deliberately long
-  calls without leaving stalls attached indefinitely. These are server-side
-  limits, and callers may stop sooner. Claude Code currently defaults to about
-  180s of downstream byte silence in proxy mode and 300s in endpoint mode, with
+  calls without leaving stalls attached indefinitely. At either deadline,
+  clodex aborts the SDK call; cancellation is cooperative, so a provider
+  transport that ignores the abort signal can settle later. These are
+  server-side limits, and callers may stop sooner. Claude Code currently
+  defaults to about 180s of downstream byte silence in proxy mode and 300s in
+  endpoint mode, with
   a 30m byte-watchdog ceiling. In Claude Code's environment, `API_TIMEOUT_MS`
   controls the pre-header deadline; `CLAUDE_STREAM_IDLE_TIMEOUT_MS` and
   `CLAUDE_BYTE_STREAM_IDLE_TIMEOUT_MS` control stream silence. Waits beyond 30m
   also require `CLAUDE_ENABLE_BYTE_WATCHDOG=false`. With a standalone server,
   set those client variables on the Claude Code process, not the server.
-- **Upstream retries:** set `CLODEX_UPSTREAM_MAX_RETRIES` to a non-negative
-  integer to override the SDK's default of two retries for retryable provider
-  failures. `0` disables retries. Clodex estimates the configuration ceiling
-  from the resolved idle timeout and the SDK's fallback 2s, 4s, 8s, … backoff:
-  the ceiling is `5` at the default timeout and can rise to `10` at the maximum.
-  Larger integers clamp with a one-time warning that names the active idle
-  timeout. Provider `retry-after` hints and time spent in failed attempts can
-  mean fewer retries start before a streaming idle deadline; the shared abort
-  signal still interrupts backoff when that deadline fires. Unset, empty, or
-  malformed values preserve the SDK default. A stream that fails after output
-  begins cannot be replayed safely and still terminates the request. The same
-  retry setting covers requests passed straight through to Anthropic, which
-  replay once by default and retain an independent ceiling of `5`; the timeout
-  settings neither add timers nor change retry limits on that raw relay. Only a
-  request sent on a pooled connection the far end had already closed, with no
-  response received, is replayed there;
-  anything else is reported as it happens. Setting Claude Code's own
-  `CLAUDE_CODE_MAX_RETRIES=0` also disables the passthrough replay, so telling
-  the client never to resend a request is not quietly undone one layer down.
+- **Upstream retries:** clodex retries retryable failures on SDK-backed
+  provider calls up to `5` times by default. Set
+  `CLODEX_UPSTREAM_MAX_RETRIES` to a non-negative integer to override it; `0`
+  disables retries. The default and configuration ceiling
+  are derived from the resolved idle timeout and the SDK's fallback 2s, 4s, 8s,
+  … backoff, so a shorter idle timeout automatically lowers both. The ceiling
+  is `5` at the default timeout and can rise to `10` at the maximum. Larger
+  integers clamp with a one-time warning that names the active idle timeout.
+  On a genuinely unavailable provider, five retries can add roughly 62s of
+  fallback backoff instead of the SDK default's roughly 6s; the longer wait is
+  deliberate so transient failures have more time to recover. Provider
+  `retry-after` hints and time spent in failed attempts can mean fewer retries
+  start before a streaming idle deadline; the shared abort signal still
+  interrupts backoff when that deadline fires. If a deadline interrupts a
+  retry delay, clodex preserves the provider failure that prompted the retry;
+  if a currently active call is silent, clodex reports the timeout instead.
+  Unset, empty, or malformed values preserve the clodex default. The SDK only
+  retries before model output is exposed downstream; a stream that fails after
+  partial output cannot be
+  replayed safely and still terminates the request. The same
+  retry setting also controls proxy mode's raw HTTP MITM path, which replays
+  once by default and retains an independent ceiling of `5`. Only a request
+  sent on a pooled connection the far end had already closed, with no response
+  received, is replayed there; other direct raw relays add no transport-failure
+  replay (an OAuth 401 refresh can still start a new authenticated call). The
+  timeout settings add no timers to any raw relay. A valid
+  `CLODEX_UPSTREAM_MAX_RETRIES` value takes precedence on the HTTP MITM path;
+  otherwise, Claude Code's own `CLAUDE_CODE_MAX_RETRIES=0` disables that replay
+  so telling the client never to resend a request is not quietly undone one
+  layer down.
   Recovered requests appear in the inference log as `response_retried`.
 
 ## Known limitations

--- a/docs/background-agents.md
+++ b/docs/background-agents.md
@@ -14,6 +14,10 @@ This page explains how to bridge **every** Claude Code process on your machine â
 - For your own terminal sessions, run **`clodex-claude`** instead of `claude` â€” same auto-discovery, no port or CA path to hardcode anywhere.
 - Set **`CLODEX_REQUIRE_SERVER=1`** in an isolated routed profile when bypassing Clodex must be impossible. `clodex-claude` then exits with an error if no advertised server passes its process and TCP checks. The default remains fail-open for ordinary installations.
 - A live standalone server has already snapshotted its credentials and account selection. If a wrapper launch sets `CLODEX_OAUTH_ACCOUNT` or a nonblank `CLODEX_KEY_*`, `clodex-claude` warns that the variable is ignored and still launches through that server. Restart the server with the selector, or save the provider credential and refresh its models, before launching without the process-only variable. With no live server these variables pass through unchanged.
+- Provider timeout and retry variables are also server-owned. Set
+  `CLODEX_UPSTREAM_IDLE_TIMEOUT_MS`, `CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS`, and
+  `CLODEX_UPSTREAM_MAX_RETRIES` when starting `clodex server`; setting them only on a later
+  `clodex-claude` invocation does not reconfigure the running server.
 - Proxy-mode wrapper launches remove Anthropic entries from the union of `NO_PROXY` and `no_proxy`, while preserving unrelated bypasses. The manual server output prints the same adjusted values for users who export the proxy settings themselves.
 
 ## Setup steps

--- a/src/oauth/responses-websocket.ts
+++ b/src/oauth/responses-websocket.ts
@@ -1645,8 +1645,8 @@ function handleSocketMessage(entry: ConnectionEntry, data: RawData): void {
   if (errorStatus !== undefined) {
     // The AI SDK strips unknown frame fields, so a backoff hint survives only
     // baked into the message text — same reason the connection-limit branch
-    // above spells it out. Clamped, so a hostile hint cannot park a client past
-    // the 120s no-event stream abort.
+    // above spells it out. Clamped, so a hostile hint cannot park a client
+    // indefinitely.
     // Only when upstream actually gave one. `clampRetryAfterSeconds` supplies a
     // 5s DEFAULT for a missing hint, so clamping unconditionally would have
     // every 429 assert a backoff upstream never stated — and that value becomes

--- a/src/openai-adapter.ts
+++ b/src/openai-adapter.ts
@@ -4,6 +4,7 @@ import { parseToolArguments } from './proxy-shared.js';
 import type { SdkCallParams } from './sdk-adapter.js';
 import { oauthServiceTier, reportUnsupportedServiceTier } from './sdk-adapter.js';
 import { upstreamRequestBudget } from './upstream-retry.js';
+import { trackUpstreamAttempts } from './upstream-attempts.js';
 
 // ── OpenAI request shapes ───────────────────────────────────────────────────
 
@@ -195,29 +196,32 @@ export async function collectOpenAiStream(stream: AsyncIterable<unknown>): Promi
 }
 
 interface ActiveUpstreamBudget {
-  maxRetries: number | undefined;
+  model: LanguageModel;
+  maxRetries: number;
   abortSignal: AbortSignal;
   onStreamPart: () => void;
   close: () => void;
 }
 
-function startUpstreamBudget(streaming: boolean): ActiveUpstreamBudget {
+function startUpstreamBudget(model: LanguageModel, streaming: boolean): ActiveUpstreamBudget {
   const { idleTimeoutMs, totalTimeoutMs, maxRetries } = upstreamRequestBudget();
+  const attempts = trackUpstreamAttempts(model);
   const abort = new AbortController();
-  const idleError = () => new Error(
+  const idleError = () => attempts.deadlineError(new Error(
     `no data received from provider for ${Math.round(idleTimeoutMs / 1000)}s`,
-  );
+  ));
   let idleTimer = streaming
     ? setTimeout(() => abort.abort(idleError()), idleTimeoutMs)
     : undefined;
   const totalTimer = setTimeout(
-    () => abort.abort(new Error(
+    () => abort.abort(attempts.deadlineError(new Error(
       `provider ${streaming ? 'stream' : 'request'} exceeded ${Math.round(totalTimeoutMs / 1000)}s`,
-    )),
+    ))),
     totalTimeoutMs,
   );
 
   return {
+    model: attempts.model,
     maxRetries,
     abortSignal: abort.signal,
     onStreamPart: () => {
@@ -261,14 +265,14 @@ export async function generateOpenAiResponse(
 ) {
   let result: { text: string; toolCalls?: CollectedOpenAiStream['toolCalls']; finishReason?: string; usage?: CollectedOpenAiStream['usage']; warnings?: unknown };
   const streaming = options?.forceStream === true;
-  const budget = startUpstreamBudget(streaming);
+  const budget = startUpstreamBudget(model, streaming);
   try {
     if (streaming) {
       // Some upstreams (e.g. ChatGPT's Codex OAuth backend) only ever answer as a
       // stream. Request a real stream from the SDK and collect it into one
       // response instead of issuing a non-streaming request upstream.
       const { stream } = streamText({
-        model,
+        model: budget.model,
         ...(params as any),
         maxRetries: budget.maxRetries,
         abortSignal: budget.abortSignal,
@@ -277,12 +281,19 @@ export async function generateOpenAiResponse(
       });
       result = await collectOpenAiStream(watchOpenAiStream(stream, budget));
     } else {
-      result = (await generateText({
-        model,
-        ...(params as any),
-        maxRetries: budget.maxRetries,
-        abortSignal: budget.abortSignal,
-      })) as any;
+      try {
+        result = (await generateText({
+          model: budget.model,
+          ...(params as any),
+          maxRetries: budget.maxRetries,
+          abortSignal: budget.abortSignal,
+        })) as any;
+      } catch (error) {
+        if (budget.abortSignal.aborted && budget.abortSignal.reason instanceof Error) {
+          throw budget.abortSignal.reason;
+        }
+        throw error;
+      }
     }
   } finally {
     budget.close();
@@ -318,10 +329,10 @@ export async function streamOpenAiResponse(
   responseModelId: string,
   onChunk: (chunk: string) => void,
 ): Promise<void> {
-  const budget = startUpstreamBudget(true);
+  const budget = startUpstreamBudget(model, true);
   try {
     const { stream } = streamText({
-      model,
+      model: budget.model,
       ...(params as any),
       maxRetries: budget.maxRetries,
       abortSignal: budget.abortSignal,

--- a/src/openai-adapter.ts
+++ b/src/openai-adapter.ts
@@ -3,7 +3,7 @@ import type { LanguageModel, ModelMessage } from 'ai';
 import { parseToolArguments } from './proxy-shared.js';
 import type { SdkCallParams } from './sdk-adapter.js';
 import { oauthServiceTier, reportUnsupportedServiceTier } from './sdk-adapter.js';
-import { upstreamMaxRetries } from './upstream-retry.js';
+import { upstreamRequestBudget } from './upstream-retry.js';
 
 // ── OpenAI request shapes ───────────────────────────────────────────────────
 
@@ -194,6 +194,65 @@ export async function collectOpenAiStream(stream: AsyncIterable<unknown>): Promi
   return collected;
 }
 
+interface ActiveUpstreamBudget {
+  maxRetries: number | undefined;
+  abortSignal: AbortSignal;
+  onStreamPart: () => void;
+  close: () => void;
+}
+
+function startUpstreamBudget(streaming: boolean): ActiveUpstreamBudget {
+  const { idleTimeoutMs, totalTimeoutMs, maxRetries } = upstreamRequestBudget();
+  const abort = new AbortController();
+  const idleError = () => new Error(
+    `no data received from provider for ${Math.round(idleTimeoutMs / 1000)}s`,
+  );
+  let idleTimer = streaming
+    ? setTimeout(() => abort.abort(idleError()), idleTimeoutMs)
+    : undefined;
+  const totalTimer = setTimeout(
+    () => abort.abort(new Error(
+      `provider ${streaming ? 'stream' : 'request'} exceeded ${Math.round(totalTimeoutMs / 1000)}s`,
+    )),
+    totalTimeoutMs,
+  );
+
+  return {
+    maxRetries,
+    abortSignal: abort.signal,
+    onStreamPart: () => {
+      if (idleTimer === undefined) return;
+      clearTimeout(idleTimer);
+      idleTimer = setTimeout(() => abort.abort(idleError()), idleTimeoutMs);
+    },
+    close: () => {
+      if (idleTimer !== undefined) clearTimeout(idleTimer);
+      clearTimeout(totalTimer);
+      if (!abort.signal.aborted) abort.abort();
+    },
+  };
+}
+
+async function* watchOpenAiStream(
+  stream: AsyncIterable<unknown>,
+  budget: ActiveUpstreamBudget,
+): AsyncIterable<unknown> {
+  for await (const part of stream) {
+    if (budget.abortSignal.aborted || (part as { type?: string }).type === 'abort') {
+      throw budget.abortSignal.reason instanceof Error
+        ? budget.abortSignal.reason
+        : new Error('SDK stream aborted');
+    }
+    budget.onStreamPart();
+    yield part;
+  }
+  if (budget.abortSignal.aborted) {
+    throw budget.abortSignal.reason instanceof Error
+      ? budget.abortSignal.reason
+      : new Error('SDK stream aborted');
+  }
+}
+
 export async function generateOpenAiResponse(
   model: LanguageModel,
   params: SdkCallParams,
@@ -201,24 +260,32 @@ export async function generateOpenAiResponse(
   options?: { forceStream?: boolean },
 ) {
   let result: { text: string; toolCalls?: CollectedOpenAiStream['toolCalls']; finishReason?: string; usage?: CollectedOpenAiStream['usage']; warnings?: unknown };
-  if (options?.forceStream) {
-    // Some upstreams (e.g. ChatGPT's Codex OAuth backend) only ever answer as a
-    // stream. Request a real stream from the SDK and collect it into one
-    // response instead of issuing a non-streaming request upstream.
-    const { stream } = streamText({
-      model,
-      ...(params as any),
-      maxRetries: upstreamMaxRetries(),
-      onError: () => {},
-      onStepFinish: step => reportUnsupportedServiceTier(params, step.warnings),
-    });
-    result = await collectOpenAiStream(stream);
-  } else {
-    result = (await generateText({
-      model,
-      ...(params as any),
-      maxRetries: upstreamMaxRetries(),
-    })) as any;
+  const streaming = options?.forceStream === true;
+  const budget = startUpstreamBudget(streaming);
+  try {
+    if (streaming) {
+      // Some upstreams (e.g. ChatGPT's Codex OAuth backend) only ever answer as a
+      // stream. Request a real stream from the SDK and collect it into one
+      // response instead of issuing a non-streaming request upstream.
+      const { stream } = streamText({
+        model,
+        ...(params as any),
+        maxRetries: budget.maxRetries,
+        abortSignal: budget.abortSignal,
+        onError: () => {},
+        onStepFinish: step => reportUnsupportedServiceTier(params, step.warnings),
+      });
+      result = await collectOpenAiStream(watchOpenAiStream(stream, budget));
+    } else {
+      result = (await generateText({
+        model,
+        ...(params as any),
+        maxRetries: budget.maxRetries,
+        abortSignal: budget.abortSignal,
+      })) as any;
+    }
+  } finally {
+    budget.close();
   }
   reportUnsupportedServiceTier(params, result.warnings);
   const message: Record<string, any> = { role: 'assistant', content: result.text || null };
@@ -251,43 +318,49 @@ export async function streamOpenAiResponse(
   responseModelId: string,
   onChunk: (chunk: string) => void,
 ): Promise<void> {
-  const { stream } = streamText({
-    model,
-    ...(params as any),
-    maxRetries: upstreamMaxRetries(),
-    onStepFinish: step => reportUnsupportedServiceTier(params, step.warnings),
-  });
-  const baseData = {
-    id: `chatcmpl-${Date.now()}`,
-    object: 'chat.completion.chunk',
-    created: Math.floor(Date.now() / 1000),
-    model: responseModelId,
-  };
+  const budget = startUpstreamBudget(true);
+  try {
+    const { stream } = streamText({
+      model,
+      ...(params as any),
+      maxRetries: budget.maxRetries,
+      abortSignal: budget.abortSignal,
+      onStepFinish: step => reportUnsupportedServiceTier(params, step.warnings),
+    });
+    const baseData = {
+      id: `chatcmpl-${Date.now()}`,
+      object: 'chat.completion.chunk',
+      created: Math.floor(Date.now() / 1000),
+      model: responseModelId,
+    };
 
-  const send = (delta: Record<string, any>, finish_reason: string | null = null) =>
-    onChunk(`data: ${JSON.stringify({ ...baseData, choices: [{ index: 0, delta, finish_reason }] })}\n\n`);
+    const send = (delta: Record<string, any>, finish_reason: string | null = null) =>
+      onChunk(`data: ${JSON.stringify({ ...baseData, choices: [{ index: 0, delta, finish_reason }] })}\n\n`);
 
-  for await (const part of stream) {
-    const p = part as any;
-    switch (p.type) {
-      case 'text-delta':
-        send({ role: 'assistant', content: p.textDelta ?? p.text ?? '' });
-        break;
-      case 'tool-input-start':
-        send({ role: 'assistant', tool_calls: [{ index: 0, id: p.id ?? p.toolCallId, type: 'function', function: { name: p.toolName, arguments: '' } }] });
-        break;
-      case 'tool-input-delta':
-        send({ tool_calls: [{ index: 0, function: { arguments: p.delta ?? p.text ?? p.argsTextDelta ?? '' } }] });
-        break;
-      case 'finish':
-        send({}, p.finishReason || 'stop');
-        break;
-      case 'error':
-        throw p.error instanceof Error || (p.error && typeof p.error === 'object')
-          ? p.error
-          : new Error(typeof p.error === 'string' ? p.error : 'Upstream stream failed');
+    for await (const part of watchOpenAiStream(stream, budget)) {
+      const p = part as any;
+      switch (p.type) {
+        case 'text-delta':
+          send({ role: 'assistant', content: p.textDelta ?? p.text ?? '' });
+          break;
+        case 'tool-input-start':
+          send({ role: 'assistant', tool_calls: [{ index: 0, id: p.id ?? p.toolCallId, type: 'function', function: { name: p.toolName, arguments: '' } }] });
+          break;
+        case 'tool-input-delta':
+          send({ tool_calls: [{ index: 0, function: { arguments: p.delta ?? p.text ?? p.argsTextDelta ?? '' } }] });
+          break;
+        case 'finish':
+          send({}, p.finishReason || 'stop');
+          break;
+        case 'error':
+          throw p.error instanceof Error || (p.error && typeof p.error === 'object')
+            ? p.error
+            : new Error(typeof p.error === 'string' ? p.error : 'Upstream stream failed');
+      }
     }
-  }
 
-  onChunk('data: [DONE]\n\n');
+    onChunk('data: [DONE]\n\n');
+  } finally {
+    budget.close();
+  }
 }

--- a/src/parent-notice.ts
+++ b/src/parent-notice.ts
@@ -9,8 +9,8 @@ import { writeSync } from 'node:fs';
  * terminal and a stray parent write corrupts its TUI. clodex's gateway/MITM,
  * however, runs in that same process and handles every translated request while
  * the child is alive — so the few warnings that are documented as reaching
- * stderr (the reasoning- and tool-argument normalization canaries, the retry
- * clamp notice) were written straight into the mute and were never seen.
+ * stderr (the reasoning- and tool-argument normalization canaries, retry and
+ * timeout configuration notices) were written straight into the mute and were never seen.
  *
  * This channel is deliberately OPT-IN and enumerable: a caller must import
  * `emitParentNotice` to reach the terminal. There is no prefix sniffing or other

--- a/src/sdk-adapter.ts
+++ b/src/sdk-adapter.ts
@@ -22,6 +22,7 @@ import { sanitizeToolInput } from './tool-input-sanitize.js';
 import type { AnthropicRequestMessage, AnthropicToolDefinition } from './proxy-types.js';
 import { anthropicErrorType, upstreamHttpStatus } from './upstream-error.js';
 import { upstreamRequestBudget } from './upstream-retry.js';
+import { trackUpstreamAttempts } from './upstream-attempts.js';
 import { emitParentNotice } from './parent-notice.js';
 import { CLAUDE_CODE_BILLING_HEADER_PREFIX } from './oauth/claude-identity.js';
 
@@ -966,45 +967,45 @@ export async function streamAnthropicResponse(
   const { idleTimeoutMs, totalTimeoutMs, maxRetries } = upstreamRequestBudget({
     idleTimeoutMs: observer?.idleTimeoutMs,
   });
+  const attempts = trackUpstreamAttempts(model);
   const idleAbort = new AbortController();
   const stopForwardingAbort = forwardAbortSignal(observer?.abortSignal, idleAbort);
   const abortSignal = idleAbort.signal;
-  let idleTimer = setTimeout(
-    () => idleAbort.abort(new Error(`no data received from provider for ${Math.round(idleTimeoutMs / 1000)}s`)),
-    idleTimeoutMs,
+  const idleError = () => attempts.deadlineError(
+    new Error(`no data received from provider for ${Math.round(idleTimeoutMs / 1000)}s`),
   );
+  let idleTimer = setTimeout(() => idleAbort.abort(idleError()), idleTimeoutMs);
   const totalTimer = setTimeout(
-    () => idleAbort.abort(new Error(`provider stream exceeded ${Math.round(totalTimeoutMs / 1000)}s`)),
+    () => idleAbort.abort(attempts.deadlineError(
+      new Error(`provider stream exceeded ${Math.round(totalTimeoutMs / 1000)}s`),
+    )),
     totalTimeoutMs,
   );
   // Do not combine streamText's total/chunk timeout signals here. In AI SDK
   // 7.0.22 that composition retains completed StreamTextResult graphs. Relay
   // owns the timers and explicitly settles its controller after consumption.
-  const result = streamText({
-    model,
-    ...params,
-    maxRetries,
-    abortSignal,
-    onError: () => {},
-    onStepFinish: step => reportUnsupportedServiceTier(params, step.warnings),
-  } as Parameters<typeof streamText>[0]);
-
-  const watchedStream = (async function* () {
-    try {
-      for await (const part of result.stream as AsyncIterable<FullStreamPart>) {
-        clearTimeout(idleTimer);
-        idleTimer = setTimeout(
-          () => idleAbort.abort(new Error(`no data received from provider for ${Math.round(idleTimeoutMs / 1000)}s`)),
-          idleTimeoutMs,
-        );
-        yield part;
-      }
-    } finally {
-      clearTimeout(idleTimer);
-    }
-  })();
-
   try {
+    const result = streamText({
+      model: attempts.model,
+      ...params,
+      maxRetries,
+      abortSignal,
+      onError: () => {},
+      onStepFinish: step => reportUnsupportedServiceTier(params, step.warnings),
+    } as Parameters<typeof streamText>[0]);
+
+    const watchedStream = (async function* () {
+      try {
+        for await (const part of result.stream as AsyncIterable<FullStreamPart>) {
+          clearTimeout(idleTimer);
+          idleTimer = setTimeout(() => idleAbort.abort(idleError()), idleTimeoutMs);
+          yield part;
+        }
+      } finally {
+        clearTimeout(idleTimer);
+      }
+    })();
+
     await writeAnthropicStream(watchedStream, modelId, write, log, { ...observer, abortSignal }, params.tools);
   } finally {
     stopForwardingAbort();
@@ -1037,6 +1038,7 @@ export async function generateAnthropicResponse(
   const { idleTimeoutMs, totalTimeoutMs, maxRetries } = upstreamRequestBudget({
     idleTimeoutMs: options?.forceStream ? options.idleTimeoutMs : undefined,
   });
+  const attempts = trackUpstreamAttempts(model);
 
   if (options?.forceStream) {
     // Some upstreams (e.g. ChatGPT's Codex backend) reject non-streaming requests
@@ -1045,35 +1047,34 @@ export async function generateAnthropicResponse(
     const forceAbort = new AbortController();
     const stopForwardingAbort = forwardAbortSignal(options.abortSignal, forceAbort);
     const abortSignal = forceAbort.signal;
-    let idleTimer = setTimeout(
-      () => forceAbort.abort(new Error(`no data received from provider for ${Math.round(idleTimeoutMs / 1000)}s`)),
-      idleTimeoutMs,
+    const idleError = () => attempts.deadlineError(
+      new Error(`no data received from provider for ${Math.round(idleTimeoutMs / 1000)}s`),
     );
+    let idleTimer = setTimeout(() => forceAbort.abort(idleError()), idleTimeoutMs);
     const totalTimer = setTimeout(
-      () => forceAbort.abort(new Error(`provider stream exceeded ${Math.round(totalTimeoutMs / 1000)}s`)),
+      () => forceAbort.abort(attempts.deadlineError(
+        new Error(`provider stream exceeded ${Math.round(totalTimeoutMs / 1000)}s`),
+      )),
       totalTimeoutMs,
     );
     // See the streaming path above: Relay owns these timers and explicitly
     // settles its controller when the stream has been fully reduced.
-    const r = streamText({
-      model,
-      ...params,
-      maxRetries,
-      abortSignal,
-      onError: () => {},
-      onStepFinish: step => reportUnsupportedServiceTier(params, step.warnings),
-    } as Parameters<typeof streamText>[0]);
     const streamedText: string[] = [];
     const streamedToolCalls: Array<{ toolCallId: string; toolName: string; input: unknown }> = [];
     let streamedFinishReason = 'stop';
     let streamedUsage: SdkUsage | undefined;
     try {
+      const r = streamText({
+        model: attempts.model,
+        ...params,
+        maxRetries,
+        abortSignal,
+        onError: () => {},
+        onStepFinish: step => reportUnsupportedServiceTier(params, step.warnings),
+      } as Parameters<typeof streamText>[0]);
       for await (const part of r.stream as AsyncIterable<FullStreamPart>) {
         clearTimeout(idleTimer);
-        idleTimer = setTimeout(
-          () => forceAbort.abort(new Error(`no data received from provider for ${Math.round(idleTimeoutMs / 1000)}s`)),
-          idleTimeoutMs,
-        );
+        idleTimer = setTimeout(() => forceAbort.abort(idleError()), idleTimeoutMs);
         options.onPart?.(part.type);
         if (abortSignal.aborted || part.type === 'abort') {
           throw streamAbortError(abortSignal);
@@ -1114,17 +1115,22 @@ export async function generateAnthropicResponse(
     const generateAbort = new AbortController();
     const stopForwardingAbort = forwardAbortSignal(options?.abortSignal, generateAbort);
     const totalTimer = setTimeout(
-      () => generateAbort.abort(new Error(`provider request exceeded ${Math.round(totalTimeoutMs / 1000)}s`)),
+      () => generateAbort.abort(attempts.deadlineError(
+        new Error(`provider request exceeded ${Math.round(totalTimeoutMs / 1000)}s`),
+      )),
       totalTimeoutMs,
     );
     try {
       const r = await generateText({
-        model,
+        model: attempts.model,
         ...params,
         maxRetries,
         abortSignal: generateAbort.signal,
       } as Parameters<typeof generateText>[0]);
       ({ text, toolCalls, finishReason, usage, warnings } = r);
+    } catch (error) {
+      if (generateAbort.signal.aborted) throw streamAbortError(generateAbort.signal);
+      throw error;
     } finally {
       stopForwardingAbort();
       clearTimeout(totalTimer);

--- a/src/sdk-adapter.ts
+++ b/src/sdk-adapter.ts
@@ -21,7 +21,7 @@ import { resolveUpstreamTools } from './tool-search.js';
 import { sanitizeToolInput } from './tool-input-sanitize.js';
 import type { AnthropicRequestMessage, AnthropicToolDefinition } from './proxy-types.js';
 import { anthropicErrorType, upstreamHttpStatus } from './upstream-error.js';
-import { upstreamMaxRetries } from './upstream-retry.js';
+import { upstreamRequestBudget } from './upstream-retry.js';
 import { emitParentNotice } from './parent-notice.js';
 import { CLAUDE_CODE_BILLING_HEADER_PREFIX } from './oauth/claude-identity.js';
 
@@ -708,9 +708,6 @@ export interface AnthropicStreamObserver {
   idleTimeoutMs?: number;
 }
 
-const SDK_STREAM_IDLE_TIMEOUT_MS = 120_000;
-const SDK_TOTAL_TIMEOUT_MS = 10 * 60_000;
-
 function streamAbortError(signal?: AbortSignal): Error {
   if (signal?.reason instanceof Error) return signal.reason;
   const error = new Error(
@@ -966,7 +963,9 @@ export async function streamAnthropicResponse(
   log?: LogFn,
   observer?: AnthropicStreamObserver,
 ): Promise<void> {
-  const idleTimeoutMs = observer?.idleTimeoutMs ?? SDK_STREAM_IDLE_TIMEOUT_MS;
+  const { idleTimeoutMs, totalTimeoutMs, maxRetries } = upstreamRequestBudget({
+    idleTimeoutMs: observer?.idleTimeoutMs,
+  });
   const idleAbort = new AbortController();
   const stopForwardingAbort = forwardAbortSignal(observer?.abortSignal, idleAbort);
   const abortSignal = idleAbort.signal;
@@ -975,8 +974,8 @@ export async function streamAnthropicResponse(
     idleTimeoutMs,
   );
   const totalTimer = setTimeout(
-    () => idleAbort.abort(new Error(`provider stream exceeded ${Math.round(SDK_TOTAL_TIMEOUT_MS / 1000)}s`)),
-    SDK_TOTAL_TIMEOUT_MS,
+    () => idleAbort.abort(new Error(`provider stream exceeded ${Math.round(totalTimeoutMs / 1000)}s`)),
+    totalTimeoutMs,
   );
   // Do not combine streamText's total/chunk timeout signals here. In AI SDK
   // 7.0.22 that composition retains completed StreamTextResult graphs. Relay
@@ -984,7 +983,7 @@ export async function streamAnthropicResponse(
   const result = streamText({
     model,
     ...params,
-    maxRetries: upstreamMaxRetries(),
+    maxRetries,
     abortSignal,
     onError: () => {},
     onStepFinish: step => reportUnsupportedServiceTier(params, step.warnings),
@@ -1035,6 +1034,9 @@ export async function generateAnthropicResponse(
   let finishReason: string;
   let usage: SdkUsage | undefined;
   let warnings: unknown;
+  const { idleTimeoutMs, totalTimeoutMs, maxRetries } = upstreamRequestBudget({
+    idleTimeoutMs: options?.forceStream ? options.idleTimeoutMs : undefined,
+  });
 
   if (options?.forceStream) {
     // Some upstreams (e.g. ChatGPT's Codex backend) reject non-streaming requests
@@ -1043,21 +1045,20 @@ export async function generateAnthropicResponse(
     const forceAbort = new AbortController();
     const stopForwardingAbort = forwardAbortSignal(options.abortSignal, forceAbort);
     const abortSignal = forceAbort.signal;
-    const idleTimeoutMs = options.idleTimeoutMs ?? SDK_STREAM_IDLE_TIMEOUT_MS;
     let idleTimer = setTimeout(
       () => forceAbort.abort(new Error(`no data received from provider for ${Math.round(idleTimeoutMs / 1000)}s`)),
       idleTimeoutMs,
     );
     const totalTimer = setTimeout(
-      () => forceAbort.abort(new Error(`provider stream exceeded ${Math.round(SDK_TOTAL_TIMEOUT_MS / 1000)}s`)),
-      SDK_TOTAL_TIMEOUT_MS,
+      () => forceAbort.abort(new Error(`provider stream exceeded ${Math.round(totalTimeoutMs / 1000)}s`)),
+      totalTimeoutMs,
     );
     // See the streaming path above: Relay owns these timers and explicitly
     // settles its controller when the stream has been fully reduced.
     const r = streamText({
       model,
       ...params,
-      maxRetries: upstreamMaxRetries(),
+      maxRetries,
       abortSignal,
       onError: () => {},
       onStepFinish: step => reportUnsupportedServiceTier(params, step.warnings),
@@ -1108,17 +1109,19 @@ export async function generateAnthropicResponse(
     finishReason = streamedFinishReason;
     usage = streamedUsage;
   } else {
+    // generateText exposes no intermediate events that could reset an idle
+    // timer, so only the total provider-call deadline applies on this path.
     const generateAbort = new AbortController();
     const stopForwardingAbort = forwardAbortSignal(options?.abortSignal, generateAbort);
     const totalTimer = setTimeout(
-      () => generateAbort.abort(new Error(`provider request exceeded ${Math.round(SDK_TOTAL_TIMEOUT_MS / 1000)}s`)),
-      SDK_TOTAL_TIMEOUT_MS,
+      () => generateAbort.abort(new Error(`provider request exceeded ${Math.round(totalTimeoutMs / 1000)}s`)),
+      totalTimeoutMs,
     );
     try {
       const r = await generateText({
         model,
         ...params,
-        maxRetries: upstreamMaxRetries(),
+        maxRetries,
         abortSignal: generateAbort.signal,
       } as Parameters<typeof generateText>[0]);
       ({ text, toolCalls, finishReason, usage, warnings } = r);

--- a/src/upstream-attempts.ts
+++ b/src/upstream-attempts.ts
@@ -1,0 +1,57 @@
+import { RetryError, wrapLanguageModel } from 'ai';
+import type { LanguageModel, LanguageModelMiddleware } from 'ai';
+
+interface TrackedUpstreamModel {
+  model: LanguageModel;
+  deadlineError: (timeoutError: Error) => Error;
+}
+
+/**
+ * Preserve provider errors when a request deadline interrupts the AI SDK's
+ * retry delay. A deadline during an active provider call remains a timeout so
+ * an older rejection cannot hide a newly silent attempt.
+ */
+export function trackUpstreamAttempts(model: LanguageModel): TrackedUpstreamModel {
+  if (typeof model === 'string') {
+    return { model, deadlineError: timeoutError => timeoutError };
+  }
+
+  const failedAttempts: unknown[] = [];
+  let waitingToRetry = false;
+
+  const track = async <T>(call: () => PromiseLike<T>): Promise<T> => {
+    waitingToRetry = false;
+    try {
+      const result = await call();
+      failedAttempts.length = 0;
+      return result;
+    } catch (error) {
+      failedAttempts.push(error);
+      waitingToRetry = true;
+      throw error;
+    }
+  };
+
+  const middleware: LanguageModelMiddleware = {
+    specificationVersion: 'v4',
+    wrapGenerate: ({ doGenerate }) => track(doGenerate),
+    wrapStream: ({ doStream }) => track(doStream),
+  };
+
+  return {
+    model: wrapLanguageModel({ model, middleware }),
+    deadlineError: timeoutError => {
+      if (!waitingToRetry || failedAttempts.length === 0) return timeoutError;
+      const count = failedAttempts.length;
+      return new RetryError({
+        message: [
+          'Provider retry interrupted by a request deadline after',
+          count,
+          `failed ${count === 1 ? 'attempt' : 'attempts'}`,
+        ].join(' '),
+        reason: 'abort',
+        errors: [...failedAttempts],
+      });
+    },
+  };
+}

--- a/src/upstream-error.ts
+++ b/src/upstream-error.ts
@@ -26,7 +26,7 @@ export const DEFAULT_RETRY_AFTER_SECONDS = 5;
 /**
  * Upper bound for any retry-after hint clodex produces or forwards. Keeps the
  * AI SDK's bounded backoff (default maxRetries=2) and downstream clients well
- * clear of clodex's 120s no-event stream abort.
+ * clear of clodex's default 120s no-event stream abort.
  */
 export const MAX_RETRY_AFTER_SECONDS = 60;
 

--- a/src/upstream-error.ts
+++ b/src/upstream-error.ts
@@ -24,9 +24,9 @@ export interface SdkUpstreamErrorDetails {
 /** Default downstream backoff hint when the upstream throttle gives none. */
 export const DEFAULT_RETRY_AFTER_SECONDS = 5;
 /**
- * Upper bound for any retry-after hint clodex produces or forwards. Keeps the
- * AI SDK's bounded backoff (default maxRetries=2) and downstream clients well
- * clear of clodex's default 120s no-event stream abort.
+ * Upper bound for any retry-after hint clodex produces or forwards. This caps
+ * one provider-directed delay at a minute; translated streams still request
+ * cancellation at their configured idle and total deadlines across attempts.
  */
 export const MAX_RETRY_AFTER_SECONDS = 60;
 

--- a/src/upstream-retry.ts
+++ b/src/upstream-retry.ts
@@ -11,7 +11,6 @@ export const MAX_UPSTREAM_IDLE_TIMEOUT_MS = 60 * 60_000;
 export const MIN_UPSTREAM_TOTAL_TIMEOUT_MS = 60_000;
 export const MAX_UPSTREAM_TOTAL_TIMEOUT_MS = 6 * 60 * 60_000;
 
-const SDK_DEFAULT_MAX_RETRIES = 2;
 const SDK_INITIAL_RETRY_DELAY_MS = 2_000;
 const reportedValues = new Set<string>();
 type Warn = (message: string) => void;
@@ -70,7 +69,8 @@ function timeoutSetting(
 /**
  * Largest retry count whose cumulative AI SDK fallback backoff is shorter
  * than the resolved idle window. Provider retry hints and failed-attempt time
- * can consume the window sooner; the shared abort signal enforces the deadline.
+ * can consume the window sooner; the shared signal requests cancellation at
+ * the deadline.
  */
 function maxRetriesForIdleTimeout(idleTimeoutMs: number): number {
   let retries = 0;
@@ -88,6 +88,9 @@ function maxRetriesForIdleTimeout(idleTimeoutMs: number): number {
 export const MAX_UPSTREAM_MAX_RETRIES = maxRetriesForIdleTimeout(
   DEFAULT_UPSTREAM_IDLE_TIMEOUT_MS,
 );
+
+/** Default retry count, derived from the default idle window rather than duplicated. */
+const DEFAULT_UPSTREAM_MAX_RETRIES = MAX_UPSTREAM_MAX_RETRIES;
 
 function configuredUpstreamMaxRetries(
   env: NodeJS.ProcessEnv,
@@ -112,11 +115,11 @@ function resolveUpstreamMaxRetries(
   env: NodeJS.ProcessEnv,
   warn: Warn,
   idleTimeoutMs: number,
-): number | undefined {
+): number {
   const ceiling = maxRetriesForIdleTimeout(idleTimeoutMs);
-  const sdkDefault = ceiling < SDK_DEFAULT_MAX_RETRIES ? ceiling : undefined;
+  const defaultRetries = Math.min(DEFAULT_UPSTREAM_MAX_RETRIES, ceiling);
   const value = configuredUpstreamMaxRetries(env, warn);
-  if (value === undefined) return sdkDefault;
+  if (value === undefined) return defaultRetries;
 
   if (value > ceiling) {
     reportOnce(
@@ -134,7 +137,7 @@ function resolveUpstreamMaxRetries(
 export interface UpstreamRequestBudget {
   idleTimeoutMs: number;
   totalTimeoutMs: number;
-  maxRetries: number | undefined;
+  maxRetries: number;
 }
 
 /** Resolve the timeout pair and retry ceiling as one coherent request budget. */
@@ -206,11 +209,11 @@ export function upstreamRequestBudget(options: {
 const CLIENT_MAX_RETRIES_ENV = 'CLAUDE_CODE_MAX_RETRIES';
 
 /**
- * Retry budget for raw Anthropic passthrough requests. These are not SDK
- * generations, but they share the knob so that turning retries off turns them
- * off everywhere. One retry is enough for the failure this exists to absorb: a
- * pooled keep-alive socket the far end closed while it sat idle, which the
- * agent evicts as soon as it resets.
+ * Retry budget for proxy mode's raw Anthropic HTTP MITM path. Other direct raw
+ * relays do not use this transport replay. This path shares the SDK retry knob
+ * so turning retries off turns it off too. One retry is enough for the failure
+ * this exists to absorb: a pooled keep-alive socket the far end closed while
+ * it sat idle, which the agent evicts as soon as it resets.
  */
 export const DEFAULT_PASSTHROUGH_RETRIES = 1;
 
@@ -224,7 +227,7 @@ export function passthroughUpstreamRetries(
     reportOnce(
       `${UPSTREAM_MAX_RETRIES_ENV}=${explicit}:passthrough`,
       `clamping ${UPSTREAM_MAX_RETRIES_ENV}=${explicit} to ${MAX_UPSTREAM_MAX_RETRIES} `
-      + '(Anthropic passthrough supports at most this many replays)',
+      + '(the raw HTTP MITM path supports at most this many replays)',
       warn,
     );
     return MAX_UPSTREAM_MAX_RETRIES;

--- a/src/upstream-retry.ts
+++ b/src/upstream-retry.ts
@@ -1,52 +1,202 @@
 import { emitParentNotice } from './parent-notice.js';
 
 export const UPSTREAM_MAX_RETRIES_ENV = 'CLODEX_UPSTREAM_MAX_RETRIES';
-export const MAX_UPSTREAM_MAX_RETRIES = 5;
-const reportedValues = new Set<string>();
+export const UPSTREAM_IDLE_TIMEOUT_ENV = 'CLODEX_UPSTREAM_IDLE_TIMEOUT_MS';
+export const UPSTREAM_TOTAL_TIMEOUT_ENV = 'CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS';
 
-function reportOnce(raw: string, message: string, warn: (message: string) => void): void {
-  if (reportedValues.has(raw)) return;
-  reportedValues.add(raw);
+export const DEFAULT_UPSTREAM_IDLE_TIMEOUT_MS = 120_000;
+export const DEFAULT_UPSTREAM_TOTAL_TIMEOUT_MS = 10 * 60_000;
+export const MIN_UPSTREAM_IDLE_TIMEOUT_MS = 10_000;
+export const MAX_UPSTREAM_IDLE_TIMEOUT_MS = 60 * 60_000;
+export const MIN_UPSTREAM_TOTAL_TIMEOUT_MS = 60_000;
+export const MAX_UPSTREAM_TOTAL_TIMEOUT_MS = 6 * 60 * 60_000;
+
+const SDK_DEFAULT_MAX_RETRIES = 2;
+const SDK_INITIAL_RETRY_DELAY_MS = 2_000;
+const reportedValues = new Set<string>();
+type Warn = (message: string) => void;
+
+const defaultWarn: Warn = message => emitParentNotice(`clodex: ${message}`);
+
+function reportOnce(key: string, message: string, warn: Warn): void {
+  if (reportedValues.has(key)) return;
+  reportedValues.add(key);
   try {
     warn(message);
   } catch {
-    // A diagnostic must never turn a retry setting into a request failure.
+    // A diagnostic must never turn an upstream setting into a request failure.
   }
 }
 
+interface ResolvedTimeoutSetting {
+  value: number;
+  explicit: boolean;
+}
+
+function timeoutSetting(
+  env: NodeJS.ProcessEnv,
+  envName: string,
+  fallback: number,
+  min: number,
+  max: number,
+  warn: Warn,
+): ResolvedTimeoutSetting {
+  const raw = env[envName]?.trim();
+  if (raw === undefined || raw === '') return { value: fallback, explicit: false };
+
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    reportOnce(
+      `${envName}=${raw}`,
+      `ignoring ${envName}=${raw} (expected a positive integer number of milliseconds)`,
+      warn,
+    );
+    return { value: fallback, explicit: false };
+  }
+
+  if (value < min || value > max) {
+    const clamped = Math.min(max, Math.max(min, value));
+    reportOnce(
+      `${envName}=${raw}`,
+      `clamping ${envName}=${raw} to ${clamped}ms (supported range is ${min}-${max}ms)`,
+      warn,
+    );
+    return { value: clamped, explicit: true };
+  }
+
+  return { value, explicit: true };
+}
+
 /**
- * Optional request retry override. Five retries complete before the translated
- * streaming paths' 120-second no-data timeout; larger integer values clamp to
- * that effective ceiling instead of stalling until a generic timeout.
+ * Largest retry count whose cumulative AI SDK fallback backoff is shorter
+ * than the resolved idle window. Provider retry hints and failed-attempt time
+ * can consume the window sooner; the shared abort signal enforces the deadline.
  */
-export function upstreamMaxRetries(
-  env: NodeJS.ProcessEnv = process.env,
-  // emitParentNotice rather than console.error: this fires from a request while
-  // `clodex claude` has the parent's stdout/stderr muted for Claude Code's TUI,
-  // and console.error resolves the muted write at call time.
-  warn: (message: string) => void = message => emitParentNotice(`clodex: ${message}`),
+function maxRetriesForIdleTimeout(idleTimeoutMs: number): number {
+  let retries = 0;
+  let elapsedMs = 0;
+  let delayMs = SDK_INITIAL_RETRY_DELAY_MS;
+  while (elapsedMs + delayMs < idleTimeoutMs) {
+    elapsedMs += delayMs;
+    delayMs *= 2;
+    retries += 1;
+  }
+  return retries;
+}
+
+/** The retry ceiling at the default 120-second idle timeout. */
+export const MAX_UPSTREAM_MAX_RETRIES = maxRetriesForIdleTimeout(
+  DEFAULT_UPSTREAM_IDLE_TIMEOUT_MS,
+);
+
+function configuredUpstreamMaxRetries(
+  env: NodeJS.ProcessEnv,
+  warn: Warn,
 ): number | undefined {
   const raw = env[UPSTREAM_MAX_RETRIES_ENV]?.trim();
   if (raw === undefined || raw === '') return undefined;
+
   const value = Number(raw);
   if (!Number.isInteger(value) || value < 0) {
     reportOnce(
-      raw,
+      `${UPSTREAM_MAX_RETRIES_ENV}=${raw}`,
       `ignoring ${UPSTREAM_MAX_RETRIES_ENV}=${raw} (expected a non-negative integer)`,
       warn,
     );
     return undefined;
   }
-  if (value > MAX_UPSTREAM_MAX_RETRIES) {
+  return value;
+}
+
+function resolveUpstreamMaxRetries(
+  env: NodeJS.ProcessEnv,
+  warn: Warn,
+  idleTimeoutMs: number,
+): number | undefined {
+  const ceiling = maxRetriesForIdleTimeout(idleTimeoutMs);
+  const sdkDefault = ceiling < SDK_DEFAULT_MAX_RETRIES ? ceiling : undefined;
+  const value = configuredUpstreamMaxRetries(env, warn);
+  if (value === undefined) return sdkDefault;
+
+  if (value > ceiling) {
     reportOnce(
-      raw,
-      `clamping ${UPSTREAM_MAX_RETRIES_ENV}=${raw} to ${MAX_UPSTREAM_MAX_RETRIES} `
-      + '(higher values exceed the 120s streaming idle budget)',
+      `${UPSTREAM_MAX_RETRIES_ENV}=${value}:idle=${idleTimeoutMs}`,
+      `clamping ${UPSTREAM_MAX_RETRIES_ENV}=${value} to ${ceiling} `
+      + `(estimated from the SDK fallback backoff and resolved ${idleTimeoutMs}ms idle timeout; `
+      + 'provider delays may allow fewer retries)',
       warn,
     );
-    return MAX_UPSTREAM_MAX_RETRIES;
+    return ceiling;
   }
   return value;
+}
+
+export interface UpstreamRequestBudget {
+  idleTimeoutMs: number;
+  totalTimeoutMs: number;
+  maxRetries: number | undefined;
+}
+
+/** Resolve the timeout pair and retry ceiling as one coherent request budget. */
+export function upstreamRequestBudget(options: {
+  env?: NodeJS.ProcessEnv;
+  warn?: Warn;
+  /** Internal override used by direct adapter callers; environment values remain bounded. */
+  idleTimeoutMs?: number;
+} = {}): UpstreamRequestBudget {
+  const env = options.env ?? process.env;
+  const warn = options.warn ?? defaultWarn;
+  const hasIdleOverride = options.idleTimeoutMs !== undefined;
+  const configuredIdle = options.idleTimeoutMs !== undefined
+    ? { value: options.idleTimeoutMs, explicit: false }
+    : timeoutSetting(
+      env,
+      UPSTREAM_IDLE_TIMEOUT_ENV,
+      DEFAULT_UPSTREAM_IDLE_TIMEOUT_MS,
+      MIN_UPSTREAM_IDLE_TIMEOUT_MS,
+      MAX_UPSTREAM_IDLE_TIMEOUT_MS,
+      warn,
+    );
+  const configuredTotal = timeoutSetting(
+    env,
+    UPSTREAM_TOTAL_TIMEOUT_ENV,
+    DEFAULT_UPSTREAM_TOTAL_TIMEOUT_MS,
+    MIN_UPSTREAM_TOTAL_TIMEOUT_MS,
+    MAX_UPSTREAM_TOTAL_TIMEOUT_MS,
+    warn,
+  );
+
+  let idleTimeoutMs = configuredIdle.value;
+  let totalTimeoutMs = configuredTotal.value;
+  if (totalTimeoutMs < idleTimeoutMs) {
+    if (hasIdleOverride) {
+      // Direct adapter overrides never raised the fixed total timeout before
+      // configuration was added, so retain that precedence without an env warning.
+      idleTimeoutMs = totalTimeoutMs;
+    } else if (configuredIdle.explicit && !configuredTotal.explicit) {
+      reportOnce(
+        `timeout-pair:raise-total:${idleTimeoutMs}:${totalTimeoutMs}`,
+        `raising the resolved total timeout from ${totalTimeoutMs}ms to ${idleTimeoutMs}ms `
+        + `so it is not shorter than ${UPSTREAM_IDLE_TIMEOUT_ENV}`,
+        warn,
+      );
+      totalTimeoutMs = idleTimeoutMs;
+    } else {
+      reportOnce(
+        `timeout-pair:lower-idle:${idleTimeoutMs}:${totalTimeoutMs}`,
+        `lowering the resolved idle timeout from ${idleTimeoutMs}ms to ${totalTimeoutMs}ms `
+        + `because it cannot exceed ${UPSTREAM_TOTAL_TIMEOUT_ENV}`,
+        warn,
+      );
+      idleTimeoutMs = totalTimeoutMs;
+    }
+  }
+
+  return {
+    idleTimeoutMs,
+    totalTimeoutMs,
+    maxRetries: resolveUpstreamMaxRetries(env, warn, idleTimeoutMs),
+  };
 }
 
 /**
@@ -64,9 +214,21 @@ const CLIENT_MAX_RETRIES_ENV = 'CLAUDE_CODE_MAX_RETRIES';
  */
 export const DEFAULT_PASSTHROUGH_RETRIES = 1;
 
-export function passthroughUpstreamRetries(env: NodeJS.ProcessEnv = process.env): number {
-  const explicit = upstreamMaxRetries(env);
-  if (explicit !== undefined) return explicit;
+export function passthroughUpstreamRetries(
+  env: NodeJS.ProcessEnv = process.env,
+  warn: Warn = defaultWarn,
+): number {
+  const explicit = configuredUpstreamMaxRetries(env, warn);
+  if (explicit !== undefined) {
+    if (explicit <= MAX_UPSTREAM_MAX_RETRIES) return explicit;
+    reportOnce(
+      `${UPSTREAM_MAX_RETRIES_ENV}=${explicit}:passthrough`,
+      `clamping ${UPSTREAM_MAX_RETRIES_ENV}=${explicit} to ${MAX_UPSTREAM_MAX_RETRIES} `
+      + '(Anthropic passthrough supports at most this many replays)',
+      warn,
+    );
+    return MAX_UPSTREAM_MAX_RETRIES;
+  }
   // Replaying here is safe to default on because Claude Code already resends a
   // 502 itself, so the ambiguous "upstream may have served it" window is one
   // the client already accepts. `CLAUDE_CODE_MAX_RETRIES=0` withdraws exactly

--- a/tests/openai-adapter.test.ts
+++ b/tests/openai-adapter.test.ts
@@ -28,7 +28,8 @@ function setTimeoutEnv(values: Record<typeof TIMEOUT_ENV_KEYS[number], string>):
   };
 }
 
-vi.mock('ai', () => ({
+vi.mock('ai', async () => ({
+  ...(await vi.importActual<typeof import('ai')>('ai')),
   streamText: vi.fn(),
   generateText: vi.fn(),
   tool: vi.fn((spec: unknown) => spec),
@@ -171,6 +172,71 @@ describe('configured upstream timeouts', () => {
     }
   });
 
+  it.each([
+    ['forwarded OpenAI stream', 'stream'],
+    ['collected OpenAI stream', 'forceStream'],
+  ] as const)('rejects a %s when abort closes the SDK iterator without an error', async (_name, route) => {
+    vi.useFakeTimers();
+    const restoreEnv = setTimeoutEnv({
+      CLODEX_UPSTREAM_IDLE_TIMEOUT_MS: '10000',
+      CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS: '60000',
+    });
+    let sdkSignal: AbortSignal | undefined;
+    let output = '';
+    let finishForCleanup: () => void = () => {};
+    const cleanup = new Promise<void>(resolve => { finishForCleanup = resolve; });
+    vi.mocked(streamText).mockImplementation((options) => {
+      sdkSignal = options.abortSignal;
+      async function* stream() {
+        yield { type: 'text-delta', text: 'partial' };
+        await Promise.race([
+          cleanup,
+          new Promise<void>(resolve => {
+            if (options.abortSignal?.aborted) resolve();
+            else options.abortSignal?.addEventListener('abort', () => resolve(), { once: true });
+          }),
+        ]);
+      }
+      return { stream: stream() } as never;
+    });
+
+    let request: Promise<unknown> | undefined;
+    try {
+      request = route === 'stream'
+        ? streamOpenAiResponse(
+          {} as never,
+          { messages: [] },
+          'test-model',
+          chunk => { output += chunk; },
+        )
+        : generateOpenAiResponse(
+          {} as never,
+          { messages: [] },
+          'test-model',
+          { forceStream: true },
+        );
+      const rejection = request.catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(9_999);
+      expect(sdkSignal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(sdkSignal?.aborted).toBe(true);
+      await expect(rejection).resolves.toMatchObject({
+        message: 'no data received from provider for 10s',
+      });
+      if (route === 'stream') expect(output).toContain('partial');
+      expect(output).not.toContain('[DONE]');
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      finishForCleanup();
+      await vi.advanceTimersByTimeAsync(0);
+      await Promise.allSettled(request ? [request] : []);
+      restoreEnv();
+      vi.mocked(streamText).mockReset();
+      vi.useRealTimers();
+    }
+  });
+
   it('clears timeout timers after successful OpenAI generations', async () => {
     vi.useFakeTimers();
     const restoreEnv = setTimeoutEnv({
@@ -207,11 +273,17 @@ describe('configured upstream timeouts', () => {
       CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS: '60000',
     });
     let sdkSignal: AbortSignal | undefined;
+    let finishForCleanup: () => void = () => {};
+    const cleanup = new Promise<void>(resolve => { finishForCleanup = resolve; });
     vi.mocked(streamText).mockImplementation((options) => {
       sdkSignal = options.abortSignal;
       async function* stream() {
         while (true) {
-          await new Promise(resolve => setTimeout(resolve, 5_000));
+          const shouldStop = await Promise.race([
+            new Promise<false>(resolve => setTimeout(() => resolve(false), 5_000)),
+            cleanup.then(() => true),
+          ]);
+          if (shouldStop) return;
           yield { type: 'text-delta', text: 'active' };
         }
       }
@@ -232,6 +304,8 @@ describe('configured upstream timeouts', () => {
       });
       expect(vi.getTimerCount()).toBe(0);
     } finally {
+      finishForCleanup();
+      await vi.advanceTimersByTimeAsync(0);
       await Promise.allSettled(request ? [request] : []);
       restoreEnv();
       vi.mocked(streamText).mockReset();

--- a/tests/openai-adapter.test.ts
+++ b/tests/openai-adapter.test.ts
@@ -12,6 +12,22 @@ function captureNotices(): { lines: string[]; release: () => void } {
   return { lines, release: installParentNoticeSink(line => lines.push(line)) };
 }
 
+const TIMEOUT_ENV_KEYS = [
+  'CLODEX_UPSTREAM_IDLE_TIMEOUT_MS',
+  'CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS',
+] as const;
+
+function setTimeoutEnv(values: Record<typeof TIMEOUT_ENV_KEYS[number], string>): () => void {
+  const previous = new Map(TIMEOUT_ENV_KEYS.map(key => [key, process.env[key]]));
+  for (const key of TIMEOUT_ENV_KEYS) process.env[key] = values[key];
+  return () => {
+    for (const [key, value] of previous) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  };
+}
+
 vi.mock('ai', () => ({
   streamText: vi.fn(),
   generateText: vi.fn(),
@@ -81,6 +97,198 @@ describe('configured upstream retries', () => {
       if (previous === undefined) delete process.env['CLODEX_UPSTREAM_MAX_RETRIES'];
       else process.env['CLODEX_UPSTREAM_MAX_RETRIES'] = previous;
       vi.mocked(generateText).mockReset();
+    }
+  });
+});
+
+describe('configured upstream timeouts', () => {
+  it.each([
+    ['forwarded OpenAI stream', 'stream'],
+    ['collected OpenAI stream', 'forceStream'],
+  ] as const)('applies and refreshes the idle timeout for a %s', async (_name, route) => {
+    vi.useFakeTimers();
+    const restoreEnv = setTimeoutEnv({
+      CLODEX_UPSTREAM_IDLE_TIMEOUT_MS: '10000',
+      CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS: '60000',
+    });
+    let sdkSignal: AbortSignal | undefined;
+    let releaseFirstPart: () => void = () => {};
+    const firstPart = new Promise<void>(resolve => { releaseFirstPart = resolve; });
+    let finishForCleanup: () => void = () => {};
+    const cleanup = new Promise<void>(resolve => { finishForCleanup = resolve; });
+    vi.mocked(streamText).mockImplementation((options) => {
+      sdkSignal = options.abortSignal;
+      async function* stream() {
+        await firstPart;
+        yield { type: 'text-delta', text: 'started' };
+        await Promise.race([
+          cleanup,
+          new Promise<never>((_resolve, reject) => {
+            options.abortSignal?.addEventListener(
+              'abort',
+              () => reject(options.abortSignal?.reason),
+              { once: true },
+            );
+          }),
+        ]);
+      }
+      return { stream: stream() } as never;
+    });
+
+    let request: Promise<unknown> | undefined;
+    try {
+      request = route === 'stream'
+        ? streamOpenAiResponse({} as never, { messages: [] }, 'test-model', () => {})
+        : generateOpenAiResponse(
+          {} as never,
+          { messages: [] },
+          'test-model',
+          { forceStream: true },
+        );
+      const rejection = request.catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(9_999);
+      expect(sdkSignal?.aborted).toBe(false);
+      releaseFirstPart();
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(sdkSignal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(9_998);
+      expect(sdkSignal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(sdkSignal?.aborted).toBe(true);
+      await expect(rejection).resolves.toMatchObject({
+        message: 'no data received from provider for 10s',
+      });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      finishForCleanup();
+      await vi.advanceTimersByTimeAsync(0);
+      await Promise.allSettled(request ? [request] : []);
+      restoreEnv();
+      vi.mocked(streamText).mockReset();
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears timeout timers after successful OpenAI generations', async () => {
+    vi.useFakeTimers();
+    const restoreEnv = setTimeoutEnv({
+      CLODEX_UPSTREAM_IDLE_TIMEOUT_MS: '10000',
+      CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS: '60000',
+    });
+    async function* stream() {
+      yield { type: 'finish', finishReason: 'stop' };
+    }
+    vi.mocked(streamText).mockReturnValue({ stream: stream() } as never);
+    vi.mocked(generateText).mockResolvedValue({
+      text: 'done',
+      toolCalls: [],
+      finishReason: 'stop',
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+    } as never);
+
+    try {
+      await streamOpenAiResponse({} as never, { messages: [] }, 'test-model', () => {});
+      await generateOpenAiResponse({} as never, { messages: [] }, 'test-model');
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      restoreEnv();
+      vi.mocked(streamText).mockReset();
+      vi.mocked(generateText).mockReset();
+      vi.useRealTimers();
+    }
+  });
+
+  it('applies the total timeout to an active OpenAI stream', async () => {
+    vi.useFakeTimers();
+    const restoreEnv = setTimeoutEnv({
+      CLODEX_UPSTREAM_IDLE_TIMEOUT_MS: '10000',
+      CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS: '60000',
+    });
+    let sdkSignal: AbortSignal | undefined;
+    vi.mocked(streamText).mockImplementation((options) => {
+      sdkSignal = options.abortSignal;
+      async function* stream() {
+        while (true) {
+          await new Promise(resolve => setTimeout(resolve, 5_000));
+          yield { type: 'text-delta', text: 'active' };
+        }
+      }
+      return { stream: stream() } as never;
+    });
+
+    let request: Promise<unknown> | undefined;
+    try {
+      request = streamOpenAiResponse({} as never, { messages: [] }, 'test-model', () => {});
+      const rejection = request.catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(59_999);
+      expect(sdkSignal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(sdkSignal?.aborted).toBe(true);
+      await expect(rejection).resolves.toMatchObject({
+        message: 'provider stream exceeded 60s',
+      });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      await Promise.allSettled(request ? [request] : []);
+      restoreEnv();
+      vi.mocked(streamText).mockReset();
+      vi.useRealTimers();
+    }
+  });
+
+  it('applies the total timeout to a non-streaming OpenAI response', async () => {
+    vi.useFakeTimers();
+    const restoreEnv = setTimeoutEnv({
+      CLODEX_UPSTREAM_IDLE_TIMEOUT_MS: '10000',
+      CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS: '60000',
+    });
+    let sdkSignal: AbortSignal | undefined;
+    let finishForCleanup: () => void = () => {};
+    const cleanup = new Promise<void>(resolve => { finishForCleanup = resolve; });
+    vi.mocked(generateText).mockImplementation((options) => {
+      sdkSignal = options.abortSignal;
+      return Promise.race([
+        cleanup.then(() => ({
+          text: 'done',
+          toolCalls: [],
+          finishReason: 'stop',
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        })),
+        new Promise<never>((_resolve, reject) => {
+          options.abortSignal?.addEventListener(
+            'abort',
+            () => reject(options.abortSignal?.reason),
+            { once: true },
+          );
+        }),
+      ]) as never;
+    });
+
+    let request: Promise<unknown> | undefined;
+    try {
+      request = generateOpenAiResponse({} as never, { messages: [] }, 'test-model');
+      const rejection = request.catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(sdkSignal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(49_999);
+      expect(sdkSignal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(sdkSignal?.aborted).toBe(true);
+      await expect(rejection).resolves.toMatchObject({
+        message: 'provider request exceeded 60s',
+      });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      finishForCleanup();
+      await vi.advanceTimersByTimeAsync(0);
+      await Promise.allSettled(request ? [request] : []);
+      restoreEnv();
+      vi.mocked(generateText).mockReset();
+      vi.useRealTimers();
     }
   });
 });

--- a/tests/responses-websocket.test.ts
+++ b/tests/responses-websocket.test.ts
@@ -1065,7 +1065,7 @@ describe('createResponsesWebSocketFetch', () => {
       status: 429,
     })));
 
-    // Bounded so a hostile hint cannot park a client past the 120s stream abort.
+    // Bound a hostile day-long hint to the documented 60-second cap.
     expect(await readAll(res)).toContain('retry after 60s');
   });
 
@@ -1292,8 +1292,7 @@ describe('createResponsesWebSocketFetch', () => {
         error: { type: 'usage_limit_reached', message: 'weekly limit reached', retry_after_seconds: 1800 },
       },
     });
-    // Clamped to MAX_RETRY_AFTER_SECONDS: a hint of hours must not park the
-    // client past the 120s no-event stream abort.
+    // Clamped to MAX_RETRY_AFTER_SECONDS so an hour-scale hint cannot park the client.
     expect(body).toContain('retry after 60s');
     expect(await classifyThroughSdk(body)).toMatchObject({ statusCode: 429, retryAfterSeconds: 60 });
   });

--- a/tests/sdk-adapter.test.ts
+++ b/tests/sdk-adapter.test.ts
@@ -696,7 +696,8 @@ describe('generateAnthropicResponse', () => {
       finishReason: 'stop',
       usage: { inputTokens: 1, outputTokens: 1 },
     }));
-    vi.doMock('ai', () => ({
+    vi.doMock('ai', async () => ({
+      ...(await vi.importActual<typeof import('ai')>('ai')),
       generateText,
       streamText: vi.fn(),
       tool: vi.fn((spec: unknown) => spec),
@@ -725,7 +726,8 @@ describe('generateAnthropicResponse', () => {
       yield { type: 'finish', finishReason: 'stop' };
     }
     const streamText = vi.fn(() => ({ stream: stream() }));
-    vi.doMock('ai', () => ({
+    vi.doMock('ai', async () => ({
+      ...(await vi.importActual<typeof import('ai')>('ai')),
       generateText: vi.fn(),
       streamText,
       tool: vi.fn((spec: unknown) => spec),
@@ -765,7 +767,8 @@ describe('generateAnthropicResponse', () => {
         inputTokenDetails: { cacheReadTokens: 280_000, cacheWriteTokens: 1_000 },
       },
     }));
-    vi.doMock('ai', () => ({
+    vi.doMock('ai', async () => ({
+      ...(await vi.importActual<typeof import('ai')>('ai')),
       generateText,
       streamText: vi.fn(),
       tool: vi.fn((spec: unknown) => spec),
@@ -800,7 +803,8 @@ describe('generateAnthropicResponse', () => {
       finishReason: 'stop',
       usage: undefined,
     }));
-    vi.doMock('ai', () => ({
+    vi.doMock('ai', async () => ({
+      ...(await vi.importActual<typeof import('ai')>('ai')),
       generateText,
       streamText: vi.fn(),
       tool: vi.fn((spec: unknown) => spec),
@@ -830,7 +834,8 @@ describe('generateAnthropicResponse', () => {
         totalUsage: { inputTokens: 300_000, outputTokens: 5 },
       };
     }
-    vi.doMock('ai', () => ({
+    vi.doMock('ai', async () => ({
+      ...(await vi.importActual<typeof import('ai')>('ai')),
       generateText: vi.fn(),
       streamText: vi.fn(() => ({ stream: stream() })),
       tool: vi.fn((spec: unknown) => spec),
@@ -864,7 +869,8 @@ describe('generateAnthropicResponse', () => {
       finishReason: 'tool-calls',
       usage: { inputTokens: 1, outputTokens: 2 },
     }));
-    vi.doMock('ai', () => ({
+    vi.doMock('ai', async () => ({
+      ...(await vi.importActual<typeof import('ai')>('ai')),
       generateText,
       streamText: vi.fn(),
       tool: vi.fn((spec: unknown) => spec),
@@ -897,7 +903,8 @@ describe('generateAnthropicResponse', () => {
       });
     }
     const streamText = vi.fn(() => result);
-    vi.doMock('ai', () => ({
+    vi.doMock('ai', async () => ({
+      ...(await vi.importActual<typeof import('ai')>('ai')),
       generateText,
       streamText,
       tool: vi.fn((spec: unknown) => spec),
@@ -945,7 +952,8 @@ describe('generateAnthropicResponse', () => {
       yield { type: 'error', error: upstreamError };
     }
     const streamText = vi.fn(() => ({ stream: stream() }));
-    vi.doMock('ai', () => ({
+    vi.doMock('ai', async () => ({
+      ...(await vi.importActual<typeof import('ai')>('ai')),
       generateText: vi.fn(),
       streamText,
       tool: vi.fn((spec: unknown) => spec),
@@ -981,7 +989,8 @@ describe('generateAnthropicResponse', () => {
       usage: Promise.resolve({ inputTokens: 0, outputTokens: 0 }),
       stream: stream(),
     }));
-    vi.doMock('ai', () => ({
+    vi.doMock('ai', async () => ({
+      ...(await vi.importActual<typeof import('ai')>('ai')),
       generateText: vi.fn(),
       streamText,
       tool: vi.fn((spec: unknown) => spec),
@@ -1011,7 +1020,8 @@ describe('streamAnthropicResponse idle timeout', () => {
       yield { type: 'finish', finishReason: 'stop' };
     }
     const streamText = vi.fn(() => ({ stream: stream() }));
-    vi.doMock('ai', () => ({
+    vi.doMock('ai', async () => ({
+      ...(await vi.importActual<typeof import('ai')>('ai')),
       generateText: vi.fn(),
       streamText,
       tool: vi.fn((spec: unknown) => spec),
@@ -1041,7 +1051,8 @@ describe('streamAnthropicResponse idle timeout', () => {
       options.onStepFinish?.({ warnings: [{ type: 'unsupported', feature: 'serviceTier' }] });
       return { stream: stream() };
     });
-    vi.doMock('ai', () => ({
+    vi.doMock('ai', async () => ({
+      ...(await vi.importActual<typeof import('ai')>('ai')),
       generateText: vi.fn(),
       streamText,
       tool: vi.fn((spec: unknown) => spec),
@@ -1085,7 +1096,8 @@ describe('streamAnthropicResponse idle timeout', () => {
       });
     }
     const streamText = vi.fn(() => result);
-    vi.doMock('ai', () => ({
+    vi.doMock('ai', async () => ({
+      ...(await vi.importActual<typeof import('ai')>('ai')),
       generateText: vi.fn(),
       streamText,
       tool: vi.fn((spec: unknown) => spec),

--- a/tests/upstream-error.test.ts
+++ b/tests/upstream-error.test.ts
@@ -298,8 +298,7 @@ describe('provider stream error frames', () => {
     });
     expect(sdkUpstreamErrorDetails(frame('throttled; retry after 7s')))
       .toMatchObject({ statusCode: 429, isRetryable: true, retryAfterSeconds: 7 });
-    // Clamped so a hostile or absurd hint cannot park a client past the
-    // 120s no-event stream abort.
+    // Clamp an hour-scale hint to the documented 60-second cap.
     expect(sdkUpstreamErrorDetails(frame('throttled; retry after 3600s'))?.retryAfterSeconds).toBe(60);
   });
 

--- a/tests/upstream-error.test.ts
+++ b/tests/upstream-error.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { APICallError, RetryError } from 'ai';
+import { MockLanguageModelV4 } from 'ai/test';
 import {
   anthropicErrorType,
   clampRetryAfterSeconds,
@@ -8,12 +9,16 @@ import {
   sdkUpstreamErrorDetails,
   upstreamHttpStatus,
 } from '../src/upstream-error.js';
+import { generateAnthropicResponse, streamAnthropicResponse } from '../src/sdk-adapter.js';
+import { generateOpenAiResponse, streamOpenAiResponse } from '../src/openai-adapter.js';
+import { trackUpstreamAttempts } from '../src/upstream-attempts.js';
 
 function apiCallError(overrides: {
   statusCode: number;
   message?: string;
   responseBody?: string;
   responseHeaders?: Record<string, string>;
+  isRetryable?: boolean;
   data?: unknown;
 }): APICallError {
   return new APICallError({
@@ -482,5 +487,262 @@ describe('clampRetryAfterSeconds', () => {
     expect(clampRetryAfterSeconds(0)).toBe(0);
     expect(clampRetryAfterSeconds(12)).toBe(12);
     expect(clampRetryAfterSeconds(3600)).toBe(60);
+  });
+});
+
+describe('retry deadline error preservation', () => {
+  it.each(['doStream', 'doGenerate'] as const)(
+    'preserves a rejected provider error from %s while the SDK waits to retry',
+    async method => {
+      const providerError = apiCallError({
+        statusCode: 429,
+        responseBody: JSON.stringify({ error: { message: 'rate limited' } }),
+        responseHeaders: { 'retry-after': '31' },
+        isRetryable: true,
+      });
+      const model = new MockLanguageModelV4({
+        doStream: async () => { throw providerError; },
+        doGenerate: async () => { throw providerError; },
+      });
+      const tracked = trackUpstreamAttempts(model);
+      if (typeof tracked.model === 'string') throw new Error('expected a wrapped language model');
+
+      await expect(tracked.model[method]({} as never)).rejects.toBe(providerError);
+
+      expect(sdkUpstreamErrorDetails(tracked.deadlineError(new Error('request timed out'))))
+        .toMatchObject({
+          statusCode: 429,
+          retryAfterSeconds: 31,
+          attemptCount: 1,
+        });
+    },
+  );
+
+  it('keeps the last 429 when the idle deadline interrupts real SDK retry backoff', async () => {
+    vi.useFakeTimers();
+    const envKeys = [
+      'CLODEX_UPSTREAM_IDLE_TIMEOUT_MS',
+      'CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS',
+      'CLODEX_UPSTREAM_MAX_RETRIES',
+    ] as const;
+    const previous = new Map(envKeys.map(key => [key, process.env[key]]));
+    for (const key of envKeys) delete process.env[key];
+
+    let attempts = 0;
+    const providerError = apiCallError({
+      statusCode: 429,
+      responseBody: JSON.stringify({ error: { message: 'rate limited' } }),
+      responseHeaders: { 'retry-after': '31' },
+      isRetryable: true,
+    });
+    const model = new MockLanguageModelV4({
+      doStream: async () => {
+        attempts += 1;
+        throw providerError;
+      },
+    });
+
+    let request: Promise<void> | undefined;
+    try {
+      request = streamAnthropicResponse(
+        model,
+        { messages: [{ role: 'user', content: 'test' }] },
+        'test-model',
+        () => {},
+      );
+      const rejection = request.catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(119_999);
+      expect(attempts).toBe(4);
+      await vi.advanceTimersByTimeAsync(1);
+
+      const error = await rejection;
+      expect(sdkUpstreamErrorDetails(error)).toMatchObject({
+        statusCode: 429,
+        retryAfterSeconds: 31,
+        attemptCount: 4,
+      });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      await Promise.allSettled(request ? [request] : []);
+      for (const [key, value] of previous) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    ['collected Anthropic stream', 'anthropic'],
+    ['forwarded OpenAI stream', 'openai'],
+    ['collected OpenAI stream', 'openai-collected'],
+  ] as const)('preserves provider failures on the %s route', async (_name, route) => {
+    vi.useFakeTimers();
+    const priorIdle = process.env.CLODEX_UPSTREAM_IDLE_TIMEOUT_MS;
+    const priorTotal = process.env.CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS;
+    const priorRetries = process.env.CLODEX_UPSTREAM_MAX_RETRIES;
+    process.env.CLODEX_UPSTREAM_IDLE_TIMEOUT_MS = '10000';
+    process.env.CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS = '60000';
+    process.env.CLODEX_UPSTREAM_MAX_RETRIES = '2';
+
+    let attempts = 0;
+    const providerError = apiCallError({
+      statusCode: 429,
+      responseHeaders: { 'retry-after': '6' },
+      isRetryable: true,
+    });
+    const model = new MockLanguageModelV4({
+      doStream: async () => {
+        attempts += 1;
+        throw providerError;
+      },
+    });
+
+    let request: Promise<unknown> | undefined;
+    try {
+      const params = { messages: [{ role: 'user' as const, content: 'test' }] };
+      request = route === 'anthropic'
+        ? generateAnthropicResponse(model, params, 'test-model', { forceStream: true })
+        : route === 'openai'
+          ? streamOpenAiResponse(model, params, 'test-model', () => {})
+          : generateOpenAiResponse(model, params, 'test-model', { forceStream: true });
+      const rejection = request.catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(9_999);
+      expect(attempts).toBe(2);
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(sdkUpstreamErrorDetails(await rejection)).toMatchObject({
+        statusCode: 429,
+        retryAfterSeconds: 6,
+        attemptCount: 2,
+      });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      await Promise.allSettled(request ? [request] : []);
+      if (priorIdle === undefined) delete process.env.CLODEX_UPSTREAM_IDLE_TIMEOUT_MS;
+      else process.env.CLODEX_UPSTREAM_IDLE_TIMEOUT_MS = priorIdle;
+      if (priorTotal === undefined) delete process.env.CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS;
+      else process.env.CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS = priorTotal;
+      if (priorRetries === undefined) delete process.env.CLODEX_UPSTREAM_MAX_RETRIES;
+      else process.env.CLODEX_UPSTREAM_MAX_RETRIES = priorRetries;
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    ['Anthropic', 'anthropic'],
+    ['OpenAI', 'openai'],
+  ] as const)('preserves provider failures on the non-streaming %s route', async (_name, route) => {
+    vi.useFakeTimers();
+    const priorIdle = process.env.CLODEX_UPSTREAM_IDLE_TIMEOUT_MS;
+    const priorTotal = process.env.CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS;
+    const priorRetries = process.env.CLODEX_UPSTREAM_MAX_RETRIES;
+    process.env.CLODEX_UPSTREAM_IDLE_TIMEOUT_MS = '60000';
+    process.env.CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS = '60000';
+    process.env.CLODEX_UPSTREAM_MAX_RETRIES = '4';
+
+    let attempts = 0;
+    const providerError = apiCallError({
+      statusCode: 429,
+      responseHeaders: { 'retry-after': '31' },
+      isRetryable: true,
+    });
+    const model = new MockLanguageModelV4({
+      doGenerate: async () => {
+        attempts += 1;
+        throw providerError;
+      },
+    });
+
+    let request: Promise<unknown> | undefined;
+    try {
+      const params = { messages: [{ role: 'user' as const, content: 'test' }] };
+      request = route === 'anthropic'
+        ? generateAnthropicResponse(model, params, 'test-model')
+        : generateOpenAiResponse(model, params, 'test-model');
+      const rejection = request.catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(59_999);
+      expect(attempts).toBe(2);
+      await vi.advanceTimersByTimeAsync(1);
+
+      const error = await rejection;
+      expect(sdkUpstreamErrorDetails(error)).toMatchObject({
+        statusCode: 429,
+        retryAfterSeconds: 31,
+        attemptCount: 2,
+      });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      await Promise.allSettled(request ? [request] : []);
+      if (priorIdle === undefined) delete process.env.CLODEX_UPSTREAM_IDLE_TIMEOUT_MS;
+      else process.env.CLODEX_UPSTREAM_IDLE_TIMEOUT_MS = priorIdle;
+      if (priorTotal === undefined) delete process.env.CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS;
+      else process.env.CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS = priorTotal;
+      if (priorRetries === undefined) delete process.env.CLODEX_UPSTREAM_MAX_RETRIES;
+      else process.env.CLODEX_UPSTREAM_MAX_RETRIES = priorRetries;
+      vi.useRealTimers();
+    }
+  });
+
+  it('uses the timeout when a retried provider call is currently silent', async () => {
+    vi.useFakeTimers();
+    const priorIdle = process.env.CLODEX_UPSTREAM_IDLE_TIMEOUT_MS;
+    const priorTotal = process.env.CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS;
+    const priorRetries = process.env.CLODEX_UPSTREAM_MAX_RETRIES;
+    process.env.CLODEX_UPSTREAM_IDLE_TIMEOUT_MS = '10000';
+    process.env.CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS = '60000';
+    process.env.CLODEX_UPSTREAM_MAX_RETRIES = '2';
+
+    let attempts = 0;
+    const providerError = apiCallError({
+      statusCode: 429,
+      responseHeaders: { 'retry-after': '2' },
+      isRetryable: true,
+    });
+    const model = new MockLanguageModelV4({
+      doStream: async options => {
+        attempts += 1;
+        if (attempts === 1) throw providerError;
+        return new Promise<never>((_resolve, reject) => {
+          options.abortSignal?.addEventListener(
+            'abort',
+            () => reject(options.abortSignal?.reason),
+            { once: true },
+          );
+        });
+      },
+    });
+
+    let request: Promise<void> | undefined;
+    try {
+      request = streamAnthropicResponse(
+        model,
+        { messages: [{ role: 'user', content: 'test' }] },
+        'test-model',
+        () => {},
+      );
+      const rejection = request.catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(9_999);
+      expect(attempts).toBe(2);
+      await vi.advanceTimersByTimeAsync(1);
+
+      const error = await rejection;
+      expect(error).toMatchObject({ message: 'no data received from provider for 10s' });
+      expect(sdkUpstreamErrorDetails(error)).toBeUndefined();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      await Promise.allSettled(request ? [request] : []);
+      if (priorIdle === undefined) delete process.env.CLODEX_UPSTREAM_IDLE_TIMEOUT_MS;
+      else process.env.CLODEX_UPSTREAM_IDLE_TIMEOUT_MS = priorIdle;
+      if (priorTotal === undefined) delete process.env.CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS;
+      else process.env.CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS = priorTotal;
+      if (priorRetries === undefined) delete process.env.CLODEX_UPSTREAM_MAX_RETRIES;
+      else process.env.CLODEX_UPSTREAM_MAX_RETRIES = priorRetries;
+      vi.useRealTimers();
+    }
   });
 });

--- a/tests/upstream-retry.test.ts
+++ b/tests/upstream-retry.test.ts
@@ -2,15 +2,21 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   DEFAULT_PASSTHROUGH_RETRIES,
   MAX_UPSTREAM_MAX_RETRIES,
+  UPSTREAM_IDLE_TIMEOUT_ENV,
   UPSTREAM_MAX_RETRIES_ENV,
+  UPSTREAM_TOTAL_TIMEOUT_ENV,
   passthroughUpstreamRetries,
-  upstreamMaxRetries,
+  upstreamRequestBudget,
 } from '../src/upstream-retry.js';
 import { installParentNoticeSink } from '../src/parent-notice.js';
 
-describe('upstreamMaxRetries', () => {
+function resolvedRetries(env: NodeJS.ProcessEnv, warn?: (message: string) => void): number | undefined {
+  return upstreamRequestBudget({ env, ...(warn ? { warn } : {}) }).maxRetries;
+}
+
+describe('upstream retry budget', () => {
   it('leaves the SDK default in control when the setting is absent', () => {
-    expect(upstreamMaxRetries({})).toBeUndefined();
+    expect(resolvedRetries({})).toBeUndefined();
   });
 
   it.each([
@@ -18,13 +24,13 @@ describe('upstreamMaxRetries', () => {
     ['higher budget', '4', 4],
     ['ceiling', '5', 5],
   ])('accepts %s', (_name, raw, expected) => {
-    expect(upstreamMaxRetries({ [UPSTREAM_MAX_RETRIES_ENV]: raw })).toBe(expected);
+    expect(resolvedRetries({ [UPSTREAM_MAX_RETRIES_ENV]: raw })).toBe(expected);
   });
 
   it.each(['lots', '1.5', '-1'])('ignores and reports invalid value %s', raw => {
     const log = vi.fn();
 
-    expect(upstreamMaxRetries({ [UPSTREAM_MAX_RETRIES_ENV]: raw }, log)).toBeUndefined();
+    expect(resolvedRetries({ [UPSTREAM_MAX_RETRIES_ENV]: raw }, log)).toBeUndefined();
     expect(log).toHaveBeenCalledWith(
       `ignoring ${UPSTREAM_MAX_RETRIES_ENV}=${raw} (expected a non-negative integer)`,
     );
@@ -33,18 +39,19 @@ describe('upstreamMaxRetries', () => {
   it('leaves the SDK default in control for whitespace-only input', () => {
     const log = vi.fn();
 
-    expect(upstreamMaxRetries({ [UPSTREAM_MAX_RETRIES_ENV]: '   ' }, log)).toBeUndefined();
+    expect(resolvedRetries({ [UPSTREAM_MAX_RETRIES_ENV]: '   ' }, log)).toBeUndefined();
     expect(log).not.toHaveBeenCalled();
   });
 
   it('clamps values above the streaming-safe ceiling', () => {
     const log = vi.fn();
 
-    expect(upstreamMaxRetries({ [UPSTREAM_MAX_RETRIES_ENV]: '8' }, log))
+    expect(resolvedRetries({ [UPSTREAM_MAX_RETRIES_ENV]: '8' }, log))
       .toBe(MAX_UPSTREAM_MAX_RETRIES);
     expect(log).toHaveBeenCalledWith(
       `clamping ${UPSTREAM_MAX_RETRIES_ENV}=8 to ${MAX_UPSTREAM_MAX_RETRIES} `
-      + '(higher values exceed the 120s streaming idle budget)',
+      + '(estimated from the SDK fallback backoff and resolved 120000ms idle timeout; '
+      + 'provider delays may allow fewer retries)',
     );
   });
 
@@ -52,8 +59,8 @@ describe('upstreamMaxRetries', () => {
     const log = vi.fn();
     const env = { [UPSTREAM_MAX_RETRIES_ENV]: '99' };
 
-    expect(upstreamMaxRetries(env, log)).toBe(MAX_UPSTREAM_MAX_RETRIES);
-    expect(upstreamMaxRetries(env, log)).toBe(MAX_UPSTREAM_MAX_RETRIES);
+    expect(resolvedRetries(env, log)).toBe(MAX_UPSTREAM_MAX_RETRIES);
+    expect(resolvedRetries(env, log)).toBe(MAX_UPSTREAM_MAX_RETRIES);
 
     expect(log).toHaveBeenCalledOnce();
   });
@@ -64,11 +71,12 @@ describe('upstreamMaxRetries', () => {
       .mockImplementation((chunk: unknown) => { stderr.push(String(chunk)); return true; });
 
     try {
-      expect(upstreamMaxRetries({ [UPSTREAM_MAX_RETRIES_ENV]: '6' }))
+      expect(resolvedRetries({ [UPSTREAM_MAX_RETRIES_ENV]: '6' }))
         .toBe(MAX_UPSTREAM_MAX_RETRIES);
       expect(stderr.join('')).toBe(
         `clodex: clamping ${UPSTREAM_MAX_RETRIES_ENV}=6 to ${MAX_UPSTREAM_MAX_RETRIES} `
-        + '(higher values exceed the 120s streaming idle budget)\n',
+        + '(estimated from the SDK fallback backoff and resolved 120000ms idle timeout; '
+        + 'provider delays may allow fewer retries)\n',
       );
     } finally {
       spy.mockRestore();
@@ -86,7 +94,7 @@ describe('upstreamMaxRetries', () => {
     const release = installParentNoticeSink(line => notices.push(line));
 
     try {
-      expect(upstreamMaxRetries({ [UPSTREAM_MAX_RETRIES_ENV]: '7' }))
+      expect(resolvedRetries({ [UPSTREAM_MAX_RETRIES_ENV]: '7' }))
         .toBe(MAX_UPSTREAM_MAX_RETRIES);
       expect(notices.join('')).toContain(`clamping ${UPSTREAM_MAX_RETRIES_ENV}=7`);
       expect(stderr.join('')).toBe('');
@@ -94,6 +102,240 @@ describe('upstreamMaxRetries', () => {
       release();
       spy.mockRestore();
     }
+  });
+});
+
+describe('upstreamRequestBudget', () => {
+  it('preserves the existing timeout and retry defaults when settings are absent', () => {
+    const warn = vi.fn();
+
+    expect(upstreamRequestBudget({ env: {}, warn })).toEqual({
+      idleTimeoutMs: 120_000,
+      totalTimeoutMs: 600_000,
+      maxRetries: undefined,
+    });
+    expect(MAX_UPSTREAM_MAX_RETRIES).toBe(5);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('treats empty timeout settings as absent', () => {
+    const warn = vi.fn();
+
+    expect(upstreamRequestBudget({
+      env: {
+        [UPSTREAM_IDLE_TIMEOUT_ENV]: '   ',
+        [UPSTREAM_TOTAL_TIMEOUT_ENV]: '',
+      },
+      warn,
+    })).toMatchObject({
+      idleTimeoutMs: 120_000,
+      totalTimeoutMs: 600_000,
+    });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('ignores malformed timeout settings without failing the request', () => {
+    const warn = vi.fn(() => { throw new Error('notice sink unavailable'); });
+
+    expect(upstreamRequestBudget({
+      env: {
+        [UPSTREAM_IDLE_TIMEOUT_ENV]: 'not-a-duration',
+        [UPSTREAM_TOTAL_TIMEOUT_ENV]: '1.5',
+      },
+      warn,
+    })).toEqual({
+      idleTimeoutMs: 120_000,
+      totalTimeoutMs: 600_000,
+      maxRetries: undefined,
+    });
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('clamps timeout settings to their supported ranges', () => {
+    const warn = vi.fn();
+
+    expect(upstreamRequestBudget({
+      env: {
+        [UPSTREAM_IDLE_TIMEOUT_ENV]: '9',
+        [UPSTREAM_TOTAL_TIMEOUT_ENV]: '99999999',
+      },
+      warn,
+    })).toMatchObject({
+      idleTimeoutMs: 10_000,
+      totalTimeoutMs: 21_600_000,
+    });
+    expect(warn.mock.calls.map(([message]) => message)).toEqual([
+      `clamping ${UPSTREAM_IDLE_TIMEOUT_ENV}=9 to ${10_000}ms `
+        + `(supported range is ${10_000}-${3_600_000}ms)`,
+      `clamping ${UPSTREAM_TOTAL_TIMEOUT_ENV}=99999999 to ${21_600_000}ms `
+        + `(supported range is ${60_000}-${21_600_000}ms)`,
+    ]);
+  });
+
+  it('clamps a too-short total timeout without changing a shorter idle timeout', () => {
+    const warn = vi.fn();
+
+    expect(upstreamRequestBudget({
+      env: {
+        CLODEX_UPSTREAM_IDLE_TIMEOUT_MS: '10000',
+        CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS: '1',
+      },
+      warn,
+    })).toMatchObject({ idleTimeoutMs: 10_000, totalTimeoutMs: 60_000 });
+    expect(warn).toHaveBeenCalledWith(
+      'clamping CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS=1 to 60000ms '
+        + '(supported range is 60000-21600000ms)',
+    );
+  });
+
+  it('reports the same out-of-range timeout value once for each setting', () => {
+    const warn = vi.fn();
+    const env = {
+      [UPSTREAM_IDLE_TIMEOUT_ENV]: '8',
+      [UPSTREAM_TOTAL_TIMEOUT_ENV]: '8',
+    };
+
+    upstreamRequestBudget({ env, warn });
+    upstreamRequestBudget({ env, warn });
+
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn.mock.calls.map(([message]) => message)).toEqual([
+      expect.stringContaining(UPSTREAM_IDLE_TIMEOUT_ENV),
+      expect.stringContaining(UPSTREAM_TOTAL_TIMEOUT_ENV),
+    ]);
+  });
+
+  it('raises the default total timeout to honor a longer explicit idle timeout', () => {
+    const warn = vi.fn();
+
+    expect(upstreamRequestBudget({
+      env: { [UPSTREAM_IDLE_TIMEOUT_ENV]: '700000' },
+      warn,
+    })).toMatchObject({ idleTimeoutMs: 700_000, totalTimeoutMs: 700_000 });
+    expect(warn).toHaveBeenCalledWith(
+      `raising the resolved total timeout from 600000ms to 700000ms `
+      + `so it is not shorter than ${UPSTREAM_IDLE_TIMEOUT_ENV}`,
+    );
+  });
+
+  it('reports the same timeout-pair adjustment only once per process', () => {
+    const warn = vi.fn();
+    const env = { CLODEX_UPSTREAM_IDLE_TIMEOUT_MS: '710000' };
+
+    upstreamRequestBudget({ env, warn });
+    upstreamRequestBudget({ env, warn });
+
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it('honors an explicit total timeout by lowering a longer idle timeout', () => {
+    const warn = vi.fn();
+
+    expect(upstreamRequestBudget({
+      env: {
+        [UPSTREAM_IDLE_TIMEOUT_ENV]: '180000',
+        [UPSTREAM_TOTAL_TIMEOUT_ENV]: '60000',
+      },
+      warn,
+    })).toMatchObject({ idleTimeoutMs: 60_000, totalTimeoutMs: 60_000 });
+    expect(warn).toHaveBeenCalledWith(
+      `lowering the resolved idle timeout from 180000ms to 60000ms `
+      + `because it cannot exceed ${UPSTREAM_TOTAL_TIMEOUT_ENV}`,
+    );
+  });
+
+  it('treats a clamped idle value as explicit when reconciling the pair', () => {
+    const warn = vi.fn();
+
+    expect(upstreamRequestBudget({
+      env: { CLODEX_UPSTREAM_IDLE_TIMEOUT_MS: '99999999' },
+      warn,
+    })).toMatchObject({ idleTimeoutMs: 3_600_000, totalTimeoutMs: 3_600_000 });
+    expect(warn.mock.calls.map(([message]) => message)).toEqual([
+      'clamping CLODEX_UPSTREAM_IDLE_TIMEOUT_MS=99999999 to 3600000ms '
+        + '(supported range is 10000-3600000ms)',
+      'raising the resolved total timeout from 600000ms to 3600000ms '
+        + 'so it is not shorter than CLODEX_UPSTREAM_IDLE_TIMEOUT_MS',
+    ]);
+  });
+
+  it('lowers the default idle timeout when only a shorter total is explicit', () => {
+    const warn = vi.fn();
+
+    expect(upstreamRequestBudget({
+      env: { CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS: '60000' },
+      warn,
+    })).toMatchObject({ idleTimeoutMs: 60_000, totalTimeoutMs: 60_000 });
+    expect(warn).toHaveBeenCalledWith(
+      'lowering the resolved idle timeout from 120000ms to 60000ms '
+        + 'because it cannot exceed CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS',
+    );
+  });
+
+  it('does not warn for valid in-range timeout values', () => {
+    const warn = vi.fn();
+
+    expect(upstreamRequestBudget({
+      env: {
+        CLODEX_UPSTREAM_IDLE_TIMEOUT_MS: '300000',
+        CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS: '900000',
+      },
+      warn,
+    })).toMatchObject({ idleTimeoutMs: 300_000, totalTimeoutMs: 900_000 });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('lets a direct idle override supersede the environment before pair resolution', () => {
+    const warn = vi.fn();
+
+    expect(upstreamRequestBudget({
+      env: { CLODEX_UPSTREAM_IDLE_TIMEOUT_MS: '700000' },
+      idleTimeoutMs: 50,
+      warn,
+    })).toEqual({ idleTimeoutMs: 50, totalTimeoutMs: 600_000, maxRetries: 0 });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('keeps a direct idle override within an explicit total timeout', () => {
+    expect(upstreamRequestBudget({
+      env: { CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS: '60000' },
+      idleTimeoutMs: 70_000,
+      warn: vi.fn(),
+    })).toMatchObject({ idleTimeoutMs: 60_000, totalTimeoutMs: 60_000, maxRetries: undefined });
+  });
+
+  it('uses the parent notice channel for timeout warnings by default', () => {
+    const notices: string[] = [];
+    const release = installParentNoticeSink(line => notices.push(line));
+    try {
+      expect(upstreamRequestBudget({
+        env: { CLODEX_UPSTREAM_IDLE_TIMEOUT_MS: 'not-milliseconds' },
+      })).toMatchObject({ idleTimeoutMs: 120_000, totalTimeoutMs: 600_000 });
+      expect(notices).toEqual([
+        'clodex: ignoring CLODEX_UPSTREAM_IDLE_TIMEOUT_MS=not-milliseconds '
+          + '(expected a positive integer number of milliseconds)\n',
+      ]);
+    } finally {
+      release();
+    }
+  });
+
+  it.each([
+    ['shorter budget', '30000', '9', 3],
+    ['exact sixth-retry boundary', '126000', '6', 5],
+    ['longer budget', '127000', '6', 6],
+    ['maximum budget', String(3_600_000), '99', 10],
+  ])('derives the retry ceiling from the %s', (_name, idle, retries, expected) => {
+    const warn = vi.fn();
+
+    expect(upstreamRequestBudget({
+      env: {
+        [UPSTREAM_IDLE_TIMEOUT_ENV]: idle,
+        [UPSTREAM_TOTAL_TIMEOUT_ENV]: String(21_600_000),
+        [UPSTREAM_MAX_RETRIES_ENV]: retries,
+      },
+      warn,
+    }).maxRetries).toBe(expected);
   });
 });
 
@@ -118,6 +360,21 @@ describe('passthroughUpstreamRetries', () => {
     } finally {
       spy.mockRestore();
     }
+  });
+
+  it('keeps the passthrough ceiling independent of translated timeout settings', () => {
+    const warn = vi.fn();
+
+    expect(passthroughUpstreamRetries({
+      CLODEX_UPSTREAM_MAX_RETRIES: '4',
+      CLODEX_UPSTREAM_IDLE_TIMEOUT_MS: '10000',
+      CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS: '60000',
+    }, warn)).toBe(4);
+    expect(passthroughUpstreamRetries({
+      CLODEX_UPSTREAM_IDLE_TIMEOUT_MS: 'not-a-timeout',
+      CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS: 'also-not-a-timeout',
+    }, warn)).toBe(1);
+    expect(warn).not.toHaveBeenCalled();
   });
 
   it('does not resend when the client itself was told never to resend', () => {
@@ -155,10 +412,363 @@ describe('passthroughUpstreamRetries', () => {
   it('falls back to the default when the setting is unusable', () => {
     const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     try {
-      expect(passthroughUpstreamRetries({ [UPSTREAM_MAX_RETRIES_ENV]: 'lots' }))
+      expect(passthroughUpstreamRetries({ [UPSTREAM_MAX_RETRIES_ENV]: 'passthrough-invalid' }))
         .toBe(DEFAULT_PASSTHROUGH_RETRIES);
     } finally {
       spy.mockRestore();
+    }
+  });
+});
+
+const REQUEST_BUDGET_ENV_KEYS = [
+  'CLODEX_UPSTREAM_MAX_RETRIES',
+  'CLODEX_UPSTREAM_IDLE_TIMEOUT_MS',
+  'CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS',
+] as const;
+
+function setRequestBudgetEnv(values: Partial<Record<typeof REQUEST_BUDGET_ENV_KEYS[number], string>>): () => void {
+  const previous = new Map(REQUEST_BUDGET_ENV_KEYS.map(key => [key, process.env[key]]));
+  for (const key of REQUEST_BUDGET_ENV_KEYS) {
+    const value = values[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  return () => {
+    for (const [key, value] of previous) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  };
+}
+
+describe('upstream request budget adapter wiring', () => {
+  it.each([
+    {
+      name: 'non-streaming generation',
+      route: 'generate',
+      idle: '60000',
+      total: '61000',
+      retries: '4',
+      expectedDelays: [61_000],
+      expectedRetries: 4,
+    },
+    {
+      name: 'collected streaming generation',
+      route: 'forceStream',
+      idle: '127000',
+      total: '130000',
+      retries: '5',
+      expectedDelays: [127_000, 130_000],
+      expectedRetries: 5,
+    },
+    {
+      name: 'forwarded streaming generation',
+      route: 'stream',
+      idle: '127000',
+      total: '130000',
+      retries: '5',
+      expectedDelays: [127_000, 130_000],
+      expectedRetries: 5,
+    },
+  ])('passes the resolved values to $name', async ({
+    route,
+    idle,
+    total,
+    retries,
+    expectedDelays,
+    expectedRetries,
+  }) => {
+    vi.resetModules();
+    const restoreEnv = setRequestBudgetEnv({
+      CLODEX_UPSTREAM_MAX_RETRIES: retries,
+      CLODEX_UPSTREAM_IDLE_TIMEOUT_MS: idle,
+      CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS: total,
+    });
+    async function* stream() {
+      yield { type: 'start' };
+      yield { type: 'finish', finishReason: 'stop' };
+    }
+    const streamText = vi.fn(() => ({ stream: stream() }));
+    const generateText = vi.fn(async () => ({
+      text: 'done',
+      toolCalls: [],
+      finishReason: 'stop',
+      usage: { inputTokens: 1, outputTokens: 1 },
+    }));
+    vi.doMock('ai', () => ({
+      generateText,
+      streamText,
+      tool: vi.fn((spec: unknown) => spec),
+      jsonSchema: vi.fn((schema: unknown) => schema),
+    }));
+    const timeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    try {
+      const adapter = await import('../src/sdk-adapter.js');
+      if (route === 'generate') {
+        await adapter.generateAnthropicResponse({} as never, { messages: [] }, 'test-model');
+      } else if (route === 'forceStream') {
+        await adapter.generateAnthropicResponse(
+          {} as never,
+          { messages: [] },
+          'test-model',
+          { forceStream: true },
+        );
+      } else {
+        await adapter.streamAnthropicResponse(
+          {} as never,
+          { messages: [] },
+          'test-model',
+          () => {},
+        );
+      }
+
+      const sdkCall = route === 'generate' ? generateText : streamText;
+      expect(sdkCall.mock.calls[0]![0].maxRetries).toBe(expectedRetries);
+      for (const delay of expectedDelays) {
+        expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), delay);
+      }
+    } finally {
+      timeoutSpy.mockRestore();
+      restoreEnv();
+      vi.doUnmock('ai');
+      vi.resetModules();
+    }
+  });
+
+  it('aborts a stalled stream at the configured idle timeout', async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    const restoreEnv = setRequestBudgetEnv({
+      CLODEX_UPSTREAM_IDLE_TIMEOUT_MS: '10000',
+      CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS: '60000',
+    });
+    const callerAbort = new AbortController();
+    let sdkSignal: AbortSignal | undefined;
+    const streamText = vi.fn((options: { abortSignal: AbortSignal }) => {
+      sdkSignal = options.abortSignal;
+      async function* stream() {
+        await new Promise<never>((_resolve, reject) => {
+          options.abortSignal.addEventListener(
+            'abort',
+            () => reject(options.abortSignal.reason),
+            { once: true },
+          );
+        });
+      }
+      return { stream: stream() };
+    });
+    vi.doMock('ai', () => ({
+      generateText: vi.fn(),
+      streamText,
+      tool: vi.fn((spec: unknown) => spec),
+      jsonSchema: vi.fn((schema: unknown) => schema),
+    }));
+
+    let request: Promise<void> | undefined;
+    try {
+      const { streamAnthropicResponse } = await import('../src/sdk-adapter.js');
+      request = streamAnthropicResponse(
+        {} as never,
+        { messages: [] },
+        'test-model',
+        () => {},
+        undefined,
+        { abortSignal: callerAbort.signal },
+      );
+      const rejection = request.catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(9_999);
+      expect(sdkSignal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(sdkSignal?.aborted).toBe(true);
+      await expect(rejection).resolves.toMatchObject({
+        message: 'no data received from provider for 10s',
+      });
+    } finally {
+      callerAbort.abort(new Error('test cleanup'));
+      await Promise.allSettled(request ? [request] : []);
+      vi.useRealTimers();
+      restoreEnv();
+      vi.doUnmock('ai');
+      vi.resetModules();
+    }
+  });
+
+  it('refreshes the collected-stream idle timer with the configured timeout', async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    const restoreEnv = setRequestBudgetEnv({
+      CLODEX_UPSTREAM_IDLE_TIMEOUT_MS: '10000',
+      CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS: '60000',
+    });
+    const callerAbort = new AbortController();
+    let sdkSignal: AbortSignal | undefined;
+    let releaseFirstPart: () => void = () => {};
+    const firstPart = new Promise<void>(resolve => { releaseFirstPart = resolve; });
+    const streamText = vi.fn((options: { abortSignal: AbortSignal }) => {
+      sdkSignal = options.abortSignal;
+      async function* stream() {
+        await firstPart;
+        yield { type: 'text-delta', text: 'started' };
+        await new Promise<never>((_resolve, reject) => {
+          options.abortSignal.addEventListener(
+            'abort',
+            () => reject(options.abortSignal.reason),
+            { once: true },
+          );
+        });
+      }
+      return { stream: stream() };
+    });
+    vi.doMock('ai', () => ({
+      generateText: vi.fn(),
+      streamText,
+      tool: vi.fn((spec: unknown) => spec),
+      jsonSchema: vi.fn((schema: unknown) => schema),
+    }));
+
+    let request: Promise<Record<string, unknown>> | undefined;
+    try {
+      const { generateAnthropicResponse } = await import('../src/sdk-adapter.js');
+      request = generateAnthropicResponse(
+        {} as never,
+        { messages: [] },
+        'test-model',
+        { forceStream: true, abortSignal: callerAbort.signal },
+      );
+      const rejection = request.catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(9_999);
+      expect(sdkSignal?.aborted).toBe(false);
+      releaseFirstPart();
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(sdkSignal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(9_998);
+      expect(sdkSignal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(sdkSignal?.aborted).toBe(true);
+      await expect(rejection).resolves.toMatchObject({
+        message: 'no data received from provider for 10s',
+      });
+    } finally {
+      callerAbort.abort(new Error('test cleanup'));
+      await Promise.allSettled(request ? [request] : []);
+      vi.useRealTimers();
+      restoreEnv();
+      vi.doUnmock('ai');
+      vi.resetModules();
+    }
+  });
+
+  it('aborts an active collected stream at the configured total timeout', async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    const restoreEnv = setRequestBudgetEnv({
+      CLODEX_UPSTREAM_IDLE_TIMEOUT_MS: '10000',
+      CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS: '60000',
+    });
+    const callerAbort = new AbortController();
+    let sdkSignal: AbortSignal | undefined;
+    const streamText = vi.fn((options: { abortSignal: AbortSignal }) => {
+      sdkSignal = options.abortSignal;
+      async function* stream() {
+        while (true) {
+          await new Promise(resolve => setTimeout(resolve, 5_000));
+          yield { type: 'text-delta', text: 'active' };
+        }
+      }
+      return { stream: stream() };
+    });
+    vi.doMock('ai', () => ({
+      generateText: vi.fn(),
+      streamText,
+      tool: vi.fn((spec: unknown) => spec),
+      jsonSchema: vi.fn((schema: unknown) => schema),
+    }));
+
+    let request: Promise<Record<string, unknown>> | undefined;
+    try {
+      const { generateAnthropicResponse } = await import('../src/sdk-adapter.js');
+      request = generateAnthropicResponse(
+        {} as never,
+        { messages: [] },
+        'test-model',
+        { forceStream: true, abortSignal: callerAbort.signal },
+      );
+      const rejection = request.catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(59_999);
+      expect(sdkSignal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(sdkSignal?.aborted).toBe(true);
+      await expect(rejection).resolves.toMatchObject({
+        message: 'provider stream exceeded 60s',
+      });
+    } finally {
+      callerAbort.abort(new Error('test cleanup'));
+      await Promise.allSettled(request ? [request] : []);
+      vi.useRealTimers();
+      restoreEnv();
+      vi.doUnmock('ai');
+      vi.resetModules();
+    }
+  });
+
+  it('aborts a non-streaming generation at the configured total timeout', async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    const restoreEnv = setRequestBudgetEnv({
+      CLODEX_UPSTREAM_IDLE_TIMEOUT_MS: '10000',
+      CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS: '60000',
+    });
+    const callerAbort = new AbortController();
+    let sdkSignal: AbortSignal | undefined;
+    const generateText = vi.fn((options: { abortSignal: AbortSignal }) => {
+      sdkSignal = options.abortSignal;
+      return new Promise<never>((_resolve, reject) => {
+        options.abortSignal.addEventListener(
+          'abort',
+          () => reject(options.abortSignal.reason),
+          { once: true },
+        );
+      });
+    });
+    vi.doMock('ai', () => ({
+      generateText,
+      streamText: vi.fn(),
+      tool: vi.fn((spec: unknown) => spec),
+      jsonSchema: vi.fn((schema: unknown) => schema),
+    }));
+
+    let request: Promise<Record<string, unknown>> | undefined;
+    try {
+      const { generateAnthropicResponse } = await import('../src/sdk-adapter.js');
+      request = generateAnthropicResponse(
+        {} as never,
+        { messages: [] },
+        'test-model',
+        { abortSignal: callerAbort.signal },
+      );
+      const rejection = request.catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(sdkSignal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(49_999);
+      expect(sdkSignal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(sdkSignal?.aborted).toBe(true);
+      await expect(rejection).resolves.toMatchObject({
+        message: 'provider request exceeded 60s',
+      });
+    } finally {
+      callerAbort.abort(new Error('test cleanup'));
+      await Promise.allSettled(request ? [request] : []);
+      vi.useRealTimers();
+      restoreEnv();
+      vi.doUnmock('ai');
+      vi.resetModules();
     }
   });
 });

--- a/tests/upstream-retry.test.ts
+++ b/tests/upstream-retry.test.ts
@@ -10,13 +10,22 @@ import {
 } from '../src/upstream-retry.js';
 import { installParentNoticeSink } from '../src/parent-notice.js';
 
-function resolvedRetries(env: NodeJS.ProcessEnv, warn?: (message: string) => void): number | undefined {
+function resolvedRetries(env: NodeJS.ProcessEnv, warn?: (message: string) => void): number {
   return upstreamRequestBudget({ env, ...(warn ? { warn } : {}) }).maxRetries;
 }
 
 describe('upstream retry budget', () => {
-  it('leaves the SDK default in control when the setting is absent', () => {
-    expect(resolvedRetries({})).toBeUndefined();
+  it('retries transient provider failures five times by default', () => {
+    expect(resolvedRetries({})).toBe(5);
+  });
+
+  it('lowers the default retry count with a shorter idle timeout', () => {
+    expect(upstreamRequestBudget({
+      env: {
+        CLODEX_UPSTREAM_IDLE_TIMEOUT_MS: '30000',
+        CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS: '60000',
+      },
+    }).maxRetries).toBe(3);
   });
 
   it.each([
@@ -30,16 +39,16 @@ describe('upstream retry budget', () => {
   it.each(['lots', '1.5', '-1'])('ignores and reports invalid value %s', raw => {
     const log = vi.fn();
 
-    expect(resolvedRetries({ [UPSTREAM_MAX_RETRIES_ENV]: raw }, log)).toBeUndefined();
+    expect(resolvedRetries({ [UPSTREAM_MAX_RETRIES_ENV]: raw }, log)).toBe(5);
     expect(log).toHaveBeenCalledWith(
       `ignoring ${UPSTREAM_MAX_RETRIES_ENV}=${raw} (expected a non-negative integer)`,
     );
   });
 
-  it('leaves the SDK default in control for whitespace-only input', () => {
+  it('uses the clodex default for whitespace-only input', () => {
     const log = vi.fn();
 
-    expect(resolvedRetries({ [UPSTREAM_MAX_RETRIES_ENV]: '   ' }, log)).toBeUndefined();
+    expect(resolvedRetries({ [UPSTREAM_MAX_RETRIES_ENV]: '   ' }, log)).toBe(5);
     expect(log).not.toHaveBeenCalled();
   });
 
@@ -112,7 +121,7 @@ describe('upstreamRequestBudget', () => {
     expect(upstreamRequestBudget({ env: {}, warn })).toEqual({
       idleTimeoutMs: 120_000,
       totalTimeoutMs: 600_000,
-      maxRetries: undefined,
+      maxRetries: 5,
     });
     expect(MAX_UPSTREAM_MAX_RETRIES).toBe(5);
     expect(warn).not.toHaveBeenCalled();
@@ -146,7 +155,7 @@ describe('upstreamRequestBudget', () => {
     })).toEqual({
       idleTimeoutMs: 120_000,
       totalTimeoutMs: 600_000,
-      maxRetries: undefined,
+      maxRetries: 5,
     });
     expect(warn).toHaveBeenCalledTimes(2);
   });
@@ -301,7 +310,7 @@ describe('upstreamRequestBudget', () => {
       env: { CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS: '60000' },
       idleTimeoutMs: 70_000,
       warn: vi.fn(),
-    })).toMatchObject({ idleTimeoutMs: 60_000, totalTimeoutMs: 60_000, maxRetries: undefined });
+    })).toMatchObject({ idleTimeoutMs: 60_000, totalTimeoutMs: 60_000, maxRetries: 4 });
   });
 
   it('uses the parent notice channel for timeout warnings by default', () => {
@@ -442,111 +451,20 @@ function setRequestBudgetEnv(values: Partial<Record<typeof REQUEST_BUDGET_ENV_KE
 }
 
 describe('upstream request budget adapter wiring', () => {
-  it.each([
-    {
-      name: 'non-streaming generation',
-      route: 'generate',
-      idle: '60000',
-      total: '61000',
-      retries: '4',
-      expectedDelays: [61_000],
-      expectedRetries: 4,
-    },
-    {
-      name: 'collected streaming generation',
-      route: 'forceStream',
-      idle: '127000',
-      total: '130000',
-      retries: '5',
-      expectedDelays: [127_000, 130_000],
-      expectedRetries: 5,
-    },
-    {
-      name: 'forwarded streaming generation',
-      route: 'stream',
-      idle: '127000',
-      total: '130000',
-      retries: '5',
-      expectedDelays: [127_000, 130_000],
-      expectedRetries: 5,
-    },
-  ])('passes the resolved values to $name', async ({
-    route,
-    idle,
-    total,
-    retries,
-    expectedDelays,
-    expectedRetries,
-  }) => {
-    vi.resetModules();
-    const restoreEnv = setRequestBudgetEnv({
-      CLODEX_UPSTREAM_MAX_RETRIES: retries,
-      CLODEX_UPSTREAM_IDLE_TIMEOUT_MS: idle,
-      CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS: total,
-    });
-    async function* stream() {
-      yield { type: 'start' };
-      yield { type: 'finish', finishReason: 'stop' };
-    }
-    const streamText = vi.fn(() => ({ stream: stream() }));
-    const generateText = vi.fn(async () => ({
-      text: 'done',
-      toolCalls: [],
-      finishReason: 'stop',
-      usage: { inputTokens: 1, outputTokens: 1 },
-    }));
-    vi.doMock('ai', () => ({
-      generateText,
-      streamText,
-      tool: vi.fn((spec: unknown) => spec),
-      jsonSchema: vi.fn((schema: unknown) => schema),
-    }));
-    const timeoutSpy = vi.spyOn(globalThis, 'setTimeout');
-
-    try {
-      const adapter = await import('../src/sdk-adapter.js');
-      if (route === 'generate') {
-        await adapter.generateAnthropicResponse({} as never, { messages: [] }, 'test-model');
-      } else if (route === 'forceStream') {
-        await adapter.generateAnthropicResponse(
-          {} as never,
-          { messages: [] },
-          'test-model',
-          { forceStream: true },
-        );
-      } else {
-        await adapter.streamAnthropicResponse(
-          {} as never,
-          { messages: [] },
-          'test-model',
-          () => {},
-        );
-      }
-
-      const sdkCall = route === 'generate' ? generateText : streamText;
-      expect(sdkCall.mock.calls[0]![0].maxRetries).toBe(expectedRetries);
-      for (const delay of expectedDelays) {
-        expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), delay);
-      }
-    } finally {
-      timeoutSpy.mockRestore();
-      restoreEnv();
-      vi.doUnmock('ai');
-      vi.resetModules();
-    }
-  });
-
   it('aborts a stalled stream at the configured idle timeout', async () => {
     vi.useFakeTimers();
     vi.resetModules();
     const restoreEnv = setRequestBudgetEnv({
+      CLODEX_UPSTREAM_MAX_RETRIES: '0',
       CLODEX_UPSTREAM_IDLE_TIMEOUT_MS: '10000',
       CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS: '60000',
     });
     const callerAbort = new AbortController();
     let sdkSignal: AbortSignal | undefined;
-    const streamText = vi.fn((options: { abortSignal: AbortSignal }) => {
+    let sdkMaxRetries: number | undefined;
+    const streamText = vi.fn((options: { abortSignal: AbortSignal; maxRetries: number }) => {
       sdkSignal = options.abortSignal;
+      sdkMaxRetries = options.maxRetries;
       async function* stream() {
         await new Promise<never>((_resolve, reject) => {
           options.abortSignal.addEventListener(
@@ -558,7 +476,8 @@ describe('upstream request budget adapter wiring', () => {
       }
       return { stream: stream() };
     });
-    vi.doMock('ai', () => ({
+    vi.doMock('ai', async () => ({
+      ...(await vi.importActual<typeof import('ai')>('ai')),
       generateText: vi.fn(),
       streamText,
       tool: vi.fn((spec: unknown) => spec),
@@ -578,6 +497,7 @@ describe('upstream request budget adapter wiring', () => {
       );
       const rejection = request.catch((error: unknown) => error);
 
+      expect(sdkMaxRetries).toBe(0);
       await vi.advanceTimersByTimeAsync(9_999);
       expect(sdkSignal?.aborted).toBe(false);
       await vi.advanceTimersByTimeAsync(1);
@@ -599,15 +519,18 @@ describe('upstream request budget adapter wiring', () => {
     vi.useFakeTimers();
     vi.resetModules();
     const restoreEnv = setRequestBudgetEnv({
+      CLODEX_UPSTREAM_MAX_RETRIES: '0',
       CLODEX_UPSTREAM_IDLE_TIMEOUT_MS: '10000',
       CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS: '60000',
     });
     const callerAbort = new AbortController();
     let sdkSignal: AbortSignal | undefined;
+    let sdkMaxRetries: number | undefined;
     let releaseFirstPart: () => void = () => {};
     const firstPart = new Promise<void>(resolve => { releaseFirstPart = resolve; });
-    const streamText = vi.fn((options: { abortSignal: AbortSignal }) => {
+    const streamText = vi.fn((options: { abortSignal: AbortSignal; maxRetries: number }) => {
       sdkSignal = options.abortSignal;
+      sdkMaxRetries = options.maxRetries;
       async function* stream() {
         await firstPart;
         yield { type: 'text-delta', text: 'started' };
@@ -621,7 +544,8 @@ describe('upstream request budget adapter wiring', () => {
       }
       return { stream: stream() };
     });
-    vi.doMock('ai', () => ({
+    vi.doMock('ai', async () => ({
+      ...(await vi.importActual<typeof import('ai')>('ai')),
       generateText: vi.fn(),
       streamText,
       tool: vi.fn((spec: unknown) => spec),
@@ -639,6 +563,7 @@ describe('upstream request budget adapter wiring', () => {
       );
       const rejection = request.catch((error: unknown) => error);
 
+      expect(sdkMaxRetries).toBe(0);
       await vi.advanceTimersByTimeAsync(9_999);
       expect(sdkSignal?.aborted).toBe(false);
       releaseFirstPart();
@@ -671,17 +596,24 @@ describe('upstream request budget adapter wiring', () => {
     });
     const callerAbort = new AbortController();
     let sdkSignal: AbortSignal | undefined;
+    let finishForCleanup: () => void = () => {};
+    const cleanup = new Promise<void>(resolve => { finishForCleanup = resolve; });
     const streamText = vi.fn((options: { abortSignal: AbortSignal }) => {
       sdkSignal = options.abortSignal;
       async function* stream() {
         while (true) {
-          await new Promise(resolve => setTimeout(resolve, 5_000));
+          const shouldStop = await Promise.race([
+            new Promise<false>(resolve => setTimeout(() => resolve(false), 5_000)),
+            cleanup.then(() => true),
+          ]);
+          if (shouldStop) return;
           yield { type: 'text-delta', text: 'active' };
         }
       }
       return { stream: stream() };
     });
-    vi.doMock('ai', () => ({
+    vi.doMock('ai', async () => ({
+      ...(await vi.importActual<typeof import('ai')>('ai')),
       generateText: vi.fn(),
       streamText,
       tool: vi.fn((spec: unknown) => spec),
@@ -708,6 +640,8 @@ describe('upstream request budget adapter wiring', () => {
       });
     } finally {
       callerAbort.abort(new Error('test cleanup'));
+      finishForCleanup();
+      await vi.advanceTimersByTimeAsync(0);
       await Promise.allSettled(request ? [request] : []);
       vi.useRealTimers();
       restoreEnv();
@@ -720,13 +654,16 @@ describe('upstream request budget adapter wiring', () => {
     vi.useFakeTimers();
     vi.resetModules();
     const restoreEnv = setRequestBudgetEnv({
+      CLODEX_UPSTREAM_MAX_RETRIES: '0',
       CLODEX_UPSTREAM_IDLE_TIMEOUT_MS: '10000',
       CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS: '60000',
     });
     const callerAbort = new AbortController();
     let sdkSignal: AbortSignal | undefined;
-    const generateText = vi.fn((options: { abortSignal: AbortSignal }) => {
+    let sdkMaxRetries: number | undefined;
+    const generateText = vi.fn((options: { abortSignal: AbortSignal; maxRetries: number }) => {
       sdkSignal = options.abortSignal;
+      sdkMaxRetries = options.maxRetries;
       return new Promise<never>((_resolve, reject) => {
         options.abortSignal.addEventListener(
           'abort',
@@ -735,7 +672,8 @@ describe('upstream request budget adapter wiring', () => {
         );
       });
     });
-    vi.doMock('ai', () => ({
+    vi.doMock('ai', async () => ({
+      ...(await vi.importActual<typeof import('ai')>('ai')),
       generateText,
       streamText: vi.fn(),
       tool: vi.fn((spec: unknown) => spec),
@@ -753,6 +691,7 @@ describe('upstream request budget adapter wiring', () => {
       );
       const rejection = request.catch((error: unknown) => error);
 
+      expect(sdkMaxRetries).toBe(0);
       await vi.advanceTimersByTimeAsync(10_000);
       expect(sdkSignal?.aborted).toBe(false);
       await vi.advanceTimersByTimeAsync(49_999);
@@ -768,6 +707,40 @@ describe('upstream request budget adapter wiring', () => {
       vi.useRealTimers();
       restoreEnv();
       vi.doUnmock('ai');
+      vi.resetModules();
+    }
+  });
+
+  it('clears Anthropic timers when SDK stream setup rejects synchronously', async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    const restoreEnv = setRequestBudgetEnv({
+      CLODEX_UPSTREAM_IDLE_TIMEOUT_MS: '10000',
+      CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS: '60000',
+    });
+    try {
+      const { MockLanguageModelV4 } = await import('ai/test');
+      const { generateAnthropicResponse, streamAnthropicResponse } =
+        await import('../src/sdk-adapter.js');
+      const model = new MockLanguageModelV4();
+      const params = {
+        messages: [{ role: 'user' as const, content: 'test' }],
+        maxOutputTokens: 0,
+      };
+
+      await expect(streamAnthropicResponse(model, params, 'test-model', () => {}))
+        .rejects.toThrow('maxOutputTokens must be >= 1');
+      expect(vi.getTimerCount()).toBe(0);
+      await expect(generateAnthropicResponse(
+        model,
+        params,
+        'test-model',
+        { forceStream: true },
+      )).rejects.toThrow('maxOutputTokens must be >= 1');
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+      restoreEnv();
       vi.resetModules();
     }
   });


### PR DESCRIPTION
Long model turns could be stopped after ten minutes even while the provider was still producing useful
work. This makes the provider-call deadlines configurable while preserving the existing defaults, and
it retries short provider outages longer before giving up.

Closes #166.

## What changed

- Add `CLODEX_UPSTREAM_IDLE_TIMEOUT_MS` (default `120000`, range
  `10000`–`3600000`) for translated streams that produce no SDK event.
- Add `CLODEX_UPSTREAM_TOTAL_TIMEOUT_MS` (default `600000`, range
  `60000`–`21600000`) for each SDK provider call.
- Parse the timeout pair and `CLODEX_UPSTREAM_MAX_RETRIES` through one bounded request budget. Invalid,
  clamped, and reconciled values emit a deduplicated parent notice without failing request setup.
- Abort all Anthropic- and OpenAI-format `streamText` paths at idle and total deadlines, and abort
  `generateText` paths at total only because they expose no intermediate event that could reset idle.
- Raise the translated-provider retry default from two to five. A shorter resolved idle timeout lowers
  both the default and the permitted maximum; explicit values still win and `0` still disables retries.

When only idle is raised above the default total, total rises to match. An explicit shorter total wins
and lowers idle, so total can never be shorter than idle. Each provider call gets a fresh total timer;
an OAuth 401 refresh may therefore start a second call with a fresh budget rather than sharing one
route-wide deadline.

The retry ceiling estimates how many AI SDK fallback delays fit strictly inside idle: 2s, 4s, 8s,
16s, 32s, and so on. Five retries add about 62 seconds on a dead provider instead of the SDK default's
roughly six seconds. Provider retry hints and time spent in failed attempts can consume the deadline
sooner. Clodex requests SDK cancellation when a timer expires; cancellation is cooperative, so a
provider transport that ignores the signal can settle later. If a timer interrupts retry backoff,
clodex keeps and reports the provider failures accumulated so far. If it interrupts a currently
active silent call, the timeout remains the reported error instead of an older provider rejection.

## Reachability and boundaries

Claude Code's proxy and endpoint translated requests use the Anthropic-format adapter. The
OpenAI-format adapter is reachable separately from a non-Claude client through standalone
`clodex server --endpoint`; its three SDK generation paths now follow the same budget.

Raw relays are not SDK generations and get no new timer. Proxy mode's raw HTTP MITM path shares the
retry setting, with one replay by default and an independent maximum of five; other direct raw relays
add no transport-failure replay, although an OAuth 401 refresh can start a new authenticated call.

These are server-side limits. Claude Code has independent pre-header and stream watchdogs, documented
in the README; raising the server limit alone does not raise the client limit.

This does not replay a failed stream after model output has reached the client. At that point the HTTP
200 and partial content are already committed, and replay could duplicate text or tool calls.

## Verification

- Reproduced the original behavior: setting a 10-second idle value on `main` did not abort at ten
  seconds because both provider timers were still hardcoded.
- Behavioral fake-timer tests prove configured idle abort, per-event idle refresh, active-stream total
  abort, non-streaming total-only behavior, and timer cleanup across all six SDK generation shapes.
- Real AI SDK tests prove a deadline during retry delay preserves status 429, `Retry-After`, and the
  accumulated attempt count on all six paths, while a deadline during an active silent retry reports
  the timeout rather than the earlier 429.
- Resolver tests cover defaults, malformed and out-of-range values, warning failure isolation and
  deduplication, pair reconciliation, strict retry boundaries, the five-retry default, default
  reduction under shorter idle, explicit zero, and raw HTTP MITM isolation.
- Mutation checks made the relevant tests fail when the OpenAI timers or post-loop abort guard were
  deleted, collected-stream idle/total timers were swapped, idle refresh was hardcoded, pair
  reconciliation was disabled, the strict retry boundary was widened, the retry default returned to
  two, short-idle default reduction was removed, HTTP MITM replay was recoupled to timeouts, or the
  default warning sink was disabled. Separate mutations also removed each route's attempt tracker,
  provider-error accumulation, active-attempt reset, and non-streaming abort-reason recovery; each
  corresponding behavioral test failed. Reverting either Anthropic setup-cleanup block left two
  timers live and failed its real-SDK regression assertion.
- `CLAUDE_CODE_ENTRYPOINT=cli pnpm typecheck && pnpm test && pnpm build` passes on Node 24.14.1 and
  pnpm 10.34.5 with an isolated `CLODEX_HOME` and no ambient proxy variables: 104 test files,
  2075 tests.
- No live-provider run was used to claim the long-duration behavior; the timing evidence is the
  deterministic adapter tests and the issue's 600-second production trace.
