### PR TITLE
fix(openai): honor stated retry delays to improve rate-limit recovery

### DIFF
--- a/.claude/docs/oauth-continuation.md
+++ b/.claude/docs/oauth-continuation.md
@@ -185,10 +185,27 @@ SDK generation entry points retry transient provider failures up to five times b
 `CLODEX_UPSTREAM_MAX_RETRIES` through the same budget. Valid non-negative integers override the
 default; unset or malformed values preserve it. The default and ceiling fall with a shorter idle
 timeout. At the default timeout the ceiling is five, and the configured range permits at most ten,
-estimated from the SDK's fallback exponential backoff. Five retries can add roughly 62s of fallback
-backoff on a dead provider, versus roughly 6s for the SDK's former two-retry default. Provider retry
-hints and failed-attempt time can mean fewer retries begin before a streaming idle deadline; the
-stream's shared signal requests cancellation when that deadline expires. A deadline during retry
+estimated from the SDK's fallback exponential backoff. Without a retry hint, five retries can add
+roughly 62s of fallback backoff on a dead provider, versus roughly 6s for the SDK's former two-retry
+default. That fallback budget gives a transiently unavailable provider more time to recover. When
+OpenAI explicitly states an acceptable delay for a WebSocket throttle, clodex gives that value to
+the SDK instead of its fallback schedule. Clodex's existing 5s default remains a client-facing hint
+for upgrade 403s and WebSocket connection-limit errors that state no delay; it is not promoted into
+the SDK's retry loop. Other hintless 429s also retain the fallback schedule. A long accepted
+upstream delay can replace an early fallback rung and consume more of the request budget, so fewer
+retries may begin before the streaming idle deadline; the stream's shared signal requests
+cancellation when that deadline expires.
+
+Provider-utils snapshots Response headers when `fetch` resolves, before an asynchronous WebSocket
+failure supplies its throttle hint. The transport therefore preserves the hint's source and raw
+upstream value in the synthetic error's string `param`, which survives the OpenAI stream schema.
+`trackUpstreamAttempts` restores only an upstream-stated safe hint into the captured `APICallError`
+header record before the SDK selects its retry delay. A clodex-defaulted marker is deliberately
+ignored. Restoration never replaces an existing `retry-after` or `retry-after-ms`,
+even when that existing value is malformed; for values the SDK can parse, `retry-after-ms` takes
+precedence. Restored second-based hints cap at 59s so acceptance does not depend on the current
+fallback rung. An upstream value above clodex's 60s client-facing cap remains in diagnostics but is
+not promoted into repeated in-process waits. A deadline during retry
 backoff preserves the provider failure that prompted the retry, while a deadline during a silent
 active provider call remains a timeout. Proxy mode's raw HTTP MITM path shares the retry setting but
 retains its independent ceiling of five and one-retry default; other direct raw relays add no

--- a/README.md
+++ b/README.md
@@ -379,11 +379,16 @@ clodex --version    # version
   … backoff, so a shorter idle timeout automatically lowers both. The ceiling
   is `5` at the default timeout and can rise to `10` at the maximum. Larger
   integers clamp with a one-time warning that names the active idle timeout.
-  On a genuinely unavailable provider, five retries can add roughly 62s of
-  fallback backoff instead of the SDK default's roughly 6s; the longer wait is
-  deliberate so transient failures have more time to recover. Provider
-  `retry-after` hints and time spent in failed attempts can mean fewer retries
-  start before a streaming idle deadline; the shared abort signal still
+  Without a retry hint, five retries can add roughly 62s of fallback
+  backoff instead of the SDK default's roughly 6s, giving a transiently
+  unavailable provider more time to recover. When OpenAI explicitly states an
+  acceptable delay for a WebSocket throttle, clodex gives that value to the
+  SDK instead of its fallback schedule. Clodex's existing 5s default remains a
+  client-facing hint for upgrade 403s and WebSocket connection-limit errors
+  that state no delay; it does not replace the SDK's fallback. Other hintless
+  429s also retain the fallback schedule. Provider `retry-after` hints and time
+  spent in failed attempts can mean fewer retries start before a streaming idle
+  deadline; the shared abort signal still
   interrupts backoff when that deadline fires. If a deadline interrupts a
   retry delay, clodex preserves the provider failure that prompted the retry;
   if a currently active call is silent, clodex reports the timeout instead.

--- a/src/oauth/responses-websocket.ts
+++ b/src/oauth/responses-websocket.ts
@@ -13,7 +13,13 @@ import type { RawData, WebSocket as WsWebSocket } from 'ws';
 import { CODEX_RESPONSES_WEBSOCKETS_BETA } from '../constants.js';
 import { outboundWsProxyAgent } from '../outbound-proxy.js';
 import { emitParentNotice } from '../parent-notice.js';
-import { anthropicErrorType, clampRetryAfterSeconds, frameStatusCode } from '../upstream-error.js';
+import {
+  anthropicErrorType,
+  clampRetryAfterSeconds,
+  frameStatusCode,
+  retryAfterProvenanceParam,
+  type RetryAfterProvenance,
+} from '../upstream-error.js';
 import { sanitizeToolInput } from '../tool-input-sanitize.js';
 import {
   resetWsUpgradePacerForTests,
@@ -77,6 +83,8 @@ interface OutputAccumulator {
   summaries: Map<number, string>;
   done?: JsonObject;
 }
+
+type RetryAfterHint = { seconds: number } & RetryAfterProvenance;
 
 interface RequestContext {
   controller: ReadableStreamDefaultController<Uint8Array>;
@@ -1316,12 +1324,23 @@ function failContext(
   message: string,
   diagnosticDetails: Record<string, unknown>,
   statusCode?: number,
-  retryAfterSeconds?: number,
+  retryAfter?: RetryAfterHint,
 ): void {
   if (ctx.closed || entry.current !== ctx) return;
+  const retryAfterSeconds = retryAfter === undefined
+    ? undefined
+    : clampRetryAfterSeconds(retryAfter.seconds);
   entry.debug(`fail: ${message}`);
   emitResponseErrorDiagnostic(entry, ctx, {
     ...diagnosticDetails,
+    ...(retryAfter !== undefined
+      ? {
+          retryAfterSource: retryAfter.source,
+          ...('rawSeconds' in retryAfter
+            ? { rawRetryAfterSeconds: retryAfter.rawSeconds }
+            : {}),
+        }
+      : {}),
     ...diagnosticTextFingerprint('errorMessage', message),
   });
   flushPending(ctx);
@@ -1332,7 +1351,9 @@ function failContext(
       type: statusCode === undefined ? 'transport_error' : anthropicErrorType(statusCode),
       code: statusCode === undefined ? 'websocket_transport_error' : String(statusCode),
       message,
-      param: null,
+      param: retryAfter === undefined
+        ? null
+        : retryAfterProvenanceParam(retryAfter),
       ...(retryAfterSeconds !== undefined ? { retry_after_seconds: retryAfterSeconds } : {}),
     },
   });
@@ -1582,7 +1603,8 @@ function handleSocketMessage(entry: ConnectionEntry, data: RawData): void {
   const previousMissing = errorCode === 'previous_response_not_found';
   const willRetry = previousMissing && ctx.continued && !ctx.retried && !ctx.emittedModelData;
   if (errorCode === 'websocket_connection_limit_reached' && !ctx.emittedModelData) {
-    const retryAfterSeconds = clampRetryAfterSeconds(responseRetryAfterSeconds(event));
+    const rawRetryAfterSeconds = responseRetryAfterSeconds(event);
+    const retryAfterSeconds = clampRetryAfterSeconds(rawRetryAfterSeconds);
     failContext(
       entry,
       ctx,
@@ -1594,7 +1616,9 @@ function handleSocketMessage(entry: ConnectionEntry, data: RawData): void {
         retryAfterSeconds,
       },
       429,
-      retryAfterSeconds,
+      rawRetryAfterSeconds === undefined
+        ? { seconds: retryAfterSeconds, source: 'default' }
+        : { seconds: retryAfterSeconds, source: 'upstream', rawSeconds: rawRetryAfterSeconds },
     );
     return;
   }
@@ -1654,10 +1678,11 @@ function handleSocketMessage(entry: ConnectionEntry, data: RawData): void {
   }
 
   if (errorStatus !== undefined) {
-    // The AI SDK strips unknown frame fields, so a backoff hint survives only
-    // baked into the message text — same reason the connection-limit branch
-    // above spells it out. Clamped, so a hostile hint cannot park a client
-    // indefinitely.
+    // The closed SDK schema strips `retry_after_seconds`, while its declared
+    // string `param` survives; Response headers were already snapshotted before
+    // this event arrived. Keep the existing bounded message suffix for
+    // downstream recovery and carry authoritative source/raw data in `param` so
+    // the retry boundary can restore a safe captured header.
     // Only when upstream actually gave one. `clampRetryAfterSeconds` supplies a
     // 5s DEFAULT for a missing hint, so clamping unconditionally would have
     // every 429 assert a backoff upstream never stated — and that value becomes
@@ -1665,9 +1690,14 @@ function handleSocketMessage(entry: ConnectionEntry, data: RawData): void {
     // where the reason says hours: a prose-only "retry after 1800s" would get
     // "; retry after 5s" appended, and the client reads the first match.
     const statedRetryAfter = errorStatus === 429 ? responseRetryAfterSeconds(event) : undefined;
-    const retryAfterSeconds = statedRetryAfter === undefined
+    const retryAfter: RetryAfterHint | undefined = statedRetryAfter === undefined
       ? undefined
-      : clampRetryAfterSeconds(statedRetryAfter);
+      : {
+          seconds: clampRetryAfterSeconds(statedRetryAfter),
+          source: 'upstream',
+          rawSeconds: statedRetryAfter,
+        };
+    const retryAfterSeconds = retryAfter?.seconds;
     const reason = responseErrorMessage(event) ?? `OpenAI rejected the request (HTTP ${errorStatus})`;
     failContext(
       entry,
@@ -1687,7 +1717,7 @@ function handleSocketMessage(entry: ConnectionEntry, data: RawData): void {
         ...(retryAfterSeconds !== undefined ? { retryAfterSeconds } : {}),
       },
       errorStatus,
-      retryAfterSeconds,
+      retryAfter,
     );
     return;
   }
@@ -1741,13 +1771,20 @@ function handleSocketMessage(entry: ConnectionEntry, data: RawData): void {
       ? classified
       : settledReason ? 400 : 502;
     const usageLimited = statusCode === 429;
-    // Only when upstream stated one, and only baked into the TEXT: the AI SDK's
-    // chunk schema is a closed zod object that strips `retry_after_seconds`, so
-    // a hint carried only in the frame field never reaches the client. This is
-    // the same reason the status-carrying branch above spells it out.
-    const retryAfterSeconds = usageLimited && responseRetryAfterSeconds(event) !== undefined
-      ? clampRetryAfterSeconds(responseRetryAfterSeconds(event))
-      : undefined;
+    // Only when upstream stated one. The closed SDK schema strips
+    // `retry_after_seconds` but keeps the declared string `param`; Response
+    // headers were already snapshotted. The marker drives safe restoration,
+    // while this bounded summary remains the downstream fallback when a long
+    // upstream value is deliberately not restored.
+    const rawRetryAfterSeconds = usageLimited ? responseRetryAfterSeconds(event) : undefined;
+    const retryAfter: RetryAfterHint | undefined = rawRetryAfterSeconds === undefined
+      ? undefined
+      : {
+          seconds: clampRetryAfterSeconds(rawRetryAfterSeconds),
+          source: 'upstream',
+          rawSeconds: rawRetryAfterSeconds,
+        };
+    const retryAfterSeconds = retryAfter?.seconds;
     // The BOUNDED summary is the message, upstream's prose is not used at all.
     // A `response.failed` body can echo request content or backend detail, and
     // it does not stay in one place: the synthetic error is rethrown by the SDK
@@ -1775,7 +1812,7 @@ function handleSocketMessage(entry: ConnectionEntry, data: RawData): void {
         ...diagnosticTextFingerprint('upstreamMessage', responseErrorMessage(event)),
       },
       statusCode,
-      retryAfterSeconds,
+      retryAfter,
     );
     return;
   }
@@ -1819,10 +1856,9 @@ function handleSocketMessage(entry: ConnectionEntry, data: RawData): void {
  * standalone: a refusal happens before any connection or request context
  * exists, so there is no stream to write into, nothing registered to delete and
  * no context to close. `code` is the stringified status `frameStatusCode` reads
- * preferentially. The `Retry-After` header is what the SDK's own backoff reads;
- * the "retry after Ns" prose is the separate channel that carries the hint to
- * the CLIENT, because the SDK's chunk schema strips `retry_after_seconds`
- * before `sdkUpstreamErrorDetails` ever sees it.
+ * preferentially. The `Retry-After` header is what the SDK's own backoff and
+ * downstream classifier read; the prose keeps a user-facing explanation if
+ * the header is unavailable. The SDK schema strips `retry_after_seconds`.
  */
 function pacedRefusalResponse(retryAfterSeconds: number): Response {
   const frame = {
@@ -1919,18 +1955,21 @@ function createConnection(
       // to a retryable Anthropic 429 synchronously; failContext closes the
       // context here, so the socket error/close transport-retry path sees a
       // finished request and cannot double-handle this failure.
-      const retryAfterSeconds = clampRetryAfterSeconds(
-        numericRetryAfterHeader(response.headers['retry-after']),
-      );
-      // "retry after Ns" is load-bearing: the AI SDK strips unknown frame
-      // fields, so sdkUpstreamErrorDetails recovers the hint from this text.
+      const rawRetryAfterSeconds = numericRetryAfterHeader(response.headers['retry-after']);
+      const retryAfterSeconds = clampRetryAfterSeconds(rawRetryAfterSeconds);
+      // The closed SDK schema strips `retry_after_seconds` but keeps its
+      // declared string `param`, and the Response headers were captured before
+      // this rejection. The marker drives retry restoration; the message keeps
+      // the existing downstream fallback when no header is restored.
       failContext(entry, ctx, 'OpenAI edge throttled the Responses WebSocket upgrade '
         + `(HTTP 403); retry after ${retryAfterSeconds}s`, {
         source: 'unexpected_response',
         httpStatusCode: statusCode,
         mappedStatusCode: 429,
         retryAfterSeconds,
-      }, 429, retryAfterSeconds);
+      }, 429, rawRetryAfterSeconds === undefined
+        ? { seconds: retryAfterSeconds, source: 'default' }
+        : { seconds: retryAfterSeconds, source: 'upstream', rawSeconds: rawRetryAfterSeconds });
       return;
     }
     failContext(entry, ctx, `WebSocket upgrade failed (HTTP ${statusCode})`, {

--- a/src/oauth/ws-upgrade-pacer.ts
+++ b/src/oauth/ws-upgrade-pacer.ts
@@ -139,7 +139,10 @@ const SDK_INITIAL_BACKOFF_MS = 2_000;
  * `totalBackoffMs` is the SDK's own exponential ladder, used when a failure
  * carries no `Retry-After`. A refusal from this module DOES carry one, and
  * `getRetryDelayInMs` SUBSTITUTES it for the rung rather than taking the larger
- * of the two, so the real gap between paced attempts is the hint.
+ * of the two, so the real gap between paced attempts is the hint. Other
+ * provider-directed delays, including WebSocket throttle hints, are outside
+ * this queue-budget proof and can stop the retry ladder early at its shared
+ * request deadline; they do not extend this module's per-attempt queue bound.
  *
  * The ladder is therefore NOT an upper bound on the pacing case — do not read
  * it as one. `pacedRetryAfterSeconds` caps the hint at this bound, and this

--- a/src/upstream-attempts.ts
+++ b/src/upstream-attempts.ts
@@ -1,9 +1,43 @@
-import { RetryError, wrapLanguageModel } from 'ai';
+import { APICallError, RetryError, wrapLanguageModel } from 'ai';
 import type { LanguageModel, LanguageModelMiddleware } from 'ai';
+import {
+  clampAiSdkRetryAfterSeconds,
+  MAX_RETRY_AFTER_SECONDS,
+  providerErrorFrame,
+  retryAfterProvenanceFromParam,
+} from './upstream-error.js';
 
 interface TrackedUpstreamModel {
   model: LanguageModel;
   deadlineError: (timeoutError: Error) => Error;
+}
+
+/**
+ * OpenAI snapshots a streaming Response's headers before a later WebSocket
+ * failure supplies its hint. Restore only safe, upstream-stated synthetic hints
+ * at the model boundary, before the AI SDK chooses its retry delay.
+ */
+function restoreSyntheticRetryAfterHeader(error: unknown): void {
+  if (!APICallError.isInstance(error) || error.statusCode !== 429) return;
+  const headers = error.responseHeaders;
+  if (!headers || headers['retry-after'] !== undefined
+    || headers['retry-after-ms'] !== undefined) return;
+  const rawFrame = error.data;
+  if (!rawFrame || typeof rawFrame !== 'object'
+    || (rawFrame as Record<string, unknown>).type !== 'error') return;
+  const frame = providerErrorFrame(rawFrame);
+  if (frame?.retryAfterSeconds === undefined) return;
+  const nestedError = (rawFrame as { error?: unknown }).error;
+  const provenance = retryAfterProvenanceFromParam(
+    nestedError && typeof nestedError === 'object'
+      ? (nestedError as { param?: unknown }).param
+      : undefined,
+  );
+  if (provenance?.source !== 'upstream') return;
+  if (provenance.rawSeconds < 0
+    || provenance.rawSeconds > MAX_RETRY_AFTER_SECONDS) return;
+
+  headers['retry-after'] = String(clampAiSdkRetryAfterSeconds(provenance.rawSeconds));
 }
 
 /**
@@ -26,6 +60,7 @@ export function trackUpstreamAttempts(model: LanguageModel): TrackedUpstreamMode
       failedAttempts.length = 0;
       return result;
     } catch (error) {
+      restoreSyntheticRetryAfterHeader(error);
       failedAttempts.push(error);
       waitingToRetry = true;
       throw error;

--- a/src/upstream-error.ts
+++ b/src/upstream-error.ts
@@ -38,11 +38,38 @@ export function clampRetryAfterSeconds(value?: number): number {
   return Math.min(Math.round(value), MAX_RETRY_AFTER_SECONDS);
 }
 
-/**
- * Recover a backoff hint from message prose. The OAuth WebSocket transport's
- * synthetic error frames can only carry the hint this way — the AI SDK's chunk
- * schema is a closed zod object, so it strips `retry_after_seconds`.
- */
+/** Cap below 60s so the AI SDK accepts the hint independent of its current backoff rung. */
+export function clampAiSdkRetryAfterSeconds(value?: number): number {
+  return Math.min(clampRetryAfterSeconds(value), MAX_RETRY_AFTER_SECONDS - 1);
+}
+
+export type RetryAfterProvenance =
+  | { source: 'default' }
+  | { source: 'upstream'; rawSeconds: number };
+
+const RETRY_AFTER_PARAM_PREFIX = 'clodex_retry_after:';
+
+/** Preserve retry-hint provenance through the OpenAI stream schema's string `param`. */
+export function retryAfterProvenanceParam(provenance: RetryAfterProvenance): string {
+  return provenance.source === 'default'
+    ? `${RETRY_AFTER_PARAM_PREFIX}default`
+    : `${RETRY_AFTER_PARAM_PREFIX}upstream:${String(provenance.rawSeconds)}`;
+}
+
+export function retryAfterProvenanceFromParam(
+  value: unknown,
+): RetryAfterProvenance | undefined {
+  if (value === `${RETRY_AFTER_PARAM_PREFIX}default`) return { source: 'default' };
+  if (typeof value !== 'string' || !value.startsWith(`${RETRY_AFTER_PARAM_PREFIX}upstream:`)) {
+    return undefined;
+  }
+  const rawValue = value.slice(`${RETRY_AFTER_PARAM_PREFIX}upstream:`.length);
+  if (rawValue.length === 0) return undefined;
+  const rawSeconds = Number(rawValue);
+  return Number.isFinite(rawSeconds) ? { source: 'upstream', rawSeconds } : undefined;
+}
+
+/** Recover a backoff hint from the message retained by the OpenAI stream schema. */
 function retryAfterFromText(message: unknown): number | undefined {
   if (typeof message !== 'string') return undefined;
   const match = /retry after (\d+)s\b/i.exec(message);

--- a/tests/responses-websocket.test.ts
+++ b/tests/responses-websocket.test.ts
@@ -33,6 +33,7 @@ import {
   type ResponsesWebSocketDiagnosticEvent,
 } from '../src/oauth/responses-websocket.js';
 import { sdkUpstreamErrorDetails } from '../src/upstream-error.js';
+import { trackUpstreamAttempts } from '../src/upstream-attempts.js';
 import type { UpgradeAdmission } from '../src/oauth/ws-upgrade-pacer.js';
 
 const WS_URL = 'wss://chatgpt.com/backend-api/codex/responses';
@@ -757,6 +758,7 @@ describe('createResponsesWebSocketFetch', () => {
     expect(frame.error.code).toBe('429');
     expect(frame.error.retry_after_seconds).toBe(5);
     expect(frame.error.message).toMatch(/retry after 5s/i);
+    expect(frame.error.param).toBe('clodex_retry_after:default');
     expect(resume).toHaveBeenCalledOnce();
 
     // Through the real AI SDK the failure surfaces as a retryable 429 with the
@@ -777,11 +779,15 @@ describe('createResponsesWebSocketFetch', () => {
       httpStatusCode: 403,
       mappedStatusCode: 429,
       retryAfterSeconds: 5,
+      retryAfterSource: 'default',
     }));
   });
 
   it('honors an upstream retry-after header on a 403 rejection', async () => {
-    const wsFetch = createResponsesWebSocketFetch(WS_URL);
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
+      onDiagnostic: event => diagnostics.push(event),
+    });
     const res = await wsFetch('https://x', {
       method: 'POST',
       headers: { Authorization: 'Bearer tok' },
@@ -792,6 +798,12 @@ describe('createResponsesWebSocketFetch', () => {
     const frame = await readErrorFrame(res);
     expect(frame.error.type).toBe('rate_limit_error');
     expect(frame.error.retry_after_seconds).toBe(12);
+    expect(frame.error.param).toBe('clodex_retry_after:upstream:12');
+    expect(diagnostics).toContainEqual(expect.objectContaining({
+      event: 'ws_response_error',
+      retryAfterSource: 'upstream',
+      rawRetryAfterSeconds: 12,
+    }));
   });
 
   it('clamps an oversized retry-after header and defaults a malformed one', async () => {
@@ -805,8 +817,9 @@ describe('createResponsesWebSocketFetch', () => {
     rejectUpgrade(lastSocket(), 403, { headers: { 'retry-after': '3600' } });
     const oversizedFrame = await readErrorFrame(oversized);
     expect(oversizedFrame.error.retry_after_seconds).toBe(60);
-    // The message text is the only channel that survives the AI SDK's chunk
-    // schema stripping, so the CLAMPED value must appear there too.
+    expect(oversizedFrame.error.param).toBe('clodex_retry_after:upstream:3600');
+    // The client-facing message uses the clamped value while provenance keeps
+    // the raw upstream value available to the retry boundary.
     expect(oversizedFrame.error.message).toMatch(/retry after 60s\b/i);
 
     const malformed = await wsFetch('https://x', {
@@ -848,41 +861,77 @@ describe('createResponsesWebSocketFetch', () => {
     }));
   });
 
-  it('lets the AI SDK transparently retry a 403-throttled upgrade and recover', async () => {
-    // The design premise of the 403->429 mapping: because the synthetic error
-    // frame arrives BEFORE any output chunk, @ai-sdk/openai's
-    // throwIfOpenAIStreamErrorBeforeOutput rejects doStream with a retryable
-    // 429 APICallError, so the AI SDK's own retry loop re-attempts the whole
-    // request — including a fresh WebSocket upgrade. This drives that loop for
-    // real: attempt 1 gets a 403 upgrade rejection, attempt 2 succeeds.
-    const wsFetch = createResponsesWebSocketFetch(WS_URL);
-    const provider = createOpenAI({ apiKey: 'test-only', fetch: wsFetch });
-    const streamed = streamText({
-      model: provider.responses('gpt-5.6-sol'),
-      prompt: 'retry me',
-      maxRetries: 1,
-      onError: () => {},
-    });
-    const collected = (async () => {
-      let out = '';
-      for await (const chunk of streamed.textStream) out += chunk;
-      return out;
-    })();
+  it.each([
+    // OpenAI did not state a delay: keep the SDK's roughly 2s fallback rather
+    // than promoting clodex's client-facing 5s default into the retry loop.
+    { label: 'defaulted', retryAfterSeconds: undefined, minimumDelayMs: 1_600, timeoutMs: 4_500 },
+    { label: 'upstream 0s', retryAfterSeconds: 0, minimumDelayMs: 0, timeoutMs: 1_000 },
+    { label: 'upstream 3s', retryAfterSeconds: 3, minimumDelayMs: 2_600, timeoutMs: 4_500 },
+    // Above clodex's accepted ceiling: retain the SDK's roughly 2s fallback
+    // rather than promoting the client-facing 60s clamp into a 59s wait.
+    { label: 'upstream 3600s', retryAfterSeconds: 3_600, minimumDelayMs: 1_600, timeoutMs: 4_500 },
+  ])(
+    'handles a $label 403 throttle in the real SDK retry loop',
+    async ({ retryAfterSeconds, minimumDelayMs, timeoutMs }) => {
+      // Because this synthetic frame arrives before output, @ai-sdk/openai
+      // rejects doStream with a retryable 429. Production's attempt-tracking
+      // middleware restores an upstream-stated late hint before the SDK
+      // schedules the next whole-request attempt; a local default is ignored.
+      const wsFetch = createResponsesWebSocketFetch(WS_URL);
+      const provider = createOpenAI({ apiKey: 'test-only', fetch: wsFetch });
+      const model = trackUpstreamAttempts(provider.responses('gpt-5.6-sol')).model;
+      const abortController = new AbortController();
+      const streamed = streamText({
+        model,
+        prompt: 'retry me',
+        maxRetries: 1,
+        abortSignal: abortController.signal,
+        onError: () => {},
+      });
+      const collected = (async () => {
+        let out = '';
+        for await (const chunk of streamed.textStream) out += chunk;
+        return out;
+      })();
+      // Attach a rejection handler immediately. If a mutation makes an assertion
+      // fail while the SDK is sleeping, `finally` aborts and settles this attempt
+      // before the next table case resets the shared fake-socket list.
+      const outcome = collected.then(
+        value => ({ value }),
+        error => ({ error }),
+      );
 
-    await vi.waitFor(() => expect(fakeSockets).toHaveLength(1));
-    rejectUpgrade(lastSocket(), 403);
+      try {
+        await vi.waitFor(() => expect(fakeSockets).toHaveLength(1));
+        const rejectedAt = performance.now();
+        if (retryAfterSeconds === undefined) rejectUpgrade(lastSocket(), 403);
+        else {
+          rejectUpgrade(lastSocket(), 403, {
+            headers: { 'retry-after': String(retryAfterSeconds) },
+          });
+        }
 
-    // The SDK backs off (no retry-after header on the synthetic SSE response,
-    // so its default ~2s exponential delay) and opens a SECOND upgrade.
-    await vi.waitFor(() => expect(fakeSockets).toHaveLength(2), { timeout: 10_000 });
-    const replacement = lastSocket();
-    replacement.emit('open');
-    emitTextResponse(replacement, 'resp_retry_recovered', 'recovered');
+        await vi.waitFor(
+          () => expect(fakeSockets).toHaveLength(2),
+          { timeout: timeoutMs },
+        );
+        const elapsedMs = performance.now() - rejectedAt;
+        expect(elapsedMs).toBeGreaterThanOrEqual(minimumDelayMs);
 
-    // Transparent recovery: the caller sees only the successful text.
-    await expect(collected).resolves.toBe('recovered');
-    expect(fakeSockets).toHaveLength(2);
-  }, 20_000);
+        const replacement = lastSocket();
+        replacement.emit('open');
+        emitTextResponse(replacement, 'resp_retry_recovered', 'recovered');
+
+        // Transparent recovery: the caller sees only the successful text.
+        await expect(outcome).resolves.toEqual({ value: 'recovered' });
+        expect(fakeSockets).toHaveLength(2);
+      } finally {
+        abortController.abort();
+        await outcome;
+      }
+    },
+    20_000,
+  );
 
   it('maps an in-band WebSocket connection limit error to a retryable 429', async () => {
     const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
@@ -916,7 +965,7 @@ describe('createResponsesWebSocketFetch', () => {
         type: 'rate_limit_error',
         code: '429',
         message: 'OpenAI reported the Responses WebSocket connection limit was reached; retry after 12s',
-        param: null,
+        param: 'clodex_retry_after:upstream:12',
         retry_after_seconds: 12,
       },
     });
@@ -933,6 +982,8 @@ describe('createResponsesWebSocketFetch', () => {
       errorCode: 'websocket_connection_limit_reached',
       mappedStatusCode: 429,
       retryAfterSeconds: 12,
+      retryAfterSource: 'upstream',
+      rawRetryAfterSeconds: 12,
       emittedModelData: false,
     }));
   });
@@ -1019,7 +1070,7 @@ describe('createResponsesWebSocketFetch', () => {
     expect(record?.errorCode).toBeUndefined();
   });
 
-  it('carries an in-band 429 backoff hint through as message text', async () => {
+  it('carries an in-band 429 backoff hint through the synthetic error', async () => {
     const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
     const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
       onDiagnostic: event => diagnostics.push(event),
@@ -1036,9 +1087,10 @@ describe('createResponsesWebSocketFetch', () => {
     })));
 
     const body = await readAll(res);
-    // The AI SDK strips unknown frame fields, so the hint only survives baked
-    // into the message — which is how the consumer recovers it.
+    // The closed SDK schema strips `retry_after_seconds` but preserves its
+    // declared string `param`; the message remains the downstream fallback.
     expect(body).toContain('retry after 45s');
+    expect(body).toContain('clodex_retry_after:upstream:45');
     expect(await classifyThroughSdk(body)).toMatchObject({
       statusCode: 429,
       isRetryable: true,
@@ -1050,6 +1102,8 @@ describe('createResponsesWebSocketFetch', () => {
       // The record that survives dedup must still name the failure.
       errorType: 'rate_limit_error',
       retryAfterSeconds: 45,
+      retryAfterSource: 'upstream',
+      rawRetryAfterSeconds: 45,
     }));
   });
 
@@ -1086,8 +1140,7 @@ describe('createResponsesWebSocketFetch', () => {
 
     const body = await readAll(res);
     expect(body).toContain('Resets in 4 hours.');
-    // Inventing a hint here would become a real `retry-after: 5` header and
-    // send the client back long before the limit resets.
+    // Inventing a hint here would send the client back long before the limit resets.
     expect(body).not.toContain('retry after');
     expect(await classifyThroughSdk(body)).toMatchObject({ statusCode: 429 });
   });
@@ -1281,10 +1334,9 @@ describe('createResponsesWebSocketFetch', () => {
     }
   });
 
-  it('carries an output-less usage-limit backoff in the message text', async () => {
-    // The AI SDK's chunk schema is a closed zod object that strips
-    // `retry_after_seconds`, so a hint carried only in the frame field never
-    // reaches the client — it has to be baked into the prose.
+  it('carries an output-less usage-limit backoff in the synthetic error', async () => {
+    // The AI SDK's chunk schema strips `retry_after_seconds`, so the clamped
+    // hint is baked into the prose and its raw provenance into the string param.
     const body = await failWith({
       type: 'response.failed',
       response: {
@@ -1293,8 +1345,8 @@ describe('createResponsesWebSocketFetch', () => {
         error: { type: 'usage_limit_reached', message: 'weekly limit reached', retry_after_seconds: 1800 },
       },
     });
-    // Clamped to MAX_RETRY_AFTER_SECONDS so an hour-scale hint cannot park the client.
     expect(body).toContain('retry after 60s');
+    expect(body).toContain('clodex_retry_after:upstream:1800');
     expect(await classifyThroughSdk(body)).toMatchObject({ statusCode: 429, retryAfterSeconds: 60 });
   });
 

--- a/tests/upstream-error.test.ts
+++ b/tests/upstream-error.test.ts
@@ -3,6 +3,7 @@ import { APICallError, RetryError } from 'ai';
 import { MockLanguageModelV4 } from 'ai/test';
 import {
   anthropicErrorType,
+  clampAiSdkRetryAfterSeconds,
   clampRetryAfterSeconds,
   formatUpstreamError,
   isContextLengthExceededError,
@@ -488,9 +489,148 @@ describe('clampRetryAfterSeconds', () => {
     expect(clampRetryAfterSeconds(12)).toBe(12);
     expect(clampRetryAfterSeconds(3600)).toBe(60);
   });
+
+  it('keeps AI SDK retry headers below 60s so early backoff rungs accept them', () => {
+    expect(clampAiSdkRetryAfterSeconds(58.6)).toBe(59);
+    expect(clampAiSdkRetryAfterSeconds(3600)).toBe(59);
+  });
 });
 
 describe('retry deadline error preservation', () => {
+  async function passThroughTrackedFailure(providerError: APICallError): Promise<void> {
+    const model = new MockLanguageModelV4({
+      doStream: async () => { throw providerError; },
+    });
+    const tracked = trackUpstreamAttempts(model);
+    if (typeof tracked.model === 'string') throw new Error('expected a wrapped language model');
+    await expect(tracked.model.doStream({} as never)).rejects.toBe(providerError);
+  }
+
+  it('uses raw upstream hints without replacing captured retry headers', async () => {
+    const conflictingProseFrame = {
+      type: 'error',
+      sequence_number: 0,
+      error: {
+        type: 'rate_limit_error',
+        code: '429',
+        message: 'upstream prose says retry after 900s; retry after 2s',
+        param: 'clodex_retry_after:upstream:2',
+      },
+    };
+    const authoritativeRawSeconds = apiCallError({
+      statusCode: 429,
+      data: conflictingProseFrame,
+      responseBody: JSON.stringify(conflictingProseFrame),
+      responseHeaders: { 'content-type': 'text/event-stream' },
+      isRetryable: true,
+    });
+    await passThroughTrackedFailure(authoritativeRawSeconds);
+    expect(authoritativeRawSeconds.responseHeaders?.['retry-after']).toBe('2');
+
+    const capturedMilliseconds = apiCallError({
+      statusCode: 429,
+      data: conflictingProseFrame,
+      responseBody: JSON.stringify(conflictingProseFrame),
+      responseHeaders: { 'retry-after-ms': '1' },
+      isRetryable: true,
+    });
+    await passThroughTrackedFailure(capturedMilliseconds);
+    expect(capturedMilliseconds.responseHeaders).toEqual({ 'retry-after-ms': '1' });
+
+    const capturedSeconds = apiCallError({
+      statusCode: 429,
+      data: conflictingProseFrame,
+      responseBody: JSON.stringify(conflictingProseFrame),
+      responseHeaders: { 'retry-after': '7' },
+      isRetryable: true,
+    });
+    await passThroughTrackedFailure(capturedSeconds);
+    expect(capturedSeconds.responseHeaders).toEqual({ 'retry-after': '7' });
+  });
+
+  it('does not turn a clamped long upstream hint into repeated 59s waits', async () => {
+    const syntheticFrame = {
+      type: 'error',
+      sequence_number: 0,
+      error: {
+        type: 'rate_limit_error',
+        code: '429',
+        message: 'retry after 60s',
+        param: 'clodex_retry_after:upstream:1800',
+      },
+    };
+    const providerError = apiCallError({
+      statusCode: 429,
+      data: syntheticFrame,
+      responseBody: JSON.stringify(syntheticFrame),
+      responseHeaders: { 'content-type': 'text/event-stream' },
+      isRetryable: true,
+    });
+
+    await passThroughTrackedFailure(providerError);
+
+    expect(providerError.responseHeaders).toEqual({
+      'content-type': 'text/event-stream',
+    });
+  });
+
+  it.each([
+    ['a non-429 error', 500, {
+      type: 'error', error: {
+        code: '429', message: 'retry after 12s', param: 'clodex_retry_after:upstream:12',
+      },
+    }],
+    ['a non-synthetic 429 body', 429, {
+      error: {
+        code: '429', message: 'retry after 12s', param: 'clodex_retry_after:upstream:12',
+      },
+    }],
+    ['a synthetic 429 wrapper around a non-rate-limit frame', 429, {
+      type: 'error', error: {
+        code: '500', message: 'retry after 12s', param: 'clodex_retry_after:upstream:12',
+      },
+    }],
+    ['a synthetic 429 without a hint', 429, {
+      type: 'error', error: {
+        code: '429', message: 'rate limited', param: 'clodex_retry_after:upstream:12',
+      },
+    }],
+    ['a synthetic 429 hint without clodex provenance', 429, {
+      type: 'error', error: { code: '429', message: 'retry after 12s', param: null },
+    }],
+    ['a synthetic 429 hint with incomplete clodex provenance', 429, {
+      type: 'error', error: {
+        code: '429',
+        message: 'retry after 12s',
+        param: 'clodex_retry_after:upstream:',
+      },
+    }],
+    ['a synthetic 429 hint with non-finite upstream provenance', 429, {
+      type: 'error', error: {
+        code: '429',
+        message: 'retry after 12s',
+        param: 'clodex_retry_after:upstream:NaN',
+      },
+    }],
+    ['a synthetic 429 hint with negative upstream provenance', 429, {
+      type: 'error', error: {
+        code: '429',
+        message: 'retry after 12s',
+        param: 'clodex_retry_after:upstream:-1',
+      },
+    }],
+  ] as const)('leaves %s without a fabricated retry header', async (_name, statusCode, data) => {
+    const providerError = apiCallError({
+      statusCode,
+      data,
+      responseBody: JSON.stringify(data),
+      responseHeaders: { 'content-type': 'text/event-stream' },
+      isRetryable: statusCode >= 500 || statusCode === 429,
+    });
+    await passThroughTrackedFailure(providerError);
+    expect(providerError.responseHeaders?.['retry-after']).toBeUndefined();
+  });
+
   it.each(['doStream', 'doGenerate'] as const)(
     'preserves a rejected provider error from %s while the SDK waits to retry',
     async method => {


### PR DESCRIPTION
Clodex now follows retry delays that OpenAI explicitly supplies when rate-limiting OAuth requests. When OpenAI supplies no delay—as in every observed upgrade throttle—clodex keeps the existing retry schedule instead of replacing it with its local five-second default.

## User-visible failure

An OpenAI-supplied delay on an asynchronous rate-limit failure never reached the AI SDK's retry scheduler, which used its generic 2s, 4s, … fallback instead. The fix is deliberately conditional: it changes scheduling only when OpenAI actually states a delay. A locally defaulted client hint remains client-facing and does not alter in-process retries.

## Root cause and production reachability

`@ai-sdk/provider-utils` snapshots a fetch response's headers as soon as `fetch` resolves. WebSocket upgrade failures and in-band error frames arrive asynchronously after clodex has returned its synthetic streaming `Response`, so changing that response's headers later cannot affect the captured `APICallError`.

That means the issue's proposed fix sketch—set a real `retry-after` header on the response—was insufficient for asynchronous failures. The relevant Responses transport uses `openaiResponsesNestedErrorChunkSchema`, not the issue-cited `openaiErrorDataSchema`: it strips the undeclared numeric `retry_after_seconds` extension but preserves a string or null `error.param`. A non-string `param` would parse as `unknown_chunk` and swallow the error, so both production writers remain string-or-null. Every SDK generation entry point already wraps its model with `trackUpstreamAttempts`; that middleware catches the pre-output `APICallError` inside the retry loop, before the next delay is selected.

## Change and deliberate exclusions

- Preserve whether a throttle delay was stated upstream or supplied by clodex's existing default, plus the raw upstream seconds, in a schema-valid string `param`.
- Restore a safe integer `retry-after` only when provenance says OpenAI stated the delay. A defaulted marker is deliberately ignored.
- Use authoritative raw provenance rather than upstream-controlled message prose.
- Leave any captured `retry-after` or `retry-after-ms` untouched; the SDK continues to prefer a valid millisecond value.
- Keep raw upstream values in diagnostics, but do not turn values above the 60s client-facing cap into repeated 59s in-process waits.
- Record upstream-versus-default provenance in WebSocket diagnostics.
- Leave the local connection pacer's synchronous response header unchanged; its reachable ceiling is already 15s.
- Leave non-rate-limit failures, all hintless 429s, and failures after model output on their existing paths. No WebSocket state machine or continuation flow was restructured.

## Discriminating tests and mutations

The WebSocket test file drives the real `ai@7.0.22` and `@ai-sdk/openai@4.0.11` parser/retry loop over a fake socket transport:

- a defaulted upgrade throttle retries on the SDK's roughly 2s fallback rung, not after 5s;
- an upstream `retry-after: 0` retries within one second;
- an upstream `retry-after: 3` retries after approximately 3.1s and never before 2.6s;
- an upstream `retry-after: 3600` is rejected for in-process scheduling and uses the roughly 2s fallback rather than sleeping 59s.

Full-file mutations prove both directions of the new gate. Widening it to restore clodex's default failed the defaulted real-SDK timing case (1 failed / 123 passed). Deleting restoration failed both accepted upstream timing cases plus the direct middleware check (2 failed / 122 passed in the WebSocket file; 1 failed / 61 passed in the upstream-error file). Existing guard mutations also pin status and frame scope, provenance validation, raw-value bounds, header precedence, the 59s SDK-facing cap, and diagnostics.

Unmutated focused files pass: `tests/responses-websocket.test.ts` (124/124) and `tests/upstream-error.test.ts` (62/62).

## Runtime evidence and environment

Ledger mining covered 771,936 diagnostic records. All 822 observed upgrade-403 throttles carried `retryAfterSeconds: 5`, clodex's own default; none carried an upstream `retry-after`. A post-fix real-`streamText` run at the shipped five-retry setting measured attempts at 0.05s, 2.09s, 6.14s, 14.20s, 30.23s, and 62.29s—the unchanged fallback ladder. The rejected ungated implementation measured attempts at approximately 0, 5, 10, 15, 20, and 25 seconds, increasing attempts in the first 25 seconds and shortening the ladder. This gated implementation is therefore a scheduling no-op for the observed population; its benefit begins only when OpenAI supplies a delay.

The isolated project gate passed on Node v24.14.1 and pnpm 10.34.5 with `CLAUDE_CODE_ENTRYPOINT=cli`, a temporary `CLODEX_HOME`, and both with and without ambient `CLODEX_WS_MAX_*` caps: typecheck, 107 test files / 2,332 tests, and the Node 22-targeted production build. Installed SDK versions were `ai@7.0.22`, `@ai-sdk/openai@4.0.11`, and `@ai-sdk/provider-utils@5.0.7`.

## What could not be verified

This run did not provoke a live ChatGPT throttle, and the observed corpus contained none with an upstream retry delay. Tests inject that conditional wire shape through clodex's production WebSocket transport and the installed SDK packages, with only the socket and upstream service simulated. No de-synchronization benefit is claimed or measured.

## Rollback

Reverting this commit requires no configuration or data migration. OpenAI-stated asynchronous throttle delays would again be ignored by the SDK retry scheduler; hintless traffic would behave identically.

Closes #174
