### PR TITLE
fix(auth): stop stalled OpenAI responses from hanging model refresh and sign-in

### DIFF
--- a/src/oauth/openai.ts
+++ b/src/oauth/openai.ts
@@ -3,7 +3,11 @@
 import { generatePkce, generateOAuthState, positiveSecondsToMs, sleepMs } from './pkce.js';
 import type { OAuthTokenResponse } from './types.js';
 import { VERSION } from '../constants.js';
-import { postOAuthRefresh } from './refresh-http.js';
+import {
+  OAUTH_REQUEST_TIMEOUT_MS,
+  postOAuthRefresh,
+  withOAuthRequestTimeout,
+} from './refresh-http.js';
 import { startCallbackServer } from './callback-server.js';
 
 const CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
@@ -29,6 +33,10 @@ export interface OpenAiDeviceCodeData {
   expires_in?: number;
 }
 
+function isTimeoutError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'TimeoutError';
+}
+
 export function extractOpenAiAccountId(tokens: OAuthTokenResponse): string | undefined {
   const token = tokens.id_token ?? tokens.access_token;
   if (!token) return undefined;
@@ -45,18 +53,30 @@ export function extractOpenAiAccountId(tokens: OAuthTokenResponse): string | und
 }
 
 export async function requestOpenAiDeviceCode(): Promise<OpenAiDeviceCodeData> {
-  const response = await fetch(`${ISSUER}/api/accounts/deviceauth/usercode`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'User-Agent': `clodex/${VERSION}`,
-    },
-    body: JSON.stringify({ client_id: CLIENT_ID }),
-  });
-  if (!response.ok) {
-    throw new Error('Failed to initiate OpenAI device authorization');
+  try {
+    return await withOAuthRequestTimeout(async signal => {
+      const response = await fetch(`${ISSUER}/api/accounts/deviceauth/usercode`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': `clodex/${VERSION}`,
+        },
+        body: JSON.stringify({ client_id: CLIENT_ID }),
+        signal,
+      });
+      if (!response.ok) {
+        throw new Error('Failed to initiate OpenAI device authorization');
+      }
+      return await response.json() as OpenAiDeviceCodeData;
+    });
+  } catch (error) {
+    if (isTimeoutError(error)) {
+      throw new Error('OpenAI device authorization timed out while requesting a sign-in code', {
+        cause: error,
+      });
+    }
+    throw error;
   }
-  return response.json() as Promise<OpenAiDeviceCodeData>;
 }
 
 export function openAiDeviceCodeUrl(): string {
@@ -72,44 +92,79 @@ export async function pollOpenAiDeviceCodeToken(
   const intervalMs = Math.max(parseInt(deviceData.interval, 10) || 5, 1) * 1000;
   const deadline = now() + positiveSecondsToMs(deviceData.expires_in, DEVICE_CODE_DEFAULT_EXPIRES_MS);
 
-  while (now() < deadline) {
-    const response = await fetch(`${ISSUER}/api/accounts/deviceauth/token`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'User-Agent': `clodex/${VERSION}`,
-      },
-      body: JSON.stringify({
-        device_auth_id: deviceData.device_auth_id,
-        user_code: deviceData.user_code,
-      }),
-    });
+  // A poll gets at most the shared 30-second OAuth budget and cannot
+  // outlive the remaining time for the user to approve the device code.
+  const remainingPollTimeoutMs = () =>
+    Math.min(OAUTH_REQUEST_TIMEOUT_MS, Math.max(0, deadline - now()));
+  const waitForNextPoll = () =>
+    sleep(Math.min(intervalMs + OAUTH_POLLING_SAFETY_MARGIN_MS, Math.max(0, deadline - now())));
 
-    if (response.ok) {
-      const data = await response.json() as { authorization_code: string; code_verifier: string };
-      const tokenResponse = await fetch(`${ISSUER}/oauth/token`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: new URLSearchParams({
-          grant_type: 'authorization_code',
-          code: data.authorization_code,
-          redirect_uri: `${ISSUER}/deviceauth/callback`,
-          client_id: CLIENT_ID,
-          code_verifier: data.code_verifier,
-        }).toString(),
-      });
-      if (!tokenResponse.ok) {
-        throw new Error(`OpenAI token exchange failed (${tokenResponse.status})`);
+  while (now() < deadline) {
+    const pollTimeoutMs = remainingPollTimeoutMs();
+    if (pollTimeoutMs <= 0) break;
+
+    let result: {
+      status: number;
+      data?: { authorization_code: string; code_verifier: string };
+    };
+    try {
+      result = await withOAuthRequestTimeout(async signal => {
+        const response = await fetch(`${ISSUER}/api/accounts/deviceauth/token`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'User-Agent': `clodex/${VERSION}`,
+          },
+          body: JSON.stringify({
+            device_auth_id: deviceData.device_auth_id,
+            user_code: deviceData.user_code,
+          }),
+          signal,
+        });
+        const data = response.ok
+          ? await response.json() as { authorization_code: string; code_verifier: string }
+          : undefined;
+        return { status: response.status, data };
+      }, pollTimeoutMs);
+    } catch (error) {
+      if (!isTimeoutError(error)) throw error;
+      if (now() >= deadline) break;
+      await waitForNextPoll();
+      continue;
+    }
+
+    if (result.data) {
+      let tokens: OAuthTokenResponse;
+      try {
+        tokens = await postOAuthRefresh(
+          `${ISSUER}/oauth/token`,
+          new URLSearchParams({
+            grant_type: 'authorization_code',
+            code: result.data.authorization_code,
+            redirect_uri: `${ISSUER}/deviceauth/callback`,
+            client_id: CLIENT_ID,
+            code_verifier: result.data.code_verifier,
+          }),
+          {
+            contentType: 'form',
+            errorPrefix: 'OpenAI token exchange failed',
+            includeStatus: true,
+          },
+        );
+      } catch (error) {
+        if (isTimeoutError(error)) {
+          throw new Error('OpenAI token exchange timed out', { cause: error });
+        }
+        throw error;
       }
-      const tokens = await tokenResponse.json() as OAuthTokenResponse;
       return { tokens, accountId: extractOpenAiAccountId(tokens) };
     }
 
-    if (response.status !== 403 && response.status !== 404) {
-      throw new Error(`OpenAI device authorization failed (${response.status})`);
+    if (result.status !== 403 && result.status !== 404) {
+      throw new Error(`OpenAI device authorization failed (${result.status})`);
     }
 
-    await sleep(Math.min(intervalMs + OAUTH_POLLING_SAFETY_MARGIN_MS, Math.max(0, deadline - now())));
+    await waitForNextPoll();
   }
   throw new Error('OpenAI device authorization timed out');
 }

--- a/src/oauth/refresh-http.ts
+++ b/src/oauth/refresh-http.ts
@@ -1,6 +1,6 @@
 import type { OAuthTokenResponse } from './types.js';
 
-const OAUTH_REFRESH_TIMEOUT_MS = 30_000;
+export const OAUTH_REQUEST_TIMEOUT_MS = 30_000;
 
 export interface PostOAuthRefreshOptions {
   contentType: 'form' | 'json';
@@ -10,24 +10,38 @@ export interface PostOAuthRefreshOptions {
   headers?: Record<string, string>;
 }
 
-export async function postOAuthRefresh(
-  url: string,
-  body: URLSearchParams | Record<string, string>,
-  options: PostOAuthRefreshOptions,
-): Promise<OAuthTokenResponse> {
-  const isJson = options.contentType === 'json';
+export async function withOAuthRequestTimeout<T>(
+  operation: (signal: AbortSignal) => Promise<T>,
+  timeoutMs = OAUTH_REQUEST_TIMEOUT_MS,
+): Promise<T> {
   const abortController = new AbortController();
   const timeout = setTimeout(() => {
     abortController.abort(new DOMException(
       'The operation was aborted due to timeout',
       'TimeoutError',
     ));
-  }, OAUTH_REFRESH_TIMEOUT_MS);
+  }, timeoutMs);
   timeout.unref();
   try {
+    return await operation(abortController.signal);
+  } finally {
+    clearTimeout(timeout);
+    if (!abortController.signal.aborted) {
+      abortController.abort(new Error('OAuth request completed'));
+    }
+  }
+}
+
+export async function postOAuthRefresh(
+  url: string,
+  body: URLSearchParams | Record<string, string>,
+  options: PostOAuthRefreshOptions,
+): Promise<OAuthTokenResponse> {
+  const isJson = options.contentType === 'json';
+  return withOAuthRequestTimeout(async signal => {
     const response = await fetch(url, {
       method: 'POST',
-      signal: abortController.signal,
+      signal,
       headers: {
         'Content-Type': isJson ? 'application/json' : 'application/x-www-form-urlencoded',
         Accept: 'application/json',
@@ -52,7 +66,5 @@ export async function postOAuthRefresh(
     }
 
     return await response.json() as OAuthTokenResponse;
-  } finally {
-    clearTimeout(timeout);
-  }
+  });
 }

--- a/src/registry/refresh-models.ts
+++ b/src/registry/refresh-models.ts
@@ -228,9 +228,9 @@ async function fetchJsonWithAuth(
   accessToken: string,
   timeoutMs: number,
 ): Promise<{ body: unknown | null; error?: string }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const response = await fetch(url, {
       headers: {
         Accept: 'application/json',
@@ -238,7 +238,7 @@ async function fetchJsonWithAuth(
         'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
       },
       signal: controller.signal,
-    }).finally(() => clearTimeout(timer));
+    });
     if (!response.ok) {
       const detail = await response.text().then(t => t.slice(0, 200)).catch(() => '');
       return { body: null, error: `HTTP ${response.status}${detail ? `: ${detail}` : ''}` };
@@ -246,6 +246,11 @@ async function fetchJsonWithAuth(
     return { body: await response.json() };
   } catch (err) {
     return { body: null, error: err instanceof Error ? err.message : String(err) };
+  } finally {
+    clearTimeout(timer);
+    if (!controller.signal.aborted) {
+      controller.abort(new Error('OpenAI catalog request completed'));
+    }
   }
 }
 

--- a/tests/oauth-openai.test.ts
+++ b/tests/oauth-openai.test.ts
@@ -5,7 +5,9 @@ import http from 'node:http';
 import {
   buildOpenAiAuthorizeUrl,
   extractOpenAiAccountId,
+  pollOpenAiDeviceCodeToken,
   refreshOpenAiAccessToken,
+  requestOpenAiDeviceCode,
   runOpenAiBrowserFlow,
   runOpenAiDeviceCodeFlow,
 } from '../src/oauth/openai.js';
@@ -19,8 +21,37 @@ describe('oauth/openai', () => {
 
   afterEach(() => {
     global.fetch = originalFetch;
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
+
+  function responseWithStalledJsonBody(init?: RequestInit): Response {
+    const signal = init?.signal;
+    const body = new Promise<never>((_resolve, reject) => {
+      signal?.addEventListener('abort', () => reject(signal.reason), { once: true });
+    });
+    return { ok: true, status: 200, json: () => body } as Response;
+  }
+
+  async function expectErrorAtTimeout(
+    operation: Promise<unknown>,
+    timeoutMs: number,
+    message: string,
+  ): Promise<void> {
+    const pending = Symbol('pending');
+    let outcome: unknown = pending;
+    void operation.then(
+      value => { outcome = value; },
+      error => { outcome = error; },
+    );
+
+    await vi.advanceTimersByTimeAsync(timeoutMs - 1);
+    expect(outcome).toBe(pending);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(outcome).toBeInstanceOf(Error);
+    expect((outcome as Error).message).toBe(message);
+  }
 
   describe('extractOpenAiAccountId', () => {
     function buildJwt(claims: unknown): string {
@@ -305,6 +336,191 @@ describe('oauth/openai', () => {
   });
 
   describe('runOpenAiDeviceCodeFlow', () => {
+    it('aborts device-code initiation when the response body stalls', async () => {
+      vi.useFakeTimers();
+      vi.mocked(global.fetch).mockImplementationOnce(async (_input, init) =>
+        responseWithStalledJsonBody(init),
+      );
+
+      const request = requestOpenAiDeviceCode();
+
+      await expectErrorAtTimeout(
+        request,
+        30_000,
+        'OpenAI device authorization timed out while requesting a sign-in code',
+      );
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://auth.openai.com/api/accounts/deviceauth/usercode',
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+
+    it('aborts a stalled device-token poll at the device-code deadline', async () => {
+      vi.useFakeTimers();
+      vi.mocked(global.fetch).mockImplementationOnce(async (_input, init) =>
+        responseWithStalledJsonBody(init),
+      );
+
+      const poll = pollOpenAiDeviceCodeToken({
+        device_auth_id: 'auth_id',
+        user_code: 'user_code',
+        interval: '1',
+        // Synthetic short lifetime to exercise the deadline boundary quickly.
+        expires_in: 5,
+      });
+
+      await expectErrorAtTimeout(poll, 5_000, 'OpenAI device authorization timed out');
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://auth.openai.com/api/accounts/deviceauth/token',
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+
+    it('preserves a non-timeout error from the device token exchange', async () => {
+      vi.mocked(global.fetch)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({ authorization_code: 'auth_code', code_verifier: 'verifier' }),
+        } as Response)
+        .mockResolvedValueOnce({ ok: false, status: 400 } as Response);
+
+      const exchange = pollOpenAiDeviceCodeToken({
+        device_auth_id: 'auth_id',
+        user_code: 'user_code',
+        interval: '1',
+      });
+
+      const error = await exchange.catch((cause: unknown) => cause);
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).constructor).toBe(Error);
+      expect((error as Error).message).toBe('OpenAI token exchange failed (400)');
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      const exchangeSignal = vi.mocked(global.fetch).mock.calls[1]?.[1]?.signal as AbortSignal;
+      expect(exchangeSignal.aborted).toBe(true);
+      expect(exchangeSignal.reason).toMatchObject({
+        name: 'Error',
+        message: 'OAuth request completed',
+      });
+    });
+
+    it('aborts a stalled authorization-code exchange after 30 seconds', async () => {
+      vi.useFakeTimers();
+      vi.mocked(global.fetch)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({ authorization_code: 'auth_code', code_verifier: 'verifier' }),
+        } as Response)
+        .mockImplementationOnce(async (_input, init) => responseWithStalledJsonBody(init));
+
+      const exchange = pollOpenAiDeviceCodeToken({
+        device_auth_id: 'auth_id',
+        user_code: 'user_code',
+        interval: '1',
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+
+      await expectErrorAtTimeout(exchange, 30_000, 'OpenAI token exchange timed out');
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        'https://auth.openai.com/oauth/token',
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+
+    it('lets a healthy token exchange finish after the device-code deadline', async () => {
+      vi.useFakeTimers();
+      let now = 0;
+      vi.mocked(global.fetch)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => {
+            now = 4_900;
+            return { authorization_code: 'auth_code', code_verifier: 'verifier' };
+          },
+        } as Response)
+        .mockImplementationOnce(async (_input, init) => new Promise<Response>((resolve, reject) => {
+          const timer = setTimeout(() => {
+            now = 5_300;
+            resolve({
+              ok: true,
+              status: 200,
+              json: async () => ({ access_token: 'final_access_token' }),
+            } as Response);
+          }, 400);
+          init?.signal?.addEventListener('abort', () => {
+            clearTimeout(timer);
+            reject(init.signal?.reason);
+          }, { once: true });
+        }));
+
+      const exchange = pollOpenAiDeviceCodeToken({
+        device_auth_id: 'auth_id',
+        user_code: 'user_code',
+        interval: '1',
+        // Synthetic short lifetime to stage a winning poll 100ms before expiry.
+        expires_in: 5,
+      }, { now: () => now });
+      const pending = Symbol('pending');
+      let outcome: unknown = pending;
+      void exchange.then(
+        value => { outcome = value; },
+        error => { outcome = error; },
+      );
+
+      await vi.advanceTimersByTimeAsync(399);
+      expect(outcome).toBe(pending);
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(outcome).not.toBeInstanceOf(Error);
+      expect(outcome).toMatchObject({ tokens: { access_token: 'final_access_token' } });
+    });
+
+    it('continues polling after one request times out', async () => {
+      vi.useFakeTimers();
+      vi.mocked(global.fetch)
+        .mockImplementationOnce(async (_input, init) => responseWithStalledJsonBody(init))
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({ authorization_code: 'auth_code', code_verifier: 'verifier' }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({ access_token: 'final_access_token' }),
+        } as Response);
+
+      const poll = pollOpenAiDeviceCodeToken({
+        device_auth_id: 'auth_id',
+        user_code: 'user_code',
+        interval: '1',
+      });
+      const firstSignal = vi.mocked(global.fetch).mock.calls[0]?.[1]?.signal as AbortSignal;
+      const pending = Symbol('pending');
+      let outcome: unknown = pending;
+      void poll.then(
+        value => { outcome = value; },
+        error => { outcome = error; },
+      );
+
+      await vi.advanceTimersByTimeAsync(29_999);
+      expect(firstSignal.aborted).toBe(false);
+      expect(outcome).toBe(pending);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(firstSignal.aborted).toBe(true);
+      expect(outcome).toBe(pending);
+      await vi.advanceTimersByTimeAsync(3_999);
+      expect(outcome).toBe(pending);
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(outcome).toMatchObject({ tokens: { access_token: 'final_access_token' } });
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+    });
+
     it('handles successful polling loop', async () => {
       // 1. Device initiation response
       vi.mocked(global.fetch).mockResolvedValueOnce({
@@ -362,6 +578,24 @@ describe('oauth/openai', () => {
       } as Response);
 
       await expect(runOpenAiDeviceCodeFlow(vi.fn())).rejects.toThrow('Failed to initiate OpenAI device authorization');
+    });
+
+    it('propagates a non-timeout poll failure without retrying', async () => {
+      vi.mocked(global.fetch).mockRejectedValueOnce(new TypeError('fetch failed'));
+      let now = 0;
+      const sleep = vi.fn(async () => {
+        now = 300_000;
+      });
+
+      const poll = pollOpenAiDeviceCodeToken({
+        device_auth_id: 'auth_id',
+        user_code: 'user_code',
+        interval: '1',
+      }, { sleep, now: () => now });
+
+      await expect(poll).rejects.toThrowError(new TypeError('fetch failed'));
+      expect(global.fetch).toHaveBeenCalledOnce();
+      expect(sleep).not.toHaveBeenCalled();
     });
 
     it('throws if polling hits an unexpected error (e.g. 500)', async () => {

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -52,6 +52,34 @@ describe('oauth refresh http', () => {
     vi.restoreAllMocks();
   });
 
+  it('aborts the controller after a successful response body is consumed', async () => {
+    let requestSignal: AbortSignal | undefined;
+    const tokens = { access_token: 'access', refresh_token: 'refresh', expires_in: 3_600 };
+    const json = vi.fn(async () => {
+      expect(requestSignal?.aborted).toBe(false);
+      return tokens;
+    });
+    vi.stubGlobal('fetch', vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      requestSignal = init?.signal ?? undefined;
+      return { ok: true, json } as Response;
+    }));
+
+    const result = await postOAuthRefresh(
+      'https://auth/token',
+      new URLSearchParams({ grant_type: 'refresh_token' }),
+      { contentType: 'form', errorPrefix: 'token refresh failed' },
+    );
+
+    expect(result).toEqual(tokens);
+    expect(json).toHaveBeenCalledOnce();
+    expect(requestSignal?.aborted).toBe(true);
+    expect(requestSignal?.reason).toBeInstanceOf(Error);
+    expect(requestSignal?.reason).toMatchObject({
+      name: 'Error',
+      message: 'OAuth request completed',
+    });
+  });
+
   it('posts form refresh requests and includes response text in the error', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => ({
       ok: false,
@@ -124,7 +152,11 @@ describe('oauth refresh http', () => {
     expect(signal.aborted).toBe(false);
     await vi.advanceTimersByTimeAsync(1);
     expect(signal.aborted).toBe(true);
-    await expect(rejection).resolves.toMatchObject({ name: 'TimeoutError' });
+    expect(signal.reason).toMatchObject({
+      name: 'TimeoutError',
+      message: 'The operation was aborted due to timeout',
+    });
+    await expect(rejection).resolves.toBe(signal.reason);
   });
 
   it('keeps the 30-second timeout active while reading the response body', async () => {
@@ -158,7 +190,11 @@ describe('oauth refresh http', () => {
     expect(signal.aborted).toBe(false);
     await vi.advanceTimersByTimeAsync(1);
     expect(signal.aborted).toBe(true);
-    await expect(rejection).resolves.toMatchObject({ name: 'TimeoutError' });
+    expect(signal.reason).toMatchObject({
+      name: 'TimeoutError',
+      message: 'The operation was aborted due to timeout',
+    });
+    await expect(rejection).resolves.toBe(signal.reason);
   });
 });
 

--- a/tests/registry-refresh-models.test.ts
+++ b/tests/registry-refresh-models.test.ts
@@ -37,10 +37,163 @@ describe('registry/refresh-models', () => {
 
   afterEach(() => {
     global.fetch = originalFetch;
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
+  function bodyStalledUntilAbort(init?: RequestInit): Promise<never> {
+    const signal = init?.signal;
+    return new Promise<never>((_resolve, reject) => {
+      signal?.addEventListener('abort', () => reject(signal.reason), { once: true });
+    });
+  }
+
+  async function expectSettledAfterTimeout<T>(operation: Promise<T>, timeoutMs: number): Promise<T> {
+    const pending = Symbol('pending');
+    let outcome: T | unknown = pending;
+    void operation.then(
+      value => { outcome = value; },
+      error => { outcome = error; },
+    );
+
+    await vi.advanceTimersByTimeAsync(timeoutMs - 1);
+    expect(outcome).toBe(pending);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(outcome).not.toBe(pending);
+    if (outcome instanceof Error) throw outcome;
+    return outcome as T;
+  }
+
   describe('refreshProviderModels (OpenAI OAuth 3-tier fetch)', () => {
+    it('aborts the catalog controller after a successful response body is consumed', async () => {
+      const mockRegistry: ProviderRegistry = {
+        version: 1,
+        providers: [{
+          id: 'openai-oauth',
+          templateId: 'openai',
+          name: 'OpenAI (ChatGPT)',
+          enabled: true,
+          authRef: 'keyring',
+          authType: 'oauth',
+          api: {},
+        }],
+      };
+      vi.mocked(io.loadRegistryStrict).mockReturnValue(mockRegistry);
+      let requestSignal: AbortSignal | undefined;
+      const json = vi.fn(async () => {
+        expect(requestSignal?.aborted).toBe(false);
+        return { models: [{ slug: 'gpt-4', title: 'GPT-4' }] };
+      });
+      vi.mocked(global.fetch).mockImplementationOnce(async (_input, init) => {
+        requestSignal = init?.signal ?? undefined;
+        return { ok: true, status: 200, json } as Response;
+      });
+
+      const result = await refreshProviderModels('openai-oauth', 'mock_token', mockRegistry);
+
+      expect(result).toEqual({
+        id: 'openai-oauth',
+        name: 'OpenAI (ChatGPT)',
+        ok: true,
+        modelCount: 1,
+        previousModelCount: undefined,
+        reason: undefined,
+      });
+      expect(json).toHaveBeenCalledOnce();
+      expect(requestSignal?.aborted).toBe(true);
+      expect(requestSignal?.reason).toBeInstanceOf(Error);
+      expect(requestSignal?.reason).toMatchObject({
+        name: 'Error',
+        message: 'OpenAI catalog request completed',
+      });
+    });
+
+    it('times out a stalled Codex catalog body before trying the general catalog', async () => {
+      vi.useFakeTimers();
+      const mockRegistry: ProviderRegistry = {
+        version: 1,
+        providers: [{
+          id: 'openai-oauth',
+          templateId: 'openai',
+          name: 'OpenAI',
+          enabled: true,
+          authRef: 'keyring',
+          authType: 'oauth',
+          api: {},
+        }],
+      };
+      vi.mocked(io.loadRegistryStrict).mockReturnValue(mockRegistry);
+      vi.mocked(global.fetch)
+        .mockImplementationOnce(async (_input, init) => ({
+          ok: true,
+          status: 200,
+          json: () => bodyStalledUntilAbort(init),
+        } as Response))
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({ models: [{ slug: 'gpt-4', title: 'GPT-4' }] }),
+        } as Response);
+
+      const result = await expectSettledAfterTimeout(
+        refreshProviderModels('openai-oauth', 'mock_token', mockRegistry),
+        10_000,
+      );
+
+      expect(result).toMatchObject({ ok: true, modelCount: 1 });
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      const codexSignal = vi.mocked(global.fetch).mock.calls[0]?.[1]?.signal as AbortSignal;
+      expect(codexSignal.aborted).toBe(true);
+      expect(codexSignal.reason).toMatchObject({
+        name: 'AbortError',
+        message: 'This operation was aborted',
+      });
+    });
+
+    it('times out a stalled general-catalog error body before using the static seed', async () => {
+      vi.useFakeTimers();
+      const mockRegistry: ProviderRegistry = {
+        version: 1,
+        providers: [{
+          id: 'openai-oauth',
+          templateId: 'openai',
+          name: 'OpenAI',
+          enabled: true,
+          authRef: 'keyring',
+          authType: 'oauth',
+          api: {},
+        }],
+      };
+      vi.mocked(io.loadRegistryStrict).mockReturnValue(mockRegistry);
+      vi.mocked(global.fetch)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({ models: [] }),
+        } as Response)
+        .mockImplementationOnce(async (_input, init) => ({
+          ok: false,
+          status: 500,
+          text: () => bodyStalledUntilAbort(init),
+        } as Response));
+
+      const result = await expectSettledAfterTimeout(
+        refreshProviderModels('openai-oauth', 'mock_token', mockRegistry),
+        10_000,
+      );
+
+      expect(result.ok).toBe(true);
+      expect(result.modelCount).toBeGreaterThan(0);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      const generalSignal = vi.mocked(global.fetch).mock.calls[1]?.[1]?.signal as AbortSignal;
+      expect(generalSignal.aborted).toBe(true);
+      expect(generalSignal.reason).toMatchObject({
+        name: 'AbortError',
+        message: 'This operation was aborted',
+      });
+    });
+
     it('Tier 1: uses Codex endpoint if available', async () => {
       const mockRegistry: ProviderRegistry = {
         version: 1,


### PR DESCRIPTION
Refreshing OpenAI's model list and signing in with a device code no longer wait forever when OpenAI starts a reply but does not finish it. Model refresh now falls back instead of hanging, while device-code sign-in retries a timed-out approval check and reports clear OpenAI-specific errors when setup or token exchange stalls.

## User-visible failure

An OpenAI model-list refresh could remain on its spinner indefinitely if either ChatGPT catalog endpoint returned headers and then stalled its body. The same failure affected the automatic refresh after OpenAI OAuth sign-in.

The default OpenAI device-code flow could also hang indefinitely in any of its three requests: requesting the user code, polling for approval, or exchanging the authorization code for tokens. The existing device-code deadline was checked only between completed polls, so it could not interrupt a stalled request or body read.

These paths are reachable through `clodex providers refresh`, the refresh performed after authentication, `clodex providers auth openai`, and first-run OpenAI setup. OpenAI currently omits `expires_in` from the device-code response; the 300-second approval window is clodex's own fallback, not a lifetime stated by OpenAI.

## Change

- Keep each catalog request's existing 10-second abort timer active through success and error body consumption. A failed Codex catalog request proceeds to the general ChatGPT catalog, then to the existing static/cached fallback behavior.
- Reuse one timeout helper that gives each device-code setup, polling, token-exchange, browser-exchange, and token-refresh request its own 30-second timer. Each timer remains active through response-body consumption.
- Clamp only an approval poll to the remaining device-code window. Once a poll returns an authorization code, the approval deadline has served its purpose, so token exchange receives its own full 30-second request budget.
- Retry an individual timed-out approval poll while the approval window remains. Non-timeout network failures still propagate immediately instead of being misreported later as approval expiry.
- Report attributed timeout messages for device-code setup and token exchange.

The change deliberately does not make these timeouts configurable, change browser sign-in behavior, alter stored credentials or registry formats, or introduce a different catalog timeout message from the sibling model-fetch implementations.

## Discriminating tests

The new tests resolve response headers immediately and leave body reads pending until the production abort signal fires.

- Moving catalog timer cleanup back onto the `fetch()` promise made both catalog body tests fail in the full test file. Changing the catalog budget from 10,000ms to 100ms also failed both tests at the new pre-deadline assertion.
- Removing each of the three OAuth abort signals independently failed the corresponding full-file test. Changing the OAuth budget from 30,000ms to 1,000ms failed the pre-deadline assertions.
- Restoring the device-code deadline clamp on token exchange failed the positive test where approval arrives 100ms before synthetic expiry and a healthy 400ms exchange completes afterward.
- Removing timed-out-poll recovery failed both the retry test and the attributed approval-expiry assertion.
- Deleting the non-timeout poll guard changed `TypeError: fetch failed` into `OpenAI device authorization timed out`; the new test failed.
- Collapsing all token-exchange errors into the timeout branch changed `OpenAI token exchange failed (400)` into `OpenAI token exchange timed out`; the new test failed.
- Removing either timeout-message wrapper exposed the bare `The operation was aborted due to timeout` text and failed the exact-message assertion.

Every mutation used a file snapshot and a full test-file run rather than test-name isolation.

## Runtime verification

Verification ran on macOS 26.6.2 arm64 with Node v24.14.1 and pnpm 10.34.5. The automated gate used an isolated `CLODEX_HOME` and `CLAUDE_CODE_ENTRYPOINT=cli`:

- `pnpm typecheck` passed.
- `pnpm test` passed: 107 files and 2,327 tests.
- `pnpm build` passed.

Manual smoke testing used the default proxy mode and covered `--model haiku` for Anthropic passthrough and `--model luna` for the OpenAI translated path.

## Verification boundaries

I did not induce a stalled response body from the live OpenAI service; the stall behavior was exercised with deterministic fetch responses whose bodies reject only when the real production signal aborts. No live credential or persisted provider data was changed by these tests.

The documentation and CLI-help sweep found no timeout claim made stale by this change. The source tree also has no remaining `finally(() => clearTimeout(...))` pattern that would clear one of these timers at response headers.

## Rollback

There is no data migration or persisted-format change. Reverting the two commits restores the previous request behavior; existing cached model lists and OAuth credentials remain readable, but stalled catalog bodies and device-code requests can once again wait indefinitely.

Closes #168
Closes #169
