### PR TITLE
fix(context): stop cutting 5% off the context window clodex reports

### DIFF
--- a/.claude/docs/claude-code-internals.md
+++ b/.claude/docs/claude-code-internals.md
@@ -161,7 +161,10 @@ Two things that are easy to assume wrongly about the blob:
   `entryPointId` names the entry module directly and survives renames; the *name* is only how
   tweakcc happens to look it up.
 
-## Unknown-model context-window enforcement (verified 2.1.223+)
+## Unknown-model context-window enforcement (verified 2.1.223+, re-verified 2.1.261)
+
+In 2.1.261 the minified names are `RV` (gate) and `GS` (resolver); the pre-2.1.261 names below are
+`KJe` and `Q9` respectively. Names change every build — find these by behaviour, not by symbol.
 
 Enforcement hangs off a single gate: `KJe(e,t)` returns `Q9(e,t).source !== "auto"`. `Q9` returns
 `{window, configured, source}`; the enforcement branch and the fallthrough return the **identical**
@@ -179,6 +182,51 @@ clodex identities. Recognized Anthropic models hit earlier branches.
 startup notice (`if (n !== "unknown-model") return null`) and the auto-compact setup wizard both
 labels the source and seeds its initial value differently. Both are **cosmetic**, so `KJe` remains the
 only behavioural gate — but the bundle already renders `model-default` as a first-class label.
+
+## Where the context window and the compaction point come from (verified 2.1.261, darwin-arm64)
+
+Names are from 2.1.261 and will change; the constants will not.
+
+**Window** — `vp(model, betas)`, in order:
+1. the `/*ccpatch:ctx*/` table `clodex patch` injects (PATCH 7 anchors here, ahead of everything else)
+2. `JL()` — `CLAUDE_CODE_MAX_CONTEXT_TOKENS`, but **only when `DISABLE_COMPACT` is truthy**. `Ie()`
+   accepts exactly `1`/`true`/`yes`/`on`, so `DISABLE_COMPACT=0` does not arm it.
+3. `ivn()` — clamp to 200,000 when the account's long-context credits are blocked
+4. `QL()`: `[1m]` suffix → 1e6 (via `tc`, itself gated on `KN()`) · 1m-beta header → 1e6 · served
+   model catalog (`svn`/`Ya`, clamped to 200,000 unless native-1M) — a per-model experiment `sCt`
+   is consulted *inside* this branch and outranks the catalog value · `_g()` native-1M → 1e6 ·
+   `sCt` again · **`CLAUDE_CODE_MAX_CONTEXT_TOKENS` when `XL(e)`** — no `DISABLE_COMPACT` needed;
+   this is the branch endpoint mode relies on, set by `src/env.ts`. `XL` is roughly "not an id the
+   baked catalog recognises", not literally "does not start with `claude-`" · else 200,000
+
+Getting step 2 and the `XL` branch confused is an easy mistake and has been made in this repo: the
+env var is read in **three** places with different preconditions — those two, plus `XS`, which
+gates the unrecognized-model startup notice on `eor()`, the deliberate union of both. Only the
+first two decide a window; `XS` is cosmetic.
+
+`GS()` then layers overrides. **No branch can exceed `vp`:** every override is `Math.min`'d against
+it, and the remaining branches return it unchanged. Order:
+`CLAUDE_CODE_AUTO_COMPACT_WINDOW` (validated 100,000–1,000,000, `source:"env"`) → settings →
+clientdata → experiment → model-default clamps → unknown-model → `auto`.
+
+**Compaction point** — `threshold = GS().window − min(maxOutputTokens, 20,000) − 13,000`. A flat
+reserve, 33,000 for every current model; there is **no percentage on the default path**.
+`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` is a percent in `(0, 100]` — `parseFloat`, and anything outside
+that range, including `0`, is ignored silently applied as `Math.min(floor(effective × pct/100), effective − 13,000)` — it can only
+**lower** the threshold, and it multiplies the window *after* the 20,000 reserve, not the raw
+window. Identical in every cached bundle from 2.1.238 to 2.1.261. The one genuine
+percentage-of-window nearby (`0.2`) belongs to the speculative precompute arm, not the trigger.
+
+Because the reserve is flat, headroom as a *fraction* varies with window size: 16.5% at 200,000,
+12.1% at 272,000, 3.3% at 1,000,000.
+
+**The response body is not a source for the window.** A few consumers do read a model id off a
+response — one even calls `vp()` on it — but only to stamp a context window onto a cost record.
+None of them reach `GS`/`QF`/`MTe`/`RXo`, so nothing on the compaction path depends on the echo.
+The models-list fetch validates only `{id, display_name, description}`. The served-catalog lookup
+`Ya()` does prefer `runtime.max_input_tokens` over `context_window`, but in endpoint mode that
+lookup is unreachable anyway: it is gated on the Anthropic base URL being `api.anthropic.com`, and
+`src/env.ts` points the child at `127.0.0.1`.
 
 ## The shared child-environment builder (verified 2.1.221, re-verified 2.1.239 and 2.1.260)
 

--- a/.claude/docs/registry-and-server.md
+++ b/.claude/docs/registry-and-server.md
@@ -62,6 +62,7 @@ exact `Map.get`, so a wrong-case endpoint alias does not resolve.
 Invalid, reserved, conflicting, unavailable, or catalog-colliding aliases remain preserved in config
 but are reported and kept out of routing. **Aliases and canonical ids are accepted INPUT only** —
 `/models` listings advertise exactly the canonical/masked ids. **Echo invariant:** an aliased
-request's response `model` field echoes the alias verbatim (even under masking) so a patched Claude
-Code's context-window lookup keys match (`aliasNames` in `ServerOptions`).
+request's response `model` field echoes the alias verbatim (even under masking), so the id a client
+sees back is the one it sent (`aliasNames` in `ServerOptions`). Note the window lookup itself does
+not read the response body — see `.claude/docs/claude-code-internals.md`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,12 +153,21 @@ hand-rolled per-provider translation; don't add one. See `.claude/docs/translati
 
 These bite from outside the subsystem that owns them, so they live here rather than in a deep doc.
 
-- **Auto-compaction depends on the response-model echo.** The proxy-mode MITM forwards request
-  bodies **unrewritten** so responses echo the exact model id the client sent. Claude Code resolves
-  context windows from the response `model` field but uses the request alias for preflight —
-  substituting the canonical id in responses made patched/alias ids miss their window config,
-  auto-compact never fired, and agents died with "Prompt is too long". Endpoint mode's synthetic
-  `GET /v1/models` returns `context_window` per model so the status bar is accurate.
+- **The proxy-mode MITM forwards request bodies unrewritten** so responses echo the exact model id
+  the client sent. Substituting the canonical id made patched/alias ids miss their window config,
+  auto-compact never fired, and agents died with "Prompt is too long". Keep it that way.
+
+  **Keep the invariant; do not reuse the mechanism that used to be written here.** The claim that
+  Claude Code reads its window from the response `model` field does not hold in 2.1.261, and
+  repeating it cost a review. What the echo still buys is that the *request* id and the id the
+  client keys its own state on stay the same object — which is reason enough not to rewrite bodies.
+  Current internals live in `.claude/docs/claude-code-internals.md`; read that rather than
+  re-deriving, and re-stamp it when you verify against a new release.
+- **Report the provider's real context window; hold nothing back.** Claude Code already reserves
+  `min(maxOutputTokens, 20,000) + 13,000` below whatever window it is told — 33,000 for every clodex
+  identity — and applies no percentage of its own on the default path, so a window clodex
+  shrinks first is context the user simply loses. clodex once imposed a 95% share on ChatGPT OAuth
+  models; the catalog never asked for it. Honour a share a provider declares, never invent one.
 - **Anthropic-passthrough base URLs must NOT include `/v1`** — the Anthropic SDK appends
   `/v1/messages` itself.
 - **The alias IS the model identity** once a binary is patched: the short name is what lands in the

--- a/README.md
+++ b/README.md
@@ -245,8 +245,9 @@ A context window is a cost dial as much as a capacity number. OpenAI prices GPT-
 and later prompts above **272,000 input tokens at 2x input and 1.5x output for the
 full request**, which is why the Codex catalog reports a 272,000 window rather than
 the model's ceiling. Newer families inherit the same boundary, so a model released
-after this was written is covered without a clodex update. Clodex follows that: the default `standard` stop stays under the
-line, and a larger window is something you ask for.
+after this was written is covered without a clodex update. Clodex follows that: the
+default `standard` stop stays under the line, and a larger window is something you
+ask for.
 
 ```sh
 clodex models --context sol=max --save     # this model's default, with a cost warning
@@ -254,19 +255,21 @@ clodex claude --context sol=max            # this launch only, nothing saved
 clodex models --context sol=default --save # back to the provider's tuned window
 ```
 
-Each stop is reported with the numbers behind it: the raw window, the headroom
-percentage the Codex catalog uses, the effective window a client should fill, and the
-account ceiling a larger stop can reach. A stop above the ceiling is clamped and says
-so. When a request's own reported token count crosses the boundary, clodex warns once
-per model for the life of the process, because the client's token count and the
-provider's differ after translation and only the provider's settles it.
+Each stop is reported with the numbers behind it: the raw window, the effective
+window a client should fill, and the account ceiling a larger stop can reach. A stop
+above the ceiling is clamped and says so. When a request's own reported token count
+crosses the boundary, clodex warns once per model for the life of the process,
+because the client's token count and the provider's differ after translation and only
+the provider's settles it.
 
 Two things worth knowing about the numbers:
 
-- **ChatGPT/Codex OAuth models carry a 95% headroom convention**, matching the Codex
-  client. Their reported window is 5% below the raw catalog value: `gpt-5.6-sol`
-  reports 258,400 rather than 272,000. This applies to that provider only; API-key
-  and OpenCode Go models keep their full window.
+- **Clodex reports the window the provider actually gives, and holds nothing back.**
+  Deciding how much of a window to leave free is the client's job — Claude Code
+  already reserves a fixed amount below whatever window it is told, and shrinking the
+  number first only costs usable context. A provider that declares a share of its own
+  is still honoured; clodex just never invents one. Use `--context` if you want a
+  smaller window than the provider offers.
 - **The account ceiling moves.** It is server-side and per-account, and it has
   changed by more than 2x within a single day in the past. `max` reads whatever the
   catalog reports now and clamps to it, so a stale ceiling shrinks the stop rather

--- a/src/context-modes.ts
+++ b/src/context-modes.ts
@@ -3,13 +3,6 @@
 // request, so the default stop sits under that line and the larger one is opt-in.
 // The field shape mirrors the Codex model catalog.
 
-/**
- * Share of a raw window a client fills, matching the Codex catalog default. Carried
- * only by the ChatGPT OAuth provider, whose models follow that convention; applying
- * it to an API-key provider would shrink every other model by 5%.
- */
-export const DEFAULT_EFFECTIVE_CONTEXT_PERCENT = 95;
-
 export type ContextStopName = 'standard' | 'max';
 export type ContextStop = ContextStopName | number;
 
@@ -18,7 +11,7 @@ export interface ContextLimits {
   contextWindow: number;
   /** Highest raw window the model accepts. Absent means the default is the ceiling. */
   maxContextWindow?: number;
-  /** Share of the raw window to fill. Absent uses the catalog default. */
+  /** Share of the raw window to fill, when a provider declares one. Absent means all of it. */
   effectiveContextPercent?: number;
   /** Raw input size above which the provider bills at a higher rate. */
   pricingBoundary?: number;

--- a/src/data/openai-oauth-models.ts
+++ b/src/data/openai-oauth-models.ts
@@ -9,7 +9,6 @@
 // nothing. Availability still varies by tier, so the full set is listed and the user
 // discovers what their plan unlocks at inference time.
 
-import { DEFAULT_EFFECTIVE_CONTEXT_PERCENT } from '../context-modes.js';
 import { resolveContextWindow } from '../context-window.js';
 import { deriveBrand } from '../models.js';
 import type { CachedModel } from '../registry/types.js';
@@ -124,9 +123,41 @@ export function openAiPricingMetadata(
 }
 
 /**
+ * The share clodex used to impose on every ChatGPT OAuth window before reporting it.
+ * Kept only to recognise and discard the value in caches written by those versions.
+ */
+const LEGACY_IMPOSED_CONTEXT_PERCENT = 95;
+
+/**
+ * Drop a context share that clodex imposed on itself rather than being told.
+ *
+ * The Codex catalog does not report `effective_context_window_percent` — it is null
+ * for every model it returns — and no clodex command writes the field, so a cached
+ * 95 can only be the default older versions injected at discovery. Reporting a
+ * window 5% below the provider's real one made Claude Code compact early for no
+ * benefit: it already holds back a flat 33,000 tokens of its own (a 20,000 response
+ * reserve plus a 13,000 summary buffer) and applies no share of its own to the
+ * number it is given, so the reduction was pure loss of usable context.
+ *
+ * Discarded at projection rather than at refresh so an install that never re-runs
+ * `clodex providers refresh-models` still gets its window back. The cache file itself
+ * is never rewritten by this, so the check has to stay for as long as those caches do.
+ *
+ * KNOWN LIMITATION: this keys on the value, and 95 is exactly the share the Codex
+ * client uses, so it is the most plausible number the catalog would ever start
+ * reporting. If it does, clodex will ignore it. That is a deliberate trade rather than
+ * an oversight — 95 is a CLIENT-side convention, and clodex is not the client; Claude
+ * Code is, and it does its own reserving. Revisit if the catalog ever populates this
+ * field, which it does not today (null for all ten models it returns, 2026-09-05).
+ */
+function migratedEffectiveContextPercent(cached: number | undefined): number | undefined {
+  return cached === LEGACY_IMPOSED_CONTEXT_PERCENT ? undefined : cached;
+}
+
+/**
  * Fill context metadata that a catalog cached before these fields existed is missing.
  * Only absent fields are filled, so live discovery always wins; without this a stale
- * cache reports a raw window with no headroom and no reachable ceiling.
+ * cache reports no reachable ceiling, collapsing the larger stop onto the standard one.
  *
  * `reasoning` is the one field a seed OVERRIDES rather than merely fills. The Codex
  * catalog has never reported it: a cached value was written by whatever id guess the
@@ -145,9 +176,7 @@ export function applyOAuthSeedContextMetadata(models: CachedModel[]): CachedMode
     return {
       ...model,
       maxContextWindow: model.maxContextWindow ?? seed?.maxContextWindow,
-      effectiveContextPercent: model.effectiveContextPercent
-        ?? seed?.effectiveContextPercent
-        ?? DEFAULT_EFFECTIVE_CONTEXT_PERCENT,
+      effectiveContextPercent: migratedEffectiveContextPercent(model.effectiveContextPercent),
       pricingBoundary: model.pricingBoundary ?? seed?.pricingBoundary ?? pricing.pricingBoundary,
       pricingBoundaryNote: model.pricingBoundaryNote
         ?? seed?.pricingBoundaryNote
@@ -170,7 +199,7 @@ export function buildOpenAiOAuthModels(): CachedModel[] {
       brand: deriveBrand(prefix),
       contextWindow: resolveContextWindow(seed.id, seed.contextWindow),
       maxContextWindow: seed.maxContextWindow,
-      effectiveContextPercent: seed.effectiveContextPercent ?? DEFAULT_EFFECTIVE_CONTEXT_PERCENT,
+      effectiveContextPercent: seed.effectiveContextPercent,
       pricingBoundary: seed.pricingBoundary ?? pricing.pricingBoundary,
       pricingBoundaryNote: seed.pricingBoundaryNote ?? pricing.pricingBoundaryNote,
       maxOutputTokens: seed.maxOutputTokens,

--- a/src/http-proxy/server.ts
+++ b/src/http-proxy/server.ts
@@ -951,9 +951,9 @@ export async function startHttpProxy(options: HttpProxyOptions): Promise<HttpPro
         // The adapter resolves alias names itself and must echo the client's
         // requested model id in response messages. Encoded bodies are decoded
         // for this local hop, but their JSON model value is not rewritten.
-        // Claude Code resolves context windows from the response model field, so
-        // substituting the canonical route id here breaks its window lookup for
-        // patched/alias model ids (wrong auto-compact threshold → agent death).
+        // Substituting the canonical route id here broke patched/alias ids in the
+        // field. The window lookup does not read the response body in 2.1.261 (see
+        // `.claude/docs/claude-code-internals.md`); the echo is about identity.
         await forwardToAdapter(
           req,
           res,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -438,9 +438,11 @@ export async function startProxyCatalog(
       }
       const route = resolvedRoute ?? defaultRoute;
       // The identity a translated response reports. A request that named a
-      // route we honoured keeps its public id — patched Claude Code preflights
-      // with the request alias and resolves context windows from the response
-      // `model`, so rewriting it there would break auto-compaction.
+      // route we honoured keeps its public id: substituting the canonical id broke
+      // auto-compaction for patched/alias ids in the field. (The window lookup does
+      // not read the response body in 2.1.261 — see
+      // `.claude/docs/claude-code-internals.md` — so keep this for identity
+      // consistency, not because the client parses it.)
       // On a default-route fallback, report the answering/default model rather
       // than the unresolved requested id. Built-in Anthropic-format fallback is
       // routine in this PR, so the translated path must make that identity explicit.

--- a/src/registry/refresh-models.ts
+++ b/src/registry/refresh-models.ts
@@ -40,7 +40,6 @@ import {
   CHATGPT_CODEX_UNSUPPORTED_MODELS,
   openAiPricingMetadata,
 } from '../data/openai-oauth-models.js';
-import { DEFAULT_EFFECTIVE_CONTEXT_PERCENT } from '../context-modes.js';
 import { isChatGptOAuthProvider } from './provider-kind.js';
 import { deriveBrand } from '../models.js';
 import { resolveContextWindow } from '../context-window.js';
@@ -197,8 +196,10 @@ function buildDynamicOAuthModel(
     brand: deriveBrand(prefix),
     contextWindow: entry.context_window ?? resolveContextWindow(id),
     maxContextWindow: entry.max_context_window,
-    effectiveContextPercent: entry.effective_context_window_percent
-      ?? DEFAULT_EFFECTIVE_CONTEXT_PERCENT,
+    // Absent means no reduction. clodex reports the window the provider actually
+    // gives; deciding how much of it to leave free is the client's job, and Claude
+    // Code already reserves a flat 33,000 tokens below whatever it is told.
+    effectiveContextPercent: entry.effective_context_window_percent,
     maxOutputTokens: entry.max_output_tokens,
     ...openAiPricingMetadata(id),
     modelFormat: 'openai' as const,

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -862,10 +862,9 @@ async function getOrInitLanguageModel(
 }
 
 function getResponseModelId(bodyModel: unknown, model: ServerModelInfo, options: ServerOptions): string {
-  // Echo invariant: a saved short alias is echoed back verbatim even when
-  // masking is on — Claude Code resolves context windows from the response
-  // `model` field but preflights with the request alias, so rewriting it here
-  // would break auto-compaction (see CLAUDE.md).
+  // Echo invariant: a saved short alias is echoed back verbatim even when masking
+  // is on, so the id a client sees back is the id it sent. The window lookup itself
+  // does not read the response body — see `.claude/docs/claude-code-internals.md`.
   if (typeof bodyModel === 'string' && options.aliasNames?.has(bodyModel)) return bodyModel;
   return options.gateway?.maskGatewayIds
     ? gatewayDisplayName(model, options.gateway)

--- a/src/upstream-forward.ts
+++ b/src/upstream-forward.ts
@@ -107,12 +107,15 @@ export interface RelayAnthropicOptions {
   onUpstreamError?: (statusCode: number, body: string) => void;
   signal?: AbortSignal;
   /**
-   * Echo this exact model id in the relayed response instead of the upstream's.
-   * Claude Code resolves context windows from the response `model` field but
-   * uses the request id for preflight, so a passthrough route selected through
-   * an alias must echo the alias or auto-compaction misses its window config
-   * (see CLAUDE.md "alias response-model echo"). Rewrites the JSON body's
-   * `model` and the SSE `message_start` event; every other byte passes through.
+   * Echo this exact model id in the relayed response instead of the upstream's,
+   * so a passthrough route selected through an alias reports the id the client
+   * asked for rather than the canonical one. Substituting the canonical id broke
+   * auto-compaction for patched/alias ids in the field; the window lookup itself
+   * does not read the response body in 2.1.261 (see
+   * `.claude/docs/claude-code-internals.md`), so keep this for identity
+   * consistency rather than because the client parses it. Rewrites the JSON
+   * body's `model` and the SSE `message_start` event; every other byte passes
+   * through.
    */
   responseModelOverride?: string;
 }

--- a/tests/context-model-id.test.ts
+++ b/tests/context-model-id.test.ts
@@ -23,6 +23,25 @@ describe('claudeCodeClientModelId', () => {
   it('is idempotent when [1m] is already present', () => {
     expect(claudeCodeClientModelId('gemini-3.5-flash[1m]', 1_000_000)).toBe('gemini-3.5-flash[1m]');
   });
+
+  // A ChatGPT OAuth model reaches this branch for the first time now that clodex
+  // reports the provider's real ceiling: gpt-5.4's larger stop was 950,000 while a 5%
+  // share was imposed and is a full 1,000,000 without it. The suffix must appear (it is
+  // how Claude Code is told the window is 1M) and must stay transparent to routing,
+  // which keys on the bare id.
+  it('suffixes an OAuth model whose larger stop reaches 1M, without breaking routing', () => {
+    const clientId = claudeCodeClientModelId('clodex:openai-oauth:gpt-5.4', 1_000_000);
+    expect(clientId).toBe('clodex:openai-oauth:gpt-5.4[1m]');
+    expect(normalizeRouteLookupId(clientId)).toBe('clodex:openai-oauth:gpt-5.4');
+    expect(routeLookupIds(clientId)).toContain('clodex:openai-oauth:gpt-5.4');
+  });
+
+  // The same model at the standard stop must NOT be suffixed, or every session would
+  // claim a 1M window it does not have.
+  it('leaves the same model bare at its standard stop', () => {
+    expect(claudeCodeClientModelId('clodex:openai-oauth:gpt-5.4', 272_000))
+      .toBe('clodex:openai-oauth:gpt-5.4');
+  });
 });
 
 describe('routeLookupIds', () => {

--- a/tests/context-modes.test.ts
+++ b/tests/context-modes.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import {
   contextLimitsFrom,
   contextClampNotice,
-  DEFAULT_EFFECTIVE_CONTEXT_PERCENT,
   effectiveContextWindow,
   parseContextStop,
   pricingBoundaryWarning,
@@ -15,15 +14,58 @@ import {
 
 // Mirrors what the Codex catalog actually reports for this family: a 272,000
 // default and an account-scoped 872,000 ceiling, not the published model spec.
+// The percent is declared EXPLICITLY here because the mechanism still honours one
+// when a provider states it — clodex just no longer imposes a share of its own.
 const SOL = {
   contextWindow: 272_000,
   maxContextWindow: 872_000,
-  effectiveContextPercent: DEFAULT_EFFECTIVE_CONTEXT_PERCENT,
+  effectiveContextPercent: 95,
   pricingBoundary: 272_000,
   pricingBoundaryNote: 'Above it, the full request is priced higher.',
 };
 
 beforeEach(() => resetContextStops());
+
+// After clodex stopped imposing a share of its own, the standard stop for this family
+// lands EXACTLY on the pricing boundary (272,000 vs 272,000). That makes the boundary
+// comparison's strictness load-bearing for the first time: with `>=` instead of `>`,
+// every default-stop launch would warn that the window "can grow past" a line it sits
+// precisely on, contradicting the documented promise that standard stays under it.
+describe('a standard stop that lands exactly on the pricing boundary', () => {
+  const AT_BOUNDARY = {
+    contextWindow: 272_000,
+    maxContextWindow: 872_000,
+    pricingBoundary: 272_000,
+    pricingBoundaryNote: 'Above it, the full request is priced higher.',
+  };
+
+  it('does not report crossing when the window equals the boundary', () => {
+    const resolved = resolveContextStop(AT_BOUNDARY, 'standard');
+    expect(resolved.effective).toBe(272_000);
+    expect(resolved.crossesPricingBoundary).toBe(false);
+  });
+
+  it('reports crossing one token above the boundary', () => {
+    const resolved = resolveContextStop({ ...AT_BOUNDARY, contextWindow: 272_001 }, 'standard');
+    expect(resolved.crossesPricingBoundary).toBe(true);
+  });
+
+  it('still reports crossing on the larger stop', () => {
+    expect(resolveContextStop(AT_BOUNDARY, 'max').crossesPricingBoundary).toBe(true);
+  });
+
+  // The comparison reads `effective`, and with no share imposed `effective === raw` for
+  // every model in practice — so swapping one for the other is an equivalent mutant
+  // today. Pin the distinction with a declared share, which is the only way the two
+  // diverge, so the field being compared stays deliberate rather than incidental.
+  it('compares the effective window, not the raw one', () => {
+    const withShare = { ...AT_BOUNDARY, contextWindow: 300_000, effectiveContextPercent: 80 };
+    const resolved = resolveContextStop(withShare, 'standard');
+    expect(resolved.raw).toBe(300_000);
+    expect(resolved.effective).toBe(240_000);
+    expect(resolved.crossesPricingBoundary).toBe(false);
+  });
+});
 
 describe('effectiveContextWindow', () => {
   it('applies a declared percent', () => {

--- a/tests/model-metadata.test.ts
+++ b/tests/model-metadata.test.ts
@@ -11,8 +11,11 @@ const SOL: ModelMetadata = {
   context: {
     stop: 'standard',
     raw: 272_000,
-    effective: 258_400,
-    effectivePercent: 95,
+    // A share of 90 rather than 95: the serializer must still carry a declared
+    // percent, but 95 is the one value the OAuth overlay now discards as clodex's
+    // own legacy injection, so a fixture built on it would model an unreachable state.
+    effective: 244_800,
+    effectivePercent: 90,
     max: 872_000,
   },
   maxOutputTokens: 128_000,

--- a/tests/models-context-command.test.ts
+++ b/tests/models-context-command.test.ts
@@ -83,7 +83,7 @@ describe('models --json', () => {
     expect(parsed[0]!['id']).toBe('clodex:openai-oauth:gpt-5.6-sol');
     expect(parsed[0]!['alias']).toBe('sol');
     const context = parsed[0]!['context'] as Record<string, unknown>;
-    expect(context['effective']).toBe(258_400);
+    expect(context['effective']).toBe(272_000);
     expect(context['max']).toBe(872_000);
     expect(parsed[0]!['pricingBoundary']).toBe(272_000);
   });
@@ -100,8 +100,8 @@ describe('models --json', () => {
     const parsed = JSON.parse(cap.stdout.join('')) as Array<Record<string, unknown>>;
     const context = parsed[0]!['context'] as Record<string, unknown>;
     expect(context['stop']).toBe('max');
-    expect(context['effective']).toBe(828_400);
-    expect(cap.stderr.join('\n')).toContain('828,400');
+    expect(context['effective']).toBe(872_000);
+    expect(cap.stderr.join('\n')).toContain('872,000');
     // Session-scoped: nothing was written to preferences.
     expect(loadPreferences().modelContextModes ?? {}).toEqual({});
   });
@@ -125,7 +125,7 @@ describe('--context assignments', () => {
       after.restore();
     }
     const parsed = JSON.parse(after.stdout.join('')) as Array<Record<string, unknown>>;
-    expect((parsed[0]!['context'] as Record<string, unknown>)['effective']).toBe(828_400);
+    expect((parsed[0]!['context'] as Record<string, unknown>)['effective']).toBe(872_000);
   });
 
   it('warns when the selected stop can reach the higher-rate band', async () => {
@@ -159,7 +159,7 @@ describe('--context assignments', () => {
       cap.restore();
     }
     const all = [...cap.stdout, ...cap.stderr].join('\n');
-    expect(all).toContain('828,400');
+    expect(all).toContain('872,000');
     expect(all).not.toContain('Add --save');
     expect(all).toContain('clodex models --context');
   });
@@ -173,7 +173,7 @@ describe('--context assignments', () => {
     } finally {
       cap.restore();
     }
-    expect(cap.stderr.join('\n')).not.toContain('828,400');
+    expect(cap.stderr.join('\n')).not.toContain('872,000');
     expect(cap.stdout.join('\n')).toContain('--context');
   });
 

--- a/tests/oauth-seed-overlay.test.ts
+++ b/tests/oauth-seed-overlay.test.ts
@@ -1,14 +1,18 @@
 import { describe, it, expect } from 'vitest';
 import { projectProviderCachedModels } from '../src/registry/materialize.js';
+import { buildOpenAiOAuthModels } from '../src/data/openai-oauth-models.js';
 import type { RegistryProvider } from '../src/registry/types.js';
 
 /**
  * A catalog cached before the context-budget fields existed carries none of them.
- * Reading it back unchanged reports a raw window with no headroom and no reachable
- * ceiling, which silently collapses the larger stop onto the standard one. That is
- * not hypothetical: the install this was written against held a cache in exactly
- * that shape, and the export returned 272,000 instead of 258,400 until the overlay
- * was added.
+ * Reading it back unchanged reports no reachable ceiling, which silently collapses the
+ * larger stop onto the standard one. That is not hypothetical: the install this was
+ * written against held a cache in exactly that shape.
+ *
+ * The overlay originally also imposed a 95% share on the window. It no longer does —
+ * that share was clodex's own invention and cost usable context — so these tests now
+ * assert the provider's real numbers, and one of them pins the discard of a share left
+ * behind in caches written by those versions.
  */
 function providerWithLegacyCache(overrides: Partial<RegistryProvider> = {}): RegistryProvider {
   return {
@@ -39,7 +43,9 @@ describe('legacy OAuth cache overlay', () => {
   it('fills the budget fields a pre-existing cache never stored', () => {
     const [sol] = projectProviderCachedModels(providerWithLegacyCache());
     expect(sol?.contextWindow).toBe(272_000);
-    expect(sol?.effectiveContextPercent).toBe(95);
+    // No share is imposed: the provider does not report one, so the window clodex
+    // reports is the window the provider actually gives.
+    expect(sol?.effectiveContextPercent).toBeUndefined();
     expect(sol?.maxContextWindow).toBe(872_000);
     expect(sol?.pricingBoundary).toBe(272_000);
     expect(sol?.maxOutputTokens).toBe(128_000);
@@ -161,6 +167,39 @@ describe('legacy OAuth cache overlay', () => {
         .toBeUndefined();
     },
   );
+
+  // The seed list is written straight into the cache on the Tier-3 discovery-outage
+  // path, so a share injected here would be persisted even though projection strips it
+  // on the way back out. Assert the source, not just the projection, or the injection
+  // is invisible for as long as the migration happens to mask it.
+  it('declares no context share in the seed list itself', () => {
+    for (const model of buildOpenAiOAuthModels()) {
+      expect(model.effectiveContextPercent, model.id).toBeUndefined();
+    }
+  });
+
+  // The migration for installs that refreshed while clodex still imposed a share.
+  // A cached 95 is not a provider answer — the Codex catalog reports null for this
+  // field on every model, and no clodex command writes it — so it can only be the
+  // value older versions injected. Left in place it would keep costing 13,600
+  // tokens on every session until the user happened to re-run a model refresh.
+  it('discards the share clodex used to impose on a cached window', () => {
+    const provider = providerWithLegacyCache();
+    const cached = provider.modelsCache?.models[0];
+    if (cached) cached.effectiveContextPercent = 95;
+    const [sol] = projectProviderCachedModels(provider);
+    expect(sol?.effectiveContextPercent).toBeUndefined();
+  });
+
+  // Under-scope: a share a provider genuinely declares must still be honoured, or
+  // the migration has become a blanket "ignore this field".
+  it.each([90, 80, 50])('keeps a declared share of %i%%', percent => {
+    const provider = providerWithLegacyCache();
+    const cached = provider.modelsCache?.models[0];
+    if (cached) cached.effectiveContextPercent = percent;
+    const [sol] = projectProviderCachedModels(provider);
+    expect(sol?.effectiveContextPercent).toBe(percent);
+  });
 
   // Only the ChatGPT OAuth provider uses the Codex effective-window convention.
   // Applying it to an API-key provider would shrink every other model by 5%.

--- a/tests/registry-refresh-models.test.ts
+++ b/tests/registry-refresh-models.test.ts
@@ -119,6 +119,42 @@ describe('registry/refresh-models', () => {
       }
     });
 
+    // The Codex catalog reports effective_context_window_percent as null for every
+    // model it returns. Inventing a share here is what made clodex hand Claude Code
+    // a window 5% below the provider's real one, for no benefit: Claude Code already
+    // holds back a flat 33,000 tokens and applies no share of its own.
+    it('invents no context share when the catalog reports none', async () => {
+      const mockRegistry: ProviderRegistry = {
+        version: 1,
+        providers: [{
+          id: 'openai-oauth',
+          templateId: 'openai',
+          name: 'OpenAI (ChatGPT)',
+          enabled: true,
+          authRef: 'keyring',
+          authType: 'oauth',
+          api: {},
+        }],
+      };
+      vi.mocked(io.loadRegistryStrict).mockReturnValue(mockRegistry);
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          models: [
+            { slug: 'gpt-5.6-sol', title: 'Sol', context_window: 272000, max_context_window: 872000 },
+            { slug: 'gpt-brand-new', title: 'New', context_window: 272000 },
+          ],
+        }),
+      } as Response);
+
+      await refreshProviderModels('openai-oauth', 'mock_token', mockRegistry);
+
+      const saved = vi.mocked(io.saveRegistry).mock.calls[0]?.[0] as ProviderRegistry;
+      for (const model of saved.providers[0]?.modelsCache?.models ?? []) {
+        expect(model.effectiveContextPercent, model.id).toBeUndefined();
+      }
+    });
+
     // Scope guard for the default above. Tier 2 is the general ChatGPT catalog — the
     // web model picker — which carries plainly non-reasoning models, so the
     // "only agentic models" premise that justifies the default does not hold there.
@@ -388,7 +424,8 @@ describe('registry/refresh-models', () => {
       const sol = models.find(m => m.id === 'gpt-5.6-sol');
       expect(sol?.contextWindow).toBe(272_000);
       expect(sol?.maxContextWindow).toBe(872_000);
-      expect(sol?.effectiveContextPercent).toBe(95);
+      // Discovery no longer invents a share the catalog did not report.
+      expect(sol?.effectiveContextPercent).toBeUndefined();
       expect(sol?.pricingBoundary).toBe(272_000);
 
       // A discovered model outside the seed still gets no invented ceiling.


### PR DESCRIPTION
Clodex was telling Claude Code that your model's context window was 5% smaller than it really is. On `gpt-5.6-sol` it reported **258,400 instead of 272,000**, and the larger stop as 828,400 instead of 872,000. That number is what Claude Code plans against, so those 13,600 tokens were usable context you paid for and never got to use. This reports the provider's real window instead.

---

## Nobody asked for the reduction

The Codex catalog reports `effective_context_window_percent` as **null for every model it returns** — captured live from `chatgpt.com/backend-api/codex/models`, all 10 models, 2026-09-05 — and no clodex command writes that field. The 5% came from a `DEFAULT_EFFECTIVE_CONTEXT_PERCENT = 95` that discovery injected whenever the catalog stayed silent, which was always.

## And it was redundant

Verified against the extracted Claude Code 2.1.261 bundle. The auto-compact threshold is:

```
window − min(maxOutputTokens, 20000) − 13000
```

A flat 33,000-token reserve, with **no percentage applied on the default path** — the number clodex supplies is used verbatim, exactly once. Deciding how much of a window to leave free is the client's job and it was already doing it. Shrinking the number first just moved compaction 13,600 tokens earlier for nothing.

| | reported 258,400 | reported 272,000 |
|---|---|---|
| compacts at | 225,400 | **239,000** |
| headroom below the real window | 46,600 (17.1%) | 33,000 (12.1%) |

Compaction still fires well below the 272,000 pricing cliff either way, so this does not push sessions into the higher-rate band.

## The mechanism is intact

A share a provider genuinely declares is still honoured (tests pin 90/80/50 surviving), and `--context` still sets a smaller window on request. clodex just no longer invents one. `normalizedPercent` already documented this exact rule — *"an undeclared or out-of-range percent means no reduction, never a silent 95%"* — and worked correctly; the injection sites upstream of it were what made it unreachable.

## Upgrade path

Repaired at projection, not at refresh. A cached `95` can only be the value an older clodex injected, so it is discarded when the catalog is read and the window comes back **without the user re-running `clodex providers refresh-models`**. Verified against a real install's cache: 258,400 → 272,000 with no refresh. Any other declared value is left alone.

The trade is documented at the call site: 95 is the Codex *client's* own default and so the likeliest number the catalog would ever populate, and clodex would then ignore it. That is deliberate — it is a client-side convention and clodex is not the client.

## Two edges this opens, both pinned

- The standard stop now lands **exactly on** the pricing boundary, so `crossesPricingBoundary` depends on strict `>` for the first time. Relaxing it to `>=` would warn on every default launch; that mutation previously survived green.
- `gpt-5.4`'s larger stop reaches a full 1,000,000, the threshold where a `[1m]` suffix starts being appended to the id Claude Code is given. No OAuth model could reach it before, and the suffix has to stay transparent to route lookup.

## Docs

The README described the 95% as a Codex convention clodex was matching. It is a Codex **client** default — which is exactly why clodex is the wrong layer to apply it.

Six places also repeated the claim that Claude Code reads its context window from the response `model` echo. It does not in 2.1.261: the window resolves through `vp()` from the patch-baked table, then `CLAUDE_CODE_MAX_CONTEXT_TOKENS` under `DISABLE_COMPACT`, then a long-context clamp, then the served catalog and a *separate* `CLAUDE_CODE_MAX_CONTEXT_TOKENS` branch for ids the baked catalog does not recognise. That stale claim is why this behaviour was defended rather than fixed when first reported, so the verified internals now live in `.claude/docs/claude-code-internals.md` under a version stamp instead of scattered through comments that get copied forward. **The unrewritten-request-body invariant still stands and is kept** — only the mechanism claim is removed.

## Verification

`pnpm typecheck && pnpm test && pnpm build` green: **2318 tests / 107 files**. Clean under an isolated `CLODEX_HOME`. Smoke: Anthropic passthrough `HAIKU-OK`, routed `MODEL-OK`. Real-cache check reports 272,000 / 872,000.

Mutations, each verified red: migration deleted; migration over-broad; sentinel 95→96; discovery re-injects (both the seeded and unseeded branches); seed list re-injects; overlay restores the fallback; `normalizedPercent` default 95; `>` → `>=`; `effective` → `raw`; `stripOneMContextSuffix` gutted.

Non-comment source delta is **9 lines** — one export removed, one migration function added, three call sites changed.

## Not verified

- **darwin-arm64 only.** The constants are shared across builds but minified symbol names differ per platform.
- The binary findings are **current-version facts**, not claims about every past release — though the compaction formula is byte-identical across every cached bundle from 2.1.238 to 2.1.261.
- The live-catalog null capture was taken from one account; another tier could in principle be served different metadata.
