### PR TITLE
fix(openai): reuse connections that free up while parallel agents wait, so prompts stay cached

### DIFF
--- a/.claude/docs/oauth-continuation.md
+++ b/.claude/docs/oauth-continuation.md
@@ -33,8 +33,12 @@ is too small.
 traffic sampled below those rejections clustered in the minutes that opened the most new
 connections. The rejection is handled (see below) but the rate was previously unlimited. That the
 rate is what the edge reacts to is this module's working assumption, not a demonstrated cause. A process-wide token bucket now gates **primary connection creation** — a request that
-reuses an established or nursery head never consults it, so pacing can never add latency to a
-continuation, and the two replacement paths below are exempt by design.
+ALREADY has an established or nursery head to reuse when it arrives never consults it, so pacing
+never adds latency to a continuation it could have made on arrival, and the two replacement paths
+below are exempt by design. The one continuation that does pay is the one that could not have been
+made on arrival: a request admitted after queueing may find a head freed during its wait and
+continue that instead (see below), in which case it waited for a connection it then did not open
+and hands its token back.
 
 Defaults: 60 new connections per minute sustained, burst 10. Override the rate with
 `CLODEX_WS_MAX_NEW_CONNECTIONS_PER_MIN` (integer 1-600; `0` disables pacing, values above 600 clamp,
@@ -143,15 +147,66 @@ connection rate, not a latency, and the fallback mostly adds no latency: at 1/mi
 simultaneous requests, 19 are admitted immediately, one waits out the bound and none is refused.
 A separately budgeted hint would be a reasonable follow-up.
 
-Because the head scan runs before the wait, an admitted request re-reads the clock, reaps whatever
-expired while it was queued, and demotes itself to `parallel_isolated` if a same-partition request
-went in flight meanwhile — otherwise two requests would each register a persistent nursery head for
-one key and a fan-out would evict other conversations' heads.
+Because the head scan runs before the wait, an admitted request re-reads the clock and reaps
+whatever expired while it was queued, then re-evaluates the partition before it opens anything.
+
+**A request that was actually QUEUED runs the head scan a second time**, because a sibling may have
+FINISHED during the wait and left an idle head it can continue. Without that it would open a
+duplicate head for a chain sitting right there — filling the nursery, evicting other conversations'
+heads and forcing the full-context resends that open still more connections. The second scan is the
+first one, unchanged: the same exact-prefix `continuationMatch`, the same tie-breaks, so a freed
+head whose lineage does not match is still not continued. Adopting a head restores exactly the state
+an arrival-time match would have left, including the persistence a transport-retry replacement
+inherits, and RETURNS the pacing token the request was charged — it opened no connection, so
+holding it would delay the next request for an upgrade that never happened. The scan is skipped for
+a request admitted on arrival: it resumes in the same microtask turn, and a head can only be freed
+by an upstream completion, which arrives on a socket event. The gate reads the pacer's `queued`
+flag, not `waitedMs`, which is a difference of two clock reads and reports zero for a genuinely
+queued request when the clock steps backwards. Nothing between that scan and the dispatch that
+claims the head awaits, so two queued requests cannot both adopt one freed head.
+
+**What makes this reachable at all is that `expectedAssistant` can be EMPTY.** A match needs the
+head's stored `requestInput ++ expectedAssistant` to be a strict prefix of the waiting request,
+which reads as though the waiter must already hold the head's output — something two independent
+agents never have. But a response that completes with no output items stores a prefix equal to its
+own input, and `continuationMatch`'s guard is `!entry.expectedAssistant`, which `[]` passes. Two
+subagents fanned out from one Claude session open with byte-identical inputs, so the second can
+extend the first's prefix having copied nothing from it.
+
+**How often that happens is not known, and the available diagnostics cannot say.** The necessary
+conditions are enumerable — a predecessor leaving a *reusable* head (a nursery creation or a
+continuation; a `parallel_isolated` socket is discarded and leaves nothing), that head's input
+being a strict prefix of the waiting request's, it completing inside the waiter's queue wait
+(4,833ms at the shipped defaults), and the waiter having matched nothing on arrival — and no
+qualifying opportunity appears anywhere in the local corpus (17 ledger files, 178,298 head
+decisions, 63,508 primary creations). But that corpus records **zero pacing events and zero
+decisions carrying `pacingWaitedMs`**, so it contains no queued requests at all and therefore
+supports no rate for this: there is no denominator. Do not convert the zero into a frequency.
+Note also that `ws_new_connection_paced` is emitted only on a nonzero wait, a refusal or an abort,
+so its absence is not evidence that pacing did not engage — replaying real creation timestamps
+through the shipped bucket predicts 1,686 waits and 1,590 refusals in one of those files.
+
+**Boundary, deliberate:** the second scan cannot undo an ARRIVAL-time `parallel_isolated` demotion
+when the partition simply goes quiet during the wait. Such a request already has `persistent` false
+and, absent a re-match, keeps it, so it opens an isolated socket that retains no head at all.
+Isolated sockets are 35-38% of decisions in busy diagnostics files — a larger share of the same
+harm than the case this closes.
+
+Failing a re-match, an admitted request still demotes itself to `parallel_isolated` if a
+same-partition request went in flight meanwhile — otherwise two requests would each register a
+persistent nursery head for one key and a fan-out would evict other conversations' heads. That check
+is unconditional; only the re-match is gated on having been queued.
 
 Diagnostics: a `ws_new_connection_paced` event (`outcome` of `admitted`, `refused`, or `aborted`,
 with `waitedMs` / `requiredWaitMs` / `retryAfterSeconds`) and `pacingWaitedMs` on the same request's
-`ws_head_decision`. Requests admitted on arrival record nothing. A request cancelled while queued
-returns its reservation and opens no connection.
+`ws_head_decision`. A request that waited also carries `pacingRescanOutcome` — `continuation` when
+the second scan adopted a freed head, `parallel_isolated` when the in-flight demotion decided it,
+`no_change` otherwise — so the ledger distinguishes a decision the second look changed. A queued
+request whose clock stepped backwards carries `pacingRescanOutcome` with no `pacingWaitedMs`. When it
+adopts a head, `candidateCount` / `idleCandidateCount` / `matchingCandidateCount` / `heads` report
+the partition as re-scanned; otherwise they remain the arrival scan's, so a head that appeared or
+was reaped during the wait shows up only in the pool counts. Requests admitted on arrival record
+nothing. A request cancelled while queued returns its reservation and opens no connection.
 
 The numbers come from re-reading one machine's `ws_head_decision` log (103,698 records over about a
 day and a half), bucketing records that carry a `createdConnectionId` by wall-clock minute. Every

--- a/README.md
+++ b/README.md
@@ -412,10 +412,17 @@ clodex --version    # version
   burst of parallel work less likely to trip OpenAI's own rate limit. (In the
   traffic we sampled, the rejections clustered in the busiest minutes; that the
   rate is what triggers them is a reasonable reading of that, not something we
-  can prove.) A follow-up turn that can reuse the connection it already has is
-  never delayed by this;
+  can prove.) A follow-up turn that already has a connection it can reuse when
+  it arrives is never delayed by this;
   what goes through the limiter is work that needs a *new* connection — a first
-  turn, a conversation that branched, or several agents running at once. The
+  turn, a conversation that branched, or several agents running at once. If a
+  turn that is waiting its place in the queue finds, on being let through, that
+  a connection has freed up and is carrying exactly the conversation it is
+  continuing, it picks that one up instead of opening another. That is
+  uncommon — it needs another turn to finish inside the few seconds this one
+  spends waiting AND to have been on the same conversation history — so treat
+  it as an edge taken when it appears, not as agents routinely sharing
+  connections. The
   default is 60 new connections a minute, with an allowance of 10 opened back
   to back after a quiet spell.
   **This is a real throughput ceiling, not a brief pause.** One new connection

--- a/src/oauth/responses-websocket.ts
+++ b/src/oauth/responses-websocket.ts
@@ -654,7 +654,20 @@ function continuationMismatchDetails(
   // head is described in the diagnostic, and a gap on a head that lost to a better
   // match costs nothing, so warning on those would overstate the damage.
   warnOnGap = false,
+  /**
+   * Collects the stderr warnings as thunks instead of raising them, for a caller
+   * that may still overturn the mismatch being described — today, a request that
+   * goes on to continue a head freed during a pacing wait. Deferring the whole
+   * warning rather than emitting and retracting it is what keeps a dropped
+   * warning from spending the per-signature budget the next genuine occurrence
+   * needs.
+   */
+  deferWarnings?: Array<() => void>,
 ): Record<string, unknown> {
+  const raise = (warn: () => void): void => {
+    if (deferWarnings) deferWarnings.push(warn);
+    else warn();
+  };
   const full = inputArray(payload);
   const prefix = [...(entry.requestInput ?? []), ...(entry.expectedAssistant ?? [])];
   const comparable = Math.min(full.length, prefix.length);
@@ -668,7 +681,7 @@ function continuationMismatchDetails(
   const expected = mismatch < prefix.length ? prefix[mismatch] : undefined;
   const actual = mismatch < full.length ? full[mismatch] : undefined;
   const reasoningGap = reasoningNormalizationGap(expected, actual);
-  if (reasoningGap && warnOnGap) warnReasoningNormalizationGap(reasoningGap, log);
+  if (reasoningGap && warnOnGap) raise(() => warnReasoningNormalizationGap(reasoningGap, log));
   // Claude may legitimately omit stored reasoning items (continuationMatch's
   // omitted_reasoning mode), which shifts the exact-prefix divergence onto a
   // reasoning-vs-call pair and would hide a forked strip rule sitting on the
@@ -703,7 +716,8 @@ function continuationMismatchDetails(
   // shared with Claude Code's UI. Those are still recorded on the diagnostic, and
   // traced here so --trace alone shows a counted-but-not-warned gap.
   if (toolArgumentGap?.equalAfterStrip === true) {
-    if (warnOnGap) warnToolArgumentNormalizationGap(toolArgumentGap, log);
+    const gap = toolArgumentGap;
+    if (warnOnGap) raise(() => warnToolArgumentNormalizationGap(gap, log));
   } else if (toolArgumentGap && warnOnGap) {
     // Same gating as the warner: only the head clodex gave up on is described,
     // so the per-candidate loop cannot turn one mismatch into a trace stream.
@@ -2087,26 +2101,41 @@ export function createResponsesWebSocketFetch(
     let now = resolvedOptions.now();
     const evictions = cleanupExpiredConnections(now);
 
-    const candidates = partitionKey ? connectionEntries(partitionKey) : [];
-    const idleCandidates = candidates.filter(entry => !entry.inFlight);
-    // Canonicalize the incoming conversation ONCE, not once per candidate head.
-    const clientItems = idleCandidates.length ? canonicalItemStrings(inputArray(payload)) : [];
-    const matches = idleCandidates
-      .map(entry => ({ entry, match: continuationMatch(entry, payload, clientItems) }))
-      .filter((candidate): candidate is { entry: ConnectionEntry; match: ContinuationMatch } => candidate.match !== undefined)
-      // Prefer the longest matching history, which produces the smallest delta.
-      .sort((left, right) => left.match.delta.length - right.match.delta.length
-        || (left.match.mode === right.match.mode ? 0 : left.match.mode === 'exact' ? -1 : 1));
+    // Hoisted verbatim so the SAME scan can run a second time after a pacing
+    // wait: same expressions, same ordering, same tie-breaks. Nothing here is
+    // re-tuned — a difference between the two scans could only come from the
+    // partition having changed, which is the point.
+    const scanForHeads = (): {
+      candidates: ConnectionEntry[];
+      idleCandidates: ConnectionEntry[];
+      matches: Array<{ entry: ConnectionEntry; match: ContinuationMatch }>;
+    } => {
+      const scanned = partitionKey ? connectionEntries(partitionKey) : [];
+      const idle = scanned.filter(entry => !entry.inFlight);
+      // Canonicalize the incoming conversation ONCE, not once per candidate head.
+      const clientItems = idle.length ? canonicalItemStrings(inputArray(payload)) : [];
+      return {
+        candidates: scanned,
+        idleCandidates: idle,
+        matches: idle
+          .map(entry => ({ entry, match: continuationMatch(entry, payload, clientItems) }))
+          .filter((candidate): candidate is { entry: ConnectionEntry; match: ContinuationMatch } => candidate.match !== undefined)
+          // Prefer the longest matching history, which produces the smallest delta.
+          .sort((left, right) => left.match.delta.length - right.match.delta.length
+            || (left.match.mode === right.match.mode ? 0 : left.match.mode === 'exact' ? -1 : 1)),
+      };
+    };
+    let { candidates, idleCandidates, matches } = scanForHeads();
     let selected: ConnectionEntry | undefined = matches[0]?.entry;
-    const selectedMatch = matches[0]?.match;
-    const selectedDelta = selectedMatch?.delta;
+    let selectedMatch = matches[0]?.match;
+    let selectedDelta = selectedMatch?.delta;
     const diagnosticEntry = selected
       ?? [...idleCandidates].sort((left, right) => right.lastUsedAt - left.lastUsedAt)[0]
       ?? candidates[0];
     debug(
       `lookup key=${debugKey(partitionKey)} prompt=${debugKey(promptFingerprint)} hit=${candidates.length > 0} heads=${candidates.length} active_connections=${connectionCount()}`,
     );
-    const promptChanges = changedPromptFields(diagnosticEntry?.promptFieldHashes, promptFieldHashes);
+    let promptChanges = changedPromptFields(diagnosticEntry?.promptFieldHashes, promptFieldHashes);
     if (promptChanges.length) debug(`prompt fields changed: ${promptChanges.join(',')}`);
     if (promptChanges.includes('instructions')) {
       const summary = instructionChangeSummary(diagnosticEntry?.instructionsSnapshot, instructionsSnapshot);
@@ -2118,24 +2147,42 @@ export function createResponsesWebSocketFetch(
     let promotedConnectionId: number | undefined;
     let decision: 'continuation' | 'parallel_isolated' | 'history_mismatch_new_head' | 'new_partition_head' | 'unpartitioned_socket';
     let candidateMismatchDetails: Map<ConnectionEntry, Record<string, unknown>> | undefined;
+    // Held until this request's outcome is final. Classification runs against
+    // the partition as it stood on ARRIVAL, so a warning it raises can still be
+    // overturned by a head that frees up during a pacing wait — and telling a
+    // user their caching is degraded on a turn that ends up perfectly cached is
+    // how the one warning whose value depends on being believed gets ignored.
+    const deferredMismatchWarnings: Array<() => void> = [];
+    const flushMismatchWarnings = (): void => {
+      for (const warn of deferredMismatchWarnings) warn();
+      deferredMismatchWarnings.length = 0;
+    };
 
-    if (selected && selectedDelta) {
-      sendPayload = { ...payload, input: selectedDelta, previous_response_id: selected.responseId };
+    // Hoisted alongside the scan, and for the same reason: adopting a head found
+    // by the second scan has to leave exactly the state an arrival-time match
+    // would have left. Returns the decision so the chain below still assigns
+    // `decision` on every path.
+    const continueOnHead = (entry: ConnectionEntry, match: ContinuationMatch): 'continuation' => {
+      sendPayload = { ...payload, input: match.delta, previous_response_id: entry.responseId };
       continued = true;
-      if (selected.generation === 'nursery') {
+      if (entry.generation === 'nursery') {
         evictions.push(...evictOldestIdleGeneration(
           'established',
           resolvedOptions.maxConnections,
           'established_lru_cap',
         ));
-        selected.generation = 'established';
-        promotedConnectionId = selected.debugId;
+        entry.generation = 'established';
+        promotedConnectionId = entry.debugId;
       }
-      decision = 'continuation';
       debug(
-        `continuing chain with ${selectedDelta.length} incremental input item(s)`
-        + (selectedMatch.mode === 'omitted_reasoning' ? ' after accepting omitted reasoning' : ''),
+        `continuing chain with ${match.delta.length} incremental input item(s)`
+        + (match.mode === 'omitted_reasoning' ? ' after accepting omitted reasoning' : ''),
       );
+      return 'continuation';
+    };
+
+    if (selected && selectedDelta) {
+      decision = continueOnHead(selected, selectedMatch);
     } else if (candidates.some(entry => entry.inFlight)) {
       // Claude auxiliary requests can share a session id. Never multiplex or
       // queue a request whose lineage cannot yet include the active response.
@@ -2146,7 +2193,9 @@ export function createResponsesWebSocketFetch(
     } else if (diagnosticEntry) {
       // A rewind, branch, or hidden auxiliary inference gets its own full-context
       // head. Existing heads remain eligible for later exact-prefix matches.
-      const diagnosticMismatch = continuationMismatchDetails(diagnosticEntry, payload, debug, true);
+      const diagnosticMismatch = continuationMismatchDetails(
+        diagnosticEntry, payload, debug, true, deferredMismatchWarnings,
+      );
       candidateMismatchDetails = new Map([[diagnosticEntry, diagnosticMismatch]]);
       // Every abandoned non-diagnostic head warns independently of diagnostics.
       // Cache each mismatch so the diagnostic payload does not evaluate it again.
@@ -2154,7 +2203,7 @@ export function createResponsesWebSocketFetch(
         if (candidate === diagnosticEntry) continue;
         candidateMismatchDetails.set(
           candidate,
-          continuationMismatchDetails(candidate, payload, debug, true),
+          continuationMismatchDetails(candidate, payload, debug, true, deferredMismatchWarnings),
         );
       }
       debug(
@@ -2180,6 +2229,8 @@ export function createResponsesWebSocketFetch(
     // the nursery eviction below so a queued request does not retire a head it
     // may still be seconds away from needing.
     let pacingWaitedMs: number | undefined;
+    /** What the post-wait re-evaluation concluded; absent when nothing queued. */
+    let pacingRescanOutcome: 'continuation' | 'parallel_isolated' | 'no_change' | undefined;
     if (!selected) {
       const pacer = options.pacer ?? sharedWsUpgradePacer();
       const pacingStartedAt = resolvedOptions.now();
@@ -2194,6 +2245,8 @@ export function createResponsesWebSocketFetch(
           decision,
           waitedMs: Math.max(0, resolvedOptions.now() - pacingStartedAt),
         }, diagnosticCorrelation);
+        // Nothing will overturn the classification now, so it stands.
+        flushMismatchWarnings();
         throw error;
       }
       if (admission.kind === 'refused') {
@@ -2207,6 +2260,7 @@ export function createResponsesWebSocketFetch(
           requiredWaitMs: admission.requiredWaitMs,
           retryAfterSeconds: admission.retryAfterSeconds,
         }, diagnosticCorrelation);
+        flushMismatchWarnings();
         return pacedRefusalResponse(admission.retryAfterSeconds);
       }
       if (admission.waitedMs > 0) {
@@ -2219,29 +2273,96 @@ export function createResponsesWebSocketFetch(
           waitedMs: admission.waitedMs,
         }, diagnosticCorrelation);
       }
-      // Unconditional, NOT gated on having waited: `admit` is async, so even an
-      // immediate admission resumes a microtask later, and two same-partition
-      // requests arriving in one tick both resume having waited zero. The head
-      // scan above ran before that yield either way.
-      //
       // Re-read the clock and reap what expired meanwhile, so head ages are
-      // measured from now rather than from arrival. The candidate SET is still
-      // the one scanned on arrival: a head that appeared or was reaped during
-      // the wait is not reflected in `heads`, only in the pool counts.
+      // measured from now rather than from arrival.
       now = resolvedOptions.now();
       evictions.push(...cleanupExpiredConnections(now));
+      // A sibling may also have FINISHED while this request was queued, leaving
+      // an idle head it could continue. It was classified against the partition
+      // as it stood on arrival, so without a second scan it opens a duplicate
+      // persistent head for a chain that is sitting right there — which fills
+      // the nursery, evicts other conversations' heads and forces the
+      // full-context resends that open still more connections.
+      //
+      // Only when it was actually QUEUED. A request admitted on arrival resumes
+      // in the same microtask turn, and a head can only be freed by an upstream
+      // completion, which arrives on a socket event — a macrotask. So there the
+      // second scan could not see anything the first did not, and is skipped.
+      //
+      // Read from the pacer's own queued flag rather than from `waitedMs`,
+      // which is a difference of two clock reads: a clock stepped backwards
+      // during the wait reports 0 for a request that really did queue, and
+      // gating on the number would skip the re-scan exactly there. A pacer that
+      // reports no flag (an injected one) still falls back to the elapsed time.
+      //
+      // Nothing between this scan and `dispatchContext` below awaits, so the
+      // selection and the `inFlight` claim on the head happen in one
+      // synchronous run: two queued requests resuming from the pacer cannot
+      // both adopt the same freed head.
+      if (admission.queued ?? admission.waitedMs > 0) {
+        const rescan = scanForHeads();
+        const rematched = rescan.matches[0];
+        if (rematched) {
+          ({ candidates, idleCandidates, matches } = rescan);
+          selected = rematched.entry;
+          selectedMatch = rematched.match;
+          selectedDelta = rematched.match.delta;
+          // Restore what the in-flight demotion below (or on arrival) may have
+          // taken away: an adopted head must leave the same state an
+          // arrival-time match would have, including the persistence a
+          // transport-retry replacement inherits.
+          persistent = Boolean(partitionKey);
+          // Report the prompt drift against the head actually being continued,
+          // not against whichever idle branch the arrival scan happened to pick
+          // as its diagnostic stand-in.
+          promptChanges = changedPromptFields(rematched.entry.promptFieldHashes, promptFieldHashes);
+          decision = continueOnHead(rematched.entry, rematched.match);
+          pacingRescanOutcome = 'continuation';
+          debug('continuing a chain head that freed up during the pacing wait');
+          if (promptChanges.length) debug(`prompt fields changed: ${promptChanges.join(',')}`);
+          // This request opens no connection after all, so the token it was
+          // charged goes back instead of pacing the next request against an
+          // upgrade that never happened — the same rule a cancellation follows.
+          admission.release?.();
+        } else {
+          pacingRescanOutcome = 'no_change';
+        }
+      }
       // A same-partition request may have gone in flight across the yield. It
       // was classified when no head existed, so without this both would open a
       // persistent nursery head for one key — and a fan-out would fill the
       // nursery with duplicates, evicting other conversations' heads and
       // forcing the full-context resends that open still more connections. An
       // overlap like this takes an isolated socket today; keep that.
-      if (persistent && partitionKey
+      //
+      // Unconditional, NOT gated on having waited: `admit` is async, so even an
+      // immediate admission resumes a microtask later, and two same-partition
+      // requests arriving in one tick both resume having waited zero. The head
+      // scan above ran before that yield either way. It yields to a head this
+      // request can continue, exactly as the arrival-time chain does.
+      if (!selected && persistent && partitionKey
         && connectionEntries(partitionKey).some(entry => entry.inFlight)) {
         persistent = false;
         decision = 'parallel_isolated';
         debug('parallel request using an isolated socket after pacing');
+        if (pacingRescanOutcome === 'no_change') pacingRescanOutcome = 'parallel_isolated';
       }
+    }
+
+    // The classification is final here. A request that rematched after its wait
+    // was not degraded after all, so its arrival warnings are dropped rather
+    // than raised; the count stays in the ledger and the trace so the drop is
+    // never invisible.
+    let suppressedMismatchWarnings: number | undefined;
+    if (selected && deferredMismatchWarnings.length) {
+      suppressedMismatchWarnings = deferredMismatchWarnings.length;
+      debug(
+        `suppressed ${suppressedMismatchWarnings} arrival mismatch warning(s) after continuing a `
+        + 'head that freed up during the pacing wait',
+      );
+      deferredMismatchWarnings.length = 0;
+    } else {
+      flushMismatchWarnings();
     }
 
     if (!selected && persistent) {
@@ -2291,6 +2412,8 @@ export function createResponsesWebSocketFetch(
       promotedConnectionId,
       createdConnectionId: selected ? undefined : nextConnectionDebugId,
       ...(pacingWaitedMs !== undefined ? { pacingWaitedMs } : {}),
+      ...(pacingRescanOutcome !== undefined ? { pacingRescanOutcome } : {}),
+      ...(suppressedMismatchWarnings !== undefined ? { suppressedMismatchWarnings } : {}),
       createdGeneration: selected ? undefined : persistent ? 'nursery' : 'isolated',
       incrementalInputItems: selectedDelta?.length,
       heads: candidates.map(entry => ({

--- a/src/oauth/ws-upgrade-pacer.ts
+++ b/src/oauth/ws-upgrade-pacer.ts
@@ -7,7 +7,9 @@
 // rejection — every upgrade 403 becomes a retryable 429 carrying a backoff hint
 // — but nothing limited how fast clodex asked for new connections. This module
 // shapes that rate on the assumption, not the proof, that it is what the edge
-// is reacting to. A request that reuses an existing chain head never comes here.
+// is reacting to. A request that already has a reusable chain head when it
+// arrives never comes here; a request that only finds one AFTER waiting does
+// come here, and returns its token through `release` when it opens nothing.
 //
 // Why these numbers. Measured by re-reading one machine's own
 // `ws_head_decision` diagnostics log (103,698 records spanning roughly a day
@@ -276,6 +278,21 @@ export type UpgradeAdmission =
     kind: 'admitted';
     /** Milliseconds spent queued. 0 means admitted on arrival. */
     waitedMs: number;
+    /**
+     * Whether this request was actually parked on the bucket. `waitedMs` alone
+     * cannot answer that: it is a difference of two clock reads, so a clock
+     * adjusted backwards during the wait reports 0 for a request that really
+     * did queue. Callers deciding what to re-check after the wait must read
+     * this, not the number.
+     */
+    queued?: boolean;
+    /**
+     * Returns the token this admission debited, for a caller that ends up
+     * opening NO connection after all. Idempotent. Same reasoning as the
+     * cancellation refund: pacing someone else against an upgrade that never
+     * happened is a delay charged for nothing.
+     */
+    release?: () => void;
   }
   | {
     kind: 'refused';
@@ -376,8 +393,8 @@ function reportOnce(key: string, message: string, warn: (message: string) => voi
  * queue is therefore bounded by construction, every queued request drains within
  * the bound, and — while refusals are available, i.e. with retries enabled —
  * admissions in any window T are at most `burst + maxWaitMs x refillPerMs +
- * rate x T + cancellations` however many retries arrive. With retries disabled
- * nothing is refused, so only the opening burst is shaped and that bound does
+ * rate x T + cancellations + releases` however many retries arrive. With retries
+ * disabled nothing is refused, so only the opening burst is shaped and that bound does
  * not hold.
  *
  * Two caveats on that bound, both real:
@@ -389,7 +406,14 @@ function reportOnce(key: string, message: string, warn: (message: string) => voi
  *   * A cancellation refunds its token but does not reschedule the reservations
  *     already queued behind it, so a later arrival can take the vacated slot
  *     alongside them. Each cancellation therefore permits one extra admission
- *     at that instant. It cannot reorder admissions, only coalesce them.
+ *     at that instant. It cannot reorder admissions, only coalesce them. A
+ *     `release` behaves identically. Both give back a token for a connection
+ *     that was never opened, so at the moment of the refund neither has raised
+ *     the socket count. That is NOT a guarantee about the socket count
+ *     afterwards: the released request continues on the head it found, and if
+ *     that head's transport then fails it builds a replacement through
+ *     `createReplacement` — an exempt path by the caveat above — so a released
+ *     admission can still be followed by a socket. Observed in a live probe.
  *
  * The bound is also on reservations, not on wall-clock departures: a stalled
  * event loop releases overdue timers together, and the pacer neither observes
@@ -464,8 +488,11 @@ export class WsUpgradePacer implements ConnectionPacer {
 
   /**
    * Resolves when this request may open a new connection, or resolves to a
-   * refusal the caller must report as a retryable rate limit. Callers that
-   * reuse an existing connection must not call this at all.
+   * refusal the caller must report as a retryable rate limit. A caller that can
+   * already reuse an existing connection must not call this at all; one that
+   * discovers a reusable connection only after being admitted must hand the
+   * token back through `release` instead of holding it for a socket it never
+   * opened.
    */
   async admit(signal?: AbortSignal): Promise<UpgradeAdmission> {
     if (!this.enabled) return { kind: 'admitted', waitedMs: 0 };
@@ -486,7 +513,14 @@ export class WsUpgradePacer implements ConnectionPacer {
         ),
       };
     }
-    if (reservation.waitMs <= 0) return { kind: 'admitted', waitedMs: 0 };
+    if (reservation.waitMs <= 0) {
+      return {
+        kind: 'admitted',
+        waitedMs: 0,
+        queued: false,
+        release: this.releaser(reservation.consumed),
+      };
+    }
 
     const startedAt = this.now();
     try {
@@ -497,7 +531,29 @@ export class WsUpgradePacer implements ConnectionPacer {
       this.refund(reservation.consumed);
       throw error;
     }
-    return { kind: 'admitted', waitedMs: Math.max(0, this.now() - startedAt) };
+    return {
+      kind: 'admitted',
+      // A clock moved backwards during the wait would otherwise report this
+      // request as never queued at all.
+      waitedMs: Math.max(0, this.now() - startedAt),
+      queued: true,
+      release: this.releaser(reservation.consumed),
+    };
+  }
+
+  /**
+   * One-shot refund for an admission whose caller opened nothing. Guarded
+   * because a second call would mint a token the bucket never charged, which
+   * is the one way a refund can raise the sustained rate instead of correcting
+   * it.
+   */
+  private releaser(consumed: number): () => void {
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      this.refund(consumed);
+    };
   }
 
   private reserve(now: number): Reservation {

--- a/tests/responses-websocket.test.ts
+++ b/tests/responses-websocket.test.ts
@@ -4108,6 +4108,9 @@ describe('new-connection pacing', () => {
       decision: 'parallel_isolated',
       createdGeneration: 'isolated',
       pacingWaitedMs: 25,
+      // It waited, so it re-scanned; the sibling head it found was in flight,
+      // so the demotion is still what decided this.
+      pacingRescanOutcome: 'parallel_isolated',
     });
 
     for (const socket of fakeSockets) socket.emit('open');
@@ -4478,5 +4481,817 @@ describe('new-connection pacing', () => {
     }));
     // The request never reached a head decision, so none is reported.
     expect(diagnostics.some(event => event.event === 'ws_head_decision')).toBe(false);
+  });
+  /**
+   * Stage ONE ordering of the overlap: a sibling holding the only head of a
+   * partition while a second same-partition request is classified and then
+   * held inside the pacer. The caller finishes the sibling — through the
+   * production producer, `response.output_item.done` — and releases.
+   *
+   * This ordering is a fixture, NOT a claim about how production reaches the
+   * state. Real traffic arrives at "an idle matching head exists by the time a
+   * queued request is admitted" by several routes, and what the queued request
+   * was classified as on arrival differs between them; the blank-completion
+   * test below stages a different one deliberately. What every route shares is
+   * only the end state, which is what the code reads.
+   */
+  function heldBehindASibling(options: {
+    accountId: string;
+    debug?: string[];
+    diagnostics: ResponsesWebSocketDiagnosticEvent[];
+    /** Elapsed time the held admission reports. It is queued either way. */
+    waitedMs?: number;
+  }) {
+    const clock = { ms: 0 };
+    const waitedMs = options.waitedMs ?? 4_000;
+    const releaseToken = vi.fn();
+    let releaseQueued: (() => void) | undefined;
+    const queued = new Promise<void>(resolve => { releaseQueued = resolve; });
+    let markQueued: (() => void) | undefined;
+    const isQueued = new Promise<void>(resolve => { markQueued = resolve; });
+    let admissions = 0;
+    const wsFetch = createResponsesWebSocketFetch(
+      WS_URL,
+      options.debug ? message => options.debug!.push(message) : undefined,
+      {
+        accountId: options.accountId,
+        // Injected: two heads created in the same millisecond tie on
+        // `lastUsedAt`, and a stable sort then silently reverses which is the
+        // most recent. Nothing here reads the wall clock.
+        now: () => clock.ms,
+        pacer: {
+          admit: async (): Promise<UpgradeAdmission> => {
+            admissions += 1;
+            if (admissions === 1) return { kind: 'admitted', waitedMs: 0, queued: false };
+            markQueued!();
+            await queued;
+            clock.ms += waitedMs;
+            return { kind: 'admitted', waitedMs, queued: true, release: releaseToken };
+          },
+        },
+        onDiagnostic: event => options.diagnostics.push(event),
+      },
+    );
+    return { wsFetch, isQueued, release: () => releaseQueued!(), releaseToken };
+  }
+
+  const FIRST_TURN = [{ role: 'user', content: [{ type: 'input_text', text: 'first turn' }] }];
+  const ECHOED_ASSISTANT = { role: 'assistant', content: [{ type: 'output_text', text: 'hi' }] };
+
+  it('continues a chain head that a sibling freed while this request was queued', async () => {
+    // The head scan runs BEFORE the wait, so this request is classified while
+    // its sibling still holds the only head of the partition — on arrival it
+    // can take nothing but an isolated socket. By the time the pacer admits
+    // it, the sibling has finished and left a head whose lineage it matches
+    // exactly. Continuing that head is one connection fewer and keeps the
+    // cached prefix; opening a duplicate instead is what evicts other
+    // conversations' heads out of the nursery.
+    const debug: string[] = [];
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const nextTurn = { role: 'user', content: [{ type: 'input_text', text: 'second turn' }] };
+    const { wsFetch, isQueued, release, releaseToken } = heldBehindASibling({
+      accountId: 'acct-pacing-rematch',
+      debug,
+      diagnostics,
+    });
+
+    // The sibling opens the only head and is still in flight.
+    const sibling = await wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(FIRST_TURN)),
+    });
+    const siblingSocket = lastSocket();
+    siblingSocket.emit('open');
+
+    // Same partition, the next turn of the same conversation.
+    const held = wsFetch('https://x', {
+      method: 'POST', headers: {},
+      body: JSON.stringify(sessionPayload([...FIRST_TURN, ECHOED_ASSISTANT, nextTurn])),
+    });
+    await isQueued;
+    expect(fakeSockets).toHaveLength(1);
+
+    // The sibling COMPLETES while the queued request waits, leaving an idle
+    // reusable head. Staged through the production producer — the head's
+    // expected-assistant history is built from `response.output_item.done`,
+    // never planted in the request input.
+    emitTextResponse(siblingSocket, 'resp_rematch_1', 'hi');
+    await readAll(sibling);
+
+    release();
+    const heldResponse = await held;
+
+    // No second connection: the freed head carried the turn.
+    expect(fakeSockets).toHaveLength(1);
+    expect(siblingSocket.send).toHaveBeenCalledTimes(2);
+    const sent = JSON.parse(siblingSocket.send.mock.calls[1]![0] as string);
+    expect(sent.previous_response_id).toBe('resp_rematch_1');
+    expect(sent.input).toEqual([nextTurn]);
+
+    const decision = diagnostics.filter(event => event.event === 'ws_head_decision').at(-1);
+    expect(decision).toMatchObject({
+      decision: 'continuation',
+      pacingWaitedMs: 4_000,
+      pacingRescanOutcome: 'continuation',
+      continuationMatchMode: 'exact',
+      selectedConnectionId: 1,
+      promotedConnectionId: 1,
+      // The duplicate this replaces would have taken a nursery slot of its own.
+      nurseryConnectionCount: 0,
+      establishedConnectionCount: 1,
+      // The candidate counts are the RE-SCANNED partition, as the deep doc
+      // says: on arrival the only head was in flight, so idle and matching
+      // were both zero.
+      candidateCount: 1,
+      idleCandidateCount: 1,
+      matchingCandidateCount: 1,
+    });
+    expect((decision as { heads: Array<{ connectionId: number; inFlight: boolean }> }).heads)
+      .toEqual([expect.objectContaining({ connectionId: 1, inFlight: false })]);
+    // It opened no connection, so the new-connection token it was charged goes
+    // back rather than delaying whoever asks next.
+    expect(releaseToken).toHaveBeenCalledTimes(1);
+    expect((decision as { createdConnectionId?: number }).createdConnectionId).toBeUndefined();
+    expect(debug).toContain('ws: continuing a chain head that freed up during the pacing wait');
+
+    emitTextResponse(siblingSocket, 'resp_rematch_2', 'done');
+    await readAll(heldResponse);
+  });
+
+  it('opens its own head when the head freed during the wait does not match', async () => {
+    // The safety property. A head that frees up mid-wait is continued ONLY
+    // where the exact-prefix check accepts it; continuing a chain whose
+    // lineage does not match is the failure that check exists to prevent, and
+    // a re-scan that ignored it would reintroduce exactly that.
+    const debug: string[] = [];
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const otherConversation = [
+      { role: 'user', content: [{ type: 'input_text', text: 'an unrelated conversation' }] },
+    ];
+    const { wsFetch, isQueued, release, releaseToken } = heldBehindASibling({
+      accountId: 'acct-pacing-rematch-mismatch',
+      debug,
+      diagnostics,
+    });
+
+    const sibling = await wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(FIRST_TURN)),
+    });
+    const siblingSocket = lastSocket();
+    siblingSocket.emit('open');
+
+    // Same partition (one Claude session, one model), divergent history.
+    const held = wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(otherConversation)),
+    });
+    await isQueued;
+
+    emitTextResponse(siblingSocket, 'resp_mismatch_1', 'hi');
+    await readAll(sibling);
+
+    release();
+    const heldResponse = await held;
+
+    // A head was freed and it was NOT continued.
+    expect(fakeSockets).toHaveLength(2);
+    const ownSocket = lastSocket();
+    ownSocket.emit('open');
+    const sent = JSON.parse(ownSocket.send.mock.calls[0]![0] as string);
+    expect(sent.previous_response_id).toBeUndefined();
+    expect(sent.input).toEqual(otherConversation);
+
+    const decision = diagnostics.filter(event => event.event === 'ws_head_decision').at(-1);
+    expect(decision).toMatchObject({
+      decision: 'parallel_isolated',
+      pacingWaitedMs: 4_000,
+      pacingRescanOutcome: 'no_change',
+      createdConnectionId: 2,
+      createdGeneration: 'isolated',
+    });
+    expect((decision as { selectedConnectionId?: number }).selectedConnectionId).toBeUndefined();
+    expect(debug).not.toContain('ws: continuing a chain head that freed up during the pacing wait');
+    // It DID open a connection, so it keeps the token it was charged for it.
+    expect(releaseToken).not.toHaveBeenCalled();
+
+    emitTextResponse(ownSocket, 'resp_mismatch_2', 'done');
+    await readAll(heldResponse);
+  });
+
+  it('continues a head whose response completed with no output, having copied nothing from it', async () => {
+    // THE SHAPE THAT MAKES THIS FEATURE REACHABLE, and it is not the obvious
+    // one. A continuation needs the head's stored `requestInput ++
+    // expectedAssistant` to be a strict prefix of the waiting request — which
+    // reads like the waiter must already contain the head's OUTPUT, i.e. must
+    // have been sent it, which two independent agents never are.
+    //
+    // `expectedAssistant` can be EMPTY. A response that completes with no
+    // output items stores a prefix equal to its own input alone, so any
+    // same-partition request that merely extends that input matches it having
+    // copied nothing. Two agents fanned out from one Claude session open with
+    // byte-identical inputs, which is exactly that condition.
+    //
+    // Everything here is staged through production producers: agent B's second
+    // turn is reconstructed only from frames B was itself sent, and agent A's
+    // head is built by A's own `response.completed`.
+    const debug: string[] = [];
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const releaseToken = vi.fn();
+    const clock = { ms: 0 };
+    let holdNext = false;
+    let releaseQueued: (() => void) | undefined;
+    const queued = new Promise<void>(resolve => { releaseQueued = resolve; });
+    let markQueued: (() => void) | undefined;
+    const isQueued = new Promise<void>(resolve => { markQueued = resolve; });
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, message => debug.push(message), {
+      accountId: 'acct-pacing-blank-head',
+      now: () => clock.ms,
+      pacer: {
+        // Held on demand rather than by counting admissions: this ordering has
+        // four of them and only the last one queues.
+        admit: async (): Promise<UpgradeAdmission> => {
+          if (!holdNext) return { kind: 'admitted', waitedMs: 0, queued: false };
+          holdNext = false;
+          markQueued!();
+          await queued;
+          clock.ms += 4_000;
+          return { kind: 'admitted', waitedMs: 4_000, queued: true, release: releaseToken };
+        },
+      },
+      onDiagnostic: event => diagnostics.push(event),
+    });
+    // The identical opening two subagents of one session are handed.
+    const OPENING = [
+      { role: 'user', content: [{ type: 'input_text', text: '<system-reminder>shared preamble' }] },
+      { role: 'user', content: [{ type: 'input_text', text: 'do the assigned task' }] },
+    ];
+    const send = (input: unknown[]) => wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(input)),
+    });
+
+    // Agent A takes the partition's head and is still in flight.
+    const agentA = await send(OPENING);
+    const socketA = lastSocket();
+    socketA.emit('open');
+
+    // Agent B's first turn: same partition, byte-identical input, so it is
+    // classified `parallel_isolated` and retains no head of its own.
+    const agentBFirst = await send(OPENING);
+    const socketB = lastSocket();
+    socketB.emit('open');
+    emitTextResponse(socketB, 'resp_b_1', 'B answer');
+    await readAll(agentBFirst);
+    expect(diagnostics.filter(event => event.event === 'ws_head_decision').at(-1))
+      .toMatchObject({ decision: 'parallel_isolated', createdGeneration: 'isolated' });
+
+    // Agent B's second turn, built only from what B was sent.
+    const bAssistant = { role: 'assistant', content: [{ type: 'output_text', text: 'B answer' }] };
+    const bNextUser = { role: 'user', content: [{ type: 'input_text', text: 'B follow-up' }] };
+    holdNext = true;
+    const held = send([...OPENING, bAssistant, bNextUser]);
+    await isQueued;
+    expect(fakeSockets).toHaveLength(2);
+
+    // Agent A completes with NO output items — a real terminal shape — leaving
+    // a head whose stored prefix is its own two-item input and nothing else.
+    socketA.emit('message', Buffer.from(JSON.stringify({
+      type: 'response.created', response: { id: 'resp_a_blank' },
+    })));
+    socketA.emit('message', Buffer.from(JSON.stringify({
+      type: 'response.completed', response: { id: 'resp_a_blank' },
+    })));
+    await readAll(agentA);
+
+    releaseQueued!();
+    const heldResponse = await held;
+
+    // B continued A's head, on A's socket, with no new connection.
+    expect(fakeSockets).toHaveLength(2);
+    expect(socketA.send).toHaveBeenCalledTimes(2);
+    const sent = JSON.parse(socketA.send.mock.calls[1]![0] as string);
+    expect(sent.previous_response_id).toBe('resp_a_blank');
+    expect(sent.input).toEqual([bAssistant, bNextUser]);
+    expect(diagnostics.filter(event => event.event === 'ws_head_decision').at(-1))
+      .toMatchObject({
+        decision: 'continuation',
+        pacingRescanOutcome: 'continuation',
+        continuationMatchMode: 'exact',
+        selectedConnectionId: 1,
+        incrementalInputItems: 2,
+      });
+    expect(releaseToken).toHaveBeenCalledTimes(1);
+
+    emitTextResponse(socketA, 'resp_a_next', 'done');
+    await readAll(heldResponse);
+  });
+
+  it('re-matches on the pacer\'s queued flag, not on the elapsed time it reports', async () => {
+    // `waitedMs` is a difference of two clock reads, so a clock stepped
+    // backwards during the wait reports 0 for a request that really did queue.
+    // Gating on the number would skip the re-scan exactly there and open the
+    // duplicate connection this change exists to avoid.
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const nextTurn = { role: 'user', content: [{ type: 'input_text', text: 'second turn' }] };
+    const { wsFetch, isQueued, release } = heldBehindASibling({
+      accountId: 'acct-pacing-rematch-clockskew',
+      diagnostics,
+      waitedMs: 0,
+    });
+
+    const sibling = await wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(FIRST_TURN)),
+    });
+    const siblingSocket = lastSocket();
+    siblingSocket.emit('open');
+    const held = wsFetch('https://x', {
+      method: 'POST', headers: {},
+      body: JSON.stringify(sessionPayload([...FIRST_TURN, ECHOED_ASSISTANT, nextTurn])),
+    });
+    await isQueued;
+    emitTextResponse(siblingSocket, 'resp_skew_1', 'hi');
+    await readAll(sibling);
+    release();
+    const heldResponse = await held;
+
+    expect(fakeSockets).toHaveLength(1);
+    const decision = diagnostics.filter(event => event.event === 'ws_head_decision').at(-1);
+    expect(decision).toMatchObject({
+      decision: 'continuation',
+      pacingRescanOutcome: 'continuation',
+    });
+    // It reported no elapsed time, so the paced-wait field is absent — and the
+    // re-scan ran anyway.
+    expect(decision).not.toHaveProperty('pacingWaitedMs');
+
+    emitTextResponse(siblingSocket, 'resp_skew_2', 'done');
+    await readAll(heldResponse);
+  });
+
+  it('does not continue a freed head that diverges deep inside a long history', async () => {
+    // THE STRONGEST SAFETY TEST IN THIS FILE, because this is the property whose
+    // failure corrupts a conversation: continuing a chain whose lineage is not
+    // actually ours. The other negative diverges at the FIRST item, which a
+    // matcher that compared only the first item would still reject — so it
+    // cannot see a shallow-comparison regression. This one diverges at item 20
+    // of a 25-item stored prefix: everything before it is byte-identical, which
+    // is what a genuine rewind or branch of a long agent conversation looks
+    // like.
+    const debug: string[] = [];
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    // 24 alternating turns, all produced the same way, so the only difference
+    // between the two histories is the one this test is about.
+    const longHistory = (rewoundAt?: number) => Array.from({ length: 24 }, (_, index) => (
+      index % 2 === 0
+        ? { role: 'user', content: [{ type: 'input_text', text: `turn ${index}` }] }
+        : {
+          role: 'assistant',
+          content: [{
+            type: 'output_text',
+            text: index === rewoundAt ? `answer ${index} (regenerated)` : `answer ${index}`,
+          }],
+        }
+    ));
+    const { wsFetch, isQueued, release, releaseToken } = heldBehindASibling({
+      accountId: 'acct-pacing-rematch-deep',
+      debug,
+      diagnostics,
+    });
+
+    const sibling = await wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(longHistory())),
+    });
+    const siblingSocket = lastSocket();
+    siblingSocket.emit('open');
+
+    // Same 24 turns except item 20, then this conversation's own next turn: 26
+    // items against a 25-item stored prefix, agreeing on the first 19.
+    const divergent = [
+      ...longHistory(19),
+      { role: 'assistant', content: [{ type: 'output_text', text: 'hi' }] },
+      { role: 'user', content: [{ type: 'input_text', text: 'branch follow-up' }] },
+    ];
+    const held = wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(divergent)),
+    });
+    await isQueued;
+
+    // The sibling completes, leaving a 25-item prefix (24 sent + one answer).
+    emitTextResponse(siblingSocket, 'resp_deep_1', 'hi');
+    await readAll(sibling);
+
+    release();
+    const heldResponse = await held;
+
+    // Rejected: its own head, full context, nothing continued.
+    expect(fakeSockets).toHaveLength(2);
+    const ownSocket = lastSocket();
+    ownSocket.emit('open');
+    const sent = JSON.parse(ownSocket.send.mock.calls[0]![0] as string);
+    expect(sent.previous_response_id).toBeUndefined();
+    expect(sent.input).toEqual(divergent);
+    expect(diagnostics.filter(event => event.event === 'ws_head_decision').at(-1))
+      .toMatchObject({ pacingRescanOutcome: 'no_change', createdGeneration: 'isolated' });
+    expect(debug).not.toContain('ws: continuing a chain head that freed up during the pacing wait');
+    expect(releaseToken).not.toHaveBeenCalled();
+
+    emitTextResponse(ownSocket, 'resp_deep_2', 'done');
+    await readAll(heldResponse);
+  });
+
+  it('continues a head opened by a shorter sibling that overtook it from an empty partition', async () => {
+    // #173's OWN ordering, which none of the tests above stage: the queued
+    // request is the FIRST into an empty partition, so it is classified
+    // `new_partition_head` and keeps `persistent` — and then a shorter sibling
+    // overtakes it and completes while it waits. Rematching only requests that
+    // arrived non-persistent would leave every other test here green and this
+    // one opening a second connection.
+    const debug: string[] = [];
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const clock = { ms: 0 };
+    let holdNext = true;
+    let releaseQueued: (() => void) | undefined;
+    const queued = new Promise<void>(resolve => { releaseQueued = resolve; });
+    let markQueued: (() => void) | undefined;
+    const isQueued = new Promise<void>(resolve => { markQueued = resolve; });
+    const releaseToken = vi.fn();
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, message => debug.push(message), {
+      accountId: 'acct-pacing-rematch-overtaken',
+      now: () => clock.ms,
+      pacer: {
+        admit: async (): Promise<UpgradeAdmission> => {
+          if (!holdNext) return { kind: 'admitted', waitedMs: 0, queued: false };
+          holdNext = false;
+          markQueued!();
+          await queued;
+          clock.ms += 4_000;
+          return { kind: 'admitted', waitedMs: 4_000, queued: true, release: releaseToken };
+        },
+      },
+      onDiagnostic: event => diagnostics.push(event),
+    });
+    const opening = { role: 'user', content: [{ type: 'input_text', text: 'shared opening' }] };
+    const longer = [
+      opening,
+      { role: 'assistant', content: [{ type: 'output_text', text: 'its own earlier answer' }] },
+      { role: 'user', content: [{ type: 'input_text', text: 'its own follow-up' }] },
+    ];
+
+    // First into an EMPTY partition, then held: nothing to demote it, so it is
+    // classified as the partition's new head and stays persistent.
+    const held = wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(longer)),
+    });
+    await isQueued;
+    expect(fakeSockets).toHaveLength(0);
+
+    // A shorter sibling overtakes it, and finishes with no output — so its head
+    // stores only its own one-item input, which the queued request extends.
+    const overtaking = await wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload([opening])),
+    });
+    const overtakingSocket = lastSocket();
+    overtakingSocket.emit('open');
+    overtakingSocket.emit('message', Buffer.from(JSON.stringify({
+      type: 'response.created', response: { id: 'resp_overtaking' },
+    })));
+    overtakingSocket.emit('message', Buffer.from(JSON.stringify({
+      type: 'response.completed', response: { id: 'resp_overtaking' },
+    })));
+    await readAll(overtaking);
+
+    releaseQueued!();
+    const heldResponse = await held;
+
+    // One connection for both, and the queued request continued the chain.
+    expect(fakeSockets).toHaveLength(1);
+    expect(overtakingSocket.send).toHaveBeenCalledTimes(2);
+    const sent = JSON.parse(overtakingSocket.send.mock.calls[1]![0] as string);
+    expect(sent.previous_response_id).toBe('resp_overtaking');
+    expect(sent.input).toEqual(longer.slice(1));
+    // What the HELD request was classified as on arrival — the paced event
+    // carries the pre-wait decision, and it is the only place that survives.
+    expect(diagnostics).toContainEqual(expect.objectContaining({
+      event: 'ws_new_connection_paced',
+      outcome: 'admitted',
+      decision: 'new_partition_head',
+      waitedMs: 4_000,
+    }));
+    const decisions = diagnostics.filter(event => event.event === 'ws_head_decision');
+    expect(decisions.at(-1)).toMatchObject({
+      decision: 'continuation',
+      pacingRescanOutcome: 'continuation',
+      selectedConnectionId: 1,
+    });
+    expect(releaseToken).toHaveBeenCalledTimes(1);
+
+    emitTextResponse(overtakingSocket, 'resp_overtaken_next', 'done');
+    await readAll(heldResponse);
+  });
+
+  it('does not warn about degraded caching for a turn that then continued a freed head', async () => {
+    // The arrival classification can raise the "Prompt caching is degraded for
+    // this turn" canary against an idle head it gave up on — and then the
+    // re-scan continues a DIFFERENT head that freed up during the wait, so the
+    // turn was cached after all. Showing that warning anyway is how the one
+    // warning whose value depends on being believed gets trained away.
+    resetToolArgumentGapWarningsForTests();
+    const debug: string[] = [];
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const notices: string[] = [];
+    const releaseSink = installParentNoticeSink(line => notices.push(line));
+    try {
+      const clock = { ms: 0 };
+      let holdNext = false;
+      let releaseQueued: (() => void) | undefined;
+      const queued = new Promise<void>(resolve => { releaseQueued = resolve; });
+      let markQueued: (() => void) | undefined;
+      const isQueued = new Promise<void>(resolve => { markQueued = resolve; });
+      const wsFetch = createResponsesWebSocketFetch(WS_URL, message => debug.push(message), {
+        accountId: 'acct-pacing-rematch-warning',
+        now: () => clock.ms,
+        pacer: {
+          admit: async (): Promise<UpgradeAdmission> => {
+            if (!holdNext) return { kind: 'admitted', waitedMs: 0, queued: false };
+            holdNext = false;
+            markQueued!();
+            await queued;
+            clock.ms += 4_000;
+            return { kind: 'admitted', waitedMs: 4_000, queued: true };
+          },
+        },
+        onDiagnostic: event => diagnostics.push(event),
+      });
+      const opening = { role: 'user', content: [{ type: 'input_text', text: 'run the search' }] };
+      const send = (input: unknown[]) => wsFetch('https://x', {
+        method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(input)),
+      });
+
+      // A forked head: its snapshot of the call carries no filler, the echo
+      // does, so abandoning it trips the filler-strip canary.
+      const forked = await send([opening]);
+      const forkedSocket = lastSocket();
+      forkedSocket.emit('open');
+      forkedSocket.emit('message', Buffer.from(JSON.stringify({
+        type: 'response.created', response: { id: 'resp_forked' },
+      })));
+      forkedSocket.emit('message', Buffer.from(JSON.stringify({
+        type: 'response.output_item.done', output_index: 0,
+        item: {
+          type: 'function_call', id: 'fc_1', call_id: 'call_w', name: 'Ripgrep',
+          arguments: '{"pattern":"x"}', status: 'completed',
+        },
+      })));
+      forkedSocket.emit('message', Buffer.from(JSON.stringify({
+        type: 'response.completed', response: { id: 'resp_forked' },
+      })));
+      await readAll(forked);
+
+      // The queued turn: it mismatches that head only by the filler the strip
+      // rule removes, so classification warns — and is then held.
+      const echoedCall = {
+        type: 'function_call', call_id: 'call_w', name: 'Ripgrep',
+        arguments: '{"pattern":"x","glob":null}',
+      };
+      const output = { type: 'function_call_output', call_id: 'call_w', output: 'hits' };
+      holdNext = true;
+      const held = send([opening, echoedCall, output]);
+      await isQueued;
+      expect(debug.some(line => line.startsWith('ws: tool argument normalization gap'))).toBe(false);
+
+      // A sibling runs to completion inside that wait and leaves a head the
+      // queued turn extends exactly.
+      const sibling = await send([opening]);
+      const siblingSocket = lastSocket();
+      siblingSocket.emit('open');
+      siblingSocket.emit('message', Buffer.from(JSON.stringify({
+        type: 'response.created', response: { id: 'resp_sibling' },
+      })));
+      siblingSocket.emit('message', Buffer.from(JSON.stringify({
+        type: 'response.completed', response: { id: 'resp_sibling' },
+      })));
+      await readAll(sibling);
+
+      releaseQueued!();
+      const heldResponse = await held;
+
+      // It continued a head, on an existing socket ...
+      expect(fakeSockets).toHaveLength(2);
+      const sent = JSON.parse(siblingSocket.send.mock.calls[1]![0] as string);
+      expect(sent.previous_response_id).toBe('resp_sibling');
+      // ... so nothing was degraded, and the user is told nothing. This is the
+      // assertion the whole test exists for; it is checked before the ledger.
+      expect(notices.join('')).not.toContain('Prompt caching is degraded');
+      expect(notices.join('')).not.toContain('Ripgrep');
+      expect(diagnostics.filter(event => event.event === 'ws_head_decision').at(-1))
+        .toMatchObject({
+          decision: 'continuation',
+          pacingRescanOutcome: 'continuation',
+          suppressedMismatchWarnings: 1,
+        });
+      // The drop is never invisible: it is in the trace and on the record.
+      expect(debug).toContain(
+        'ws: suppressed 1 arrival mismatch warning(s) after continuing a head that freed up '
+        + 'during the pacing wait',
+      );
+
+      emitTextResponse(siblingSocket, 'resp_sibling_next', 'done');
+      await readAll(heldResponse);
+    } finally {
+      releaseSink();
+      resetToolArgumentGapWarningsForTests();
+    }
+  });
+
+  it('reports prompt drift against the head it adopted, not against another idle branch', async () => {
+    // The arrival scan picks a diagnostic stand-in when nothing matches — the
+    // most recently used idle head, which on a busy session is some other
+    // branch of the same conversation. If the re-scan then adopts a DIFFERENT
+    // head, the record must describe the one actually being continued;
+    // otherwise the ledger attributes a prompt change to a chain that never
+    // saw it, which is the sort of thing these records get read to settle.
+    const debug: string[] = [];
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const clock = { ms: 0 };
+    let holdNext = false;
+    let releaseQueued: (() => void) | undefined;
+    const queued = new Promise<void>(resolve => { releaseQueued = resolve; });
+    let markQueued: (() => void) | undefined;
+    const isQueued = new Promise<void>(resolve => { markQueued = resolve; });
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, message => debug.push(message), {
+      accountId: 'acct-pacing-rematch-prompt',
+      now: () => clock.ms,
+      pacer: {
+        admit: async (): Promise<UpgradeAdmission> => {
+          if (!holdNext) return { kind: 'admitted', waitedMs: 0, queued: false };
+          holdNext = false;
+          markQueued!();
+          await queued;
+          clock.ms += 4_000;
+          return { kind: 'admitted', waitedMs: 4_000, queued: true };
+        },
+      },
+      onDiagnostic: event => diagnostics.push(event),
+    });
+
+    // A stale branch of the same session, left idle under DIFFERENT
+    // instructions. It is the newest idle head, so it is the stand-in the
+    // arrival scan reaches for.
+    const branch = await wsFetch('https://x', {
+      method: 'POST', headers: {},
+      body: JSON.stringify(sessionPayload(
+        [{ role: 'user', content: [{ type: 'input_text', text: 'an older branch' }] }],
+        { instructions: 'You are a coding assistant. A different skill was active.' },
+      )),
+    });
+    lastSocket().emit('open');
+    emitTextResponse(lastSocket(), 'resp_branch_head', 'branch answer');
+    await readAll(branch);
+
+    // The sibling, under the instructions the queued request also sends.
+    const sibling = await wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(FIRST_TURN)),
+    });
+    const siblingSocket = lastSocket();
+    siblingSocket.emit('open');
+
+    // The queued turn declares one more tool than either head was snapshotted
+    // under, so the two candidates disagree about what drifted: measured
+    // against the stale branch it is `instructions,tools`, against the head it
+    // actually continues it is `tools` alone.
+    const nextTurn = { role: 'user', content: [{ type: 'input_text', text: 'second turn' }] };
+    holdNext = true;
+    const held = wsFetch('https://x', {
+      method: 'POST', headers: {},
+      body: JSON.stringify(sessionPayload([...FIRST_TURN, ECHOED_ASSISTANT, nextTurn], {
+        tools: [
+          { type: 'function', name: 'Read', parameters: { type: 'object' } },
+          { type: 'function', name: 'Write', parameters: { type: 'object' } },
+        ],
+      })),
+    });
+    await isQueued;
+    emitTextResponse(siblingSocket, 'resp_prompt_1', 'hi');
+    await readAll(sibling);
+    releaseQueued!();
+    const heldResponse = await held;
+
+    const decision = diagnostics.filter(event => event.event === 'ws_head_decision').at(-1);
+    expect(decision).toMatchObject({
+      decision: 'continuation',
+      pacingRescanOutcome: 'continuation',
+      selectedConnectionId: 2,
+      promptChanges: ['tools'],
+    });
+    expect(debug).toContain('ws: prompt fields changed: tools');
+
+    emitTextResponse(siblingSocket, 'resp_prompt_2', 'done');
+    await readAll(heldResponse);
+  });
+
+  it('keeps an adopted head reusable when its transport then fails', async () => {
+    // The adopting request was demoted on arrival, and that demotion also
+    // cleared the persistence a replacement connection inherits. Adopting a
+    // head has to put it back: otherwise a transport failure on the very turn
+    // it continued drops the chain onto a throwaway socket, and the turn after
+    // that resends full context and opens yet another connection.
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const nextTurn = { role: 'user', content: [{ type: 'input_text', text: 'second turn' }] };
+    const secondTurnInput = [...FIRST_TURN, ECHOED_ASSISTANT, nextTurn];
+    const { wsFetch, isQueued, release } = heldBehindASibling({
+      accountId: 'acct-pacing-rematch-persistent',
+      diagnostics,
+    });
+
+    const sibling = await wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(FIRST_TURN)),
+    });
+    const siblingSocket = lastSocket();
+    siblingSocket.emit('open');
+    const held = wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(secondTurnInput)),
+    });
+    await isQueued;
+    emitTextResponse(siblingSocket, 'resp_persist_1', 'hi');
+    await readAll(sibling);
+    release();
+    const heldResponse = await held;
+    expect(fakeSockets).toHaveLength(1);
+
+    // That continued turn's transport fails before any downstream output, so
+    // it replays with full context on a replacement connection.
+    siblingSocket.emit('error', Object.assign(new Error('reset'), { code: 'ECONNRESET' }));
+    expect(fakeSockets).toHaveLength(2);
+    const replacement = lastSocket();
+    replacement.emit('open');
+    expect(JSON.parse(replacement.send.mock.calls[0]![0] as string).input).toEqual(secondTurnInput);
+    emitTextResponse(replacement, 'resp_persist_2', 'recovered');
+    await readAll(heldResponse);
+
+    // The replacement kept the chain, so the next turn continues it instead of
+    // opening a third connection.
+    const third = await wsFetch('https://x', {
+      method: 'POST', headers: {},
+      body: JSON.stringify(sessionPayload([
+        ...secondTurnInput,
+        { role: 'assistant', content: [{ type: 'output_text', text: 'recovered' }] },
+        { role: 'user', content: [{ type: 'input_text', text: 'third turn' }] },
+      ])),
+    });
+    expect(fakeSockets).toHaveLength(2);
+    expect(JSON.parse(replacement.send.mock.calls[1]![0] as string).previous_response_id)
+      .toBe('resp_persist_2');
+    expect(diagnostics.filter(event => event.event === 'ws_head_decision').at(-1))
+      .toMatchObject({ decision: 'continuation' });
+    emitTextResponse(replacement, 'resp_persist_3', 'done');
+    await readAll(third);
+  });
+
+  it('re-scans nothing for a request that was never delayed', async () => {
+    // `CLODEX_WS_MAX_NEW_CONNECTIONS_PER_MIN=0` switches pacing off, which is
+    // where the whole race is unreachable: nothing waits, so nothing is
+    // re-scanned and the decision is exactly the one the arrival scan made.
+    // A zero-wait admission resumes in the same microtask turn, and a head can
+    // only be freed by an upstream completion, which arrives on a socket event.
+    process.env.CLODEX_WS_MAX_NEW_CONNECTIONS_PER_MIN = '0';
+    try {
+      resetResponsesWebSocketConnectionsForTests();
+      const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+      let clockMs = 0;
+      const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
+        accountId: 'acct-pacing-disabled',
+        now: () => clockMs,
+        onDiagnostic: event => diagnostics.push(event),
+      });
+
+      const sibling = await wsFetch('https://x', {
+        method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(FIRST_TURN)),
+      });
+      const siblingSocket = lastSocket();
+      siblingSocket.emit('open');
+
+      clockMs += 4_000;
+      const parallel = await wsFetch('https://x', {
+        method: 'POST', headers: {},
+        body: JSON.stringify(sessionPayload([...FIRST_TURN, ECHOED_ASSISTANT,
+          { role: 'user', content: [{ type: 'input_text', text: 'second turn' }] }])),
+      });
+
+      const decision = diagnostics.filter(event => event.event === 'ws_head_decision').at(-1);
+      expect(decision).toMatchObject({
+        decision: 'parallel_isolated',
+        createdGeneration: 'isolated',
+      });
+      // Unpaced, so neither pacing field is recorded at all.
+      expect(decision).not.toHaveProperty('pacingWaitedMs');
+      expect(decision).not.toHaveProperty('pacingRescanOutcome');
+
+      emitTextResponse(siblingSocket, 'resp_unpaced_1', 'hi');
+      await readAll(sibling);
+      const ownSocket = lastSocket();
+      ownSocket.emit('open');
+      emitTextResponse(ownSocket, 'resp_unpaced_2', 'done');
+      await readAll(parallel);
+    } finally {
+      delete process.env.CLODEX_WS_MAX_NEW_CONNECTIONS_PER_MIN;
+      resetResponsesWebSocketConnectionsForTests();
+    }
   });
 });

--- a/tests/ws-upgrade-pacer.test.ts
+++ b/tests/ws-upgrade-pacer.test.ts
@@ -23,6 +23,15 @@ import {
   upstreamRequestBudget,
 } from '../src/upstream-retry.js';
 
+/**
+ * The full admitted shape. `queued` is asserted explicitly rather than derived
+ * from `waitedMs`, because the whole point of the flag is that the two can
+ * disagree when the clock moves.
+ */
+function admitted(waitedMs: number, queued: boolean) {
+  return { kind: 'admitted', waitedMs, queued, release: expect.any(Function) };
+}
+
 /** The AI SDK's fallback ladder: 2s, 4s, 8s, … with no jitter. */
 function sdkBackoffMs(maxRetries: number): number {
   return 2_000 * (2 ** maxRetries - 1);
@@ -590,14 +599,14 @@ describe('WsUpgradePacer', () => {
     expect(admissions.slice(10).map(entry => entry.state())).toEqual(['pending', 'pending', 'pending']);
 
     await clock.advance(1_000);
-    expect(admissions[10]!.admission()).toEqual({ kind: 'admitted', waitedMs: 1_000 });
+    expect(admissions[10]!.admission()).toEqual(admitted(1_000, true));
     expect(admissions[11]!.state()).toBe('pending');
 
     await clock.advance(1_000);
-    expect(admissions[11]!.admission()).toEqual({ kind: 'admitted', waitedMs: 2_000 });
+    expect(admissions[11]!.admission()).toEqual(admitted(2_000, true));
 
     await clock.advance(1_000);
-    expect(admissions[12]!.admission()).toEqual({ kind: 'admitted', waitedMs: 3_000 });
+    expect(admissions[12]!.admission()).toEqual(admitted(3_000, true));
     expect(clock.pending).toBe(0);
   });
 
@@ -712,7 +721,7 @@ describe('WsUpgradePacer', () => {
     const admissions = Array.from({ length: 5 }, () => track(clock, pacer.admit()));
     await flush();
 
-    expect(admissions[0]!.admission()).toEqual({ kind: 'admitted', waitedMs: 0 });
+    expect(admissions[0]!.admission()).toEqual(admitted(0, false));
     // The deficit is 3s but the bound is 2s, and the SDK spends this hint
     // INSTEAD of its own backoff rung — so the hint is capped at the bound
     // while `requiredWaitMs` still reports the deficit honestly.
@@ -725,8 +734,8 @@ describe('WsUpgradePacer', () => {
 
     await clock.advance(2_000);
     // The two that fitted inside the bound were queued, not refused.
-    expect(admissions[1]!.admission()).toEqual({ kind: 'admitted', waitedMs: 1_000 });
-    expect(admissions[2]!.admission()).toEqual({ kind: 'admitted', waitedMs: 2_000 });
+    expect(admissions[1]!.admission()).toEqual(admitted(1_000, true));
+    expect(admissions[2]!.admission()).toEqual(admitted(2_000, true));
     expect(clock.pending).toBe(0);
   });
 
@@ -753,7 +762,7 @@ describe('WsUpgradePacer', () => {
     await flush();
     // Three refusals debited nothing, so the bucket is back to full credit.
     // Had they each taken a token, this would be refused too.
-    expect(retried.admission()).toEqual({ kind: 'admitted', waitedMs: 0 });
+    expect(retried.admission()).toEqual(admitted(0, false));
   });
 
   it('lets a refused request through on a later attempt as the bucket refills', async () => {
@@ -813,7 +822,7 @@ describe('WsUpgradePacer', () => {
     const next = track(clock, pacer.admit());
     await flush();
     await clock.advance(1_000);
-    expect(next.admission()).toEqual({ kind: 'admitted', waitedMs: 1_000 });
+    expect(next.admission()).toEqual(admitted(1_000, true));
   });
 
   it('makes a queued request wait out the full queue when nobody aborts', async () => {
@@ -834,7 +843,7 @@ describe('WsUpgradePacer', () => {
     await clock.advance(1_000);
     expect(follower.state()).toBe('pending');
     await clock.advance(1_000);
-    expect(follower.admission()).toEqual({ kind: 'admitted', waitedMs: 2_000 });
+    expect(follower.admission()).toEqual(admitted(2_000, true));
   });
 
   it('spends no token on a request that was already cancelled', async () => {
@@ -854,7 +863,7 @@ describe('WsUpgradePacer', () => {
     const next = track(clock, pacer.admit());
     await flush();
     // Had the dead request taken the only token, this would have been queued.
-    expect(next.admission()).toEqual({ kind: 'admitted', waitedMs: 0 });
+    expect(next.admission()).toEqual(admitted(0, false));
     expect(clock.pending).toBe(0);
   });
 
@@ -894,6 +903,117 @@ describe('WsUpgradePacer', () => {
     await flush();
     expect(admissions.every(entry => entry.admission()?.kind === 'admitted')).toBe(true);
     expect(clock.pending).toBe(0);
+  });
+  it('returns a released token to the bucket, and only once', async () => {
+    // A caller admitted for a connection it then does not open — the head it
+    // needed freed up while it was queued — hands the token back, exactly as a
+    // cancellation does. Holding it would pace the next request against an
+    // upgrade that never happened.
+    const clock = new TestClock();
+    const pacer = new WsUpgradePacer({
+      ratePerMinute: 60,
+      burst: 2,
+      ...boundedBy(15_000),
+      now: clock.now,
+      schedule: clock.schedule,
+    });
+
+    const first = track(clock, pacer.admit());
+    const second = track(clock, pacer.admit());
+    await flush();
+    expect(first.admission()).toEqual(admitted(0, false));
+    expect(second.admission()).toEqual(admitted(0, false));
+
+    // Both tokens are spent; a third arrival would have to queue for one.
+    (first.admission() as { release: () => void }).release();
+    // A second call must mint nothing: that would raise the sustained rate
+    // rather than correct it.
+    (first.admission() as { release: () => void }).release();
+
+    const third = track(clock, pacer.admit());
+    await flush();
+    // The one returned token covers this arrival with no delay ...
+    expect(third.admission()).toEqual(admitted(0, false));
+
+    const fourth = track(clock, pacer.admit());
+    await flush();
+    // ... and there is no second one, so this waits out a refill.
+    expect(fourth.state()).toBe('pending');
+    await clock.advance(1_000);
+    expect(fourth.admission()).toEqual(admitted(1_000, true));
+  });
+
+  it('returns a queued admission\'s token, and only the fraction it debited', async () => {
+    // The release above is taken on the immediate path, which debits a whole
+    // token. Production's interesting case is the other one: a QUEUED admission,
+    // and — once the bucket is against its debt floor — one that could only
+    // debit a FRACTION of a token. Refunding a whole one there would mint
+    // capacity the bucket never charged, which raises the sustained rate rather
+    // than correcting it.
+    const clock = new TestClock();
+    // maxRetries 0 means nothing is ever refused, so overflow is shaped by the
+    // debt floor instead — the only path that debits a fraction.
+    const pacer = new WsUpgradePacer({
+      ratePerMinute: 60,
+      burst: 1,
+      idleTimeoutMs: 9_667,
+      maxRetries: 0,
+      now: clock.now,
+      schedule: clock.schedule,
+    });
+    // Bound 4833ms at one token per second, so the floor is 4.833 tokens down.
+    expect(pacer.maxWaitMs).toBe(4_833);
+
+    // Six reservations taken in one tick: the burst, four whole-token debits,
+    // and a sixth that finds only 0.833 of a token above the floor.
+    const admissions = Array.from({ length: 6 }, () => track(clock, pacer.admit()));
+    await flush();
+    await clock.advance(4_833);
+    expect(admissions[0]!.admission()).toEqual(admitted(0, false));
+    const fractional = admissions[5]!.admission();
+    expect(fractional).toEqual(admitted(4_833, true));
+
+    // It waited, then opened nothing, so it hands back what it took.
+    (fractional as { release: () => void }).release();
+
+    // 4900ms after those reservations the bucket has refilled 4.9 tokens. On top
+    // of the 0.833 returned that is 0.9 — still short of one, so the next
+    // arrival waits. A whole token returned instead would have made it 1.067,
+    // capped to a full token, and this would have been admitted immediately:
+    // one connection the configured rate never authorized.
+    await clock.advance(4_900 - clock.time);
+    const next = track(clock, pacer.admit());
+    await flush();
+    expect(next.state()).toBe('pending');
+    await clock.advance(200);
+    expect(next.admission()).toMatchObject({ kind: 'admitted', queued: true });
+  });
+
+  it('reports a request as queued even when the clock steps backwards', async () => {
+    // `waitedMs` is a difference of two clock reads. A machine that adjusts its
+    // clock backwards mid-wait reports 0 for a request that really was parked
+    // on the bucket, so a caller deciding what to re-check after the wait has
+    // to read the flag rather than the number.
+    const clock = new TestClock();
+    let skewMs = 0;
+    const pacer = new WsUpgradePacer({
+      ratePerMinute: 60,
+      burst: 1,
+      ...boundedBy(15_000),
+      now: () => clock.time + skewMs,
+      schedule: clock.schedule,
+    });
+
+    track(clock, pacer.admit());
+    await flush();
+    const queued = track(clock, pacer.admit());
+    await flush();
+    expect(queued.state()).toBe('pending');
+
+    skewMs = -5_000;
+    await clock.advance(1_000);
+    // Really queued for a second; reports zero elapsed, and says so.
+    expect(queued.admission()).toEqual(admitted(0, true));
   });
 });
 


### PR DESCRIPTION
When you run a lot of agents at once on a ChatGPT/Codex plan, clodex spaces out how fast it opens
new connections to OpenAI. A turn that gets held in that queue used to decide what it needed the
moment it arrived, and then stick to that decision. So if another turn finished while it was
waiting — freeing up a connection that was already holding exactly the conversation it was about to
continue — it opened a second connection anyway. Now it takes over the freed one instead. That
saves a connection, keeps the prompt cached rather than resending it, and stops one conversation's
duplicates from pushing another conversation's connection out. **This is an edge case, not
something you hit routinely** (what is and is not known about that is below), and nothing else
about pacing changes: a turn that
already has a connection to reuse when it arrives is still never delayed.

Closes #173.

> **Stacked.** This branch is based on `main` but is intended to land *after* the #174 retry-after
> fix and will be rebased onto it. Both touch `src/oauth/responses-websocket.ts`; the diffs are
> disjoint (#174 at `failContext` ~1313 and the 403 site ~1919, this one at ~2050-2320), so the
> rebase should carry cleanly.

## The user-visible failure

Under parallel fan-out on one Claude session, clodex opened a new WebSocket connection for a turn
that could have continued a chain head sitting idle in the same partition. Each duplicate head
consumes one of the 8 nursery slots, so it evicts *another* conversation's reusable head; that
conversation then resends its full context on its next turn — a cache miss, a larger prompt — and
opens another connection, which is more pacing, which widens the window in which this happens
again.

## Root cause

#172 introduced an `await` (pacing admission) between the head scan and connection creation. After
that wait it re-read the partition and demoted itself to `parallel_isolated` if a sibling had gone
*in flight* meanwhile. It did not handle the other direction: a sibling that **completed** during
the wait leaves an idle, reusable head, and nothing re-ran `continuationMatch` after the wait.

### Why a match is possible at all — the non-obvious part

A continuation needs the head's stored `requestInput ++ expectedAssistant` to be a strict prefix of
the waiting request's input. That reads as though the waiter must already contain the head's
*output*, which two independent agents never do — and on that reading the whole scenario is
unreachable. It is wrong because **`expectedAssistant` can be empty**: `continuationMatch`'s guard
is `!entry.expectedAssistant`, and `[]` passes it. A response that completes with **no output
items** stores a prefix equal to its own input alone, so any same-partition request that merely
*extends* that input matches it having copied nothing from it. Two subagents fanned out from one
Claude session open with byte-identical inputs, which is exactly that condition. This shape is
staged directly by a test (below), and the test's premise is checked: give the predecessor output
and the same test opens a third socket instead.

## Production reachability — what is and is not known

**The necessary conditions are enumerable; the frequency is not known, and the available
diagnostics cannot establish it.** All four must hold at once:

1. a predecessor leaves a *reusable* head — a nursery creation or a continuation; a
   `parallel_isolated` socket is discarded and leaves nothing;
2. that head's stored input is a strict prefix of the waiting request's input;
3. it completes **inside the waiter's queue wait**, bounded at 4,833ms at the shipped defaults; and
4. the waiter found no match of its own on arrival (`matchingCandidateCount == 0`).

Streaming all 17 local ledger files (178,298 head decisions, 63,508 primary creations) found **no
qualifying opportunity**. That is the honest limit of what the corpus supports, because the same
corpus contains **zero `ws_new_connection_paced` events and zero decisions carrying
`pacingWaitedMs`** — it records no queued requests at all. With no paced requests in it there is no
denominator, so it cannot be turned into a rate; an earlier draft of this description quoted "about
1 in 20,500 paced requests" and that figure is withdrawn as unsupported.

**Nor is that zero evidence that pacing does not engage.** `ws_new_connection_paced` is emitted
only on a nonzero wait, a refusal or an abort, so its absence cannot distinguish "the pacer never
delayed anything" from "the pacer was not there". Replaying the real connection-creation timestamps
from those files through the shipped 60/min, burst-10 bucket predicts 0 waits in the post-release
files but **1,686 waits and 1,590 refusals** in the 2026-08-27 file.

What can be said plainly: this is an edge taken when it appears, not something users hit routinely,
and the change is judged on being *safe and free* rather than on frequency. The log analysis above
was run by the review panel against local ledgers, not re-derived by the author of this change.

Unreachable entirely with `CLODEX_WS_MAX_NEW_CONNECTIONS_PER_MIN=0`.

## The change

`src/oauth/responses-websocket.ts` (surgical; the file is under the repo's "do not restructure"
directive):

- The candidate scan is **hoisted verbatim** into `scanForHeads()` — same expressions, same
  ordering, same tie-breaks — and the continuation-application block into `continueOnHead()`, which
  returns its decision so the arrival if/else chain still assigns `decision` on every path. Both
  hoists are pure moves; the pre-existing 121 tests pass against either version.
- A request that was **queued** runs that same scan a second time after admission. On a match it
  adopts the head and leaves exactly the state an arrival-time match would have left: the promotion
  and eviction side effects, `persistent` restored (so a transport-retry replacement is still
  reusable), the scan results replacing the arrival ones so the ledger is coherent, and
  `promptChanges` re-derived against the head actually being continued rather than whichever idle
  branch the arrival scan picked as a diagnostic stand-in.
- The gate reads the pacer's new **`queued` flag, not `waitedMs`** — the latter is a difference of
  two clock reads, so a clock stepped backwards mid-wait reports 0 for a request that really did
  queue, and gating on the number would skip the re-scan precisely there.
- A rematch **returns its pacing token** (`admission.release?.()`). It opened no connection, so
  holding the token would delay the next request for an upgrade that never happened — the same rule
  a cancellation already followed. Measured before this: a real-pacer probe showed the next
  connection waiting an unnecessary ~1s.
- #172's in-flight demotion is preserved exactly and is still unconditional; it is now guarded by
  `!selected`, which is a no-op on the path #172 shipped.
- A gap warning raised while classifying against the arrival partition — "Prompt caching is
  degraded for this turn" — is **deferred** rather than raised, and dropped if the request then
  continues a freed head. Nothing was degraded, and a scary notice on a perfectly cached turn is how
  the one warning whose value depends on being believed gets trained away. Deferring the whole
  warning rather than emitting and retracting it also means a dropped warning costs none of the
  per-signature budget the next genuine occurrence needs. It is dropped only on that path: a
  refusal, an abort or any non-rematch outcome still raises it exactly as before.
- New ledger fields `pacingRescanOutcome` (`continuation` | `parallel_isolated` | `no_change`),
  recorded only when the re-scan ran, and `suppressedMismatchWarnings` when a warning was dropped;
  the drop is also traced, so it is never invisible.

`src/oauth/ws-upgrade-pacer.ts`: `UpgradeAdmission` gains optional `queued` and `release`. `release`
is one-shot — a second call would mint a token the bucket never charged, which is the one way a
refund can *raise* the sustained rate instead of correcting it.

### Atomicity

Nothing between the re-scan and `dispatchContext` awaits — the nursery eviction, the diagnostic
emit and `new ReadableStream({ start })` are all synchronous, and `start` runs synchronously in the
constructor — so selection and the `inFlight` claim happen in one synchronous run. Two queued
requests released together cannot both adopt one head. (Verified by the review panel with an
inserted-yield mutation, not only by argument.)

### What I deliberately left out

- **The post-wait block cannot undo an *arrival-time* `parallel_isolated` demotion when the
  partition simply goes quiet during the wait.** Such a request already has `persistent === false`
  and, absent a re-match, keeps it, so it opens an isolated socket that retains no head at all.
  Isolated sockets are **35-38% of decisions in busy diagnostics files** — a *larger* share of the
  same harm than the slice this PR closes. Leaving it is a deliberate scope choice, not an
  oversight; re-persisting such a request is a behaviour change to #172's demotion and deserves its
  own issue, tests and reachability analysis.
- No re-scan for a request admitted on arrival. It resumes in the same microtask turn, and a head
  can only be freed by an upstream completion, which arrives on a socket event — a macrotask.
- No change to `ws_new_connection_paced` (it still records nothing on a zero wait), and no widening
  of `continuationMatch`. The safety property is entirely delegated to the unchanged matcher.

## Discriminating tests and the mutations that prove them

Full-file runs throughout, never `-t`. Snapshots restored with `cp`, never `git checkout`. All
head/chain state is staged through production producers (`response.output_item.done` /
`response.completed`), never planted in the request input; every clock is injected, so no test
depends on `Date.now()` ordering.

| Test | Mutation | Result |
| --- | --- | --- |
| **does not continue a freed head that diverges deep inside a long history** — 24 production-produced turns plus the head's own answer, agreeing on the first 19 items and differing at item 20 | make the prefix check compare only the first item | RED: `length 2 → 1`, i.e. a shallow matcher continued a chain that was not ours. The shallow negative below stays GREEN under that same mutation, which is why this test exists |
| **continues a head opened by a shorter sibling that overtook it from an empty partition** — #173's own ordering: the queued request is first into an empty partition (`new_partition_head`, still persistent), then overtaken | rematch only requests that arrived non-persistent | RED: `length 1 → 2` |
| **no "caching is degraded" warning for a turn that then continued a freed head** | always flush the deferred warnings | RED on the user-visible assertion: the notice contains `Prompt caching is degraded` |
| same, deferral itself | make the warning raise immediately instead of deferring | RED |
| continues a head a sibling freed mid-wait | delete the re-scan | RED: `length 1 → 2` (the duplicate) |
| **continues a head that completed with no output**, having copied nothing from it | delete the re-scan | RED: opens a third socket |
| same, premise check | give the predecessor output | RED: no match, third socket — so the empty-`expectedAssistant` shape is what carries it |
| opens its own head when the freed head does not match (safety) | widen `continuationMatch` to accept anything | RED: `length 2 → 1`, i.e. it continued a chain whose lineage did not match |
| re-matches on the queued flag, not elapsed time | gate on `waitedMs > 0` | RED |
| adopted head stays reusable when its transport then fails | drop the `persistent` restore | RED: `length 2 → 3` |
| prompt drift is reported against the adopted head | drop the re-derivation | RED |
| …and its trace line | drop the debug emission | RED |
| re-scanned candidate counts in the ledger | drop the scan-result reassignment | RED |
| #172 regression: in-flight demotion still yields `parallel_isolated` (existing test, extended with the new ledger field) | delete the re-scan | RED |
| no re-scan for a request admitted on arrival (`CLODEX_WS_MAX_NEW_CONNECTIONS_PER_MIN=0`, production shared pacer) | remove the queued gate | RED |
| pacer: a released token returns to the bucket, and only once | drop the refund / drop the idempotence guard | RED in both directions |
| **pacer: returns a queued admission's token, and only the fraction it debited** — driven to the debt floor, where a reservation can only take 0.833 of a token | make the queued path's release a no-op | RED |
| same | refund a whole token instead of the consumed fraction | RED: the next arrival is admitted immediately on capacity the bucket never charged |
| pacer: reports `queued` even when the clock steps backwards | derive `queued` from elapsed time | RED |

The token-release chain is proven in two halves: the pacer unit tests prove the bucket honours a
release on both the immediate and the queued path and refunds only the fraction it debited; the
transport tests prove the call site releases exactly once on a rematch and never when it actually
opens a connection.

## Runtime evidence and environment

`export CLODEX_HOME=$(mktemp -d) CLAUDE_CODE_ENTRYPOINT=cli && pnpm typecheck && pnpm test &&
pnpm build` — typecheck clean, **2331 tests / 107 files passed**, build success. Node v24.14.1
(matches `.nvmrc` and CI), macOS 15 (darwin 25.6.0), pnpm 10.34.5.

The suite was run **both** with and without the ambient `CLODEX_WS_MAX_CONNECTIONS=64` /
`CLODEX_WS_MAX_NURSERY_CONNECTIONS=24` that this machine exports, green in both, so no assertion
here depends on the local caps. No outbound HTTP(S) proxy variables were set; `ws` is mocked and the
dynamic import is warmed before any concurrent phase, so no test opens a real socket.

## What I could NOT verify

- **No live-provider run.** Nothing here was exercised against real ChatGPT OAuth traffic; all
  behavioural evidence is the fake-socket suite. No `clodex claude -p` smoke test was run on this
  branch — the change is confined to the OAuth WebSocket transport, but the Anthropic passthrough
  and translated legs are untested here and that is a known gap, not a silent one.
- **The connection/cache saving is inferred**, not measured end to end: one fewer socket and a
  retained prefix follow from the mechanism, but no before/after cache-hit measurement was taken.
- The ~1s unnecessary delay the token release removes was observed by the review panel with a
  real-pacer probe; this branch pins the *call* and the *bucket behaviour* separately rather than
  re-measuring that latency.
- The log analysis behind the reachability statement was run by the review panel, not re-derived
  here — and, as stated above, it establishes the absence of an observed opportunity, not a rate.
- The "Prompt caching is degraded" suppression is verified against the tool-argument canary; the
  reasoning-gap canary shares the same deferral seam but is not separately staged in a rematch.
- The microtask/macrotask argument for skipping the re-scan on arrival, and the synchronous-`start`
  basis of the atomicity argument, are reasoning from the specification and the event-loop model —
  the panel's inserted-yield mutation corroborates the atomicity conclusion, but neither is a
  direct instrumented measurement of production.

## Failure and rollback

Every new path is additive and fails closed onto existing behaviour. If the re-scan finds nothing,
the request proceeds exactly as #172 left it. The one timing change on an unaffected path is that a
gap warning is now raised just *after* the pacing admission rather than just before it — the same
synchronous run of the same request, and it is still raised on the refusal and abort exits. If a pacer implementation omits `queued` or `release`
(both optional), the code falls back to the elapsed time and simply keeps the token — i.e. today's
behaviour. Reverting the commit restores #172 exactly; no persisted state, config or on-disk format
is touched, so there is no upgrade or migration concern.
