### PR TITLE
fix(openai): retry connection drops during thinking so agents can keep working

### DIFF
--- a/.claude/docs/claude-code-internals.md
+++ b/.claude/docs/claude-code-internals.md
@@ -362,6 +362,37 @@ open thinking block first (`case 'error'` in `src/sdk-adapter.ts`). Either alone
 and tool blocks are still closed: visible output already stops the retry, and a tool block's
 buffered arguments must be flushed.
 
+### Multiple thinking summaries (re-verified 2.1.263, darwin-arm64)
+
+In the pristine `claude-2.1.263-ef5d2909c8af49f3.js` bundle, the parser sets `la` on the
+start of a non-thinking, non-redacted-thinking, non-fallback block. A block stop pushes that
+block's assistant-message envelope into `dc` and sets `mr`, including for thinking. The catch first tests
+`dc.some(message => message.content.some(block => !isFallback(block))) || mr`.
+Inside this completed-content gate, an SSE server/overload error finalizes partial output
+only when `la` is true; its thinking-only case throws `Rb`, recording telemetry
+`fallback_cause: "partial_yield"` instead.
+The socket-error and watchdog branches have separate retry rules, but clodex's in-band
+`websocket_transport_error` is an API error, not a socket error at the client.
+
+The overload branch is still **after** that gate: `La instanceof Lt && AD(La)`, where
+`AD` (@3409360) accepts status 529 or the literal `"type":"overloaded_error"` in the
+message. With `la` false it increments `qp` and retries while `qp < Nle` (`Nle=3`,
+@7157194), for eligible query sources, then takes the non-streaming fallback unless disabled.
+Thus the ordinary exhausted path is three streaming attempts plus one non-streaming request,
+not four streaming attempts. A fallback model or low-priority capacity-wait policy can alter
+that path. The completed-content gate and overload branch are around @9502000–9509900.
+
+Leaving only the **last** thinking block open is insufficient if earlier summaries already
+closed blocks. Clodex now coalesces consecutive OpenAI Responses reasoning into one live
+thinking block, retaining original item/summary boundaries in an opaque signature envelope.
+The stream parser treats signatures as opaque strings (`sl.signature = hp.signature`) and appends
+thinking text verbatim; it does not understand or decode that envelope. This is not a guarantee
+of byte-exact request replay: immediately before sending a request, `oot`/`wZ` recursively scan
+all string values and replace lone UTF-16 surrogates with U+FFFD (@211704–212238 and @9461968).
+Clodex therefore keeps the original summary strings inside its JSON-encoded signature, whose
+escaped surrogate code units survive that sanitizer, rather than depending on unchanged display
+text or sanitizing individual deltas (which would break valid pairs split across deltas).
+
 ## Voice dictation transport (verified 2.1.263, darwin-arm64)
 
 How the dictation client reaches the network, read from the extracted `claude-2.1.263-*.js` bundle

--- a/.claude/docs/oauth-continuation.md
+++ b/.claude/docs/oauth-continuation.md
@@ -16,6 +16,13 @@ is emitted downstream. A transport failure likewise retries once **with full con
 same continuation payload — while no downstream bytes, model data, or accumulated output exist; buffered control frames do not close that safe window, but any model
 output makes the failure terminal. OAuth requires `store:false` (a `store:true` probe returns 400).
 
+The Anthropic translation keeps consecutive OpenAI reasoning in a single live thinking block,
+with a self-contained signature envelope that restores individual summaries and encrypted items
+on the return trip (see `translation.md`). Restored reasoning IDs are kept in outgoing requests
+but omitted from comparison, matching the existing expected-assistant snapshot. Comparison still
+accepts legacy histories that omitted earlier summaries when the encrypted content matches; this
+compatibility rule is not permission to rewrite summaries in new upstream requests.
+
 **Connection pools are process-wide, not per-partition:** `maxConnections` (established, default 32)
 and `maxNurseryConnections` (default 8). A head starts in the nursery and is promoted only when
 successfully continued — so a workload fanning out into many concurrent subagent conversations (all

--- a/.claude/docs/translation.md
+++ b/.claude/docs/translation.md
@@ -17,6 +17,25 @@ hand-rolled per-provider translation. Preserved hard-won behavior:
   responses in testing.
 - Cache reads and GPT-5.6 cache writes map to Anthropic
   `cache_read_input_tokens`/`cache_creation_input_tokens`.
+- Consecutive OpenAI Responses reasoning summaries/items stream into **one Anthropic thinking
+  block** until text, a tool, or successful completion closes it. A thinking-only WebSocket drop
+  leaves that block open, so an earlier summary cannot disable Claude Code's mid-stream retry.
+  `src/openai-thinking.ts` carries a versioned, self-contained signature envelope: original SDK
+  item IDs, original summary text, and encrypted content. On the next request it restores separate
+  SDK reasoning parts; the SDK rebuilds the original summary groups. Display-only paragraph breaks
+  never enter the upstream summaries. Original text lives inside the opaque signature rather than
+  being recovered from the display text, so client-side text edits or Unicode sanitization cannot
+  change what goes back to OpenAI. This duplicates summary text in client requests and transcripts
+  and retains any intermediate ciphertext the SDK exposes; only each item's final ciphertext goes
+  upstream. The envelope itself is never sent upstream. No process-local registry or provider
+  ciphertext rewriting is involved. Legacy raw signatures remain readable. An unknown or malformed
+  envelope is omitted, never forwarded as ciphertext; switching a valid envelope to another
+  translated provider retains only the display text. Older clodex builds cannot decode these new
+  signatures and would forward the envelope as provider ciphertext, which can cause upstream errors.
+  Resume such transcripts with an envelope-aware build rather than downgrading the bridge. This does not
+  change non-streaming responses' existing omission of reasoning, or the transport's prohibition
+  on replaying already-emitted model output. The guarantee covers SDK-visible summary text,
+  grouping and encrypted content, not output-only fields the SDK omits (such as `status`).
 - **Images in `tool_result` are lifted out of the text-only function-output channel** and delivered
   as real image parts on the following user message. Inline, a JSON.stringify'd base64 screenshot
   tokenizes at ~1.5 chars/token — 200k+ tokens per screenshot, killing agents with "Prompt is too

--- a/src/oauth/responses-websocket.ts
+++ b/src/oauth/responses-websocket.ts
@@ -392,14 +392,15 @@ function normalizeToolCallJson(value: unknown): unknown {
   // never match its own echo. An empty array carries no information; drop it
   // from both sides. A populated `content` is real data and still compared.
   if (record.type === 'reasoning') {
+    // The round-trip envelope preserves the SDK itemId to rebuild summary groups.
+    // Expected-assistant snapshots omit this ephemeral field; compare like shapes
+    // without removing the original id from the payload actually sent upstream.
+    delete out.id;
     if (Array.isArray(record.content) && record.content.length === 0) delete out.content;
     // `encrypted_content` IS the reasoning item's identity, and the real state
     // lives upstream under previous_response_id — the summary is display text.
-    // It also cannot survive the round trip intact: the SDK emits one reasoning
-    // part per summary part, but only the LAST part's `reasoning-end` carries the
-    // encrypted content, so the unsigned earlier blocks are dropped on the way
-    // back and a multi-part summary returns holding only its final part. Compare
-    // on the blob and a head can match its own echo.
+    // Legacy thinking signatures retained only the last summary of each item.
+    // Keep accepting those histories even though new envelopes retain every part.
     if (typeof record.encrypted_content === 'string' && record.encrypted_content) delete out.summary;
   }
   return out;

--- a/src/openai-thinking.ts
+++ b/src/openai-thinking.ts
@@ -1,0 +1,92 @@
+import type { FullStreamPart } from './proxy-shared.js';
+
+const SIGNATURE_PREFIX = 'clodex:openai-thinking:';
+const SIGNATURE_V1 = `${SIGNATURE_PREFIX}v1:`;
+
+interface ReasoningPart {
+  itemId: string;
+  text: string;
+  encryptedContent?: string;
+}
+
+export function openAiReasoningItemId(part: FullStreamPart): string | undefined {
+  const id = part.providerMetadata?.openai?.itemId;
+  return typeof id === 'string' && id.length > 0 ? id : undefined;
+}
+
+/** One live display block; the original SDK parts survive independently of client display edits. */
+export class OpenAiThinkingBlock {
+  private readonly parts = new Map<string, ReasoningPart>();
+  private hasText = false;
+
+  start(part: FullStreamPart): void {
+    const itemId = openAiReasoningItemId(part);
+    if (!itemId || !part.id) throw new Error('OpenAI reasoning part has no identity');
+    if (!this.parts.has(part.id)) this.parts.set(part.id, { itemId, text: '' });
+    this.end(part);
+  }
+
+  append(part: FullStreamPart): string {
+    const entry = this.parts.get(part.id ?? '');
+    if (!entry) throw new Error('OpenAI reasoning delta has no matching start');
+    const text = part.text ?? '';
+    if (!text) return '';
+    const separator = entry.text.length === 0 && this.hasText ? '\n\n' : '';
+    entry.text += text;
+    this.hasText = true;
+    return separator + text;
+  }
+
+  end(part: FullStreamPart): void {
+    const entry = this.parts.get(part.id ?? '');
+    const encrypted = part.providerMetadata?.openai?.reasoningEncryptedContent;
+    if (entry && typeof encrypted === 'string' && encrypted) entry.encryptedContent = encrypted;
+  }
+
+  signature(): string {
+    // JSON escapes lone surrogates, so request-wide Unicode sanitization cannot
+    // change the originals inside this opaque string. Avoid base64-wrapping blobs
+    // that are already encoded upstream.
+    return SIGNATURE_V1 + JSON.stringify({ parts: [...this.parts.values()] });
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * undefined is a legacy/provider signature. An invalid owned envelope yields no reasoning:
+ * never mistake our metadata for provider ciphertext, including on a model switch.
+ */
+export function restoreOpenAiThinking(
+  text: string,
+  signature: string | undefined,
+  npm: string,
+): Array<Record<string, unknown>> | undefined {
+  if (!signature?.startsWith(SIGNATURE_PREFIX)) return undefined;
+  if (!signature.startsWith(SIGNATURE_V1)) return [];
+  try {
+    const envelope: unknown = JSON.parse(signature.slice(SIGNATURE_V1.length));
+    if (!isRecord(envelope) || !Array.isArray(envelope.parts) || envelope.parts.length === 0) return [];
+    const parts: ReasoningPart[] = [];
+    for (const part of envelope.parts) {
+      if (!isRecord(part) || typeof part.itemId !== 'string' || !part.itemId
+        || typeof part.text !== 'string'
+        || (part.encryptedContent !== undefined && typeof part.encryptedContent !== 'string')) return [];
+      parts.push(part as unknown as ReasoningPart);
+    }
+    if (npm !== '@ai-sdk/openai') return text ? [{ type: 'reasoning', text }] : [];
+    return parts.map(part => ({
+      type: 'reasoning', text: part.text,
+      providerOptions: {
+        openai: {
+          itemId: part.itemId,
+          ...(part.encryptedContent ? { reasoningEncryptedContent: part.encryptedContent } : {}),
+        },
+      },
+    }));
+  } catch {
+    return [];
+  }
+}

--- a/src/proxy-shared.ts
+++ b/src/proxy-shared.ts
@@ -18,7 +18,7 @@ export type FullStreamPart = {
   };
   providerMetadata?: {
     google?: { thoughtSignature?: string; thought_signature?: string };
-    openai?: { reasoningEncryptedContent?: string | null };
+    openai?: { itemId?: string; reasoningEncryptedContent?: string | null };
   };
   error?: unknown;
   reason?: string;

--- a/src/sdk-adapter.ts
+++ b/src/sdk-adapter.ts
@@ -26,6 +26,7 @@ import { trackUpstreamAttempts } from './upstream-attempts.js';
 import { emitParentNotice } from './parent-notice.js';
 import { CLAUDE_CODE_COMPACT_PROMPT_MARKERS } from './claude-code-compact-prompt.js';
 import { CLAUDE_CODE_BILLING_HEADER_PREFIX } from './oauth/claude-identity.js';
+import { OpenAiThinkingBlock, openAiReasoningItemId, restoreOpenAiThinking } from './openai-thinking.js';
 
 export { silenceSdkWarnings };
 
@@ -396,8 +397,12 @@ export function translateMessages(
           // content, not prior assistant output_text items.
           parts.push({ type: 'text', text: b.text ?? '' });
         } else if (b.type === 'thinking') {
-          const part = thinkingToSdkPart(b, npm);
-          if (part) parts.push(part);
+          const restored = restoreOpenAiThinking(b.thinking ?? '', b.signature, npm);
+          if (restored) parts.push(...restored);
+          else {
+            const part = thinkingToSdkPart(b, npm);
+            if (part) parts.push(part);
+          }
         } else if (b.type === 'tool_use' && b.id) {
           const { rawId, thoughtSignature } = splitToolUseId(b.id);
           const part: Record<string, unknown> = {
@@ -851,6 +856,7 @@ export async function writeAnthropicStream(
   let started = false;
   let openType: 'text' | 'thinking' | 'tool' | null = null;
   let pendingThinkingSig: string | undefined;
+  let openAiThinking: OpenAiThinkingBlock | undefined;
   const idToBlock = new Map<string, number>();
   // Tool input deltas are buffered (not forwarded raw) so the complete input
   // can be sanitized once the SDK's parsed `tool-call` part arrives.
@@ -885,11 +891,14 @@ export async function writeAnthropicStream(
   };
   const closeOpen = () => {
     if (openType === 'thinking') {
+      // Emit the complete signature once: Claude Code replaces, rather than
+      // appends, signature_delta values. Splitting an envelope would lose it.
       emit('content_block_delta', {
         type: 'content_block_delta', index: blockIndex,
-        delta: { type: 'signature_delta', signature: pendingThinkingSig ?? '' },
+        delta: { type: 'signature_delta', signature: openAiThinking?.signature() ?? pendingThinkingSig ?? '' },
       });
       pendingThinkingSig = undefined;
+      openAiThinking = undefined;
     }
     // Stream ended (or moved on) without a tool-call part for this block: emit
     // the buffered raw JSON so the deltas that did arrive are not lost.
@@ -929,18 +938,32 @@ export async function writeAnthropicStream(
         throw streamAbortError(observer?.abortSignal);
 
       case 'reasoning-start':
-        openBlock('thinking', { type: 'thinking', thinking: '', signature: '' });
+        // Consecutive OpenAI summaries/items share a live block, so a thinking-only
+        // transport drop has no completed block to prevent Claude Code's retry.
+        // The signature records their identities and boundaries for lossless replay.
+        if (openAiReasoningItemId(part) && part.id) {
+          if (!openAiThinking) {
+            openBlock('thinking', { type: 'thinking', thinking: '', signature: '' });
+            openAiThinking = new OpenAiThinkingBlock();
+          }
+          openAiThinking.start(part);
+        } else {
+          openBlock('thinking', { type: 'thinking', thinking: '', signature: '' });
+        }
         break;
       case 'reasoning-delta':
         if (openType !== 'thinking') openBlock('thinking', { type: 'thinking', thinking: '', signature: '' });
         emit('content_block_delta', {
           type: 'content_block_delta', index: blockIndex,
-          delta: { type: 'thinking_delta', thinking: part.text ?? '' },
+          delta: { type: 'thinking_delta', thinking: openAiThinking ? openAiThinking.append(part) : part.text ?? '' },
         });
         break;
       case 'reasoning-end': {
-        const sig = grabRoundTripSignature(part);
-        if (sig) pendingThinkingSig = sig;
+        if (openAiThinking) openAiThinking.end(part);
+        else {
+          const sig = grabRoundTripSignature(part);
+          if (sig) pendingThinkingSig = sig;
+        }
         break;
       }
 

--- a/tests/openai-thinking.test.ts
+++ b/tests/openai-thinking.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+import { translateMessages, writeAnthropicStream } from '../src/sdk-adapter.js';
+import type { FullStreamPart } from '../src/proxy-shared.js';
+
+type ThinkingBlock = { type: 'thinking'; thinking: string; signature: string };
+
+async function display(parts: FullStreamPart[]): Promise<ThinkingBlock[]> {
+  const blocks: ThinkingBlock[] = [];
+  await writeAnthropicStream((async function* () { yield* parts; })(), 'test-model', chunk => {
+    const data = JSON.parse(chunk.split('\ndata: ')[1]);
+    if (data.type === 'content_block_start') blocks[data.index] = data.content_block;
+    if (data.type === 'content_block_delta') {
+      const block = blocks[data.index];
+      if (data.delta.type === 'thinking_delta') block.thinking += data.delta.thinking;
+      if (data.delta.type === 'signature_delta') block.signature = data.delta.signature;
+    }
+  });
+  return blocks;
+}
+
+const start = (id: string, itemId: string): FullStreamPart => ({
+  type: 'reasoning-start', id, providerMetadata: { openai: { itemId } },
+});
+const delta = (id: string, text: string): FullStreamPart => ({ type: 'reasoning-delta', id, text });
+const end = (id: string, itemId: string, encryptedContent?: string): FullStreamPart => ({
+  type: 'reasoning-end', id,
+  providerMetadata: { openai: { itemId, reasoningEncryptedContent: encryptedContent } },
+});
+
+const originalParts = [
+  start('rs_a:0', 'rs_a'), delta('rs_a:0', 'First.'), end('rs_a:0', 'rs_a'),
+  start('rs_a:1', 'rs_a'), delta('rs_a:1', 'Second.'), end('rs_a:1', 'rs_a', 'cipher-a'),
+  start('rs_b:0', 'rs_b'), delta('rs_b:0', 'Third.'), end('rs_b:0', 'rs_b', 'cipher-b'),
+];
+
+function echo(blocks: ThinkingBlock[], npm = '@ai-sdk/openai') {
+  return translateMessages([{ role: 'assistant', content: blocks }], npm);
+}
+
+const expected = [{
+  role: 'assistant', content: [
+    { type: 'reasoning', text: 'First.', providerOptions: { openai: { itemId: 'rs_a' } } },
+    { type: 'reasoning', text: 'Second.', providerOptions: { openai: { itemId: 'rs_a', reasoningEncryptedContent: 'cipher-a' } } },
+    { type: 'reasoning', text: 'Third.', providerOptions: { openai: { itemId: 'rs_b', reasoningEncryptedContent: 'cipher-b' } } },
+  ],
+}];
+
+describe('OpenAI thinking round-trip metadata', () => {
+  it('restores original parts, item identities and separate signatures from one display block', async () => {
+    const blocks = await display(originalParts);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].thinking).toBe('First.\n\nSecond.\n\nThird.');
+    // Persisted JSON is sufficient: there is no identity-keyed lookup in this echo.
+    expect(echo(JSON.parse(JSON.stringify(blocks)))).toEqual(expected);
+  });
+
+  it('attributes interleaved deltas to their original parts, including late signatures', async () => {
+    const blocks = await display([
+      start('rs_a:0', 'rs_a'), delta('rs_a:0', 'one-'),
+      start('rs_b:0', 'rs_b'), delta('rs_b:0', 'two-'),
+      delta('rs_a:0', 'A'), delta('rs_b:0', 'B'),
+      end('rs_a:0', 'rs_a', 'cipher-a'), end('rs_b:0', 'rs_b', 'cipher-b'),
+    ]);
+    expect(blocks).toHaveLength(1);
+    expect(echo(blocks)).toEqual([{
+      role: 'assistant', content: [
+        { type: 'reasoning', text: 'one-A', providerOptions: { openai: { itemId: 'rs_a', reasoningEncryptedContent: 'cipher-a' } } },
+        { type: 'reasoning', text: 'two-B', providerOptions: { openai: { itemId: 'rs_b', reasoningEncryptedContent: 'cipher-b' } } },
+      ],
+    }]);
+  });
+
+  it('keeps empty encrypted reasoning and whitespace-only summaries', async () => {
+    const blocks = await display([
+      start('rs_empty:0', 'rs_empty'), end('rs_empty:0', 'rs_empty', 'cipher-empty'),
+      start('rs_space:0', 'rs_space'), delta('rs_space:0', ' \n '), end('rs_space:0', 'rs_space', 'cipher-space'),
+    ]);
+    expect(echo(blocks)).toEqual([{
+      role: 'assistant', content: [
+        { type: 'reasoning', text: '', providerOptions: { openai: { itemId: 'rs_empty', reasoningEncryptedContent: 'cipher-empty' } } },
+        { type: 'reasoning', text: ' \n ', providerOptions: { openai: { itemId: 'rs_space', reasoningEncryptedContent: 'cipher-space' } } },
+      ],
+    }]);
+  });
+
+  it('preserves unicode even when a surrogate pair is split across stream chunks', async () => {
+    const blocks = await display([
+      start('rs_a:0', 'rs_a'), delta('rs_a:0', '\ud83d'), delta('rs_a:0', '\ude80 café'),
+      end('rs_a:0', 'rs_a', 'cipher-unicode'),
+    ]);
+    expect(echo(blocks)).toEqual([{
+      role: 'assistant', content: [{
+        type: 'reasoning', text: '🚀 café',
+        providerOptions: { openai: { itemId: 'rs_a', reasoningEncryptedContent: 'cipher-unicode' } },
+      }],
+    }]);
+  });
+
+  it('restores original summaries when the client sanitizes malformed display Unicode', async () => {
+    const blocks = await display([
+      start('rs_a:0', 'rs_a'), delta('rs_a:0', 'Broken \ud83d char.'), end('rs_a:0', 'rs_a', 'cipher-original'),
+    ]);
+    // Claude Code 2.1.263 applies toWellFormed recursively to outgoing request strings.
+    const sanitized = blocks.map(block => ({
+      ...block, thinking: block.thinking.toWellFormed(), signature: block.signature.toWellFormed(),
+    }));
+    expect(echo(sanitized)).toEqual([{
+      role: 'assistant', content: [{
+        type: 'reasoning', text: 'Broken \ud83d char.',
+        providerOptions: { openai: { itemId: 'rs_a', reasoningEncryptedContent: 'cipher-original' } },
+      }],
+    }]);
+  });
+
+  it('does not send our envelope as another provider’s signature on a model switch', async () => {
+    const blocks = await display(originalParts);
+    expect(echo(blocks, '@ai-sdk/google')).toEqual([{
+      role: 'assistant', content: [{ type: 'reasoning', text: 'First.\n\nSecond.\n\nThird.' }],
+    }]);
+    expect(echo(blocks, '@ai-sdk/openai-compatible')).toEqual([{
+      role: 'assistant', content: [{ type: 'reasoning', text: 'First.\n\nSecond.\n\nThird.' }],
+    }]);
+  });
+
+  it('restores original summaries rather than edited, truncated, or missing display text', async () => {
+    const [block] = await display(originalParts);
+    expect(echo([{ ...block, thinking: block.thinking.replace('First', 'Other') }])).toEqual(expected);
+    expect(echo([{ ...block, thinking: block.thinking.slice(0, -1) }])).toEqual(expected);
+    expect(echo([{ ...block, thinking: '' }])).toEqual(expected);
+  });
+
+  it('drops malformed and unknown-version envelopes rather than forwarding them as ciphertext', () => {
+    for (const signature of ['clodex:openai-thinking:v2:unknown', 'clodex:openai-thinking:v1:!!', 'clodex:openai-thinking:v1:e30']) {
+      expect(echo([{ type: 'thinking', thinking: 'hello', signature }])).toEqual([]);
+    }
+  });
+
+  it('rejects malformed originals instead of sending the envelope as provider ciphertext', () => {
+    // Independent v1 fixture, not an envelope produced by the encoder under test.
+    // A valid control prevents a reject-everything oracle.
+    const signature = (parts: unknown) => 'clodex:openai-thinking:v1:' + JSON.stringify({ parts });
+    const part = { itemId: 'rs_fixture', text: 'abc', encryptedContent: 'fixture-cipher' };
+    const block: ThinkingBlock = { type: 'thinking', thinking: 'abc', signature: signature([part]) };
+    expect(echo([block])).toEqual([{
+      role: 'assistant', content: [{
+        type: 'reasoning', text: 'abc',
+        providerOptions: { openai: { itemId: 'rs_fixture', reasoningEncryptedContent: 'fixture-cipher' } },
+      }],
+    }]);
+    expect(echo([{ ...block, signature: block.signature.replace(':v1:', ':v2:') }])).toEqual([]);
+    const invalidParts = [
+      null, {}, [], [null],
+      [{ ...part, itemId: '' }], [{ ...part, itemId: 1 }],
+      [{ ...part, text: null }], [{ ...part, text: 1 }], [{ ...part, text: {} }],
+      [{ ...part, encryptedContent: 1 }], [{ ...part, encryptedContent: null }],
+      [part, { itemId: 'rs_missing_text', encryptedContent: 'other-cipher' }],
+    ];
+    for (const parts of invalidParts) {
+      expect(echo([{ ...block, signature: signature(parts) }]), JSON.stringify(parts)).toEqual([]);
+    }
+  });
+
+  it('retains legacy raw OpenAI signatures and independent non-OpenAI thinking blocks', async () => {
+    expect(echo([{ type: 'thinking', thinking: 'Legacy summary', signature: 'legacy-cipher' }])).toEqual([{
+      role: 'assistant', content: [{ type: 'reasoning', text: 'Legacy summary', providerOptions: { openai: { reasoningEncryptedContent: 'legacy-cipher' } } }],
+    }]);
+    const blocks = await display([
+      { type: 'reasoning-start', id: 'a' }, delta('a', 'Google one'),
+      { type: 'reasoning-end', id: 'a', providerMetadata: { google: { thoughtSignature: 'google-one' } } },
+      { type: 'reasoning-start', id: 'b' }, delta('b', 'Google two'),
+      { type: 'reasoning-end', id: 'b', providerMetadata: { google: { thoughtSignature: 'google-two' } } },
+    ]);
+    expect(blocks).toEqual([
+      { type: 'thinking', thinking: 'Google one', signature: 'google-one' },
+      { type: 'thinking', thinking: 'Google two', signature: 'google-two' },
+    ]);
+  });
+});

--- a/tests/thinking-block-coalescing.test.ts
+++ b/tests/thinking-block-coalescing.test.ts
@@ -1,0 +1,330 @@
+import { createOpenAI } from '@ai-sdk/openai';
+import { describe, expect, it } from 'vitest';
+import { streamAnthropicResponse, translateRequest } from '../src/sdk-adapter.js';
+import { sdkUpstreamErrorDetails } from '../src/upstream-error.js';
+
+// Issue #190: a mid-stream WebSocket 1006 drop kills the agent outright when the
+// turn has produced only thinking so far.
+//
+// Claude Code 2.1.263 has three regimes on an in-band SSE error frame:
+//
+//   1. no `content_block_stop` emitted yet  -> retries, then non-streaming fallback
+//   2. >=1 block closed AND a text/tool_use block started -> partial turn, agent survives
+//   3. >=1 block closed, thinking only      -> persisted error "unknown", AGENT DIES
+//
+// `@ai-sdk/openai` emits one `reasoning-start` per reasoning summary part, and
+// `writeAnthropicStream` opens a fresh Anthropic thinking block on each one --
+// closing the previous block as it goes. So any thinking-only turn carrying two
+// or more summary parts has already emitted a `content_block_stop` and lands in
+// regime 3 instead of the retryable regime 1.
+//
+// These tests drive the REAL production stack: the real `@ai-sdk/openai`
+// Responses producer, the real `streamText` call inside `streamAnthropicResponse`,
+// and the real Anthropic SSE writer. Only `fetch` is replaced -- which is the
+// exact seam the ChatGPT/Codex OAuth WebSocket transport occupies in production
+// (`src/provider-factory.ts` passes `createResponsesWebSocketFetch` as `fetch`
+// to `createOpenAI`, then calls `.responses(modelId)`).
+
+const MODEL = 'gpt-5.6-sol';
+
+interface AnthropicSseEvent {
+  event: string;
+  data: Record<string, any>;
+}
+
+/**
+ * Upstream Responses-API SSE in the exact framing the OAuth WebSocket transport
+ * writes downstream: a bare `data: <json>` record with no `event:` line, per
+ * `encodeSse` in `src/oauth/responses-websocket.ts`.
+ */
+function upstreamSseBody(chunks: unknown[]): string {
+  return chunks.map(chunk => `data: ${JSON.stringify(chunk)}\n\n`).join('');
+}
+
+/**
+ * The reasoning chunk sequence for one Responses output item carrying `texts.length`
+ * summary parts. Field names and shapes are those required by the pinned
+ * `@ai-sdk/openai` 4.0.11 Responses chunk schema (`openaiResponsesChunkSchema`),
+ * which is what makes the SDK emit one `reasoning-start` per summary part.
+ *
+ * By default the item is left mid-flight (no `output_item.done`), which is what a
+ * drop interrupts. Pass `encryptedContent` to close the item the way a completed
+ * one arrives -- that chunk is what makes the SDK emit `reasoning-end` carrying
+ * the blob (node_modules/@ai-sdk/openai/dist/index.js:7329-7347).
+ */
+function reasoningItemChunks(
+  itemId: string,
+  texts: string[],
+  options: { outputIndex?: number; encryptedContent?: string } = {},
+): unknown[] {
+  const outputIndex = options.outputIndex ?? 0;
+  const chunks: unknown[] = [{
+    type: 'response.output_item.added',
+    output_index: outputIndex,
+    item: { type: 'reasoning', id: itemId, encrypted_content: null },
+  }];
+  texts.forEach((text, summaryIndex) => {
+    // Summary part 0 is opened by `output_item.added` itself; every later part
+    // announces itself, and that is the chunk that yields a second reasoning-start.
+    if (summaryIndex > 0) {
+      chunks.push({
+        type: 'response.reasoning_summary_part.added',
+        item_id: itemId,
+        summary_index: summaryIndex,
+      });
+    }
+    chunks.push({
+      type: 'response.reasoning_summary_text.delta',
+      item_id: itemId,
+      summary_index: summaryIndex,
+      delta: text,
+    });
+    chunks.push({
+      type: 'response.reasoning_summary_part.done',
+      item_id: itemId,
+      summary_index: summaryIndex,
+    });
+  });
+  if (options.encryptedContent !== undefined) {
+    chunks.push({
+      type: 'response.output_item.done',
+      output_index: outputIndex,
+      item: { type: 'reasoning', id: itemId, encrypted_content: options.encryptedContent },
+    });
+  }
+  return chunks;
+}
+
+/**
+ * The terminal frame the OAuth WebSocket transport injects into the Responses
+ * stream when the socket drops mid-response. Copied field-for-field from
+ * `failContext` in `src/oauth/responses-websocket.ts`, which builds
+ * `WebSocket closed (${code})` with `code: 'websocket_transport_error'` and
+ * `type: 'transport_error'` whenever there is no HTTP status to report.
+ */
+function transportDropChunk(sequenceNumber: number): unknown {
+  return {
+    type: 'error',
+    sequence_number: sequenceNumber,
+    error: {
+      type: 'transport_error',
+      code: 'websocket_transport_error',
+      message: 'WebSocket closed (1006)',
+      param: null,
+    },
+  };
+}
+
+function parseAnthropicSse(raw: string): AnthropicSseEvent[] {
+  return raw.split('\n\n').filter(Boolean).map(block => {
+    const [eventLine, dataLine] = block.split('\n');
+    return {
+      event: eventLine.replace('event: ', ''),
+      data: JSON.parse(dataLine.replace('data: ', '')),
+    };
+  });
+}
+
+/** Run the production translation path over a canned upstream Responses stream. */
+async function relayUpstream(chunks: unknown[]): Promise<{
+  events: AnthropicSseEvent[];
+  raw: string;
+  error: unknown;
+  upstreamRequests: number;
+}> {
+  let upstreamRequests = 0;
+  const provider = createOpenAI({
+    apiKey: 'synthetic-test-key',
+    fetch: async () => {
+      upstreamRequests++;
+      return new Response(upstreamSseBody(chunks), {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      });
+    },
+  });
+  const params = translateRequest(
+    { model: MODEL, messages: [{ role: 'user', content: 'go' }] },
+    '@ai-sdk/openai',
+    { openAiOAuth: true },
+  );
+
+  let raw = '';
+  let error: unknown;
+  try {
+    await streamAnthropicResponse(
+      provider.responses(MODEL), params, MODEL, chunk => { raw += chunk; },
+    );
+  } catch (e) {
+    error = e;
+  }
+  return { events: parseAnthropicSse(raw), raw, error, upstreamRequests };
+}
+
+const thinkingText = (events: AnthropicSseEvent[]): string => events
+  .filter(e => e.event === 'content_block_delta' && e.data.delta?.type === 'thinking_delta')
+  .map(e => e.data.delta.thinking)
+  .join('');
+
+const countStops = (events: AnthropicSseEvent[]): number =>
+  events.filter(e => e.event === 'content_block_stop').length;
+
+describe('thinking-only turn interrupted by a WebSocket transport drop', () => {
+  it('closes no content block, so Claude Code can retry, when several reasoning summaries arrived', async () => {
+    const summaries = ['Weighing the options.', 'Checking the constraints.', 'Picking an approach.'];
+    const { events, error, upstreamRequests } = await relayUpstream([
+      { type: 'response.created', response: { id: 'resp_1', created_at: 0, model: MODEL } },
+      ...reasoningItemChunks('rs_1', summaries),
+      transportDropChunk(12),
+    ]);
+
+    // Harness fidelity: the drop marker survived the real Responses parser and
+    // reached the adapter as a transport failure, not as some generic error.
+    expect(sdkUpstreamErrorDetails(error)?.transportCode).toBe('websocket_transport_error');
+    // clodex itself does not re-issue the turn; the retry is Claude Code's to make.
+    expect(upstreamRequests).toBe(1);
+
+    // The whole point: nothing visible was produced, so the client must still be
+    // in its retryable regime. A single `content_block_stop` moves it to the
+    // thinking-only regime that persists error "unknown" and kills the agent.
+    expect(countStops(events)).toBe(0);
+
+    // Coalescing must not silently drop reasoning the model already streamed.
+    // Consecutive summaries read as paragraphs; the blank line is display-only
+    // and must never reach the strings sent back upstream (see
+    // tests/thinking-roundtrip.test.ts).
+    expect(thinkingText(events)).toBe(
+      'Weighing the options.\n\nChecking the constraints.\n\nPicking an approach.',
+    );
+  });
+
+  it('closes no content block after many complete reasoning items, with no group cap reopening one', async () => {
+    // Twelve COMPLETE, signed reasoning items -- past any plausible group cap.
+    // Two rejected designs would both reopen a block here and put a
+    // thinking-only turn back in the regime that kills the agent: merging per
+    // item (a boundary, and so a `content_block_stop`, between every pair), and
+    // capping the group size with a fallback that starts a fresh block once the
+    // cap is hit. Neither is detectable with the two-item fixtures, because
+    // twelve is the first count that exceeds a cap anyone would pick.
+    const items = Array.from({ length: 12 }, (_, i) => ({
+      id: `rs_${i + 1}`,
+      blob: `encrypted-blob-${i + 1}`,
+      // One summary each, so the ONLY boundaries under test are between items.
+      // Boundaries within an item are already pinned by the first test.
+      text: `Step ${i + 1}.`,
+    }));
+
+    const { events, error } = await relayUpstream([
+      { type: 'response.created', response: { id: 'resp_many', created_at: 0, model: MODEL } },
+      ...items.flatMap((item, i) => reasoningItemChunks(
+        item.id, [item.text], { outputIndex: i, encryptedContent: item.blob },
+      )),
+      transportDropChunk(99),
+    ]);
+
+    expect(sdkUpstreamErrorDetails(error)?.transportCode).toBe('websocket_transport_error');
+    expect(countStops(events)).toBe(0);
+
+    const starts = events.filter(e => e.event === 'content_block_start');
+    expect(starts).toHaveLength(1);
+    expect(starts[0]!.data.content_block.type).toBe('thinking');
+
+    // Every item's reasoning is present, in order, as readable paragraphs.
+    expect(thinkingText(events)).toBe(items.map(item => item.text).join('\n\n'));
+  });
+
+  it('closes no content block when a single reasoning summary arrived', async () => {
+    const { events, error } = await relayUpstream([
+      { type: 'response.created', response: { id: 'resp_2', created_at: 0, model: MODEL } },
+      ...reasoningItemChunks('rs_2', ['Only one summary part.']),
+      transportDropChunk(6),
+    ]);
+
+    expect(sdkUpstreamErrorDetails(error)?.transportCode).toBe('websocket_transport_error');
+    expect(countStops(events)).toBe(0);
+    // A lone summary gets no separator -- the blank line joins summaries, it is
+    // not appended to each one.
+    expect(thinkingText(events)).toBe('Only one summary part.');
+  });
+
+  it('still closes blocks once visible output exists, so a partial turn is finalized', async () => {
+    // Over-scope negative: suppressing every `content_block_stop` would be wrong.
+    // Once a tool_use block is open the client finalizes the partial turn either
+    // way, and the tool block's buffered arguments must still be flushed.
+    const { events, error } = await relayUpstream([
+      { type: 'response.created', response: { id: 'resp_3', created_at: 0, model: MODEL } },
+      ...reasoningItemChunks('rs_3', ['First summary.', 'Second summary.']),
+      {
+        type: 'response.output_item.added',
+        output_index: 1,
+        item: {
+          type: 'function_call',
+          id: 'fc_1',
+          call_id: 'call_1',
+          name: 'Bash',
+          arguments: '',
+        },
+      },
+      {
+        type: 'response.function_call_arguments.delta',
+        item_id: 'fc_1',
+        output_index: 1,
+        delta: '{"command":"ls"}',
+      },
+      transportDropChunk(18),
+    ]);
+
+    expect(sdkUpstreamErrorDetails(error)?.transportCode).toBe('websocket_transport_error');
+    const startedTypes = events
+      .filter(e => e.event === 'content_block_start')
+      .map(e => e.data.content_block.type);
+    expect(startedTypes).toEqual(['thinking', 'tool_use']);
+    expect(countStops(events)).toBe(2);
+    expect(events
+      .filter(e => e.event === 'content_block_delta' && e.data.delta?.type === 'input_json_delta')
+      .map(e => ({ index: e.data.index, json: e.data.delta.partial_json })))
+      .toEqual([{ index: 1, json: '{"command":"ls"}' }]);
+  });
+
+  it('completes a multi-summary thinking turn normally when the stream is not interrupted', async () => {
+    const { events, error } = await relayUpstream([
+      { type: 'response.created', response: { id: 'resp_4', created_at: 0, model: MODEL } },
+      ...reasoningItemChunks('rs_4', ['Part one.', 'Part two.']),
+      {
+        type: 'response.output_item.added',
+        output_index: 1,
+        item: { type: 'message', id: 'msg_1' },
+      },
+      {
+        type: 'response.output_text.delta',
+        item_id: 'msg_1',
+        delta: 'Here is the answer.',
+        logprobs: [],
+      },
+      {
+        type: 'response.completed',
+        response: {
+          id: 'resp_4',
+          created_at: 0,
+          model: MODEL,
+          incomplete_details: null,
+          usage: {
+            input_tokens: 10,
+            input_tokens_details: { cached_tokens: 0 },
+            output_tokens: 5,
+            output_tokens_details: { reasoning_tokens: 3 },
+          },
+        },
+      },
+    ]);
+
+    expect(error).toBeUndefined();
+    expect(thinkingText(events)).toBe('Part one.\n\nPart two.');
+    const text = events
+      .filter(e => e.event === 'content_block_delta' && e.data.delta?.type === 'text_delta')
+      .map(e => e.data.delta.text)
+      .join('');
+    expect(text).toBe('Here is the answer.');
+    expect(events.at(-1)?.event).toBe('message_stop');
+  });
+});

--- a/tests/thinking-continuation.test.ts
+++ b/tests/thinking-continuation.test.ts
@@ -1,0 +1,459 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { createOpenAI } from '@ai-sdk/openai';
+
+// Fake `ws` WebSocket. Records every frame the transport sends, in the order it
+// was sent, so a turn that continues an EARLIER socket is still read in sequence.
+const { fakeSockets, sentFrames } = vi.hoisted(() => ({
+  fakeSockets: [] as FakeWebSocket[],
+  sentFrames: [] as Array<{ socket: FakeWebSocket; payload: Record<string, any> }>,
+}));
+
+class FakeWebSocket extends EventEmitter {
+  url: string;
+  options: { headers?: Record<string, string> };
+  send = vi.fn((data: string) => {
+    sentFrames.push({ socket: this, payload: JSON.parse(data) });
+  });
+  close = vi.fn();
+  constructor(url: string, options: { headers?: Record<string, string> }) {
+    super();
+    this.url = url;
+    this.options = options;
+    fakeSockets.push(this);
+  }
+}
+
+vi.mock('ws', () => ({ WebSocket: FakeWebSocket, default: FakeWebSocket }));
+
+import {
+  createResponsesWebSocketFetch,
+  resetResponsesWebSocketConnectionsForTests,
+  resetReasoningGapWarningsForTests,
+  resetToolArgumentGapWarningsForTests,
+  type ResponsesWebSocketDiagnosticEvent,
+  type ResponsesWebSocketFetchOptions,
+} from '../src/oauth/responses-websocket.js';
+import { streamAnthropicResponse, translateRequest } from '../src/sdk-adapter.js';
+import type { UpgradeAdmission } from '../src/oauth/ws-upgrade-pacer.js';
+
+const WS_URL = 'wss://chatgpt.com/backend-api/codex/responses';
+const MODEL = 'gpt-5.6-sol';
+const SYSTEM = 'You are a coding assistant.';
+
+/** Responses-API item shapes, written from the API contract rather than from clodex. */
+const userItem = (text: string) => ({ role: 'user', content: [{ type: 'input_text', text }] });
+const assistantItem = (text: string) => ({ role: 'assistant', content: [{ type: 'output_text', text }] });
+const summaryItems = (texts: string[]) => texts.map(text => ({ type: 'summary_text', text }));
+const reasoningItem = (id: string, encrypted: string, texts: string[]) => ({
+  type: 'reasoning', id, encrypted_content: encrypted, summary: summaryItems(texts),
+});
+
+// ── upstream producer ────────────────────────────────────────────────────────
+// Real Codex WebSocket event sequences. Every piece of assistant state under
+// test reaches the head through these frames, never by planting an item in a
+// request `input` (which the transport keeps verbatim and so can never diverge).
+
+type ReasoningSummary = string | string[];
+interface ReasoningSpec { itemId: string; encrypted: string; summaries: ReasoningSummary[] }
+
+const reasoningSummaryText = (summary: ReasoningSummary): string =>
+  Array.isArray(summary) ? summary.join('') : summary;
+
+function emitEvent(socket: FakeWebSocket, event: unknown): void {
+  socket.emit('message', Buffer.from(JSON.stringify(event)));
+}
+
+/** One reasoning item; array-valued summaries arrive as several deltas within one part. */
+function reasoningEvents(spec: ReasoningSpec, outputIndex: number): unknown[] {
+  const events: unknown[] = [{
+    type: 'response.output_item.added', output_index: outputIndex,
+    item: { type: 'reasoning', id: spec.itemId, summary: [] },
+  }];
+  spec.summaries.forEach((summary, summaryIndex) => {
+    const deltas = Array.isArray(summary) ? summary : [summary];
+    const text = reasoningSummaryText(summary);
+    if (summaryIndex > 0) {
+      events.push({
+        type: 'response.reasoning_summary_part.added', output_index: outputIndex,
+        item_id: spec.itemId, summary_index: summaryIndex, part: { type: 'summary_text', text: '' },
+      });
+    }
+    for (const delta of deltas) {
+      events.push({
+        type: 'response.reasoning_summary_text.delta', output_index: outputIndex,
+        item_id: spec.itemId, summary_index: summaryIndex, delta,
+      });
+    }
+    events.push({
+      type: 'response.reasoning_summary_part.done', output_index: outputIndex,
+      item_id: spec.itemId, summary_index: summaryIndex, part: { type: 'summary_text', text },
+    });
+  });
+  events.push({
+    type: 'response.output_item.done', output_index: outputIndex,
+    item: {
+      type: 'reasoning', id: spec.itemId, encrypted_content: spec.encrypted,
+      summary: summaryItems(spec.summaries.map(reasoningSummaryText)),
+    },
+  });
+  return events;
+}
+
+function completeResponse(
+  socket: FakeWebSocket,
+  options: { responseId: string; reasoning: ReasoningSpec[]; text: string },
+): void {
+  emitEvent(socket, {
+    type: 'response.created',
+    response: { id: options.responseId, created_at: 0, model: MODEL },
+  });
+  let outputIndex = 0;
+  for (const spec of options.reasoning) {
+    for (const event of reasoningEvents(spec, outputIndex)) emitEvent(socket, event);
+    outputIndex += 1;
+  }
+  const messageId = `msg_${options.responseId}`;
+  emitEvent(socket, {
+    type: 'response.output_item.added', output_index: outputIndex,
+    item: { type: 'message', id: messageId },
+  });
+  emitEvent(socket, { type: 'response.output_text.delta', item_id: messageId, delta: options.text });
+  emitEvent(socket, {
+    type: 'response.output_item.done', output_index: outputIndex,
+    item: { type: 'message', id: messageId },
+  });
+  emitEvent(socket, {
+    type: 'response.completed',
+    response: { id: options.responseId, usage: { input_tokens: 11, output_tokens: 22 } },
+  });
+}
+
+// ── downstream client ────────────────────────────────────────────────────────
+
+/** Rebuild the assistant message from the Anthropic SSE the way a client does. */
+function assembleAssistantMessage(raw: string): { role: 'assistant'; content: Record<string, any>[] } {
+  const content: Record<string, any>[] = [];
+  for (const block of raw.split('\n\n').filter(Boolean)) {
+    const [eventLine, dataLine] = block.split('\n');
+    const event = eventLine!.replace('event: ', '');
+    const data = JSON.parse(dataLine!.replace('data: ', ''));
+    if (event === 'content_block_start') content[data.index] = { ...data.content_block };
+    else if (event === 'content_block_delta') {
+      const target = content[data.index]!;
+      if (data.delta.type === 'thinking_delta') target.thinking += data.delta.thinking;
+      else if (data.delta.type === 'signature_delta') target.signature = data.delta.signature;
+      else if (data.delta.type === 'text_delta') target.text += data.delta.text;
+    }
+  }
+  return { role: 'assistant', content: content.filter(Boolean) };
+}
+
+/** Claude Code 2.1.263 recursively makes every outgoing request string well-formed. */
+function clientToWellFormed<T>(value: T): T {
+  if (typeof value === 'string') return value.toWellFormed() as T;
+  if (Array.isArray(value)) return value.map(clientToWellFormed) as T;
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, child]) => [key, clientToWellFormed(child)]),
+    ) as T;
+  }
+  return value;
+}
+
+interface Client {
+  provider: ReturnType<typeof createOpenAI>;
+  /** The transport's own head decisions, so a test can name the match it got. */
+  headDecisions: ResponsesWebSocketDiagnosticEvent[];
+}
+
+function createClient(options: ResponsesWebSocketFetchOptions): Client {
+  const headDecisions: ResponsesWebSocketDiagnosticEvent[] = [];
+  const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
+    pacer: { admit: async (): Promise<UpgradeAdmission> => ({ kind: 'admitted', waitedMs: 0 }) },
+    onDiagnostic: event => { if (event.event === 'ws_head_decision') headDecisions.push(event); },
+    ...options,
+  });
+  return { provider: createOpenAI({ apiKey: 'test-only', fetch: wsFetch }), headDecisions };
+}
+
+interface Turn {
+  /** The `response.create` frame this turn put on the wire. */
+  payload: Record<string, any>;
+  socket: FakeWebSocket;
+  /** Anthropic SSE accumulated downstream; filled in as the turn streams. */
+  sse: { text: string };
+  finished: Promise<unknown>;
+}
+
+/**
+ * Drive one whole turn through the production stack: translateRequest ->
+ * @ai-sdk/openai Responses -> the real WebSocket transport, stopping once the
+ * request frame is on the wire so the caller can script the upstream response.
+ */
+async function startTurn(
+  provider: ReturnType<typeof createOpenAI>,
+  messages: Record<string, any>[],
+): Promise<Turn> {
+  const framesBefore = sentFrames.length;
+  const socketsBefore = fakeSockets.length;
+  const sse = { text: '' };
+  const params = translateRequest(
+    { model: MODEL, system: SYSTEM, messages } as never,
+    '@ai-sdk/openai',
+    { openAiOAuth: true },
+  );
+  const finished = streamAnthropicResponse(
+    provider.responses(MODEL), params, MODEL, chunk => { sse.text += chunk; },
+  ).then(() => undefined, (error: unknown) => error);
+  let opened = false;
+  await vi.waitFor(() => {
+    if (!opened && fakeSockets.length > socketsBefore) {
+      opened = true;
+      fakeSockets[fakeSockets.length - 1]!.emit('open');
+    }
+    expect(sentFrames.length).toBeGreaterThan(framesBefore);
+  });
+  const frame = sentFrames[framesBefore]!;
+  return { payload: frame.payload, socket: frame.socket, sse, finished };
+}
+
+const THREE = ['weigh the options', 'check the second file', 'settle on a plan'];
+const TWO = ['double-check the edge case', 'confirm the fix'];
+
+describe('OpenAI thinking round-trip through the WebSocket chain', () => {
+  beforeEach(() => {
+    resetResponsesWebSocketConnectionsForTests();
+    resetReasoningGapWarningsForTests();
+    resetToolArgumentGapWarningsForTests();
+    fakeSockets.length = 0;
+    sentFrames.length = 0;
+  });
+
+  it('continues the chain after a multi-item, multi-summary thinking turn', async () => {
+    const client = createClient({ accountId: 'acct-continue' });
+
+    const first = await startTurn(client.provider, [{ role: 'user', content: [{ type: 'text', text: 'go' }] }]);
+    expect(first.payload.previous_response_id).toBeUndefined();
+    completeResponse(first.socket, {
+      responseId: 'resp_1',
+      reasoning: [
+        { itemId: 'rs_1', encrypted: 'enc_one', summaries: THREE },
+        { itemId: 'rs_2', encrypted: 'enc_two', summaries: TWO },
+      ],
+      text: 'answer',
+    });
+    await expect(first.finished).resolves.toBeUndefined();
+
+    // Five summary parts across two items reach the user as one thinking block.
+    const assistant = assembleAssistantMessage(first.sse.text);
+    expect(assistant.content.map(block => block.type)).toEqual(['thinking', 'text']);
+    expect(assistant.content[0]!.thinking).toBe([...THREE, ...TWO].join('\n\n'));
+
+    const second = await startTurn(client.provider, [
+      { role: 'user', content: [{ type: 'text', text: 'go' }] },
+      assistant,
+      { role: 'user', content: [{ type: 'text', text: 'next' }] },
+    ]);
+
+    // The whole prior turn was recognised as already held upstream, so only the
+    // new user message crosses the wire. `exact` rather than `omitted_reasoning`:
+    // the reasoning was echoed and matched, not skipped and forgiven.
+    expect(client.headDecisions.at(-1)).toMatchObject({
+      decision: 'continuation', continuationMatchMode: 'exact',
+    });
+    expect(second.socket).toBe(first.socket);
+    expect(second.payload.previous_response_id).toBe('resp_1');
+    expect(second.payload.input).toEqual([userItem('next')]);
+
+    completeResponse(second.socket, {
+      responseId: 'resp_2', reasoning: [{ itemId: 'rs_3', encrypted: 'enc_three', summaries: ['done'] }], text: 'ok',
+    });
+    await expect(second.finished).resolves.toBeUndefined();
+  });
+
+  it('resends each original reasoning item and ciphertext when the chain has expired', async () => {
+    let now = 1_000;
+    const client = createClient({ accountId: 'acct-expired', idleTtlMs: 100, now: () => now });
+
+    const first = await startTurn(client.provider, [{ role: 'user', content: [{ type: 'text', text: 'go' }] }]);
+    completeResponse(first.socket, {
+      responseId: 'resp_expired',
+      reasoning: [
+        { itemId: 'rs_1', encrypted: 'enc_one', summaries: THREE },
+        { itemId: 'rs_2', encrypted: 'enc_two', summaries: TWO },
+      ],
+      text: 'answer',
+    });
+    await expect(first.finished).resolves.toBeUndefined();
+
+    // The user reads the five summaries as five paragraphs of one thinking block.
+    const assistant = assembleAssistantMessage(first.sse.text);
+    expect(assistant.content.map(block => block.type)).toEqual(['thinking', 'text']);
+    expect(assistant.content[0]!.thinking).toBe([...THREE, ...TWO].join('\n\n'));
+
+    now += 101;
+    const second = await startTurn(client.provider, [
+      { role: 'user', content: [{ type: 'text', text: 'go' }] },
+      assistant,
+      { role: 'user', content: [{ type: 'text', text: 'next' }] },
+    ]);
+
+    // No chain to extend, so the full history goes back up — and it must carry
+    // the two items with their own 3 and 2 summary parts and their own
+    // ciphertext, with none of the display-only paragraph breaks.
+    expect(second.socket).not.toBe(first.socket);
+    expect(second.payload.previous_response_id).toBeUndefined();
+    expect(second.payload.input).toEqual([
+      userItem('go'),
+      reasoningItem('rs_1', 'enc_one', THREE),
+      reasoningItem('rs_2', 'enc_two', TWO),
+      assistantItem('answer'),
+      userItem('next'),
+    ]);
+
+    completeResponse(second.socket, {
+      responseId: 'resp_expired_2', reasoning: [{ itemId: 'rs_9', encrypted: 'enc_nine', summaries: ['done'] }], text: 'ok',
+    });
+    await expect(second.finished).resolves.toBeUndefined();
+  });
+
+  it('resends original Unicode after client sanitization and a full chain reset', async () => {
+    let now = 2_000;
+    const client = createClient({ accountId: 'acct-unicode', idleTtlMs: 100, now: () => now });
+    const originals = ['Valid pair 🚀 survives.', 'Original lone \ud83d survives.'];
+    const streamed: ReasoningSummary[] = [
+      ['Valid pair ', '\ud83d', '\ude80 survives.'],
+      ['Original lone ', '\ud83d', ' survives.'],
+    ];
+
+    const first = await startTurn(client.provider, [
+      { role: 'user', content: [{ type: 'text', text: 'go' }] },
+    ]);
+    completeResponse(first.socket, {
+      responseId: 'resp_unicode',
+      reasoning: [{ itemId: 'rs_unicode', encrypted: 'enc_unicode', summaries: streamed }],
+      text: 'answer',
+    });
+    await expect(first.finished).resolves.toBeUndefined();
+
+    const assistant = assembleAssistantMessage(first.sse.text);
+    expect(assistant.content[0]!.thinking).toBe(originals.join('\n\n'));
+    const sanitized = clientToWellFormed(assistant);
+    expect(sanitized.content[0]!.thinking).toBe(originals.map(text => text.toWellFormed()).join('\n\n'));
+    expect(sanitized.content[0]!.thinking).not.toBe(assistant.content[0]!.thinking);
+    expect(sanitized.content[0]!.signature).toBe(assistant.content[0]!.signature);
+
+    now += 101;
+    const second = await startTurn(client.provider, [
+      { role: 'user', content: [{ type: 'text', text: 'go' }] },
+      sanitized,
+      { role: 'user', content: [{ type: 'text', text: 'next' }] },
+    ]);
+
+    expect(second.socket).not.toBe(first.socket);
+    expect(second.payload.previous_response_id).toBeUndefined();
+    expect(second.payload.input).toEqual([
+      userItem('go'),
+      reasoningItem('rs_unicode', 'enc_unicode', originals),
+      assistantItem('answer'),
+      userItem('next'),
+    ]);
+
+    completeResponse(second.socket, {
+      responseId: 'resp_unicode_2',
+      reasoning: [{ itemId: 'rs_unicode_2', encrypted: 'enc_unicode_2', summaries: ['done'] }],
+      text: 'ok',
+    });
+    await expect(second.finished).resolves.toBeUndefined();
+  });
+
+  it('continues a chain from a transcript recorded before signatures carried item structure', async () => {
+    const client = createClient({ accountId: 'acct-legacy' });
+
+    const first = await startTurn(client.provider, [{ role: 'user', content: [{ type: 'text', text: 'go' }] }]);
+    completeResponse(first.socket, {
+      responseId: 'resp_legacy',
+      reasoning: [{ itemId: 'rs_1', encrypted: 'enc_legacy', summaries: ['weigh the options'] }],
+      text: 'answer',
+    });
+    await expect(first.finished).resolves.toBeUndefined();
+
+    // A session resumed from an older clodex: the thinking block carries the raw
+    // encrypted blob as its signature, with no item or summary structure at all.
+    const legacyAssistant = {
+      role: 'assistant',
+      content: [
+        { type: 'thinking', thinking: 'weigh the options', signature: 'enc_legacy' },
+        { type: 'text', text: 'answer' },
+      ],
+    };
+    const second = await startTurn(client.provider, [
+      { role: 'user', content: [{ type: 'text', text: 'go' }] },
+      legacyAssistant,
+      { role: 'user', content: [{ type: 'text', text: 'next' }] },
+    ]);
+
+    expect(client.headDecisions.at(-1)).toMatchObject({
+      decision: 'continuation', continuationMatchMode: 'exact',
+    });
+    expect(second.socket).toBe(first.socket);
+    expect(second.payload.previous_response_id).toBe('resp_legacy');
+    expect(second.payload.input).toEqual([userItem('next')]);
+
+    completeResponse(second.socket, {
+      responseId: 'resp_legacy_2', reasoning: [{ itemId: 'rs_2', encrypted: 'enc_l2', summaries: ['done'] }], text: 'ok',
+    });
+    await expect(second.finished).resolves.toBeUndefined();
+  });
+
+  it('refuses to continue when the history holds different reasoning under identical text', async () => {
+    const mine = createClient({ accountId: 'acct-mine' });
+    const other = createClient({ accountId: 'acct-other' });
+    const opening = [{ role: 'user', content: [{ type: 'text', text: 'go' }] }];
+
+    const myTurn = await startTurn(mine.provider, opening);
+    completeResponse(myTurn.socket, {
+      responseId: 'resp_mine',
+      reasoning: [{ itemId: 'rs_1', encrypted: 'enc_mine', summaries: THREE }],
+      text: 'answer',
+    });
+    await expect(myTurn.finished).resolves.toBeUndefined();
+
+    // A different conversation reasons to the same visible words under different
+    // ciphertext — the only thing separating the two histories.
+    const otherTurn = await startTurn(other.provider, opening);
+    completeResponse(otherTurn.socket, {
+      responseId: 'resp_other',
+      reasoning: [{ itemId: 'rs_1', encrypted: 'enc_other', summaries: THREE }],
+      text: 'answer',
+    });
+    await expect(otherTurn.finished).resolves.toBeUndefined();
+
+    const foreign = assembleAssistantMessage(otherTurn.sse.text);
+    const own = assembleAssistantMessage(myTurn.sse.text);
+    expect(foreign.content[0]!.thinking).toBe(own.content[0]!.thinking);
+    expect(foreign.content[0]!.signature).not.toBe(own.content[0]!.signature);
+
+    const resumed = await startTurn(mine.provider, [
+      ...opening,
+      foreign,
+      { role: 'user', content: [{ type: 'text', text: 'next' }] },
+    ]);
+
+    expect(mine.headDecisions.at(-1)).toMatchObject({ decision: 'history_mismatch_new_head' });
+    expect(resumed.socket).not.toBe(myTurn.socket);
+    expect(resumed.payload.previous_response_id).toBeUndefined();
+    expect(resumed.payload.input).toEqual([
+      userItem('go'),
+      reasoningItem('rs_1', 'enc_other', THREE),
+      assistantItem('answer'),
+      userItem('next'),
+    ]);
+
+    completeResponse(resumed.socket, {
+      responseId: 'resp_mine_2', reasoning: [{ itemId: 'rs_2', encrypted: 'enc_m2', summaries: ['done'] }], text: 'ok',
+    });
+    await expect(resumed.finished).resolves.toBeUndefined();
+  });
+});

--- a/tests/thinking-roundtrip.test.ts
+++ b/tests/thinking-roundtrip.test.ts
@@ -1,0 +1,305 @@
+import { createOpenAI } from '@ai-sdk/openai';
+import { describe, expect, it } from 'vitest';
+import {
+  generateAnthropicResponse,
+  streamAnthropicResponse,
+  translateRequest,
+} from '../src/sdk-adapter.js';
+
+// Issue #190, second leg: reasoning must survive a full round trip.
+//
+// Turn 1 streams reasoning down to Claude Code as Anthropic thinking blocks.
+// Claude Code persists those blocks verbatim and replays them on turn 2, where
+// clodex has to rebuild the ORIGINAL upstream reasoning items -- same item ids,
+// same encrypted blobs, and the same summary strings, split exactly where the
+// model split them.
+//
+// Two independent contracts are in play and they must not be confused:
+//
+//   * DOWNSTREAM (what a human reads) -- consecutive summaries of one reasoning
+//     item render as readable paragraphs, separated by a blank line.
+//   * OUTBOUND (what goes back upstream) -- the summary strings must be the
+//     EXACT originals, with no display separator baked into them.
+//
+// `store: false` is set unconditionally for `@ai-sdk/openai`
+// (`thinkingProviderOptions`, src/provider-factory.ts:1173-1179), so the SDK
+// takes its grouping branch: reasoning parts carrying `providerOptions.openai.itemId`
+// are merged into one `reasoning` input item per id, each part appended as its
+// own `summary_text` entry, with `encrypted_content` taken from the part options
+// (node_modules/@ai-sdk/openai/dist/index.js:3964-4013).
+//
+// Both legs run the real production path. Only `fetch` is replaced -- the seam
+// the OAuth WebSocket transport occupies in `src/provider-factory.ts:196-205`.
+// Nothing here imports the pending envelope module; these assertions are the
+// wire contract, so they stay valid whatever representation carries it.
+
+const MODEL = 'gpt-5.6-sol';
+
+const ITEM_ONE = {
+  id: 'rs_1',
+  blob: 'encrypted-reasoning-blob-one',
+  // The second summary arrives as two deltas, which must concatenate with NO
+  // separator -- that is what distinguishes a delta boundary from a summary
+  // boundary.
+  summaries: [['Weighing the options.'], ['Checking the ', 'constraints.']],
+  expected: ['Weighing the options.', 'Checking the constraints.'],
+};
+
+const ITEM_TWO = {
+  id: 'rs_2',
+  blob: 'encrypted-reasoning-blob-two',
+  summaries: [['Listing the files.'], ['Reading the adapter.']],
+  expected: ['Listing the files.', 'Reading the adapter.'],
+};
+
+interface AnthropicSseEvent { event: string; data: Record<string, any> }
+interface AnthropicBlock { type: string; thinking?: string; signature?: string; text?: string }
+
+function upstreamSseBody(chunks: unknown[]): string {
+  return chunks.map(chunk => `data: ${JSON.stringify(chunk)}\n\n`).join('');
+}
+
+/**
+ * One reasoning output item. The encrypted blob is absent while the item streams
+ * and only appears on `response.output_item.done`, which is how the Responses API
+ * delivers it -- and it is that chunk which makes the SDK emit `reasoning-end`
+ * carrying `reasoningEncryptedContent` for every summary still open
+ * (node_modules/@ai-sdk/openai/dist/index.js:7329-7347).
+ */
+function reasoningItemChunks(
+  item: { id: string; blob: string; summaries: string[][] },
+  outputIndex: number,
+): unknown[] {
+  const chunks: unknown[] = [{
+    type: 'response.output_item.added',
+    output_index: outputIndex,
+    item: { type: 'reasoning', id: item.id, encrypted_content: null },
+  }];
+  item.summaries.forEach((deltas, summaryIndex) => {
+    if (summaryIndex > 0) {
+      chunks.push({
+        type: 'response.reasoning_summary_part.added',
+        item_id: item.id,
+        summary_index: summaryIndex,
+      });
+    }
+    for (const delta of deltas) {
+      chunks.push({
+        type: 'response.reasoning_summary_text.delta',
+        item_id: item.id,
+        summary_index: summaryIndex,
+        delta,
+      });
+    }
+    chunks.push({
+      type: 'response.reasoning_summary_part.done',
+      item_id: item.id,
+      summary_index: summaryIndex,
+    });
+  });
+  chunks.push({
+    type: 'response.output_item.done',
+    output_index: outputIndex,
+    item: { type: 'reasoning', id: item.id, encrypted_content: item.blob },
+  });
+  return chunks;
+}
+
+function turnOneChunks(): unknown[] {
+  return [
+    { type: 'response.created', response: { id: 'resp_1', created_at: 0, model: MODEL } },
+    ...reasoningItemChunks(ITEM_ONE, 0),
+    ...reasoningItemChunks(ITEM_TWO, 1),
+    {
+      type: 'response.output_item.added',
+      output_index: 2,
+      item: { type: 'message', id: 'msg_1' },
+    },
+    {
+      type: 'response.output_text.delta',
+      item_id: 'msg_1',
+      delta: 'All done.',
+      logprobs: [],
+    },
+    {
+      type: 'response.output_item.done',
+      output_index: 2,
+      item: { type: 'message', id: 'msg_1' },
+    },
+    {
+      type: 'response.completed',
+      response: {
+        id: 'resp_1',
+        created_at: 0,
+        model: MODEL,
+        incomplete_details: null,
+        usage: {
+          input_tokens: 10,
+          input_tokens_details: { cached_tokens: 0 },
+          output_tokens: 5,
+          output_tokens_details: { reasoning_tokens: 4 },
+        },
+      },
+    },
+  ];
+}
+
+function parseAnthropicSse(raw: string): AnthropicSseEvent[] {
+  return raw.split('\n\n').filter(Boolean).map(block => {
+    const [eventLine, dataLine] = block.split('\n');
+    return {
+      event: eventLine.replace('event: ', ''),
+      data: JSON.parse(dataLine.replace('data: ', '')),
+    };
+  });
+}
+
+/**
+ * Rebuild the assistant message from the downstream SSE the way Claude Code
+ * does: accumulate each block's deltas and keep the signature it was closed
+ * with. Turn 2 replays exactly this.
+ */
+function assistantBlocksFromSse(events: AnthropicSseEvent[]): AnthropicBlock[] {
+  const blocks = new Map<number, AnthropicBlock>();
+  for (const e of events) {
+    const index = e.data.index as number;
+    if (e.event === 'content_block_start') {
+      blocks.set(index, e.data.content_block.type === 'thinking'
+        ? { type: 'thinking', thinking: '', signature: '' }
+        : { type: 'text', text: '' });
+    } else if (e.event === 'content_block_delta') {
+      const block = blocks.get(index);
+      if (!block) continue;
+      const delta = e.data.delta;
+      if (delta.type === 'thinking_delta') block.thinking += delta.thinking;
+      else if (delta.type === 'signature_delta') block.signature = delta.signature;
+      else if (delta.type === 'text_delta') block.text += delta.text;
+    }
+  }
+  return [...blocks.values()];
+}
+
+/** Turn 1: stream a canned upstream response through the production path. */
+async function runTurnOne(): Promise<AnthropicSseEvent[]> {
+  const provider = createOpenAI({
+    apiKey: 'synthetic-test-key',
+    fetch: async () => new Response(upstreamSseBody(turnOneChunks()), {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    }),
+  });
+  const params = translateRequest(
+    { model: MODEL, messages: [{ role: 'user', content: 'go' }] },
+    '@ai-sdk/openai',
+    { openAiOAuth: true },
+  );
+  let raw = '';
+  await streamAnthropicResponse(
+    provider.responses(MODEL), params, MODEL, chunk => { raw += chunk; },
+  );
+  return parseAnthropicSse(raw);
+}
+
+/** Turn 2: replay the assistant turn and capture what actually goes upstream. */
+async function runTurnTwo(assistant: AnthropicBlock[]): Promise<any[]> {
+  let sentInput: any[] = [];
+  const provider = createOpenAI({
+    apiKey: 'synthetic-test-key',
+    fetch: async (_input, init) => {
+      sentInput = JSON.parse(String(init?.body)).input ?? [];
+      return new Response(JSON.stringify({
+        id: 'resp_2',
+        model: MODEL,
+        output: [],
+        usage: {
+          input_tokens: 1,
+          input_tokens_details: { cached_tokens: 0 },
+          output_tokens: 0,
+          output_tokens_details: { reasoning_tokens: 0 },
+        },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    },
+  });
+  const params = translateRequest({
+    model: MODEL,
+    messages: [
+      { role: 'user', content: 'go' },
+      { role: 'assistant', content: assistant as any },
+      { role: 'user', content: 'keep going' },
+    ],
+  }, '@ai-sdk/openai', { openAiOAuth: true });
+
+  await generateAnthropicResponse(provider.responses(MODEL), params, MODEL);
+  return sentInput;
+}
+
+const thinkingBlocks = (events: AnthropicSseEvent[]): AnthropicBlock[] =>
+  assistantBlocksFromSse(events).filter(b => b.type === 'thinking');
+
+describe('reasoning round trip across two turns', () => {
+  it('replays each reasoning item upstream with its original id, blob and exact summary strings', async () => {
+    const sentInput = await runTurnTwo(assistantBlocksFromSse(await runTurnOne()));
+
+    const reasoning = sentInput.filter(item => item?.type === 'reasoning');
+    expect(reasoning).toEqual([
+      {
+        type: 'reasoning',
+        id: ITEM_ONE.id,
+        encrypted_content: ITEM_ONE.blob,
+        summary: ITEM_ONE.expected.map(text => ({ type: 'summary_text', text })),
+      },
+      {
+        type: 'reasoning',
+        id: ITEM_TWO.id,
+        encrypted_content: ITEM_TWO.blob,
+        summary: ITEM_TWO.expected.map(text => ({ type: 'summary_text', text })),
+      },
+    ]);
+  });
+
+  it('never leaks the display separator into the strings it sends upstream', async () => {
+    const sentInput = await runTurnTwo(assistantBlocksFromSse(await runTurnOne()));
+
+    const summaryTexts = sentInput
+      .filter(item => item?.type === 'reasoning')
+      .flatMap(item => (item.summary ?? []).map((s: { text: string }) => s.text));
+
+    expect(summaryTexts.length).toBeGreaterThan(0);
+    for (const text of summaryTexts) expect(text).not.toContain('\n\n');
+    // Deltas inside one summary part concatenate with nothing between them.
+    expect(summaryTexts).toContain('Checking the constraints.');
+  });
+
+  it('renders uninterrupted reasoning as readable paragraphs in ONE block, whatever the item count', async () => {
+    // Deliberately NOT one block per reasoning item. A block boundary between
+    // two reasoning items would emit a `content_block_stop`, which is exactly
+    // the regime-3 signal that kills a thinking-only turn (issue #190). So while
+    // no visible content has started, consecutive reasoning items -- however
+    // many -- must stay inside a single thinking block. The upstream item
+    // boundaries are carried by the signature envelope, not by block structure,
+    // which the outbound tests above prove is enough to rebuild both items.
+    const events = await runTurnOne();
+    const blocks = thinkingBlocks(events);
+
+    expect(blocks.map(b => b.thinking)).toEqual([
+      'Weighing the options.\n\nChecking the constraints.\n\nListing the files.\n\nReading the adapter.',
+    ]);
+
+    // The block boundary that does exist is the one before visible text, and it
+    // must come after all the reasoning.
+    const order = events
+      .filter(e => e.event === 'content_block_start' || e.event === 'content_block_stop')
+      .map(e => e.event === 'content_block_start' ? `start:${e.data.content_block.type}` : 'stop');
+    expect(order).toEqual(['start:thinking', 'stop', 'start:text', 'stop']);
+  });
+
+  it('closes every thinking block with a non-empty signature so none is dropped on replay', async () => {
+    // The SDK silently discards a reasoning part that carries neither an item id
+    // nor an encrypted blob (index.js:4013-4031), so an unsigned thinking block
+    // is reasoning the user paid for and never gets back.
+    const blocks = thinkingBlocks(await runTurnOne());
+
+    expect(blocks.length).toBeGreaterThan(0);
+    for (const block of blocks) expect(block.signature).not.toBe('');
+  });
+});


### PR DESCRIPTION
Claude Code agents can now retry OpenAI connection drops that happen while the model is still thinking, instead of failing after several thinking summaries. The displayed thinking is combined without changing the original reasoning sent back to OpenAI on later turns, preserving the data needed for conversation continuation and prompt caching.

Fixes #190.

## Root cause

In Claude Code 2.1.263, a completed thinking block can disable the mid-stream overloaded-error retry path even when no text or tool output has begun. The previous fix left the currently open thinking block unfinished on a WebSocket transport error, but earlier summaries had already completed separate blocks. Multiple reasoning summaries or items therefore still caused fatal thinking-only 1006 failures.

## Change

- Keep consecutive OpenAI reasoning summaries/items in one live Anthropic thinking block. Close normally on text, tools, or successful completion; retain the open block on a marked thinking-only WebSocket transport failure.
- Carry original SDK reasoning parts in a versioned JSON envelope in the existing thinking signature: item IDs, original summary strings, and encrypted content. Claude Code persists and echoes that signature; no separate durable registry is required.
- Restore the original parts before SDK request serialization. The SDK reconstructs the original summary groups and final per-item ciphertext; display separators never enter upstream summaries.
- Preserve originals independently of display text, including when Claude Code applies Unicode sanitization. Valid surrogate pairs split across stream deltas remain intact.
- Normalize reasoning IDs only in continuation-comparison copies, since expected-assistant snapshots already omit them. Outgoing IDs remain unchanged.
- Keep legacy raw signatures readable. Omit malformed/unsupported owned envelopes rather than sending them as provider ciphertext.

This does not add artificial text blocks, replay already-emitted text/tool calls, change retry budgets, or change the existing omission of reasoning from non-streaming responses.

## Verification

Local environment: Node 24.14.1, pnpm 10.34.5, AI SDK 7.0.22, and @ai-sdk/openai 4.0.11. The final gate used fresh `CLODEX_HOME`, `CLAUDE_CODE_ENTRYPOINT=cli`, and unreachable upper/lower HTTP/HTTPS/ALL proxy variables.

- `pnpm typecheck`, all **112 test files / 2,434 tests**, and `pnpm build` passed.
- An earlier full run hit an unchanged credential-helper test's PID-file timing failure (empty PID read). An unchanged rerun and the final gate passed; no credential-helper changes are included.
- Baseline reproduction: three summaries produced two completed thinking blocks; twelve signed reasoning items produced eleven. The fix emits zero completed thinking blocks on those thinking-only failures.
- Integration tests drive the real OpenAI SDK and adapter, replacing only fetch or sockets. They verify exact original wire items, exact continuation matching, expired-connection full resends, legacy behavior, different-cipher head rejection, tool closure, and Unicode restoration after recursive client sanitization.
- Four-lens independent review and behavioral mutations completed without unresolved blockers. Removing coalescing/restoration, reopening per item, changing original text, dropping IDs, misattributing ciphertext, removing comparison normalization, weakening envelope validation, and prematurely sanitizing deltas all failed full-file tests. The final Unicode integration case also fails independently under display-based restoration and incorrect per-delta separators.

### Manual runtime evidence

With actual Claude Code **2.1.263** and isolated local replay servers:

- Baseline: one streaming request, fatal exit 1 on 1006.
- Fix: three identical streaming attempts followed by successful genuine non-streaming fallback, exit 0. A separate healthy-second-attempt scenario finished after two streaming requests.
- An actual tool continuation preserved the opaque signature through Claude Code's Unicode sanitizer and reconstructed original summaries/ciphertexts in the next SDK-generated request.

With live OpenAI **gpt-5.6-luna**, medium effort, synthetic input only, the final build completed exactly two calls. After a controlled socket reset, the second request used `store:false`, no `previous_response_id`, and full history containing all original IDs, five summaries grouped across three reasoning items, and exact final ciphertexts. OpenAI completed successfully.

## Boundaries and rollback

The guarantee covers SDK-visible summary text, grouping, IDs, and encrypted content, not output-only fields such as `status`. The final live check proves vendor acceptance and exact reconstruction, **not a production cache-rate improvement**. An earlier seven-call cache experiment used a predecessor envelope implementation and is not attributed to this final build.

Signatures increase client-request/transcript size because they retain original text and SDK-exposed intermediate ciphertexts. Only final per-item ciphertext goes upstream; the envelope itself does not. Older clodex builds cannot decode these new signatures and may forward them as invalid provider ciphertext: resume new transcripts with an envelope-aware build rather than downgrading the bridge. Existing legacy transcripts remain readable, but already-lost summaries cannot be recovered retroactively.
