### PR TITLE
fix(openai): keep the Artifact tool working on OpenAI models instead of failing every request

### DIFF
--- a/.claude/docs/translation.md
+++ b/.claude/docs/translation.md
@@ -36,6 +36,14 @@ hand-rolled per-provider translation. Preserved hard-won behavior:
   change non-streaming responses' existing omission of reasoning, or the transport's prohibition
   on replaying already-emitted model output. The guarantee covers SDK-visible summary text,
   grouping and encrypted content, not output-only fields the SDK omits (such as `status`).
+- **A tool schema's `pattern` is dropped when Python's `re` cannot compile it**, on every route but
+  Anthropic-format ones (`src/tool-schema-sanitize.ts`). OpenAI validates each `pattern` with Python
+  — its 400 reads `'<pattern>' is not a 'regex'`, jsonschema's format-checker wording — while Claude
+  Code writes ECMAScript. Artifact's `field` constraint uses `\p{Cc}`, Python answers `bad escape
+  \p`, and since the tool ships on every request the session was dead from `hello` onward (#194).
+  The dialects agree on lookaround, so Artifact's `(?!...)` patterns are left alone; only `\p{}`,
+  `\P{}`, JS named groups and `\k<>` backreferences go. Losing the keyword loses a hint, not a
+  guard — Claude Code still validates tool input against its own schema before executing.
 - **Images in `tool_result` are lifted out of the text-only function-output channel** and delivered
   as real image parts on the following user message. Inline, a JSON.stringify'd base64 screenshot
   tokenizes at ~1.5 chars/token — 200k+ tokens per screenshot, killing agents with "Prompt is too

--- a/src/sdk-adapter.ts
+++ b/src/sdk-adapter.ts
@@ -19,6 +19,8 @@ import {
 } from './provider-factory.js';
 import { resolveUpstreamTools } from './tool-search.js';
 import { sanitizeToolInput } from './tool-input-sanitize.js';
+import { sanitizeToolSchema } from './tool-schema-sanitize.js';
+import { VERTEX_ANTHROPIC_NPM } from './constants.js';
 import type { AnthropicRequestMessage, AnthropicToolDefinition } from './proxy-types.js';
 import { anthropicErrorType, sdkUpstreamErrorDetails, upstreamHttpStatus } from './upstream-error.js';
 import { upstreamRequestBudget } from './upstream-retry.js';
@@ -456,12 +458,15 @@ function toolRequiredProps(tools?: SdkCallParams['tools']): Map<string, Readonly
 
 export function translateTools(anthropicTools?: AnthropicTool[], npm?: string): Record<string, ReturnType<typeof tool>> | undefined {
   if (!anthropicTools?.length) return undefined;
+  // Anthropic-format routes take Claude Code's ECMAScript patterns as written;
+  // every other provider validates them in a dialect that may not compile them.
+  const anthropicFormat = npm === '@ai-sdk/anthropic' || npm === VERTEX_ANTHROPIC_NPM;
   const tools: Record<string, ReturnType<typeof tool>> = {};
   for (const t of anthropicTools) {
     if (!t.name || !t.input_schema) continue;
     tools[t.name] = tool({
       description: t.description ?? '',
-      inputSchema: jsonSchema(t.input_schema),
+      inputSchema: jsonSchema(anthropicFormat ? t.input_schema : sanitizeToolSchema(t.input_schema)),
       strict: npm === '@ai-sdk/openai' ? false : undefined,
     });
   }

--- a/src/tool-schema-sanitize.ts
+++ b/src/tool-schema-sanitize.ts
@@ -1,0 +1,92 @@
+// tool-schema-sanitize.ts — drop `pattern` constraints a non-Anthropic provider cannot compile.
+//
+// Leaf module by design: it imports nothing from src/, like its sibling
+// tool-input-sanitize.ts, so the translation path can use it from anywhere in
+// the import graph.
+//
+// Claude Code writes its tool schemas in the ECMAScript regex dialect. OpenAI
+// validates every `pattern` by compiling it with Python's `re` — the 400 reads
+// `Invalid schema for function 'X': '<pattern>' is not a 'regex'`, which is
+// jsonschema's format-checker wording — and the two dialects do not agree.
+// Claude Code 2.1.266's Artifact tool spells its `field` constraint with
+// Unicode property escapes (`[^\p{Cc}\p{Cf}\p{Zl}\p{Zp}...]`), Python's `re`
+// answers `bad escape \p`, and every OpenAI-routed request 400s before the
+// model sees the turn — the tool is sent on every request, so the session is
+// dead from `hello` onward (#194).
+//
+// The dialects agree on more than the issue reports assume: lookahead and
+// lookbehind compile in both, so Artifact's `collection` pattern
+// (`^(?!\.\.?(?:\/|$))...`) is left alone. Only the constructs Python actually
+// rejects are removed, and only the `pattern` keyword goes — never the property
+// it constrains, and never a wildcard in its place, so nothing in the schema
+// starts claiming something untrue.
+//
+// Dropping the keyword loses a hint, not a guard: Claude Code validates tool
+// input against its own schema before executing, so a value the pattern would
+// have rejected still fails there, as a tool_result the model can retry.
+
+/**
+ * True when Python's `re` can compile `pattern`, which is what OpenAI's schema
+ * validator does with it. Scans rather than pattern-matches so an escaped
+ * backslash (`\\p`, a literal backslash followed by `p` — compilable) is not
+ * mistaken for the Unicode property escape `\p` that is not.
+ */
+export function isCompatiblePattern(pattern: string): boolean {
+  for (let i = 0; i < pattern.length; i++) {
+    if (pattern[i] === '\\') {
+      const next = pattern[i + 1];
+      // \p{...} / \P{...}: Python has no Unicode property escapes ("bad escape \p").
+      if ((next === 'p' || next === 'P') && pattern[i + 2] === '{') return false;
+      // \k<name>: a JS named backreference; Python spells it (?P=name).
+      if (next === 'k' && pattern[i + 2] === '<') return false;
+      i++; // an escaped character never starts a construct
+      continue;
+    }
+    // (?<name>...): a JS named group; Python spells it (?P<name>...). Lookbehind
+    // is (?<= / (?<! in both dialects and stays.
+    if (
+      pattern[i] === '(' && pattern[i + 1] === '?' && pattern[i + 2] === '<'
+      && pattern[i + 3] !== '=' && pattern[i + 3] !== '!'
+    ) return false;
+  }
+  return true;
+}
+
+/**
+ * Return `schema` with every `pattern` keyword Python's `re` cannot compile
+ * removed, at any depth (`properties`, `items`, `anyOf`, `$defs`, …).
+ *
+ * A `pattern` whose value is not a string is a property of the tool named
+ * `pattern` (Grep has one) rather than the keyword, and is walked like any
+ * other subschema. Unchanged subtrees are returned by identity, so a schema
+ * with nothing to strip — every schema but Artifact's, today — is not rebuilt.
+ */
+export function sanitizeToolSchema(schema: unknown): unknown {
+  if (Array.isArray(schema)) {
+    let changed = false;
+    const out = schema.map(entry => {
+      const next = sanitizeToolSchema(entry);
+      changed ||= next !== entry;
+      return next;
+    });
+    return changed ? out : schema;
+  }
+  if (!schema || typeof schema !== 'object') return schema;
+
+  let changed = false;
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(schema as Record<string, unknown>)) {
+    if (key === 'pattern' && typeof value === 'string') {
+      if (!isCompatiblePattern(value)) {
+        changed = true;
+        continue;
+      }
+      out[key] = value;
+      continue;
+    }
+    const next = sanitizeToolSchema(value);
+    changed ||= next !== value;
+    out[key] = next;
+  }
+  return changed ? out : schema;
+}

--- a/tests/sdk-adapter.test.ts
+++ b/tests/sdk-adapter.test.ts
@@ -110,6 +110,77 @@ describe('translateTools', () => {
     ]);
   });
 
+  it('sends Artifact without the pattern OpenAI cannot compile (#194)', async () => {
+    // Claude Code 2.1.266 sends this schema on every request; OpenAI compiles
+    // each `pattern` with Python's `re`, answers `bad escape \p`, and 400s the
+    // turn before the model sees it.
+    const fieldPattern = String.raw`^(?!__.*__$)[^\p{Cc}\p{Cf}\p{Zl}\p{Zp}"\\./[\]]{1,200}$`;
+    const collectionPattern = String.raw`^(?!\.\.?(?:\/|$))[A-Za-z0-9_\-.~:@+]{1,200}$`;
+    const requestBodies: unknown[] = [];
+    const provider = createOpenAI({
+      apiKey: 'synthetic-test-key',
+      fetch: async (_input, init) => {
+        requestBodies.push(JSON.parse(String(init?.body)));
+        return new Response(JSON.stringify({
+          id: 'resp_synthetic',
+          model: 'gpt-5.6-terra',
+          output: [],
+          usage: {
+            input_tokens: 1,
+            input_tokens_details: { cached_tokens: 0 },
+            output_tokens: 0,
+            output_tokens_details: { reasoning_tokens: 0 },
+          },
+        }), { status: 200, headers: { 'content-type': 'application/json' } });
+      },
+    });
+    const params = translateRequest({
+      model: 'gpt-5.6-terra',
+      messages: [{ role: 'user', content: 'hello' }],
+      tools: [{
+        name: 'Artifact',
+        description: 'Render an HTML file to an Artifact',
+        input_schema: {
+          type: 'object',
+          properties: {
+            field: { type: 'string', pattern: fieldPattern },
+            collection: { type: 'string', pattern: collectionPattern },
+          },
+        },
+      }],
+    }, '@ai-sdk/openai', { openAiOAuth: true });
+
+    await generateAnthropicResponse(
+      provider.responses('gpt-5.6-terra'), params, 'gpt-5.6-terra');
+
+    expect(requestBodies).toEqual([
+      expect.objectContaining({
+        tools: [{
+          type: 'function',
+          name: 'Artifact',
+          description: 'Render an HTML file to an Artifact',
+          strict: false,
+          parameters: {
+            type: 'object',
+            properties: {
+              field: { type: 'string' },
+              collection: { type: 'string', pattern: collectionPattern },
+            },
+          },
+        }],
+      }),
+    ]);
+  });
+
+  it('leaves the pattern intact on an Anthropic-format route', () => {
+    const pattern = String.raw`^\p{L}+$`;
+    const input_schema = { type: 'object', properties: { field: { type: 'string', pattern } } };
+    for (const npm of ['@ai-sdk/anthropic', '@ai-sdk/google-vertex/anthropic']) {
+      const tools = translateTools([{ name: 'Artifact', input_schema }], npm);
+      expect((tools!.Artifact.inputSchema as { jsonSchema: unknown }).jsonSchema).toBe(input_schema);
+    }
+  });
+
   it('returns undefined for empty/missing tools', () => {
     expect(translateTools(undefined)).toBeUndefined();
     expect(translateTools([])).toBeUndefined();

--- a/tests/tool-schema-sanitize.test.ts
+++ b/tests/tool-schema-sanitize.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { isCompatiblePattern, sanitizeToolSchema } from '../src/tool-schema-sanitize.js';
+
+// Claude Code 2.1.266's Artifact schema, verbatim: `field` is the pattern OpenAI
+// rejected in #194, `collection` the lookahead that compiles in both dialects.
+const ARTIFACT_FIELD_PATTERN = String.raw`^(?!__.*__$)[^\p{Cc}\p{Cf}\p{Zl}\p{Zp}"\\./[\]]{1,200}$`;
+const ARTIFACT_COLLECTION_PATTERN =
+  String.raw`^(?!\.\.?(?:\/|$))[A-Za-z0-9_\-.~:@+]{1,200}(?:\/(?!\.\.?(?:\/|$))[A-Za-z0-9_\-.~:@+]{1,200}){0,14}$`;
+
+describe('isCompatiblePattern', () => {
+  it('rejects the Unicode property escapes Python cannot compile', () => {
+    expect(isCompatiblePattern(ARTIFACT_FIELD_PATTERN)).toBe(false);
+    expect(isCompatiblePattern(String.raw`^\p{L}+$`)).toBe(false);
+    expect(isCompatiblePattern(String.raw`^\P{Nd}+$`)).toBe(false);
+  });
+
+  it('keeps lookaround, which both dialects compile', () => {
+    expect(isCompatiblePattern(ARTIFACT_COLLECTION_PATTERN)).toBe(true);
+    expect(isCompatiblePattern(String.raw`^(?!__)(?<=a)(?<!b)x$`)).toBe(true);
+  });
+
+  it('rejects JS-only named groups and backreferences', () => {
+    expect(isCompatiblePattern(String.raw`(?<year>\d{4})`)).toBe(false);
+    expect(isCompatiblePattern(String.raw`(?<y>a)\k<y>`)).toBe(false);
+  });
+
+  it('reads an escaped backslash as a literal, not as the start of an escape', () => {
+    // `\\p{2}` is a backslash repeated twice then `{2}` — compilable in both.
+    expect(isCompatiblePattern(String.raw`^a\\p{2}$`)).toBe(true);
+    expect(isCompatiblePattern(String.raw`^[A-Za-z0-9_=-]{1,4096}$`)).toBe(true);
+  });
+});
+
+describe('sanitizeToolSchema', () => {
+  it('drops only the incompatible pattern, keeping the property it constrained', () => {
+    const sanitized = sanitizeToolSchema({
+      type: 'object',
+      properties: {
+        field: { type: 'string', pattern: ARTIFACT_FIELD_PATTERN, description: 'one plain key' },
+        collection: { type: 'string', pattern: ARTIFACT_COLLECTION_PATTERN, maxLength: 1000 },
+      },
+      required: ['field'],
+    });
+    expect(sanitized).toEqual({
+      type: 'object',
+      properties: {
+        field: { type: 'string', description: 'one plain key' },
+        collection: { type: 'string', pattern: ARTIFACT_COLLECTION_PATTERN, maxLength: 1000 },
+      },
+      required: ['field'],
+    });
+  });
+
+  it('strips at any depth', () => {
+    const sanitized = sanitizeToolSchema({
+      type: 'object',
+      properties: {
+        contract: { anyOf: [{ const: 'latest' }, { type: 'string', pattern: String.raw`^\p{Nd}+$` }] },
+        writes: { type: 'array', items: { properties: { doc_id: { pattern: String.raw`\p{L}` } } } },
+      },
+    }) as any;
+    expect(sanitized.properties.contract.anyOf).toEqual([{ const: 'latest' }, { type: 'string' }]);
+    expect(sanitized.properties.writes.items.properties.doc_id).toEqual({});
+  });
+
+  it('leaves a tool parameter named `pattern` alone', () => {
+    // Grep's `pattern` is a property name, not the JSON Schema keyword.
+    const grep = {
+      type: 'object',
+      properties: { pattern: { type: 'string', description: 'the regex to search for' } },
+      required: ['pattern'],
+    };
+    expect(sanitizeToolSchema(grep)).toBe(grep);
+  });
+
+  it('returns a schema with nothing to strip by identity', () => {
+    const schema = { type: 'object', properties: { path: { type: 'string', pattern: '^/' } } };
+    expect(sanitizeToolSchema(schema)).toBe(schema);
+  });
+
+  it('passes through values that are not schemas', () => {
+    expect(sanitizeToolSchema(undefined)).toBeUndefined();
+    expect(sanitizeToolSchema('pattern')).toBe('pattern');
+  });
+});


### PR DESCRIPTION
Claude Code 2.1.266 ships a tool called Artifact, and OpenAI rejected the description of one of its
inputs. Because that tool is sent with *every* request, every OpenAI-routed session died on the
first message — `hello` came back as `API Error: 400 ... is not a 'regex'`. The only workaround was
`CLAUDE_CODE_DISABLE_ARTIFACT=1`, which turns the tool off. clodex now removes just the piece OpenAI
cannot read, and leaves the tool working.

Fixes #194.

## User-visible failure

Any `clodex:openai*` model, any prompt, from the first turn:

```
API Error: 400 Invalid schema for function 'Artifact':
'^(?!__.*__$)[^\\p{Cc}\\p{Cf}\\p{Zl}\\p{Zp}"\\\\./[\\]]{1,200}$' is not a 'regex'. (HTTP 400)
```

Reported on Windows / Node 22.19.0 / Claude Code 2.1.266 against `gpt-5.6-terra` and
`gpt-5.6-luna`; reproduced here on macOS against `gpt-6-astra` (see Evidence).

## Root cause

OpenAI validates every `pattern` in a function schema by compiling it **with Python's `re`** — the
message `'<pattern>' is not a 'regex'` is jsonschema's format-checker wording — while Claude Code
writes its schemas in the ECMAScript dialect. The two dialects diverge on Unicode property escapes:

```
>>> re.compile(r'^(?!__.*__$)[^\p{Cc}\p{Cf}\p{Zl}\p{Zp}"\\./[\]]{1,200}$')
re.error: bad escape \p at position 14
```

**The lookahead is not the problem**, contrary to the issue text and to the other reports it cites.
Python compiles `(?!...)` and `(?<=...)` fine; only `\p{}` / `\P{}` fail. Artifact's `collection`,
`doc_id` and `contract` patterns are all lookahead-bearing and all compile — of its 8 patterns,
exactly 1 is rejected.

Reachability: `translateTools` in `src/sdk-adapter.ts` is the single translation path for every
non-Anthropic provider, Claude Code sends its full tool list on every request, and the 400 is
returned before any model output. Nothing about the route is optional or vestigial — it is the
default proxy-mode path for a `clodex:` model id, and the OAuth (`openai-oauth`) transport reads its
tools from the payload this function produces.

## The change

`src/tool-schema-sanitize.ts` (new, leaf module — imports nothing from `src/`, like its sibling
`tool-input-sanitize.ts`):

- `isCompatiblePattern` scans the pattern character by character so an escaped backslash (`\\p`, a
  literal backslash followed by `p`, which Python compiles) is not mistaken for the escape `\p`,
  which it does not. It rejects `\p{}`, `\P{}`, JS named groups `(?<name>` and `\k<>`
  backreferences, and deliberately keeps lookbehind, spelled the same in both dialects.
- `sanitizeToolSchema` walks the schema to any depth and removes only the offending `pattern`
  keyword. The property it constrained stays; no wildcard is substituted, so nothing in the schema
  starts claiming something untrue. Unchanged subtrees are returned by identity.

`src/sdk-adapter.ts` applies it in `translateTools` for every route **except** Anthropic-format ones
(`@ai-sdk/anthropic`, `VERTEX_ANTHROPIC_NPM`), which take Claude Code's patterns as written.

Losing the keyword loses a hint, not a guard: Claude Code validates tool input against its own
schema before executing, so a value the pattern would have rejected still fails there — as a
tool_result the model can retry, not a dead session.

### Deliberately left out

- **`translateOpenAiRequest` in `src/openai-adapter.ts`** is the only sibling arrival point for the
  same signal (`jsonSchema(` appears in exactly two places in `src/`; this is the other). It is not
  sanitized here: those schemas come from a third-party client that chose OpenAI format, not from
  Claude Code, the function has no `npm` in scope to gate on, and nothing has reported it. Two lines
  if you want it.
- **No rewrite of `\p{Cc}` into explicit ranges.** `\p{Cf}` alone is a scattered set across five
  planes; a hand-expanded approximation would be a new source of truth that silently drifts from
  Unicode.

## Tests

`tests/tool-schema-sanitize.test.ts` (new, 9) — the real Artifact `field` and `collection` patterns,
escaped-backslash handling, named groups vs. lookbehind, nesting through `anyOf`/`items`, a tool
parameter *named* `pattern` (Grep has one) surviving untouched, and identity for schemas with
nothing to strip.

`tests/sdk-adapter.test.ts` (2) — the regression test the issue asked for: Artifact through
`translateRequest` into a real `@ai-sdk/openai` provider with a fake `fetch`, asserting the
**serialized wire body**, plus a negative proving an Anthropic-format route keeps the pattern by
identity.

**Feature-deletion mutation**, full-file runs (not `-t`): making `sanitizeToolSchema` a pass-through
turns 3 tests red across both files — the two content assertions and the wire-body regression. The
identity/negative tests stay green under the mutation, as they should.

## Evidence

Environment: macOS 24.6.0, **Node 22.19.0** (the repo's `.nvmrc` pins 24.14.1, which is not
installed on this machine; 22 is what `engines` allows and what the reporter runs), pnpm 10.34.5,
no ambient proxy vars.

- **Wire A/B against the live API, identical payload.** Two `clodex server --endpoint --saved
  --no-discovery` instances, one from this branch (port 17699) and one from the published 2.11.4
  (17700), same POST carrying Artifact's real `field` and `collection` patterns to
  `gpt-6-astra`:
  - stock 2.11.4 → `400 Invalid schema for function 'Artifact': ... is not a 'regex'` — the
    reported error, verbatim
  - this branch → `200`, `{"type":"text","text":"ok"}`
- **Python-`re` check on the whole Artifact schema:** 8 patterns before sanitizing, 1 rejected;
  7 after, 0 rejected. The one dropped is the reported `field` pattern.
- **Product smoke test, proxy mode (default), real Claude Code 2.1.266:**
  `clodex claude -- --model terra -p 'Reply with exactly: MODEL-OK'` → `MODEL-OK`.
  Anthropic passthrough leg: `--model claude-sonnet-5` → `PASSTHROUGH-OK`.
- Standard gate: `pnpm typecheck && pnpm test && pnpm build` green — 113 files, 2445 tests — and
  green again under `CLODEX_HOME="$(mktemp -d)"`. `git merge-tree` against current `main` is clean;
  no open PR I can see touches `sdk-adapter.ts`'s tool path.

### What I could not verify

- The claim that OpenAI validates with Python's `re` is an inference from the error wording plus the
  observed accept/reject split (lookahead accepted, `\p{}` rejected). It is not from OpenAI
  documentation. The fix does not depend on the inference being the whole story — it depends on the
  observed A/B.
- Only ChatGPT/Codex OAuth credentials were available. `@ai-sdk/openai` API-key, Azure,
  openai-compatible, Google, Mistral and xAI routes were not exercised; all take the same code path
  and can only lose a `pattern` they never accepted.

### Failure and rollback

If `sanitizeToolSchema` were wrong in either direction the blast radius is one JSON Schema keyword:
too eager drops a constraint the model was only ever *advised* by, too shy restores today's 400. It
holds no state, touches nothing in `~/.clodex`, and needs no migration. Reverting the two-line
`translateTools` change restores the previous behavior exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPewWu4VNToxMtFRtPibjn
