### PR TITLE
feat(models): add GPT-6 Astra and Daybreak Blue with working reasoning effort

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,10 +241,11 @@ Manage favorite models (max 20) and short aliases. Favorites feed the endpoint-m
 
 #### Context stops and the pricing boundary
 
-A context window is a cost dial as much as a capacity number. OpenAI prices GPT-5.6
-prompts above **272,000 input tokens at 2x input and 1.5x output for the full
-request**, which is why the Codex catalog reports a 272,000 window rather than the
-model's ceiling. Clodex follows that: the default `standard` stop stays under the
+A context window is a cost dial as much as a capacity number. OpenAI prices GPT-5.5
+and later prompts above **272,000 input tokens at 2x input and 1.5x output for the
+full request**, which is why the Codex catalog reports a 272,000 window rather than
+the model's ceiling. Newer families inherit the same boundary, so a model released
+after this was written is covered without a clodex update. Clodex follows that: the default `standard` stop stays under the
 line, and a larger window is something you ask for.
 
 ```sh

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,7 +11,7 @@ export const CODEX_RESPONSES_LITE_WS_URL = 'wss://chatgpt.com/backend-api/codex/
 // `version` header the Codex backend expects on Responses-Lite requests. The
 // official Codex CLI sends its own version here; OpenAI may require this to be
 // bumped over time — confirm via --trace if Luna requests start failing.
-export const CODEX_RESPONSES_LITE_VERSION = '0.144.1';
+export const CODEX_RESPONSES_LITE_VERSION = '0.153.3';
 // OpenAI-Beta opt-in for the WebSocket Responses transport.
 export const CODEX_RESPONSES_WEBSOCKETS_BETA = 'responses_websockets=2026-02-06';
 

--- a/src/data/openai-oauth-models.ts
+++ b/src/data/openai-oauth-models.ts
@@ -58,6 +58,18 @@ export const CHATGPT_CODEX_UNSUPPORTED_MODELS = new Set<string>([
 // model spec and varies by plan, so discovery overrides these whenever it answers.
 // A model with no ceiling here has none above its default window.
 const OPENAI_OAUTH_MODEL_SEEDS: OAuthModelSeed[] = [
+  // GPT-6 family. The window and ceiling are what the live Codex catalog returned on
+  // 2026-09-04 and are deliberately NOT the published API numbers: the model card
+  // lists a 1,050,000 context window, but the Codex client is served a smaller one,
+  // and this path is Codex-only. Output limit and the pricing band come from the
+  // card (https://developers.openai.com/api/docs/models/gpt-6-astra), which states
+  // "Prompts with more than 272K input tokens are priced at 2x input and cache rates
+  // and 1.5x output for the full request" — the same boundary the GPT-5.6 family has.
+  { id: 'gpt-6-astra',          name: 'GPT-6 Astra',       contextWindow: 272_000, maxContextWindow: 872_000, maxOutputTokens: 128_000, reasoning: true, useResponsesLite: true, preferWebSockets: true },
+  // "An alias for our flagship general-purpose models, with safeguards calibrated
+  // for defensive cybersecurity work" — access is gated on a separate opt-in
+  // program, so most installs will never see this id in their catalog.
+  { id: 'gpt-daybreak-blue-latest', name: 'GPT Daybreak Blue', contextWindow: 272_000, maxContextWindow: 872_000, maxOutputTokens: 128_000, reasoning: true, useResponsesLite: true, preferWebSockets: true },
   // GPT-5.6 family (Sol / Terra / Luna)
   { id: 'gpt-5.6-sol',          name: 'GPT-5.6 Sol',       contextWindow: 272_000, maxContextWindow: 872_000, maxOutputTokens: 128_000, reasoning: true },
   { id: 'gpt-5.6-terra',        name: 'GPT-5.6 Terra',     contextWindow: 272_000, maxContextWindow: 872_000, maxOutputTokens: 128_000, reasoning: true },
@@ -78,7 +90,24 @@ const OPENAI_OAUTH_MODEL_SEEDS: OAuthModelSeed[] = [
 ];
 
 /** Models priced with a higher-rate band above a documented input size. */
-const PRICING_BOUNDARY_FAMILIES = /^gpt-5\.[56]/;
+/**
+ * Families that price the whole request at a higher rate above a documented input
+ * size. Read the family version rather than listing ids, so a later family is
+ * covered the day it ships: a boundary asserted where there is none costs the user
+ * one notice, while a missing boundary means they cross into the higher rate with
+ * no warning at all (see reportPricingBoundaryCrossing). gpt-5.4 and earlier are
+ * deliberately excluded — no published boundary.
+ */
+function hasPricingBoundary(id: string): boolean {
+  const version = /^gpt-(\d+)(?:\.(\d+))?(?:-|$)/i.exec(id);
+  if (version) {
+    const major = Number(version[1]);
+    const minor = version[2] ? Number(version[2]) : 0;
+    if (major > 5 || (major === 5 && minor >= 5)) return true;
+  }
+  // Codenamed aliases carry no version to read; they track the current flagship.
+  return /^gpt-daybreak(?:-|$)/i.test(id);
+}
 
 /**
  * Pricing-band metadata for a Codex model id, applied to discovered models too so a
@@ -87,7 +116,7 @@ const PRICING_BOUNDARY_FAMILIES = /^gpt-5\.[56]/;
 export function openAiPricingMetadata(
   id: string,
 ): { pricingBoundary?: number; pricingBoundaryNote?: string } {
-  if (!PRICING_BOUNDARY_FAMILIES.test(id)) return {};
+  if (!hasPricingBoundary(id)) return {};
   return {
     pricingBoundary: GPT_5_6_PRICING_BOUNDARY,
     pricingBoundaryNote: GPT_5_6_PRICING_NOTE,
@@ -98,6 +127,15 @@ export function openAiPricingMetadata(
  * Fill context metadata that a catalog cached before these fields existed is missing.
  * Only absent fields are filled, so live discovery always wins; without this a stale
  * cache reports a raw window with no headroom and no reachable ceiling.
+ *
+ * `reasoning` is the one field a seed OVERRIDES rather than merely fills. The Codex
+ * catalog has never reported it: a cached value was written by whatever id guess the
+ * installed clodex made at refresh time, so a stale `false` is a stale guess, not
+ * user data or a provider answer. Leaving it authoritative meant a user who had
+ * refreshed under an older clodex kept the old verdict for a model this table now
+ * knows — the effort selector stayed hidden until they happened to re-run
+ * `clodex providers refresh-models`. Only seeded ids are affected; anything absent
+ * from the seed keeps its cached value.
  */
 export function applyOAuthSeedContextMetadata(models: CachedModel[]): CachedModel[] {
   const seedById = new Map(buildOpenAiOAuthModels().map(model => [model.id, model]));
@@ -115,6 +153,7 @@ export function applyOAuthSeedContextMetadata(models: CachedModel[]): CachedMode
         ?? seed?.pricingBoundaryNote
         ?? pricing.pricingBoundaryNote,
       maxOutputTokens: model.maxOutputTokens ?? seed?.maxOutputTokens,
+      reasoning: seed?.reasoning ?? model.reasoning,
     };
   });
 }

--- a/src/provider-factory.ts
+++ b/src/provider-factory.ts
@@ -326,7 +326,8 @@ export interface ReasoningCapabilities {
 
 const ANTHROPIC_EFFORT_LEVELS = ['low', 'medium', 'high'] as const;
 const OPENAI_EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh'] as const;
-const GPT_56_EFFORT_LEVELS = ['none', 'low', 'medium', 'high', 'xhigh', 'max'] as const;
+/** Full Codex effort range. gpt-5.6 introduced it; later families inherit it. */
+const CODEX_EXTENDED_EFFORT_LEVELS = ['none', 'low', 'medium', 'high', 'xhigh', 'max'] as const;
 const GEMINI_EFFORT_LEVELS = ['low', 'medium', 'high'] as const;
 const MISTRAL_EFFORT_LEVELS = ['high', 'off'] as const;
 const XAI_EFFORT_LEVELS = ['none', 'low', 'medium', 'high'] as const;
@@ -556,8 +557,68 @@ function mapCodexEffortToAnthropic(effort: string): string | undefined {
   }
 }
 
-function isGpt56Model(modelId: string): boolean {
-  return /^gpt-5\.6(?:-|$)/i.test(modelId);
+/**
+ * Families clodex is willing to send `reasoning.effort` to on the OpenAI wire,
+ * beyond the ids modelPrefersResponsesApi already names.
+ *
+ * This deliberately does NOT trust `metadata.reasoning`. That flag comes from
+ * models.dev on the API-key path, where it means "this model emits reasoning
+ * tokens" — not "this model accepts reasoning.effort". The two sets differ:
+ * models.dev marks gpt-5-chat-latest as reasoning, the AI SDK explicitly carves
+ * `gpt-5-chat*` out of its own reasoning check, and OpenAI 400s the parameter.
+ * Reading the family version keeps a later numbered family working with no code
+ * change while admitting nothing that has not earned it.
+ */
+function isCodexReasoningFamily(modelId: string): boolean {
+  return !isChatVariant(modelId) && supportsExtendedCodexEffort(modelId);
+}
+
+/**
+ * The non-reasoning sibling of a reasoning family. The AI SDK carves these out of
+ * its own reasoning check because OpenAI rejects reasoning parameters for them.
+ * Applied to the whole effort decision rather than to one branch of it, so the
+ * carve-out cannot be walked around by an id that some other rule already admits.
+ */
+function isChatVariant(modelId: string): boolean {
+  return /-chat(?:-|$)/i.test(modelId);
+}
+
+/**
+ * Codex families whose reasoning effort accepts the extended range ('xhigh',
+ * 'max') on top of low/medium/high. gpt-5.6 introduced it and every later family
+ * has kept it, so this reads the version rather than listing ids: a gpt-7 that
+ * ships tomorrow gets the full range with no code change. Verified against the
+ * live Codex backend on 2026-09-04 — gpt-6-astra and gpt-daybreak-blue-latest
+ * both accept 'xhigh' and 'max'.
+ *
+ * A model that predates the range (gpt-5.5 and earlier) still has 'xhigh'
+ * folded down to 'high' and 'max' dropped by the caller.
+ */
+function supportsExtendedCodexEffort(modelId: string): boolean {
+  const version = /^gpt-(\d+)(?:\.(\d+))?(?:-|$)/i.exec(modelId);
+  if (version) {
+    const major = Number(version[1]);
+    const minor = version[2] ? Number(version[2]) : 0;
+    if (major > 5 || (major === 5 && minor >= 6)) return true;
+  }
+  // Codenamed aliases carry no version to read; they track the current flagship.
+  return /^gpt-daybreak(?:-|$)/i.test(modelId);
+}
+
+/**
+ * 'none' is the one effort value that must NOT be assumed from the family. It is
+ * a request to skip reasoning entirely, which a model that always reasons
+ * rejects outright — gpt-6-astra answers:
+ *   400 Unsupported value: 'none' is not supported with the 'gpt-6-astra' model.
+ *   Supported values are: 'low', 'medium', 'high', 'xhigh', and 'max'.
+ * So it stays an explicit per-family opt-in instead of riding along with the
+ * extended range above. Both entries below were confirmed to accept it on
+ * 2026-09-04; guessing wrong here is a hard 400, not a downgrade.
+ */
+function supportsNoneEffort(modelId: string): boolean {
+  // Deliberately narrower than the extended-range rule above: only the colours
+  // actually confirmed to accept it, not every gpt-daybreak-* alias.
+  return /^gpt-5\.6(?:-|$)/i.test(modelId) || /^gpt-daybreak-blue(?:-|$)/i.test(modelId);
 }
 
 // gpt-5.3-codex-spark rejects `reasoning.summary` outright:
@@ -572,10 +633,13 @@ function isReasoningSummaryUnsupportedModel(modelId: string): boolean {
 }
 
 function mapCodexEffortToOpenAI(effort: string, modelId?: string): string | undefined {
+  if (effort === 'none') {
+    return modelId && supportsNoneEffort(modelId) ? 'none' : undefined;
+  }
   if (
     modelId
-    && isGpt56Model(modelId)
-    && GPT_56_EFFORT_LEVELS.includes(effort as typeof GPT_56_EFFORT_LEVELS[number])
+    && supportsExtendedCodexEffort(modelId)
+    && CODEX_EXTENDED_EFFORT_LEVELS.includes(effort as typeof CODEX_EXTENDED_EFFORT_LEVELS[number])
   ) {
     return effort;
   }
@@ -756,9 +820,15 @@ export function getReasoningCapabilities(
 
   if (npm === '@ai-sdk/openai' || npm === '@ai-sdk/azure') {
     const prefersResponses = modelPrefersResponsesApi(modelId);
-    if (prefersResponses || metadata?.reasoning) {
+    // isCodexReasoningFamily mirrors what effortProviderOptions will actually send.
+    // Without it the two disagree off the Codex route: an API-key user of a gpt-6
+    // model has no models.dev entry to vouch for it, so the effort menu stays empty
+    // while an explicitly chosen effort still goes on the wire.
+    if (prefersResponses || isCodexReasoningFamily(modelId) || metadata?.reasoning) {
       return {
-        levels: isGpt56Model(modelId) ? [...GPT_56_EFFORT_LEVELS] : [...OPENAI_EFFORT_LEVELS],
+        levels: supportsExtendedCodexEffort(modelId)
+          ? CODEX_EXTENDED_EFFORT_LEVELS.filter(level => level !== 'none' || supportsNoneEffort(modelId))
+          : [...OPENAI_EFFORT_LEVELS],
         defaultLevel: 'medium',
         supportsSummaries: true,
         mode: 'controllable',
@@ -979,12 +1049,26 @@ export function effortProviderOptions(
   }
 
   if (npm === '@ai-sdk/openai' || npm === '@ai-sdk/azure') {
-    if (!modelId || !modelPrefersResponsesApi(modelId)) return undefined;
+    // The id pattern list predates gpt-6 and the codenamed aliases, so on its own it
+    // silently dropped the user's effort for both. Widen it by FAMILY rather than by
+    // trusting metadata.reasoning — see isCodexReasoningFamily for why that flag is
+    // the wrong question to ask here.
+    if (!modelId || isChatVariant(modelId)) return undefined;
+    if (!(modelPrefersResponsesApi(modelId) || isCodexReasoningFamily(modelId))) {
+      return undefined;
+    }
     const reasoningEffort = mapCodexEffortToOpenAI(effort, modelId);
     if (!reasoningEffort) return undefined;
+    // The AI SDK re-derives "is this a reasoning model" from its OWN id list
+    // (o1/o3/o4-mini/gpt-5*) and drops reasoningEffort with an "unsupported"
+    // warning for anything it does not recognise. clodex has already decided the
+    // question above, so state the answer rather than letting the SDK re-guess a
+    // narrower one. This also selects the developer-role system message and lets
+    // the SDK strip temperature/top_p, which reasoning models reject.
+    const openaiOptions = { reasoningEffort, forceReasoning: true };
     return isReasoningSummaryUnsupportedModel(modelId)
-      ? { openai: { reasoningEffort, reasoningSummary: null } }
-      : { openai: { reasoningEffort } };
+      ? { openai: { ...openaiOptions, reasoningSummary: null } }
+      : { openai: openaiOptions };
   }
 
   if (npm === '@ai-sdk/xai') {

--- a/src/registry/refresh-models.ts
+++ b/src/registry/refresh-models.ts
@@ -42,10 +42,10 @@ import {
 } from '../data/openai-oauth-models.js';
 import { DEFAULT_EFFECTIVE_CONTEXT_PERCENT } from '../context-modes.js';
 import { isChatGptOAuthProvider } from './provider-kind.js';
-import { modelPrefersResponsesApi } from '../provider-factory.js';
 import { deriveBrand } from '../models.js';
 import { resolveContextWindow } from '../context-window.js';
 import { getInstalledClaudeVersion } from '../launch.js';
+import { modelPrefersResponsesApi } from '../provider-factory.js';
 import { classifyFreeStatus, isFreeStatus } from '../free-models.js';
 import { isLegacyAnonymousCustomEndpoint } from './materialize.js';
 import { OPENCODE_GO_PROVIDER_NAME } from '../data/opencode-go-models.js';
@@ -160,7 +160,17 @@ function parseOpenAiModelEntries(body: unknown): OpenAiModelEntry[] {
  * authoritative for context and capability flags: when the model is also seeded,
  * live values are merged over the seed (the seed is only a fallback).
  */
-function buildDynamicOAuthModel(entry: OpenAiModelEntry, seedById: Map<string, CachedModel>): CachedModel {
+function buildDynamicOAuthModel(
+  entry: OpenAiModelEntry,
+  seedById: Map<string, CachedModel>,
+  /**
+   * True only for the Codex-specific listing. That endpoint returns just the
+   * agentic models Codex supports, which is what makes the reasoning default
+   * below safe; the general ChatGPT catalog is the web model picker and includes
+   * plainly non-reasoning models.
+   */
+  codexCatalog: boolean,
+): CachedModel {
   const seed = seedById.get(entry.id);
   if (seed) {
     return {
@@ -193,7 +203,19 @@ function buildDynamicOAuthModel(entry: OpenAiModelEntry, seedById: Map<string, C
     ...openAiPricingMetadata(id),
     modelFormat: 'openai' as const,
     npm: '@ai-sdk/openai',
-    reasoning: modelPrefersResponsesApi(id),
+    // Assume a model from the Codex listing reasons. That endpoint reports no
+    // reasoning field of its own, so the old `modelPrefersResponsesApi(id)` was an
+    // id-pattern GUESS that silently said "no" to every family it had not been
+    // taught yet — gpt-6-astra and gpt-daybreak-blue-latest both landed as
+    // non-reasoning that way, which dropped the user's chosen effort and removed
+    // the effort selector from the patched binary (getPatchReasoningCapabilities
+    // early-returns on a `false`). Verified against all 11 models in the live
+    // catalog on 2026-09-04.
+    //
+    // This only decides what the effort UI offers. It is NOT on its own enough to
+    // put reasoning.effort on the wire — effortProviderOptions admits by family —
+    // so a wrong `true` here costs an unusable menu entry, not a 400.
+    reasoning: codexCatalog ? true : modelPrefersResponsesApi(id),
     useResponsesLite: entry.useResponsesLite,
     preferWebSockets: entry.preferWebSockets,
   };
@@ -248,8 +270,8 @@ async function refreshOpenAiOAuthModels(
 }> {
   const TIMEOUT_MS = 10_000;
   const seedById = new Map(buildOpenAiOAuthModels().map(m => [m.id, m]));
-  const toModels = (entries: OpenAiModelEntry[]) =>
-    entries.map(entry => buildDynamicOAuthModel(entry, seedById));
+  const toModels = (entries: OpenAiModelEntry[], codexCatalog: boolean) =>
+    entries.map(entry => buildDynamicOAuthModel(entry, seedById, codexCatalog));
 
   const claudeVersion = getInstalledClaudeVersion();
 
@@ -261,7 +283,7 @@ async function refreshOpenAiOAuthModels(
   );
   const codexEntries = parseOpenAiModelEntries(codexResult.body);
   if (codexEntries.length > 0) {
-    return { models: toModels(codexEntries), source: 'live' };
+    return { models: toModels(codexEntries, true), source: 'live' };
   }
 
   // Tier 2: General ChatGPT model list, filtered by known Codex restrictions.
@@ -273,7 +295,7 @@ async function refreshOpenAiOAuthModels(
   const chatGptEntries = parseOpenAiModelEntries(chatGptResult.body)
     .filter(({ id }) => !CHATGPT_CODEX_UNSUPPORTED_MODELS.has(id));
   if (chatGptEntries.length > 0) {
-    return { models: toModels(chatGptEntries), source: 'live' };
+    return { models: toModels(chatGptEntries, false), source: 'live' };
   }
 
   // Tier 3: Static seed — reuse already-built map instead of calling the builder again.

--- a/tests/oauth-seed-overlay.test.ts
+++ b/tests/oauth-seed-overlay.test.ts
@@ -96,6 +96,72 @@ describe('legacy OAuth cache overlay', () => {
     expect(model?.maxContextWindow).toBeUndefined();
   });
 
+  // The upgrade path that the fix would otherwise miss entirely. A user who
+  // refreshed their catalog under an older clodex has `reasoning: false` written for
+  // these ids — a stale ID GUESS, since the Codex catalog never reported the field.
+  // Left authoritative it survives the upgrade, getPatchReasoningCapabilities
+  // early-returns on it, and the effort selector stays missing until the user
+  // happens to re-run `clodex providers refresh-models`.
+  it('overrides a stale reasoning verdict for a model the seed now knows', () => {
+    const provider = providerWithLegacyCache();
+    provider.modelsCache?.models.push({
+      id: 'gpt-6-astra',
+      name: 'gpt-6-astra',
+      upstreamModelId: 'gpt-6-astra',
+      contextWindow: 272_000,
+      modelFormat: 'openai',
+      reasoning: false,
+    });
+    const model = projectProviderCachedModels(provider).find(m => m.id === 'gpt-6-astra');
+    expect(model?.reasoning).toBe(true);
+  });
+
+  // Under-scope guard: the override reaches only ids the seed actually carries, so a
+  // model discovered in the wild keeps whatever discovery decided about it.
+  it('leaves the reasoning verdict alone for a model the seed does not know', () => {
+    const provider = providerWithLegacyCache();
+    provider.modelsCache?.models.push({
+      id: 'gpt-not-in-the-seed-table',
+      name: 'unknown',
+      upstreamModelId: 'gpt-not-in-the-seed-table',
+      contextWindow: 272_000,
+      modelFormat: 'openai',
+      reasoning: false,
+    });
+    const model = projectProviderCachedModels(provider)
+      .find(m => m.id === 'gpt-not-in-the-seed-table');
+    expect(model?.reasoning).toBe(false);
+  });
+
+  // The boundary is derived from the family version, so it needs the same
+  // over/under-scope pair the effort predicate has. gpt-5.5 is a real seeded model
+  // with a live 272k band; gpt-5.4 has no published one. An off-by-one that silently
+  // drops gpt-5.5's high-rate warning is a money bug, not a cosmetic one.
+  it.each([
+    ['gpt-5.5-unreleased', 272_000],
+    ['gpt-6-unreleased', 272_000],
+    ['gpt-daybreak-unreleased', 272_000],
+  ])('applies the pricing boundary to %s', (id, boundary) => {
+    const provider = providerWithLegacyCache();
+    provider.modelsCache?.models.push({
+      id, name: id, upstreamModelId: id, contextWindow: 272_000, modelFormat: 'openai',
+    });
+    expect(projectProviderCachedModels(provider).find(m => m.id === id)?.pricingBoundary)
+      .toBe(boundary);
+  });
+
+  it.each(['gpt-5.4-unreleased', 'gpt-4o-unreleased'])(
+    'applies no pricing boundary to %s',
+    id => {
+      const provider = providerWithLegacyCache();
+      provider.modelsCache?.models.push({
+        id, name: id, upstreamModelId: id, contextWindow: 272_000, modelFormat: 'openai',
+      });
+      expect(projectProviderCachedModels(provider).find(m => m.id === id)?.pricingBoundary)
+        .toBeUndefined();
+    },
+  );
+
   // Only the ChatGPT OAuth provider uses the Codex effective-window convention.
   // Applying it to an API-key provider would shrink every other model by 5%.
   it('does not touch a non-OAuth provider', () => {

--- a/tests/openai-wire-effort.test.ts
+++ b/tests/openai-wire-effort.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { createOpenAI } from '@ai-sdk/openai';
+import { effortProviderOptions } from '../src/provider-factory.js';
+
+/**
+ * Every other effort assertion in this suite compares clodex's returned object to a
+ * literal copy of what clodex builds — so a wrong option KEY, or the AI SDK renaming
+ * one on a future pinned bump, leaves them all green while nothing reaches the wire.
+ *
+ * This drives the real @ai-sdk/openai Responses model with a stubbed fetch and reads
+ * the request body it actually serialises. No network: the fetch never leaves the
+ * process, and the WebSocket transport is not involved because this is the plain
+ * provider rather than the OAuth one.
+ *
+ * The SDK decides on its own whether a model reasons, from an id list
+ * (o1|o3|o4-mini|gpt-5*) that matches neither gpt-6 nor the codenamed aliases, and
+ * drops the effort for anything it does not recognise. That is what forceReasoning
+ * exists to override, and this is the only test that would notice if it stopped
+ * working.
+ */
+async function emittedRequestBody(modelId: string, effort: string): Promise<Record<string, unknown>> {
+  let captured: Record<string, unknown> | undefined;
+  const provider = createOpenAI({
+    apiKey: 'test-key',
+    fetch: (async (_url: string, init: RequestInit) => {
+      captured = JSON.parse(String(init.body));
+      return new Response(
+        JSON.stringify({
+          id: 'resp_1',
+          model: modelId,
+          output: [],
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }) as unknown as typeof fetch,
+  });
+
+  await provider.responses(modelId).doGenerate({
+    prompt: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+    providerOptions: effortProviderOptions(
+      '@ai-sdk/openai',
+      effort,
+      modelId,
+      { reasoning: true },
+    ) as never,
+  } as never);
+
+  if (!captured) throw new Error('no request body captured');
+  return captured;
+}
+
+describe('OpenAI reasoning effort on the wire', () => {
+  it.each(['gpt-6-astra', 'gpt-daybreak-blue-latest'])(
+    'puts the chosen effort in the %s request body',
+    async modelId => {
+      const body = await emittedRequestBody(modelId, 'high');
+      expect(body.reasoning).toMatchObject({ effort: 'high' });
+    },
+  );
+
+  // The family that already worked, to show the test is measuring the wire and not
+  // just agreeing with itself.
+  it('keeps sending the effort for gpt-5.6-sol', async () => {
+    const body = await emittedRequestBody('gpt-5.6-sol', 'high');
+    expect(body.reasoning).toMatchObject({ effort: 'high' });
+  });
+
+  // Over-scope: a model clodex refuses to admit must carry no reasoning block at all,
+  // proving the wire follows the admission decision rather than the SDK's own guess.
+  it('sends no reasoning block for a model clodex will not admit', async () => {
+    const body = await emittedRequestBody('gpt-4o', 'high');
+    expect(body.reasoning).toBeUndefined();
+  });
+});

--- a/tests/provider-factory.test.ts
+++ b/tests/provider-factory.test.ts
@@ -186,6 +186,53 @@ describe('getReasoningCapabilities', () => {
     expect(caps.defaultLevel).toBe('medium');
   });
 
+  // What `clodex patch` bakes into the binary as the effort menu. The wire tests
+  // below cover what a chosen effort DOES; this covers what the user is offered in
+  // the first place, which is the other half of the feature and was previously
+  // unpinned — the menu could silently narrow to the gpt-5.6 set with every other
+  // test still green. astra omits 'none' because the backend rejects it.
+  it.each([
+    ['gpt-6-astra', ['low', 'medium', 'high', 'xhigh', 'max']],
+    ['gpt-daybreak-blue-latest', ['none', 'low', 'medium', 'high', 'xhigh', 'max']],
+    ['gpt-7-example', ['low', 'medium', 'high', 'xhigh', 'max']],
+    ['gpt-5.6-sol', ['none', 'low', 'medium', 'high', 'xhigh', 'max']],
+  ])('offers the patched-client effort menu for %s', (modelId, levels) => {
+    expect(getPatchReasoningCapabilities('@ai-sdk/openai', modelId, { reasoning: true }).levels)
+      .toEqual(levels);
+  });
+
+  // The effort MENU and the effort actually SENT must agree on every route. Off the
+  // Codex route nothing vouches for a gpt-6 model — models.dev has no entry — so a
+  // capability gate that waits for metadata leaves an API-key user with an empty
+  // menu while an explicitly chosen effort still reaches the wire.
+  it.each(['gpt-6-astra', 'gpt-daybreak-blue-latest', 'gpt-7-example'])(
+    'reports effort capability for %s with no metadata to vouch for it',
+    modelId => {
+      const caps = getReasoningCapabilities('@ai-sdk/openai', modelId);
+      expect(caps.mode).toBe('controllable');
+      expect(caps.levels).toContain('max');
+    },
+  );
+
+  // getPatchReasoningCapabilities re-filters through effortProviderOptions, so it
+  // would hide a wrong answer here. Assert the capability reporter directly: it is
+  // the general description of the model, and 'none' is the one level whose
+  // availability differs WITHIN the extended-range families.
+  it.each([
+    ['gpt-6-astra', false],
+    ['gpt-daybreak-blue-latest', true],
+    ['gpt-5.6-sol', true],
+  ])('reports whether %s offers a none effort', (modelId, offersNone) => {
+    const levels = getReasoningCapabilities('@ai-sdk/openai', modelId, { reasoning: true }).levels;
+    expect(levels.includes('none')).toBe(offersNone);
+    expect(levels).toContain('max');
+  });
+
+  // Unchanged by the gpt-6 work, and deliberately so: widening admission by FAMILY
+  // rather than by metadata.reasoning leaves these two exactly where they were.
+  // This is also the live coverage of the provider-option filter — the capabilities
+  // side admits them on metadata while effortProviderOptions refuses, and the filter
+  // is what reconciles the two.
   it.each(['gpt-5', 'o1'])(
     'does not advertise effort when %s emits no provider option',
     modelId => {
@@ -400,14 +447,14 @@ describe('effortProviderOptions + deepMergeProviderOptions', () => {
     'preserves GPT-5.6 %s effort on the OpenAI wire',
     (effort) => {
       expect(effortProviderOptions('@ai-sdk/openai', effort, 'gpt-5.6-sol')).toEqual({
-        openai: { reasoningEffort: effort },
+        openai: { reasoningEffort: effort, forceReasoning: true },
       });
     },
   );
 
   it('keeps GPT-5.5 outside the GPT-5.6 wire-effort scope', () => {
     expect(effortProviderOptions('@ai-sdk/openai', 'xhigh', 'gpt-5.5')).toEqual({
-      openai: { reasoningEffort: 'high' },
+      openai: { reasoningEffort: 'high', forceReasoning: true },
     });
   });
 
@@ -420,6 +467,7 @@ describe('effortProviderOptions + deepMergeProviderOptions', () => {
         .toEqual({
           openai: {
             reasoningEffort: effort === 'xhigh' ? 'high' : effort,
+            forceReasoning: true,
             reasoningSummary: null,
           },
         });
@@ -428,9 +476,111 @@ describe('effortProviderOptions + deepMergeProviderOptions', () => {
 
   it('leaves the reasoning summary untouched for other Codex models', () => {
     expect(effortProviderOptions('@ai-sdk/openai', 'high', 'gpt-5.1-codex-max')).toEqual({
-      openai: { reasoningEffort: 'high' },
+      openai: { reasoningEffort: 'high', forceReasoning: true },
     });
   });
+
+  // The bug: a Codex model whose id the pattern list had never seen got NO effort on
+  // the wire at all, however the user set it. Both ids below are real models that
+  // reach this path via the ChatGPT OAuth catalog.
+  it.each(['gpt-6-astra', 'gpt-daybreak-blue-latest'])(
+    'sends the chosen effort for %s instead of dropping it',
+    modelId => {
+      expect(effortProviderOptions('@ai-sdk/openai', 'high', modelId, { reasoning: true }))
+        .toEqual({ openai: { reasoningEffort: 'high', forceReasoning: true } });
+    },
+  );
+
+  // Verified against the live Codex backend on 2026-09-04: both accept 'max', so it
+  // must survive rather than being folded down to 'high' or dropped.
+  it.each(['gpt-6-astra', 'gpt-daybreak-blue-latest'])(
+    'preserves the extended max effort for %s',
+    modelId => {
+      expect(effortProviderOptions('@ai-sdk/openai', 'max', modelId, { reasoning: true }))
+        .toEqual({ openai: { reasoningEffort: 'max', forceReasoning: true } });
+    },
+  );
+
+  // gpt-6-astra 400s on 'none' ("Supported values are: 'low', 'medium', 'high',
+  // 'xhigh', and 'max'") while gpt-daybreak-blue-latest accepts it, so 'none' cannot
+  // ride along with the extended range. Guessing it wrong is a hard error, not a
+  // downgrade — this pair is the reason the two capabilities are separate rules.
+  it('drops a none effort that gpt-6-astra would reject', () => {
+    expect(effortProviderOptions('@ai-sdk/openai', 'none', 'gpt-6-astra', { reasoning: true }))
+      .toBeUndefined();
+  });
+
+  it('keeps the none effort that gpt-daybreak-blue-latest accepts', () => {
+    expect(effortProviderOptions('@ai-sdk/openai', 'none', 'gpt-daybreak-blue-latest', { reasoning: true }))
+      .toEqual({ openai: { reasoningEffort: 'none', forceReasoning: true } });
+  });
+
+  // The maintenance property: the extended range is read off the version, so a
+  // family that does not exist yet is already covered.
+  it('extends the effort range to an unreleased later family', () => {
+    expect(effortProviderOptions('@ai-sdk/openai', 'max', 'gpt-7-example', { reasoning: true }))
+      .toEqual({ openai: { reasoningEffort: 'max', forceReasoning: true } });
+  });
+
+  // Under-scope negative: earlier families must NOT gain the extended range.
+  it.each(['gpt-5.5', 'gpt-5.4', 'gpt-5'])(
+    'does not extend the effort range to %s',
+    modelId => {
+      expect(effortProviderOptions('@ai-sdk/openai', 'max', modelId, { reasoning: true }))
+        .toBeUndefined();
+    },
+  );
+
+  // Over-scope negative: nothing here may admit a model that no metadata vouches for.
+  it('still sends no effort for an unvouched OpenAI model', () => {
+    expect(effortProviderOptions('@ai-sdk/openai', 'high', 'gpt-4o')).toBeUndefined();
+  });
+
+  // models.dev marks the -chat-latest variants as reasoning models, meaning "emits
+  // reasoning tokens" — not "accepts reasoning.effort". OpenAI 400s the parameter for
+  // them and the AI SDK carves `gpt-5-chat*` out of its own reasoning check, so
+  // admitting them here (and then overriding the SDK with forceReasoning) would break
+  // a supported API-key configuration on every request in server mode, where an
+  // effort is filled in by default.
+  it.each(['gpt-5-chat-latest', 'gpt-5.2-chat-latest', 'gpt-6-chat-latest'])(
+    'refuses to send effort to %s even when metadata claims it reasons',
+    modelId => {
+      expect(effortProviderOptions('@ai-sdk/openai', 'high', modelId, { reasoning: true }))
+        .toBeUndefined();
+    },
+  );
+
+  // The -chat carve-out must apply to the whole decision, not to one branch of it:
+  // gpt-5.6-chat-latest is admitted by the id pattern list, so a carve-out that only
+  // guards the family branch would be walked straight around.
+  it.each(['gpt-5.6-chat-latest', 'gpt-6-chat', 'gpt-5-chat-latest'])(
+    'refuses effort for the chat variant %s whichever rule would admit it',
+    modelId => {
+      expect(effortProviderOptions('@ai-sdk/openai', 'high', modelId, { reasoning: true }))
+        .toBeUndefined();
+    },
+  );
+
+  // 'none' was confirmed on blue specifically. By the same rule that keeps it off
+  // astra — a wrong 'none' is a hard 400, not a downgrade — it must not spread to
+  // every daybreak colour on the strength of the prefix alone.
+  it('does not extend the none effort to an unverified daybreak colour', () => {
+    expect(effortProviderOptions('@ai-sdk/openai', 'none', 'gpt-daybreak-red-latest', { reasoning: true }))
+      .toBeUndefined();
+    // The extended range is still granted — only 'none' is held back.
+    expect(effortProviderOptions('@ai-sdk/openai', 'max', 'gpt-daybreak-red-latest', { reasoning: true }))
+      .toEqual({ openai: { reasoningEffort: 'max', forceReasoning: true } });
+  });
+
+  // The admission rule must not be reachable through metadata alone. If this starts
+  // returning options, the family gate has been widened into a metadata gate again.
+  it.each(['gpt-4o', 'gpt-3.5-turbo', 'o1-mini'])(
+    'does not let reasoning metadata alone admit %s',
+    modelId => {
+      expect(effortProviderOptions('@ai-sdk/openai', 'high', modelId, { reasoning: true }))
+        .toBeUndefined();
+    },
+  );
 
   it('merges OpenAI thinking + effort without dropping store/include', () => {
     const merged = deepMergeProviderOptions(
@@ -493,6 +643,56 @@ describe('createLanguageModel', () => {
       },
     });
     expect(responses).toHaveBeenCalledWith('gpt-5.5');
+    vi.doUnmock('@ai-sdk/openai');
+  });
+
+  // The Codex backend gates newer models on this header: gpt-6-astra answered
+  // "requires a newer version of Codex. Please upgrade to the latest app or CLI"
+  // (HTTP 400) while it was pinned at 0.144.1. Nothing tied the header to the
+  // constant before, so a stale pin was invisible until a model stopped working.
+  it('sends the pinned Codex client version on a Responses-Lite request', async () => {
+    vi.resetModules();
+    const responses = vi.fn((modelId: string) => ({ modelId, provider: 'openai-responses' }));
+    const chat = vi.fn((modelId: string) => ({ modelId, provider: 'openai-chat' }));
+    const createOpenAI = vi.fn(() => ({ responses, chat }));
+    vi.doMock('@ai-sdk/openai', () => ({ createOpenAI }));
+
+    const { createLanguageModel: create } = await import('../src/provider-factory.js');
+    const { CODEX_RESPONSES_LITE_VERSION } = await import('../src/constants.js');
+    await create({
+      npm: '@ai-sdk/openai',
+      modelId: 'gpt-6-astra',
+      apiKey: 'tok',
+      authType: 'oauth',
+      oauthAccountId: 'acct-1',
+      useResponsesLite: true,
+    });
+
+    const headers = createOpenAI.mock.calls[0]?.[0]?.headers ?? {};
+    expect(headers.version).toBe(CODEX_RESPONSES_LITE_VERSION);
+    expect(headers['x-openai-internal-codex-responses-lite']).toBe('true');
+    vi.doUnmock('@ai-sdk/openai');
+  });
+
+  // Under-scope guard: a model the backend did not flag must not carry the header.
+  it('omits the Codex client version for a model that is not Responses-Lite', async () => {
+    vi.resetModules();
+    const responses = vi.fn((modelId: string) => ({ modelId, provider: 'openai-responses' }));
+    const chat = vi.fn((modelId: string) => ({ modelId, provider: 'openai-chat' }));
+    const createOpenAI = vi.fn(() => ({ responses, chat }));
+    vi.doMock('@ai-sdk/openai', () => ({ createOpenAI }));
+
+    const { createLanguageModel: create } = await import('../src/provider-factory.js');
+    await create({
+      npm: '@ai-sdk/openai',
+      modelId: 'gpt-5.5',
+      apiKey: 'tok',
+      authType: 'oauth',
+      oauthAccountId: 'acct-1',
+    });
+
+    const headers = createOpenAI.mock.calls[0]?.[0]?.headers ?? {};
+    expect(headers.version).toBeUndefined();
     vi.doUnmock('@ai-sdk/openai');
   });
 

--- a/tests/registry-refresh-models.test.ts
+++ b/tests/registry-refresh-models.test.ts
@@ -77,6 +77,82 @@ describe('registry/refresh-models', () => {
       expect(models?.[0]?.id).toBe('gpt-4');
     });
 
+    // A model id the seed table has never heard of must still arrive as a reasoning
+    // model. Deriving this from the id is what silently shipped gpt-6-astra and
+    // gpt-daybreak-blue-latest as non-reasoning: the effort the user picked was
+    // dropped, and the patched client offered no effort selector for them at all.
+    // Only an id ABSENT from the seed table reaches the changed default; a seeded id
+    // takes the seed branch instead. Keep this case on unseeded ids so it keeps
+    // testing the default rather than the seed.
+    it('treats an unrecognised Codex model as a reasoning model', async () => {
+      const mockRegistry: ProviderRegistry = {
+        version: 1,
+        providers: [{
+          id: 'openai-oauth',
+          templateId: 'openai',
+          name: 'OpenAI (ChatGPT)',
+          enabled: true,
+          authRef: 'keyring',
+          authType: 'oauth',
+          api: {},
+        }],
+      };
+      vi.mocked(io.loadRegistryStrict).mockReturnValue(mockRegistry);
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          models: [
+            { slug: 'gpt-something-not-invented-yet', title: 'future' },
+            { slug: 'gpt-8-codename', title: 'another' },
+            { slug: 'some-unversioned-codename', title: 'third' },
+          ],
+        }),
+      } as Response);
+
+      await refreshProviderModels('openai-oauth', 'mock_token', mockRegistry);
+
+      const savedRegistry = vi.mocked(io.saveRegistry).mock.calls[0]?.[0] as ProviderRegistry;
+      const models = savedRegistry.providers[0]?.modelsCache?.models ?? [];
+      expect(models).toHaveLength(3);
+      for (const model of models) {
+        expect(model.reasoning, `${model.id} should reason`).toBe(true);
+      }
+    });
+
+    // Scope guard for the default above. Tier 2 is the general ChatGPT catalog — the
+    // web model picker — which carries plainly non-reasoning models, so the
+    // "only agentic models" premise that justifies the default does not hold there.
+    it('does not assume reasoning for the general ChatGPT catalog', async () => {
+      const mockRegistry: ProviderRegistry = {
+        version: 1,
+        providers: [{
+          id: 'openai-oauth',
+          templateId: 'openai',
+          name: 'OpenAI (ChatGPT)',
+          enabled: true,
+          authRef: 'keyring',
+          authType: 'oauth',
+          api: {},
+        }],
+      };
+      vi.mocked(io.loadRegistryStrict).mockReturnValue(mockRegistry);
+      // Tier 1 returns nothing, so discovery falls through to Tier 2.
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ models: [] }),
+      } as Response);
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ models: [{ slug: 'gpt-4o', title: 'GPT-4o' }] }),
+      } as Response);
+
+      await refreshProviderModels('openai-oauth', 'mock_token', mockRegistry);
+
+      const savedRegistry = vi.mocked(io.saveRegistry).mock.calls[0]?.[0] as ProviderRegistry;
+      const models = savedRegistry.providers[0]?.modelsCache?.models ?? [];
+      expect(models.find(m => m.id === 'gpt-4o')?.reasoning).toBe(false);
+    });
+
     it('Tier 2: falls back to general endpoint and filters unsupported if Codex fails', async () => {
       const mockRegistry: ProviderRegistry = {
         version: 1,
@@ -385,6 +461,20 @@ describe('registry/refresh-models', () => {
       expect(luna?.contextWindow).toBe(272_000);
       expect(luna?.useResponsesLite).toBe(true);
       expect(luna?.preferWebSockets).toBe(true);
+
+      // The same guarantee for the newer families. useResponsesLite is what decides
+      // whether the pinned Codex client version is sent at all, and without that
+      // header gpt-6-astra is refused outright — so a seed that loses the flag
+      // silently disconnects the model from the fix that makes it work.
+      for (const id of ['gpt-6-astra', 'gpt-daybreak-blue-latest']) {
+        const model = savedRegistry.providers[0]?.modelsCache?.models.find(m => m.id === id);
+        expect(model, `${id} missing from the seed`).toBeDefined();
+        expect(model?.useResponsesLite, id).toBe(true);
+        expect(model?.preferWebSockets, id).toBe(true);
+        expect(model?.contextWindow, id).toBe(272_000);
+        expect(model?.maxContextWindow, id).toBe(872_000);
+        expect(model?.reasoning, id).toBe(true);
+      }
     });
 
     it('returns error if OAuth token is missing', async () => {

--- a/tests/responses-websocket.test.ts
+++ b/tests/responses-websocket.test.ts
@@ -148,7 +148,7 @@ describe('createResponsesWebSocketFetch', () => {
         Authorization: 'Bearer tok',
         'ChatGPT-Account-Id': 'acct-123',
         originator: 'clodex',
-        version: '0.144.1',
+        version: 'test-client-version',
         'x-openai-internal-codex-responses-lite': 'true',
       },
       body: JSON.stringify({ model: 'gpt-5.6-luna', input: [] }),
@@ -158,7 +158,7 @@ describe('createResponsesWebSocketFetch', () => {
     expect(lastSocket().url).toBe(WS_URL);
     expect(headers['Authorization']).toBe('Bearer tok');
     expect(headers['ChatGPT-Account-Id']).toBe('acct-123');
-    expect(headers['version']).toBe('0.144.1');
+    expect(headers['version']).toBe('test-client-version');
     expect(headers['x-openai-internal-codex-responses-lite']).toBe('true');
     expect(headers['OpenAI-Beta']).toContain('responses_websockets');
   });


### PR DESCRIPTION
Two models that OpenAI now returns in the ChatGPT/Codex catalog did not work properly through clodex. **GPT-6 Astra was refused outright**, and both it and **GPT Daybreak Blue** silently ignored the reasoning effort you picked — so asking for `high` did nothing, and the patched Claude Code offered no effort selector for them at all. This PR makes both models work, and makes clodex stop guessing about families it has not been taught yet.

---

## The two failures

**Astra was rejected before it ever ran.** The Codex backend answered:

> The 'gpt-6-astra' model requires a newer version of Codex. Please upgrade to the latest app or CLI. (HTTP 400)

clodex sends a hardcoded Codex client version on Responses-Lite requests. It was pinned at `0.144.1`; the current Codex CLI is `0.153.3`. The existing comment on that constant predicted this exact staleness.

**Effort was discarded for both.** Discovery decided "does this model reason?" from an id-pattern list that predates `gpt-6` and the codenamed aliases, so both were cached as non-reasoning. That had two consequences: `effortProviderOptions` emitted no effort, and `getPatchReasoningCapabilities` short-circuited so `clodex patch` baked in no effort menu.

## Reachability

The ChatGPT/Codex OAuth path, default proxy mode. Astra is in the catalog for any account with access; Daybreak Blue is behind a separate opt-in program. Verified against a real account's live catalog, not constructed.

## What changed

- **Codex client version → `0.153.3`.** Unblocks astra.
- **Discovery assumes a model from the Codex listing reasons**, scoped to that listing — the general ChatGPT catalog is the web model picker and carries plainly non-reasoning models.
- **Effort admission widens by family, reading the version**, so a later family is covered with no code change.
- **`forceReasoning`**, or the AI SDK re-applies its own narrower `o1|o3|o4-mini|gpt-5*` heuristic and drops the effort clodex just decided to send.
- **A seed now overrides a cached reasoning verdict** instead of losing to it.
- **Pricing boundary and output limit** for both models, from the astra model card.

### What this deliberately does *not* do

It does not admit on `metadata.reasoning`. An earlier revision did, and it was wrong: on the API-key path that flag comes from models.dev and means *"emits reasoning tokens"*, not *"accepts `reasoning.effort`"*. models.dev marks `gpt-5-chat-latest` as reasoning, the AI SDK deliberately carves `gpt-5-chat*` out of its own check, and OpenAI 400s the parameter — and in server mode an effort is filled in by default, so every request would have failed. **`gpt-5` and `o1` are untouched**; their original test expectation is restored verbatim.

### The one thing that resists the rule

Failing in the new direction is safe for *admission* (a wrong yes costs an effort the backend accepts anyway) but **not** for effort *values*. `gpt-6-astra` rejects `none`:

> Unsupported value: 'none' is not supported with the 'gpt-6-astra' model. Supported values are: 'low', 'medium', 'high', 'xhigh', and 'max'.

while `gpt-daybreak-blue-latest` accepts it. Guessing that wrong is a hard 400, not a downgrade, so `none` stays an explicit opt-in — granted to the daybreak colour actually confirmed, not to the whole prefix. The model card independently corroborates the measured 400.

## Upgrade path

The seed override is what makes this reach existing users. A cached `reasoning: false` was written by whatever id guess the installed clodex made at refresh time — the Codex catalog has never reported that field — so it is a stale guess, not user data. Without the override the fix reached nobody who had already refreshed. The override is projection-only and never persisted, so downgrading is a no-op. Users still need `clodex patch` for the effort menu, which the existing `stale-config` prompt already surfaces.

## Verification

Live, against the real backend, with an isolated `CLODEX_HOME` and a throwaway port so no running server was touched. **Effort was read off the wire, not inferred from the request succeeding** — an early probe showed all six levels "ok" for astra, which was misleading: `none` and `max` were being dropped before they were sent.

| | astra | blue | sol / luna |
|---|---|---|---|
| before | HTTP 400 | effort dropped | — |
| after | `low`/`high`/`xhigh`/`max` verbatim, `none` dropped | full range | byte-identical |

Anthropic passthrough (`HAIKU-OK`) and the aliases were smoke tested. `pnpm typecheck && pnpm test && pnpm build` green: **2306 tests / 107 files**. Reverting all four source files turns **30 tests red**.

`tests/openai-wire-effort.test.ts` drives the real AI SDK with a stubbed fetch and asserts the serialised request body — every other effort assertion compares clodex's output to a copy of what clodex builds, and would stay green if the option key were wrong.

## Not verified — stated rather than implied

- **The family rule also governs the public API-key route, and every live measurement here was against the Codex/OAuth backend.** The API-key wire for these ids is untested.
- Whether either model's output **quality** responds to the effort level. Only that the value is delivered and accepted.
- **The pinned client version cannot be caught by a test** — any assertion follows the constant. That is precisely how `0.144.1` went stale unnoticed; it stays a live-verification claim.
- The seeded context window is the Codex client's (272K/872K), smaller than the 1,050,000 the public card lists. This path is Codex-only.
