### PR TITLE
fix(openai): retry instead of failing when an OpenAI connection drops mid-response

### DIFF
--- a/.claude/docs/claude-code-internals.md
+++ b/.claude/docs/claude-code-internals.md
@@ -325,6 +325,43 @@ to 300s and `CLAUDE_STREAM_IDLE_TIMEOUT_MS` can raise it beyond 30m, but the byt
 the effective ceiling unless `CLAUDE_ENABLE_BYTE_WATCHDOG=false`. `API_TIMEOUT_MS` controls the SDK
 request deadline. Raising a clodex server timeout alone never raises any of these client limits.
 
+## Mid-stream error retry gate (verified 2.1.261, darwin-arm64)
+
+What Claude Code does with an `event: error` frame that arrives after `message_start`, and why
+clodex leaves a thinking block open on a WebSocket transport drop. Byte offsets are into the
+extracted `claude-2.1.261-*.js` bundle.
+
+- **The frame becomes a status-less APIError.** The Anthropic SDK's SSE reader (@83888) throws
+  `new APIError(undefined, body, undefined, headers, body.error.type)`; `message` is the
+  JSON-stringified body. No HTTP status is attached, so nothing that keys on `status >= 500` fires.
+- **Retry keys on the type text, not the status.** `ED(e)` (@3409302) is
+  `status === 529 || message.includes('"type":"overloaded_error"')`. A status-less `api_error`
+  matches nothing; the request-level predicate (@7169742) has `if(!e.status)return!1` and the
+  streaming catch has no branch for it. Neither path retries a status-less `api_error`.
+- **A completed content block blocks the retry, whatever the type.** The streaming catch's outer gate
+  (@9501970) is `if(Ac.some(block => block.type !== 'fallback') || Kn)`; both are set by
+  `content_block_stop` (@9489300) for any non-fallback block, thinking included. Inside the gate,
+  visible content (`Un`, set on `content_block_start` of a non-thinking block) finalizes a partial
+  response; otherwise the gate's last statement (@9505233) throws with
+  `fallback_cause:"partial_yield"`. Neither path retries. Replaying clodex's own bytes to `claude -p`
+  gave one upstream request for a closed thinking block followed by `overloaded_error`, and one
+  for `api_error`.
+- **The retry lives past the gate.** `if(e instanceof APIError && ED(e))` (@9507262), log string
+  "Mid-stream 529 before content", retries the stream up to `Rle=3` times (@7156910) while `Un` is
+  false, then falls back to a non-streaming request. Eligible query sources (`$ve`, @2083457) are
+  `undefined`, every `agent:*`, `sdk`, and the named auxiliary sources. With a fallback model
+  configured, the switch happens only after the three retries are spent (@9508100). The same
+  replay with the thinking block left open gave four upstream requests.
+- **A subagent dies on its first API-error message** (`AgentApiErrorTerminationError`, @8197079,
+  thrown at @8203646) with no agent-level retry; partial-output recovery (@8197191) applies only
+  to `rate_limit`, `overloaded`, and `server_error` kinds.
+
+So for a transport drop to be recoverable, clodex must (a) label the frame `overloaded_error`
+(`anthropicErrorType` in `src/upstream-error.ts`) and (b) not emit `content_block_stop` for an
+open thinking block first (`case 'error'` in `src/sdk-adapter.ts`). Either alone is inert. Text
+and tool blocks are still closed: visible output already stops the retry, and a tool block's
+buffered arguments must be flushed.
+
 ## Things that looked like clodex bugs and were not (not version-specific)
 
 - **"Concurrent subagents died at turn 2" was not unknown-model classification.** The agents' first

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -807,7 +807,7 @@ export async function startProxyCatalog(
               contextLengthExceeded ? (relayRequestId ?? randomUUID()) : undefined,
             );
           } else {
-            const errorType = anthropicErrorType(upstreamStatus);
+            const errorType = anthropicErrorType(upstreamStatus, details?.transportCode);
             res.write(`event: error\ndata: ${JSON.stringify({
               type: 'error',
               error: { type: errorType, message: clientMessage },

--- a/src/sdk-adapter.ts
+++ b/src/sdk-adapter.ts
@@ -20,7 +20,7 @@ import {
 import { resolveUpstreamTools } from './tool-search.js';
 import { sanitizeToolInput } from './tool-input-sanitize.js';
 import type { AnthropicRequestMessage, AnthropicToolDefinition } from './proxy-types.js';
-import { anthropicErrorType, upstreamHttpStatus } from './upstream-error.js';
+import { anthropicErrorType, sdkUpstreamErrorDetails, upstreamHttpStatus } from './upstream-error.js';
 import { upstreamRequestBudget } from './upstream-retry.js';
 import { trackUpstreamAttempts } from './upstream-attempts.js';
 import { emitParentNotice } from './parent-notice.js';
@@ -1034,9 +1034,17 @@ export async function writeAnthropicStream(
       case 'error': {
         const e = part.error as { data?: unknown; message?: string } | undefined;
         const errMsg = e?.message || (typeof part.error === 'string' ? part.error : JSON.stringify(e?.data ?? part.error));
-        const errorType = anthropicErrorType(upstreamHttpStatus(part.error, errMsg));
+        const transportCode = sdkUpstreamErrorDetails(part.error)?.transportCode;
+        const errorType = anthropicErrorType(upstreamHttpStatus(part.error, errMsg), transportCode);
         log?.(() => `sdk stream error (${errorType}): ${errMsg}`);
-        closeOpen();
+        // Claude Code retries a mid-stream failure only while no content block
+        // has completed. Closing a thinking block here would count as completed
+        // content and turn a recoverable transport drop into a dead turn, so
+        // leave it open; the client closes it itself when it retries. Text and
+        // tool blocks stay closed: once visible output exists the client
+        // finalizes the partial turn either way, and a tool block's buffered
+        // arguments must still be flushed.
+        if (!(transportCode === 'websocket_transport_error' && openType === 'thinking')) closeOpen();
         throw part.error instanceof Error || (part.error && typeof part.error === 'object')
           ? part.error
           : new Error(errMsg);

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -546,7 +546,7 @@ async function handleAnthropicMessages(
             sendJson(res, status === 500 ? 502 : status, { error: { message: clientMessage } });
           }
         } else {
-          const errorType = anthropicErrorType(status);
+          const errorType = anthropicErrorType(status, details?.transportCode);
           res.write(`event: error\ndata: ${JSON.stringify({
             type: 'error',
             error: { type: errorType, message: clientMessage },

--- a/src/upstream-error.ts
+++ b/src/upstream-error.ts
@@ -455,8 +455,24 @@ export function upstreamHttpStatus(err: unknown, message: string): number {
   return 500;
 }
 
-/** Anthropic SSE error `type` for a status code — lets clients tell retryable from terminal failures. */
-export function anthropicErrorType(status: number): string {
+/**
+ * Anthropic SSE error `type` for a status code — lets clients tell retryable
+ * from terminal failures.
+ *
+ * A mid-stream SSE error frame reaches Claude Code with no HTTP status, and its
+ * retry predicate rejects every status-less error except `overloaded_error`
+ * (matched on the type text). A WebSocket transport drop is exactly the
+ * transient failure that deserves a retry, so a frame carrying the bounded
+ * transport marker is presented as overloaded rather than as the generic
+ * `api_error` Claude Code would surface once and abandon. The recovered status
+ * (500) is untouched: logs, retryability, and the `(HTTP 500)` message text
+ * still describe what actually happened.
+ */
+export function anthropicErrorType(
+  status: number,
+  transportCode?: 'websocket_transport_error',
+): string {
+  if (transportCode === 'websocket_transport_error') return 'overloaded_error';
   switch (status) {
     case 400: return 'invalid_request_error';
     case 401: return 'authentication_error';

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -1202,6 +1202,123 @@ describe('SDK translated error logging', () => {
     }
   }, 20_000);
 
+  /**
+   * Stub the OpenAI Responses transport with a stream that has produced only
+   * reasoning and then fails in-band — the exact frame shape the WebSocket
+   * transport emits when the upstream socket drops mid-response, at the point
+   * where Claude Code is still willing to retry (no visible content yet).
+   */
+  function stubMidStreamResponsesFailure(errorFrame: Record<string, unknown>): void {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(
+      [
+        'data: {"type":"response.created","response":{"id":"resp_1","created_at":1,"model":"gpt-5.6-test"}}',
+        'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning","id":"rs_1","summary":[]}}',
+        'data: {"type":"response.reasoning_summary_text.delta","item_id":"rs_1","summary_index":0,"delta":"thinking"}',
+        `data: ${JSON.stringify(errorFrame)}`,
+        '',
+      ].join('\n\n'),
+      { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
+    )));
+  }
+
+  const responsesRoute: ProxyRoute = {
+    aliasId: 'clodex:test:responses-model',
+    realModelId: 'gpt-5.6-test',
+    displayName: 'Responses Model',
+    upstreamUrl: '',
+    apiKey: 'provider-key',
+    modelFormat: 'openai',
+    npm: '@ai-sdk/openai',
+    providerId: 'test-provider',
+  };
+
+  function midStreamErrorFrames(body: string): Array<{ type: string; error: { type: string; message: string } }> {
+    return body
+      .split('\n\n')
+      .filter(block => block.startsWith('event: error'))
+      .map(block => JSON.parse(block.split('\n')[1]!.replace('data: ', '')));
+  }
+
+  function eventNames(body: string): string[] {
+    return body.split('\n\n').filter(Boolean).map(block => block.split('\n')[0]!.replace('event: ', ''));
+  }
+
+  it('reports a mid-stream WebSocket transport drop as overloaded_error with the thinking block left open', async () => {
+    stubMidStreamResponsesFailure({
+      type: 'error',
+      sequence_number: 3,
+      error: {
+        type: 'transport_error',
+        code: 'websocket_transport_error',
+        message: 'WebSocket closed (1006)',
+        param: null,
+      },
+    });
+    const handle = await startProxyCatalog([responsesRoute], responsesRoute.aliasId, false);
+
+    try {
+      const res = await postToProxy(handle.port, handle.token, {
+        model: responsesRoute.aliasId,
+        max_tokens: 100,
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: true,
+      });
+
+      // Output had already started, so the failure must arrive in-band, and
+      // the thinking block must not be closed first: a completed content
+      // block is what stops Claude Code from retrying the turn.
+      expect(res.status).toBe(200);
+      expect(res.body).toContain('"content_block":{"type":"thinking"');
+      expect(eventNames(res.body)).toEqual([
+        'message_start', 'content_block_start', 'content_block_delta', 'error',
+      ]);
+      const frames = midStreamErrorFrames(res.body);
+      expect(frames).toHaveLength(1);
+      expect(frames[0]).toEqual({
+        type: 'error',
+        error: { type: 'overloaded_error', message: 'WebSocket closed (1006) (HTTP 500)' },
+      });
+    } finally {
+      handle.close();
+      vi.unstubAllGlobals();
+    }
+  }, 20_000);
+
+  it('keeps api_error for a mid-stream provider failure that is not a transport drop', async () => {
+    stubMidStreamResponsesFailure({
+      type: 'error',
+      sequence_number: 3,
+      error: {
+        type: 'server_error',
+        code: 'server_error',
+        message: 'The server had an error while processing your request',
+        param: null,
+      },
+    });
+    const handle = await startProxyCatalog([responsesRoute], responsesRoute.aliasId, false);
+
+    try {
+      const res = await postToProxy(handle.port, handle.token, {
+        model: responsesRoute.aliasId,
+        max_tokens: 100,
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: true,
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toContain('"content_block":{"type":"thinking"');
+      expect(eventNames(res.body)).toEqual([
+        'message_start', 'content_block_start', 'content_block_delta', 'content_block_delta', 'content_block_stop', 'error',
+      ]);
+      const frames = midStreamErrorFrames(res.body);
+      expect(frames).toHaveLength(1);
+      expect(frames[0]!.error.type).toBe('api_error');
+    } finally {
+      handle.close();
+      vi.unstubAllGlobals();
+    }
+  }, 20_000);
+
   it('translates an OpenAI context overflow into an Anthropic prompt-too-long error', async () => {
     const upstream = http.createServer((req, res) => {
       req.resume();

--- a/tests/sdk-adapter.test.ts
+++ b/tests/sdk-adapter.test.ts
@@ -1911,6 +1911,97 @@ describe('writeAnthropicStream', () => {
     await expect(writeAnthropicStream(parts() as any, 'm', () => {})).rejects.toBe(upstreamError);
   });
 
+  const transportDropFrame = {
+    type: 'error',
+    sequence_number: 3,
+    error: {
+      type: 'transport_error',
+      code: 'websocket_transport_error',
+      message: 'WebSocket closed (1006)',
+      param: null,
+    },
+  };
+
+  async function collectUntilError(parts: AsyncIterable<unknown>): Promise<{ events: string[]; error: unknown }> {
+    let raw = '';
+    let error: unknown;
+    try {
+      await writeAnthropicStream(parts as any, 'm', c => { raw += c; });
+    } catch (err) {
+      error = err;
+    }
+    const events = raw.split('\n\n').filter(Boolean).map(block => block.split('\n')[0]!.replace('event: ', ''));
+    return { events, error };
+  }
+
+  it('leaves an open thinking block unclosed when the transport drops mid-stream', async () => {
+    async function* parts() {
+      yield { type: 'reasoning-start', id: 'r1' };
+      yield { type: 'reasoning-delta', id: 'r1', text: 'thinking...' };
+      yield { type: 'error', error: transportDropFrame };
+    }
+
+    const { events, error } = await collectUntilError(parts());
+    expect(error).toBe(transportDropFrame);
+    expect(events).toEqual(['message_start', 'content_block_start', 'content_block_delta']);
+  });
+
+  it('still closes an open thinking block for a mid-stream provider error that is not a transport drop', async () => {
+    const providerError = {
+      type: 'error',
+      sequence_number: 3,
+      error: { type: 'server_error', code: 'server_error', message: 'upstream failed', param: null },
+    };
+    async function* parts() {
+      yield { type: 'reasoning-start', id: 'r1' };
+      yield { type: 'reasoning-delta', id: 'r1', text: 'thinking...' };
+      yield { type: 'error', error: providerError };
+    }
+
+    const { events, error } = await collectUntilError(parts());
+    expect(error).toBe(providerError);
+    expect(events).toEqual([
+      'message_start', 'content_block_start', 'content_block_delta', 'content_block_delta', 'content_block_stop',
+    ]);
+  });
+
+  it('still closes an open text block when the transport drops mid-stream', async () => {
+    async function* parts() {
+      yield { type: 'text-start', id: 't1' };
+      yield { type: 'text-delta', id: 't1', text: 'partial' };
+      yield { type: 'error', error: transportDropFrame };
+    }
+
+    const { events, error } = await collectUntilError(parts());
+    expect(error).toBe(transportDropFrame);
+    expect(events).toEqual(['message_start', 'content_block_start', 'content_block_delta', 'content_block_stop']);
+  });
+
+  it('still flushes and closes an open tool block when the transport drops mid-stream', async () => {
+    let raw = '';
+    let error: unknown;
+    async function* parts() {
+      yield { type: 'tool-input-start', id: 'call_1', toolName: 'Read' };
+      yield { type: 'tool-input-delta', id: 'call_1', delta: '{"path":' };
+      yield { type: 'error', error: transportDropFrame };
+    }
+    try {
+      await writeAnthropicStream(parts() as any, 'm', c => { raw += c; });
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error).toBe(transportDropFrame);
+    const blocks = raw.split('\n\n').filter(Boolean).map(block => ({
+      event: block.split('\n')[0]!.replace('event: ', ''),
+      data: JSON.parse(block.split('\n')[1]!.replace('data: ', '')),
+    }));
+    expect(blocks.map(b => b.event)).toEqual([
+      'message_start', 'content_block_start', 'content_block_delta', 'content_block_stop',
+    ]);
+    expect(blocks[2]!.data.delta).toEqual({ type: 'input_json_delta', partial_json: '{"path":' });
+  });
+
   it('reports every SDK stream part to the lifecycle observer', async () => {
     const observed: string[] = [];
     async function* parts() {

--- a/tests/server-router.test.ts
+++ b/tests/server-router.test.ts
@@ -1052,6 +1052,60 @@ describe('server router', () => {
     expect(resolveProviderCredential).toHaveBeenCalledTimes(1);
   });
 
+  it('carries the WebSocket transport marker into the mid-stream error frame as overloaded_error', async () => {
+    vi.mocked(streamAnthropicResponse).mockImplementationOnce(
+      async (_model, _params, _modelId, write) => {
+        write('event: message_start\ndata: {"type":"message_start"}\n\n');
+        // The frame the WebSocket transport emits when the socket drops
+        // mid-response, rethrown verbatim by the translation adapter.
+        throw {
+          type: 'error',
+          sequence_number: 3,
+          error: {
+            type: 'transport_error',
+            code: 'websocket_transport_error',
+            message: 'WebSocket closed (1006)',
+            param: null,
+          },
+        };
+      },
+    );
+    vi.mocked(resolveProviderCredential).mockResolvedValue('oauth-token');
+    const oauthCatalog = createGatewayModelCatalog([{
+      id: 'oauth-stream-dropped',
+      name: 'OAuth Stream Dropped',
+      isFree: false,
+      brand: 'Other',
+      providerId: 'oauth-provider',
+      sourceBackend: 'oauth-provider',
+      modelFormat: 'openai',
+      npm: '@ai-sdk/openai',
+      authType: 'oauth',
+      authRef: TEST_HELPER_REF,
+      apiKey: 'launch-token',
+    }]);
+    const server = await startTestServer({ catalog: oauthCatalog });
+
+    const response = await fetch(`${server.url}/anthropic/v1/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'anthropic-oauth-provider__oauth-stream-dropped',
+        messages: [{ role: 'user', content: 'ping' }],
+        stream: true,
+      }),
+    });
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(body).toContain('message_start');
+    const errorBlock = body.split('\n\n').find(block => block.startsWith('event: error'))!;
+    expect(JSON.parse(errorBlock.split('\n')[1]!.replace('data: ', ''))).toEqual({
+      type: 'error',
+      error: { type: 'overloaded_error', message: 'WebSocket closed (1006) (HTTP 500)' },
+    });
+  });
+
   it('refreshes once after a translated OpenAI-facing OAuth 401', async () => {
     vi.mocked(generateOpenAiResponse).mockClear();
     vi.mocked(generateOpenAiResponse).mockRejectedValueOnce(

--- a/tests/upstream-error.test.ts
+++ b/tests/upstream-error.test.ts
@@ -225,6 +225,13 @@ describe('provider stream error frames', () => {
     expect(statusFor('429', 'rate_limit_error')).toBe(429);
   });
 
+  it('presents only the WebSocket transport marker as overloaded_error', () => {
+    expect(anthropicErrorType(500, 'websocket_transport_error')).toBe('overloaded_error');
+    expect(anthropicErrorType(500)).toBe('api_error');
+    expect(anthropicErrorType(500, undefined)).toBe('api_error');
+    expect(anthropicErrorType(429)).toBe('rate_limit_error');
+  });
+
   it('never infers a status from digits in the provider message', () => {
     // A recognized frame must resolve its own status; letting the recovered
     // message reach upstreamHttpStatus's prose sniffing turned a token count


### PR DESCRIPTION
When the connection to OpenAI drops partway through a response, Claude Code used to give up on that turn immediately, and a subagent hit by it died with `API Error: WebSocket closed (1006) (HTTP 500)`. With this change Claude Code retries the request instead, so a brief network blip costs a few seconds rather than a whole agent.

## The failure

Overnight on 2026-09-05, two `sol` subagents in a high-volume polish run died with the error above. clodex's WebSocket diagnostics show the upstream chatgpt.com Responses socket closed with code 1006 (a TCP drop with no close frame) five to eight seconds into a response. Over two weeks of diagnostics the rate is 0.04 to 0.15 percent of OpenAI OAuth requests, and the overnight run was at baseline; concurrency, pool evictions, and clodex's own close handling were ruled out (clodex only ever sends a proper close frame, so it cannot produce a 1006). This is the unreliable-internet cost of a long-lived socket, and the transport already replays a drop that happens before any output. The gap was drops after output had started.

## Root cause, verified in the Claude Code 2.1.261 bundle

A mid-stream `event: error` frame becomes a status-less APIError in the Anthropic SDK. Claude Code retries it only if both hold:

1. The error type is `overloaded_error`, matched on the type text since there is no status. Neither retry path handles a status-less `api_error`.
2. No content block has completed. A `content_block_stop` for any real block, thinking included, sends the turn down a "partial yield" path that skips the retry. The retry branch's own log string says "Mid-stream 529 before content".

clodex satisfied neither: it labelled the frame `api_error`, and the translation adapter closed the open thinking block before emitting the error. Either fix alone is inert; a first draft of this PR that changed only the label was measured at zero effect by the review panel.

The gate is now written up in `.claude/docs/claude-code-internals.md` with bundle offsets so it does not have to be re-derived.

## The change

- `src/upstream-error.ts`: `anthropicErrorType(status, transportCode?)` returns `overloaded_error` when the frame carries the bounded `websocket_transport_error` marker. The recovered status stays 500, so inference logs, retryability, and the `(HTTP 500)` message text are unchanged.
- `src/proxy.ts` and `src/server/router.ts` (the `/anthropic/v1/messages` handler): both bridge modes pass the marker at their mid-stream error write.
- `src/sdk-adapter.ts` `case 'error'`: when the error is a transport drop and the open block is a thinking block, skip closing it. Claude Code closes the block itself on retry. Text and tool blocks are still closed: visible output already stops the retry, and a tool block's buffered arguments must still be flushed. The trace log line now reports the same type as the wire.

Left alone on purpose: pre-headers failures still return HTTP 502, which Claude Code already retries by status. Once a text or tool block has completed, Claude Code finalizes the partial turn whatever the type, and that is its policy, not something clodex can change. A retry only helps if the next attempt succeeds; three consecutive drops in one turn still fail the turn, and a configured fallback model switches only after those three.

## Tests and mutations

- `tests/proxy.test.ts`: a `@ai-sdk/openai` Responses route with `fetch` stubbed to stream `response.created`, a reasoning item, a reasoning delta, then the exact nested transport frame the WebSocket transport emits. Asserts the event sequence `message_start, content_block_start, content_block_delta, error` (no `content_block_stop`) and an `overloaded_error` frame. A second test with a `server_error` frame asserts the block is closed and the type stays `api_error`.
- `tests/sdk-adapter.test.ts`: the adapter leaves an open thinking block unclosed on a transport drop, still closes it on a non-transport error, still closes an open text block on a transport drop, and still flushes and closes an open tool block on a transport drop.
- `tests/server-router.test.ts`: the endpoint handler carries the marker into its mid-stream frame.
- `tests/upstream-error.test.ts`: the helper maps only the exact marker.
- Mutations run against the full files: deleting the helper mapping reddens three tests; reverting only the router call site reddens the router test; restoring the unconditional `closeOpen()` reddens the adapter test and the proxy test; widening the skip to tool blocks reddens the tool-block test. `pnpm typecheck && pnpm test && pnpm build` green, 2388 tests, isolated `CLODEX_HOME`, Node 24.

## Runtime evidence

Live replay against the installed Claude Code 2.1.261 (`claude -p` with `ANTHROPIC_BASE_URL` pointed at a local server that returns the proxy's captured bytes on every request):

| Bytes served | Upstream attempts |
| --- | --- |
| Before this change (thinking block closed, `api_error`) | 1 |
| Label only (thinking block closed, `overloaded_error`) | 1 |
| This change (thinking block open, `overloaded_error`) | 4, reproduced twice |

The four are three streaming retries then the non-streaming fallback. In production the retry goes to a fresh upstream connection, so a transient drop recovers on the first retry.

Smoke test on the built `dist/cli.js` against an isolated copy of `~/.clodex` (no `server-runtime.json`, so each launch spawned its own proxy rather than attaching to the running server): `--model luna` (OpenAI OAuth, translated) and `--model haiku` (Anthropic passthrough) in proxy mode, and `--model luna` with `--endpoint`, all answered correctly.

## Not verified

- A real 1006 drop end to end. The replay harness exercises the exact bytes the proxy emits, but I did not induce a live socket drop on chatgpt.com.
- Claude Code versions other than 2.1.261. The gate is version-specific and stamped as such in the internals doc.
- Non-Claude-Code Anthropic SDK clients on the endpoint gateway see an unclosed thinking block before the error frame. The Anthropic SDK raises on `event: error` regardless, so this should be inert, but I did not run a foreign client.

## Review

Panel: two lenses on OpenAI (sol/high), a refuter on Anthropic (opus/high), and a cold reviewer on OpenAI (sol/high) for the adapter change added after the first round. The refuter's live replay overturned the first draft; the adapter change is its recommended fix. The cold reviewer's two should-fixes (a tool-block negative test and two narrower sentences in the internals doc) are applied.
