### PR TITLE
fix(openai): stop tools with unusual regexes from failing every request in the session

### DIFF
--- a/.claude/docs/translation.md
+++ b/.claude/docs/translation.md
@@ -82,9 +82,10 @@ hand-rolled per-provider translation. Preserved hard-won behavior:
   quantified (`(?<=a+)`) — is legal in ECMAScript and rejected by Python (`look-behind requires
   fixed-width pattern`); recognising it needs a real regex parser, so it is not detected and would
   still 400. The scanner is narrower than Python in a few other spots too (`[\w-.]`, the JS `[^]`
-  idiom, bare `\pL`, backreferences to a group that does not exist). None of the 245 regexes in the
-  Claude Code 2.1.266 bundle that reach a tool schema hits any of them; they are reachable only from
-  a hand-written MCP or plugin schema. And OpenAI **does** reject lookaround outright on its strict
+  idiom, bare `\pL`, backreferences to a group that does not exist). Only 14 distinct `pattern`
+  values reach a built-in tool schema in 2.1.266 and none hits any of these — Artifact's `field` is
+  the sole Python-incompatible one — so they are reachable only from a hand-written MCP or plugin
+  schema. And OpenAI **does** reject lookaround outright on its strict
   structured-output path (`vercel/ai#16021`, `SmartBear/smartbear-mcp#491` — reports, not verified
   here; the vercel maintainers could not reproduce it synthetically). clodex does not meet that
   path: `translateTools` sends `strict: false` on `@ai-sdk/openai`, covering both OpenAI routes, and

--- a/.claude/docs/translation.md
+++ b/.claude/docs/translation.md
@@ -36,14 +36,61 @@ hand-rolled per-provider translation. Preserved hard-won behavior:
   change non-streaming responses' existing omission of reasoning, or the transport's prohibition
   on replaying already-emitted model output. The guarantee covers SDK-visible summary text,
   grouping and encrypted content, not output-only fields the SDK omits (such as `status`).
-- **A tool schema's `pattern` is dropped when Python's `re` cannot compile it**, on every route but
-  Anthropic-format ones (`src/tool-schema-sanitize.ts`). OpenAI validates each `pattern` with Python
-  — its 400 reads `'<pattern>' is not a 'regex'`, jsonschema's format-checker wording — while Claude
-  Code writes ECMAScript. Artifact's `field` constraint uses `\p{Cc}`, Python answers `bad escape
-  \p`, and since the tool ships on every request the session was dead from `hello` onward (#194).
-  The dialects agree on lookaround, so Artifact's `(?!...)` patterns are left alone; only `\p{}`,
-  `\P{}`, JS named groups and `\k<>` backreferences go. Losing the keyword loses a hint, not a
-  guard — Claude Code still validates tool input against its own schema before executing.
+- **A tool schema's regexes are dropped when they hit a known Python incompatibility**, on every
+  route but Anthropic-format ones (`src/tool-schema-sanitize.ts`). OpenAI rejects the same
+  constructs python-jsonschema does — its 400 reads `'<pattern>' is not a 'regex'`, that library's
+  format-checker wording — while Claude Code's built-ins are written in ECMAScript. (That is
+  behaviour observed from outside, not knowledge of what OpenAI runs.) Artifact's `field` constraint
+  uses `\p{Cc}`, Python answers `bad escape \p`, and since Artifact ships on every request, every
+  request 400d and the session was dead from `hello` onward (#194).
+  Two positions are regex-valued and both are checked: the `pattern` keyword, and every **key** of
+  `patternProperties` (the 2020-12 applicator vocabulary gives `patternProperties.propertyNames`
+  `format: "regex"`; a bad key returns the same 400). An incompatible `patternProperties` key is
+  dropped with its subschema, since the key *is* the constraint. What goes: `\p{}`/`\P{}`,
+  `\u{}`/`\x{}`, JS named groups and `\k<>` backreferences.
+
+  **What a dropped constraint costs depends on the tool.** Claude Code runs `inputSchema.safeParse`
+  before executing, but only a built-in whose Zod schema carries the same constraint is still
+  guarded — Artifact's `field` is. A registered tool's `inputSchema` is `c({}).passthrough()` with
+  the real schema parked in `inputJSONSchema`, and the MCP path checks only that `required` keys are
+  present. So for an MCP or plugin tool the regex is a genuinely lost guard, not a lost hint. It is
+  still the better trade — the alternative is a 400 that kills the session — but it is why nothing
+  is dropped that does not have to be. (Verified in the 2.1.266 bundle, not inferred.)
+
+  **Sanitizing only ever loosens**, and `patternProperties` is the one place that needed care to
+  keep it that way. A dropped entry was the only thing *admitting* its keys, so with a sibling
+  `additionalProperties` or `unevaluatedProperties` the removal would turn those keys from permitted
+  into forbidden and the tool would stop accepting input it used to — verified with Ajv, not
+  reasoned about. So dropping an entry drops the sibling closure keyword too (`true` is already the
+  permissive default and is left alone). Nothing else in the walk can narrow: removing `pattern`
+  only widens, and no other keyword is edited.
+
+  The walk follows only **declared schema positions**. `const`, `enum`, `default` and `examples`
+  hold instance *data*, not rules, so they are opaque: inside `const` or `enum` a `pattern` member
+  is a value the schema requires and deleting it changes which instances validate, while `default`
+  and `examples` are annotations that simply must not be rewritten as schemas. This is also why a tool
+  parameter *named* `pattern` (Grep has one) needs no special case: it lives under `properties`,
+  whose keys the walk never inspects.
+
+  The walked keyword set is the **union across every draft**, not one of them: OpenAI's validator
+  compiled regexes under `$defs` (2019+), `prefixItems` (2020) and array-form `items` (<=2019) in
+  the same session, so a keyword left out is a regex that reaches the far side and 400s. That is not
+  hypothetical — an earlier revision of this walk omitted `dependencies` and `contentSchema`, and
+  both were confirmed live as 400s.
+
+  Known limits, all deliberate. **Variable-width lookbehind** — alternated (`(?<=a|bb)`) or
+  quantified (`(?<=a+)`) — is legal in ECMAScript and rejected by Python (`look-behind requires
+  fixed-width pattern`); recognising it needs a real regex parser, so it is not detected and would
+  still 400. The scanner is narrower than Python in a few other spots too (`[\w-.]`, the JS `[^]`
+  idiom, bare `\pL`, backreferences to a group that does not exist). None of the 245 regexes in the
+  Claude Code 2.1.266 bundle that reach a tool schema hits any of them; they are reachable only from
+  a hand-written MCP or plugin schema. And OpenAI **does** reject lookaround outright on its strict
+  structured-output path (`vercel/ai#16021`, `SmartBear/smartbear-mcp#491` — reports, not verified
+  here; the vercel maintainers could not reproduce it synthetically). clodex does not meet that
+  path: `translateTools` sends `strict: false` on `@ai-sdk/openai`, covering both OpenAI routes, and
+  `@ai-sdk/openai-compatible` (OpenCode Go) goes to Chat Completions, non-strict by default. The
+  explicit opt-out is load-bearing for keeping Artifact's `collection` lookahead in the payload — if
+  it is ever removed, lookaround must be stripped here too.
 - **Images in `tool_result` are lifted out of the text-only function-output channel** and delivered
   as real image parts on the following user message. Inline, a JSON.stringify'd base64 screenshot
   tokenizes at ~1.5 chars/token — 200k+ tokens per screenshot, killing agents with "Prompt is too

--- a/src/tool-schema-sanitize.ts
+++ b/src/tool-schema-sanitize.ts
@@ -4,89 +4,268 @@
 // tool-input-sanitize.ts, so the translation path can use it from anywhere in
 // the import graph.
 //
-// Claude Code writes its tool schemas in the ECMAScript regex dialect. OpenAI
-// validates every `pattern` by compiling it with Python's `re` — the 400 reads
-// `Invalid schema for function 'X': '<pattern>' is not a 'regex'`, which is
-// jsonschema's format-checker wording — and the two dialects do not agree.
-// Claude Code 2.1.266's Artifact tool spells its `field` constraint with
-// Unicode property escapes (`[^\p{Cc}\p{Cf}\p{Zl}\p{Zp}...]`), Python's `re`
-// answers `bad escape \p`, and every OpenAI-routed request 400s before the
-// model sees the turn — the tool is sent on every request, so the session is
-// dead from `hello` onward (#194).
+// Claude Code writes its built-in tool schemas in the ECMAScript regex dialect
+// (an MCP or plugin tool's schema comes from its author, in whatever dialect
+// they wrote). OpenAI rejects every regex-valued position that python-jsonschema
+// would: the 400 reads `Invalid schema for function 'X': '<pattern>' is not a
+// 'regex'`, that library's format-checker wording, and locally its checker is a
+// bare `re.compile`. That is behavioural evidence about the far side, not
+// source-level knowledge of what it runs. Claude Code 2.1.266's Artifact tool
+// spells its `field` constraint with Unicode property escapes
+// (`[^\p{Cc}\p{Cf}\p{Zl}\p{Zp}...]`), Python answers `bad escape \p`, and every
+// request carrying that tool 400s before the model sees the turn — Artifact
+// ships on every request, so the session was dead from `hello` onward (#194).
 //
-// The dialects agree on more than the issue reports assume: lookahead and
-// lookbehind compile in both, so Artifact's `collection` pattern
-// (`^(?!\.\.?(?:\/|$))...`) is left alone. Only the constructs Python actually
-// rejects are removed, and only the `pattern` keyword goes — never the property
-// it constrains, and never a wildcard in its place, so nothing in the schema
-// starts claiming something untrue.
+// Two regex-valued positions exist, and the far side compiles both: the
+// `pattern` keyword, and every **key** of `patternProperties`
+// (`patternProperties.propertyNames` carries `format: "regex"` in the 2020-12
+// applicator vocabulary, and a bad key returns the same `is not a 'regex'`
+// message). Only those two positions are edited, and only the constraint goes —
+// never the property it constrains, and never a wildcard in its place. The
+// schema the provider sees does become more permissive than the one Claude Code
+// wrote: that is unavoidable, since the alternative is a 400. What it must not
+// do is become *less* permissive.
 //
-// Dropping the keyword loses a hint, not a guard: Claude Code validates tool
-// input against its own schema before executing, so a value the pattern would
-// have rejected still fails there, as a tool_result the model can retry.
+// **Sanitizing only ever loosens.** That is the invariant the rest of this
+// module protects, and `patternProperties` is the one place where removing a
+// constraint would otherwise tighten: with a sibling `additionalProperties` or
+// `unevaluatedProperties`, the dropped entry was the only thing *admitting* its
+// keys, so removing it alone turns them from permitted into forbidden and the
+// tool stops accepting input it used to. When an entry is dropped, the sibling
+// closure keyword is therefore dropped too (`true` is already the permissive
+// default and is left alone).
+//
+// The walk follows only **declared schema positions** (`properties` values,
+// `items`, `anyOf`, `$defs`, …). Keywords that hold instance *data* rather than
+// rules — `const`, `enum`, `default`, `examples` — are opaque. Inside `const`
+// or `enum` a `pattern` member is a value the schema requires, so deleting it
+// changes which instances validate; `default` and `examples` are annotations,
+// where the reason is simply that instance data is not a schema and must not be
+// rewritten as one.
+//
+// Simple lookahead and fixed-width lookbehind compile in both dialects, so
+// Artifact's `collection` pattern (`^(?!\.\.?(?:\/|$))...`) is left alone.
+// Two caveats, both deliberate:
+//   - **Variable-width lookbehind** — alternated (`(?<=a|bb)`) or quantified
+//     (`(?<=a+)`, `(?<=\d{2,3})`) — is legal in ECMAScript (ES2018) and
+//     rejected by Python's `re` ("look-behind requires fixed-width pattern").
+//     Recognising it needs a real regex parser, so this module does not, and
+//     such a pattern would still 400. None of the 245 regexes in Claude Code
+//     2.1.266's bundle that feed a tool schema uses one.
+//   - The scanner is narrower than Python in other ways too — `[\w-.]` (a
+//     shorthand escape as a range endpoint) and the JS `[^]` idiom compile in
+//     ECMAScript and are rejected by Python. Those are reachable only from a
+//     hand-written MCP or plugin schema, are not new here, and widening the
+//     scanner to cover them is tracked separately.
+//   - **Lookaround is reported rejected on OpenAI's strict structured-output
+//     path** (vercel/ai#16021, SmartBear/smartbear-mcp#491 — reports, not
+//     something verified here; the vercel maintainers could not reproduce it
+//     from a synthetic case). clodex does not meet that path: `translateTools`
+//     sends `strict: false` on `@ai-sdk/openai`, which covers both OpenAI
+//     routes, and `@ai-sdk/openai-compatible` goes to Chat Completions, which
+//     is non-strict by default. The explicit opt-out is load-bearing for
+//     keeping Artifact's `collection` lookahead in the payload; if it is ever
+//     removed, lookaround has to be stripped here too.
+//
+// What dropping a constraint costs depends on the tool, and the comfortable
+// version of this claim is wrong. Claude Code does `inputSchema.safeParse` before
+// executing, but only a built-in whose Zod schema carries the same constraint is
+// still guarded — Artifact's `field` is (`field: s().regex(...)` in the 2.1.266
+// bundle). A registered tool gets `c({}).passthrough()` as its `inputSchema` with
+// the real schema parked in `inputJSONSchema`, and the MCP path checks only that
+// `required` keys are present. So for an MCP or plugin tool the dropped regex is
+// a genuinely lost guard, not just a lost hint: nothing revalidates it, and a
+// bad value reaches the tool's own handler. That is still the better trade — the
+// constraint was going to 400 the whole session otherwise — but it is a real
+// cost, and it is why nothing here drops more than it must.
 
 /**
- * True when Python's `re` can compile `pattern`, which is what OpenAI's schema
- * validator does with it. Scans rather than pattern-matches so an escaped
- * backslash (`\\p`, a literal backslash followed by `p` — compilable) is not
- * mistaken for the Unicode property escape `\p` that is not.
+ * True when `pattern` contains none of the Python-incompatible constructs this
+ * targeted scanner recognizes — it is not a full `re` compatibility oracle (see
+ * the variable-width-lookbehind caveat in the module header). Scans rather than
+ * pattern-matches so an escaped backslash (`\\p`, a literal backslash followed
+ * by `p` — compilable) is not mistaken for the Unicode property escape `\p`
+ * that is not.
  */
 export function isCompatiblePattern(pattern: string): boolean {
+  // ECMAScript reading of `[`/`]`: an unescaped `]` closes the class, so `[]` is
+  // the empty class. Escapes are still scanned inside a class — Artifact's
+  // `[^\p{Cc}...]` is exactly that — but group syntax is not, so a class merely
+  // *listing* `(`, `?` and `<` is not a named group.
+  let inClass = false;
   for (let i = 0; i < pattern.length; i++) {
-    if (pattern[i] === '\\') {
+    const ch = pattern[i];
+    if (ch === '\\') {
       const next = pattern[i + 1];
       // \p{...} / \P{...}: Python has no Unicode property escapes ("bad escape \p").
-      if ((next === 'p' || next === 'P') && pattern[i + 2] === '{') return false;
-      // \k<name>: a JS named backreference; Python spells it (?P=name).
+      // \u{...}: the same u-flag family, and RegExp.source carries it into the
+      // schema with the flag lost. Python answers "incomplete escape \u".
+      // \x{...} is not the same family — it throws under `u`, and in a legacy
+      // regex it means "x, 41 times", not a code point. It is stripped because a
+      // schema author can still write the string and Python rejects it outright.
+      if (
+        (next === 'p' || next === 'P' || next === 'u' || next === 'x')
+        && pattern[i + 2] === '{'
+      ) return false;
+      // \k<name>: a JS named backreference; Python spells it (?P=name) and
+      // answers "bad escape \k".
       if (next === 'k' && pattern[i + 2] === '<') return false;
       i++; // an escaped character never starts a construct
+      continue;
+    }
+    if (inClass) {
+      if (ch === ']') inClass = false;
+      continue;
+    }
+    if (ch === '[') {
+      inClass = true;
       continue;
     }
     // (?<name>...): a JS named group; Python spells it (?P<name>...). Lookbehind
     // is (?<= / (?<! in both dialects and stays.
     if (
-      pattern[i] === '(' && pattern[i + 1] === '?' && pattern[i + 2] === '<'
+      ch === '(' && pattern[i + 1] === '?' && pattern[i + 2] === '<'
       && pattern[i + 3] !== '=' && pattern[i + 3] !== '!'
     ) return false;
   }
   return true;
 }
 
+// Keywords whose value is a subschema, or an array of subschemas (draft-04/7
+// spell `items` both ways). `sanitizeSchema` handles either shape.
+//
+// The membership is the union across every draft, not one of them: OpenAI's
+// validator is not a single draft — one session compiled regexes under `$defs`
+// (2019+), `prefixItems` (2020) and array-form `items` (<=2019) alike — so a
+// keyword omitted here is a regex that reaches the far side and 400s.
+const SUBSCHEMA_KEYWORDS = new Set([
+  'items', 'prefixItems', 'additionalItems', 'unevaluatedItems',
+  'additionalProperties', 'unevaluatedProperties', 'propertyNames', 'contains',
+  'anyOf', 'oneOf', 'allOf', 'not', 'if', 'then', 'else', 'contentSchema',
+]);
+
+// Keywords whose value is an object mapping *names* to subschemas. The keys are
+// property names, never regexes, so they are never inspected — which is why a
+// tool parameter named `pattern` (Grep has one) needs no special case.
+// `dependencies` is draft-07's union of the two: each value is either a
+// subschema or a plain array of property names, and `sanitizeSchema` returns
+// the array form by identity.
+const SUBSCHEMA_MAP_KEYWORDS = new Set([
+  'properties', '$defs', 'definitions', 'dependentSchemas', 'dependencies',
+]);
+
 /**
- * Return `schema` with every `pattern` keyword Python's `re` cannot compile
- * removed, at any depth (`properties`, `items`, `anyOf`, `$defs`, …).
+ * Return `schema` with the regexes `isCompatiblePattern` recognizes as
+ * Python-incompatible removed, everywhere the walk reaches: the `pattern`
+ * keyword, and any `patternProperties` entry whose key is incompatible (the
+ * entry goes with its key, since the key is the constraint). "Everywhere the
+ * walk reaches" is the allowlist below, not literally every nested object —
+ * and neither the scanner nor the allowlist claims to be exhaustive; see the
+ * module header for the known gaps.
  *
- * A `pattern` whose value is not a string is a property of the tool named
- * `pattern` (Grep has one) rather than the keyword, and is walked like any
- * other subschema. Unchanged subtrees are returned by identity, so a schema
- * with nothing to strip — every schema but Artifact's, today — is not rebuilt.
+ * `schema` is never mutated. Unchanged subtrees are returned by identity, so a
+ * schema with nothing to strip is not rebuilt.
  */
 export function sanitizeToolSchema(schema: unknown): unknown {
-  if (Array.isArray(schema)) {
+  return sanitizeSchema(schema);
+}
+
+function sanitizeSchema(node: unknown): unknown {
+  if (Array.isArray(node)) {
     let changed = false;
-    const out = schema.map(entry => {
-      const next = sanitizeToolSchema(entry);
+    const out = node.map(entry => {
+      const next = sanitizeSchema(entry);
       changed ||= next !== entry;
       return next;
     });
-    return changed ? out : schema;
+    return changed ? out : node;
   }
-  if (!schema || typeof schema !== 'object') return schema;
+  if (!node || typeof node !== 'object') return node;
+
+  const record = node as Record<string, unknown>;
+  // Dropping a `patternProperties` entry removes the only thing that made its
+  // keys *allowed*, so a sibling `additionalProperties`/`unevaluatedProperties`
+  // would silently turn them from permitted into forbidden — a narrower schema,
+  // which is exactly what this module promises never to produce. Decide it
+  // before the walk, because the closure keyword can appear either side of
+  // `patternProperties` in key order.
+  const patternProps = 'patternProperties' in record
+    ? sanitizePatternProperties(record.patternProperties)
+    : undefined;
+  const openClosure = patternProps?.dropped === true;
 
   let changed = false;
-  const out: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(schema as Record<string, unknown>)) {
-    if (key === 'pattern' && typeof value === 'string') {
-      if (!isCompatiblePattern(value)) {
+  const entries: [string, unknown][] = [];
+  for (const [key, value] of Object.entries(record)) {
+    if (key === 'patternProperties' && patternProps) {
+      changed ||= patternProps.value !== value;
+      entries.push([key, patternProps.value]);
+      continue;
+    }
+    // `true` is already the permissive default; anything else can only forbid
+    // or re-constrain a key the dropped entry used to admit.
+    if (
+      openClosure && value !== true
+      && (key === 'additionalProperties' || key === 'unevaluatedProperties')
+    ) {
+      changed = true;
+      continue;
+    }
+    if (key === 'pattern') {
+      // A non-string here is a malformed `pattern` keyword, not a schema. It
+      // is left exactly as written — this module's job is to remove regexes the
+      // far side cannot compile, not to repair schemas — and it is not walked.
+      if (typeof value === 'string' && !isCompatiblePattern(value)) {
         changed = true;
         continue;
       }
-      out[key] = value;
+      entries.push([key, value]);
       continue;
     }
-    const next = sanitizeToolSchema(value);
+    let next = value;
+    if (SUBSCHEMA_KEYWORDS.has(key)) next = sanitizeSchema(value);
+    else if (SUBSCHEMA_MAP_KEYWORDS.has(key)) next = sanitizeSchemaMap(value);
     changed ||= next !== value;
-    out[key] = next;
+    entries.push([key, next]);
   }
-  return changed ? out : schema;
+  // fromEntries defines rather than assigns, so a schema property named
+  // `__proto__` survives the copy instead of hitting Object.prototype's setter.
+  return changed ? Object.fromEntries(entries) : node;
+}
+
+/** Walk the values of a name-keyed subschema map; leave every key untouched. */
+function sanitizeSchemaMap(node: unknown): unknown {
+  if (!node || typeof node !== 'object' || Array.isArray(node)) return node;
+  let changed = false;
+  const entries: [string, unknown][] = [];
+  for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+    const next = sanitizeSchema(value);
+    changed ||= next !== value;
+    entries.push([key, next]);
+  }
+  return changed ? Object.fromEntries(entries) : node;
+}
+
+/**
+ * Drop entries whose key is a regex recognized as Python-incompatible; walk
+ * the rest.
+ * `dropped` tells the caller whether a key went, so it can open a sibling
+ * closure keyword rather than let the removal narrow the schema.
+ */
+function sanitizePatternProperties(node: unknown): { value: unknown; dropped: boolean } {
+  if (!node || typeof node !== 'object' || Array.isArray(node)) return { value: node, dropped: false };
+  let changed = false;
+  let dropped = false;
+  const entries: [string, unknown][] = [];
+  for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+    if (!isCompatiblePattern(key)) {
+      changed = true;
+      dropped = true;
+      continue;
+    }
+    const next = sanitizeSchema(value);
+    changed ||= next !== value;
+    entries.push([key, next]);
+  }
+  return { value: changed ? Object.fromEntries(entries) : node, dropped };
 }

--- a/src/tool-schema-sanitize.ts
+++ b/src/tool-schema-sanitize.ts
@@ -50,13 +50,14 @@
 //     (`(?<=a+)`, `(?<=\d{2,3})`) — is legal in ECMAScript (ES2018) and
 //     rejected by Python's `re` ("look-behind requires fixed-width pattern").
 //     Recognising it needs a real regex parser, so this module does not, and
-//     such a pattern would still 400. None of the 245 regexes in Claude Code
-//     2.1.266's bundle that feed a tool schema uses one.
+//     such a pattern would still 400. Only 14 distinct `pattern` values reach a
+//     built-in tool schema in 2.1.266, and none of them uses one — Artifact's
+//     `field` is the only Python-incompatible value among them.
 //   - The scanner is narrower than Python in other ways too — `[\w-.]` (a
 //     shorthand escape as a range endpoint) and the JS `[^]` idiom compile in
-//     ECMAScript and are rejected by Python. Those are reachable only from a
-//     hand-written MCP or plugin schema, are not new here, and widening the
-//     scanner to cover them is tracked separately.
+//     ECMAScript and are rejected by Python. None of those 14 values hits one
+//     either; they are reachable only from a hand-written MCP or plugin schema,
+//     are not new here, and widening the scanner is tracked separately.
 //   - **Lookaround is reported rejected on OpenAI's strict structured-output
 //     path** (vercel/ai#16021, SmartBear/smartbear-mcp#491 — reports, not
 //     something verified here; the vercel maintainers could not reproduce it

--- a/tests/tool-schema-sanitize.test.ts
+++ b/tests/tool-schema-sanitize.test.ts
@@ -14,7 +14,7 @@ describe('isCompatiblePattern', () => {
     expect(isCompatiblePattern(String.raw`^\P{Nd}+$`)).toBe(false);
   });
 
-  it('keeps lookaround, which both dialects compile', () => {
+  it('keeps simple lookahead and fixed-width lookbehind, which both dialects compile', () => {
     expect(isCompatiblePattern(ARTIFACT_COLLECTION_PATTERN)).toBe(true);
     expect(isCompatiblePattern(String.raw`^(?!__)(?<=a)(?<!b)x$`)).toBe(true);
   });
@@ -25,9 +25,38 @@ describe('isCompatiblePattern', () => {
   });
 
   it('reads an escaped backslash as a literal, not as the start of an escape', () => {
-    // `\\p{2}` is a backslash repeated twice then `{2}` — compilable in both.
+    // `\\p{2}` is an escaped backslash then `p{2}` — a literal backslash
+    // followed by two `p`s, compilable in both. Not the `\p{...}` escape.
     expect(isCompatiblePattern(String.raw`^a\\p{2}$`)).toBe(true);
     expect(isCompatiblePattern(String.raw`^[A-Za-z0-9_=-]{1,4096}$`)).toBe(true);
+  });
+
+  it('rejects the braced u/x escapes, which are the same u-flag family as the property escapes', () => {
+    // Python: "incomplete escape \u at position 1". The u flag that makes these
+    // legal in ECMAScript is lost when RegExp.source lands in the schema.
+    expect(isCompatiblePattern(String.raw`^\u{41}+$`)).toBe(false);
+    expect(isCompatiblePattern(String.raw`^\x{41}+$`)).toBe(false);
+    // `\u{}` is genuinely the u-flag form; `\x{}` is not (under `u` it throws,
+    // and in a legacy regex it reads as "x, 41 times"). It goes because an
+    // author can still write the string and Python rejects it outright.
+    // The braceless forms are spelled identically in both dialects and stay.
+    expect(isCompatiblePattern(String.raw`^A\x41$`)).toBe(true);
+  });
+
+  it('rejects the `\\k<name>` source shape even with no named group to trip on first', () => {
+    // Isolates the \k guard: `(?<y>a)\k<y>` would be rejected by the named-group
+    // check alone, so it pins nothing. Without a named group and outside `u`
+    // mode this is a legacy identity escape rather than a live backreference,
+    // but it is the JS-only spelling either way, and Python rejects it.
+    expect(isCompatiblePattern(String.raw`a\k<y>`)).toBe(false);
+  });
+
+  it('reads `(?<` inside a character class as three literal characters', () => {
+    // A class listing `(`, `?` and `<` is not a named group. Python compiles it.
+    expect(isCompatiblePattern(String.raw`^[(?<]+$`)).toBe(true);
+    expect(isCompatiblePattern(String.raw`^[]<]?(?<name>x)$`)).toBe(false);
+    // ...and a class is not a blanket amnesty: \p{} inside one still goes.
+    expect(isCompatiblePattern(String.raw`^[^\p{Cc}]$`)).toBe(false);
   });
 });
 
@@ -82,4 +111,245 @@ describe('sanitizeToolSchema', () => {
     expect(sanitizeToolSchema(undefined)).toBeUndefined();
     expect(sanitizeToolSchema('pattern')).toBe('pattern');
   });
+
+  it('drops a patternProperties entry whose KEY is a regex Python cannot compile', () => {
+    // The key is itself a regex the far side compiles: jsonschema's 2020-12
+    // applicator vocabulary gives `patternProperties.propertyNames` the
+    // `format: "regex"` check, and a bad key returns the same
+    // `'<key>' is not a 'regex'` 400 that a bad `pattern` value does.
+    const sanitized = sanitizeToolSchema({
+      type: 'object',
+      patternProperties: {
+        [String.raw`^\p{L}+$`]: { type: 'string' },
+        '^[a-z_]+$': { type: 'number' },
+      },
+    });
+    expect(sanitized).toEqual({
+      type: 'object',
+      patternProperties: { '^[a-z_]+$': { type: 'number' } },
+    });
+  });
+
+  it('opens a sibling closure when it drops a patternProperties entry, so the schema never narrows', () => {
+    // Without this, `{"abc":"ok"}` goes from accepted to REJECTED: the dropped
+    // entry was the only thing admitting those keys, and additionalProperties
+    // then forbids them. Sanitizing must only ever loosen.
+    const bad = String.raw`^\p{L}+$`;
+    expect(sanitizeToolSchema({
+      type: 'object', patternProperties: { [bad]: { type: 'string' } }, additionalProperties: false,
+    })).toEqual({ type: 'object', patternProperties: {} });
+    // A closure that re-constrains rather than forbids narrows just as much.
+    expect(sanitizeToolSchema({
+      type: 'object', patternProperties: { [bad]: { type: 'string' } }, additionalProperties: { type: 'number' },
+    })).toEqual({ type: 'object', patternProperties: {} });
+    expect(sanitizeToolSchema({
+      type: 'object', patternProperties: { [bad]: { type: 'string' } }, unevaluatedProperties: false,
+    })).toEqual({ type: 'object', patternProperties: {} });
+    // `true` is already the permissive default, so it is left as written.
+    expect(sanitizeToolSchema({
+      type: 'object', patternProperties: { [bad]: { type: 'string' } }, additionalProperties: true,
+    })).toEqual({ type: 'object', patternProperties: {}, additionalProperties: true });
+  });
+
+  it('leaves a closure keyword alone when no patternProperties entry was dropped', () => {
+    // Over-scope negative: only a dropped KEY may open the closure. A stripped
+    // `pattern`, or a bad key one level down, must not touch this schema's own
+    // additionalProperties.
+    expect(sanitizeToolSchema({
+      type: 'object',
+      properties: { f: { type: 'string', pattern: String.raw`^\p{L}+$` } },
+      patternProperties: { '^x': { type: 'string' } },
+      additionalProperties: false,
+    })).toEqual({
+      type: 'object',
+      properties: { f: { type: 'string' } },
+      patternProperties: { '^x': { type: 'string' } },
+      additionalProperties: false,
+    });
+    const nested = sanitizeToolSchema({
+      type: 'object',
+      additionalProperties: false,
+      properties: { inner: { patternProperties: { [String.raw`^\p{L}+$`]: {} }, additionalProperties: false } },
+    }) as any;
+    expect(nested.additionalProperties).toBe(false);      // outer untouched
+    expect(nested.properties.inner.additionalProperties).toBeUndefined(); // inner opened
+  });
+
+  it('drops a bad patternProperties key nested under $defs', () => {
+    const sanitized = sanitizeToolSchema({
+      $defs: { bag: { type: 'object', patternProperties: { [String.raw`^\p{Nd}$`]: { type: 'string' } } } },
+      $ref: '#/$defs/bag',
+    }) as any;
+    expect(sanitized.$defs.bag.patternProperties).toEqual({});
+  });
+
+  it('walks the values of a patternProperties entry it keeps', () => {
+    const sanitized = sanitizeToolSchema({
+      patternProperties: { '^x': { type: 'string', pattern: String.raw`\p{L}` } },
+    }) as any;
+    expect(sanitized.patternProperties['^x']).toEqual({ type: 'string' });
+  });
+
+  it('leaves instance-data keywords opaque, because editing them changes what the schema accepts', () => {
+    // `const`/`enum` say which VALUES are allowed; a member named `pattern`
+    // there is data, not a rule. Deleting it silently changes the contract.
+    const schema = {
+      type: 'object',
+      properties: {
+        rule: {
+          const: { pattern: String.raw`^\p{L}+$`, flags: 'u' },
+        },
+        preset: {
+          enum: [{ pattern: String.raw`^\p{L}+$` }, 'none'],
+          default: { pattern: String.raw`^\p{L}+$` },
+          examples: [{ pattern: String.raw`^\p{L}+$` }],
+        },
+      },
+    };
+    // Nothing to strip anywhere, so the whole schema comes back by identity.
+    expect(sanitizeToolSchema(schema)).toBe(schema);
+  });
+
+  it('strips through every declared schema position', () => {
+    const bad = String.raw`^\p{L}+$`;
+    const sanitized = sanitizeToolSchema({
+      if: { pattern: bad },
+      then: { pattern: bad },
+      else: { pattern: bad },
+      not: { pattern: bad },
+      contains: { pattern: bad },
+      propertyNames: { pattern: bad },
+      additionalProperties: { pattern: bad },
+      unevaluatedProperties: { pattern: bad },
+      unevaluatedItems: { pattern: bad },
+      additionalItems: { pattern: bad },
+      prefixItems: [{ pattern: bad }],
+      items: [{ pattern: bad }],
+      allOf: [{ pattern: bad }],
+      oneOf: [{ pattern: bad }],
+      contentSchema: { pattern: bad },
+      dependentSchemas: { other: { pattern: bad } },
+      definitions: { legacy: { pattern: bad } },
+      dependencies: { legacyDep: { pattern: bad } },
+    }) as any;
+    for (const key of [
+      'if', 'then', 'else', 'not', 'contains', 'propertyNames',
+      'additionalProperties', 'unevaluatedProperties', 'unevaluatedItems', 'additionalItems',
+      'contentSchema',
+    ]) expect(sanitized[key], key).toEqual({});
+    for (const key of ['prefixItems', 'items', 'allOf', 'oneOf']) expect(sanitized[key], key).toEqual([{}]);
+    expect(sanitized.dependentSchemas.other).toEqual({});
+    expect(sanitized.definitions.legacy).toEqual({});
+    expect(sanitized.dependencies.legacyDep).toEqual({});
+  });
+
+  it("keeps draft-07 `dependencies`' other form, a plain array of property names", () => {
+    const schema = { dependencies: { card: ['number', 'expiry'] } };
+    expect(sanitizeToolSchema(schema)).toBe(schema);
+  });
+
+  it('keeps a __proto__ key in every map it copies', () => {
+    // Assigning `out.__proto__` hits Object.prototype's setter and silently
+    // drops the key; the copies are built with Object.fromEntries, which
+    // *defines* it. Staged through JSON.parse because an object *literal* with
+    // a `__proto__` key sets the prototype rather than creating the own
+    // property — JSON.parse is also how a real `input_schema` arrives.
+    const bad = String.raw`^\p{L}+$`;
+    const schema = JSON.parse(JSON.stringify({
+      type: 'object',
+      PROTO: 'an unknown keyword, forwarded verbatim',
+      properties: { PROTO: { type: 'string' }, field: { type: 'string', pattern: bad } },
+      $defs: { PROTO: { type: 'string' } },
+      patternProperties: { PROTO: { type: 'string' }, BADKEY: { type: 'string' } },
+    }).replaceAll('"PROTO"', '"__proto__"').replaceAll('"BADKEY"', JSON.stringify(bad)));
+
+    const sanitized = sanitizeToolSchema(schema) as any;
+    // The schema object itself, and each of the three name-keyed maps.
+    expect(Object.keys(sanitized)).toContain('__proto__');
+    expect(Object.keys(sanitized.properties)).toEqual(['__proto__', 'field']);
+    expect(Object.keys(sanitized.$defs)).toEqual(['__proto__']);
+    expect(Object.keys(sanitized.patternProperties)).toEqual(['__proto__']);
+    expect(Object.getOwnPropertyDescriptor(sanitized.properties, '__proto__')?.value)
+      .toEqual({ type: 'string' });
+    expect(({} as any).type).toBeUndefined(); // no prototype pollution either way
+  });
+
+  it('keeps a compatible pattern when a sibling forces the schema to be rebuilt', () => {
+    // The copy is only taken when something changed; the compatible `pattern`
+    // has to be carried into it. With the node returned by identity (no
+    // sibling to strip) this branch never runs.
+    const sanitized = sanitizeToolSchema({
+      type: 'string',
+      pattern: '^ok$',
+      allOf: [{ pattern: String.raw`^\p{L}+$` }],
+    });
+    expect(sanitized).toEqual({ type: 'string', pattern: '^ok$', allOf: [{}] });
+  });
+
+  it('never reads a name-keyed map KEY as a regex', () => {
+    // Only `pattern` values and `patternProperties` keys are regex positions.
+    // A property or definition merely *named* like a regex is a name.
+    const schema = {
+      properties: { [String.raw`\p{L}`]: { type: 'string' } },
+      $defs: { [String.raw`\p{Nd}`]: { type: 'number' } },
+      dependencies: { [String.raw`\p{L}`]: ['x'] },
+    };
+    expect(sanitizeToolSchema(schema)).toBe(schema);
+  });
+
+  it('leaves a non-string `pattern` value verbatim rather than guessing', () => {
+    // Malformed as JSON Schema, but valid JSON on the wire. It is not a regex
+    // and not a schema position, so it is neither tested nor walked.
+    const schema = { pattern: ['\\', 'p', '{'] };
+    expect(sanitizeToolSchema(schema)).toBe(schema);
+    const numeric = { properties: { x: { pattern: 42 } } };
+    expect(sanitizeToolSchema(numeric)).toBe(numeric);
+  });
+
+  it('returns unchanged arrays and patternProperties maps by identity', () => {
+    const list = { prefixItems: [{ type: 'string' }] };
+    expect(sanitizeToolSchema(list)).toBe(list);
+    expect((sanitizeToolSchema(list) as any).prefixItems).toBe(list.prefixItems);
+    const map = { patternProperties: { '^x': { type: 'string' } } };
+    expect(sanitizeToolSchema(map)).toBe(map);
+    expect((sanitizeToolSchema(map) as any).patternProperties).toBe(map.patternProperties);
+  });
+
+  it('survives a malformed schema instead of throwing on the request path', () => {
+    // A tool ships whatever `input_schema` its author wrote; a null or an array
+    // where a subschema map belongs must not take the whole request down.
+    for (const schema of [
+      { properties: null },
+      { $defs: null },
+      { patternProperties: null },
+      { properties: ['not', 'a', 'map'] },
+      { patternProperties: ['not', 'a', 'map'] },
+      { items: null },
+    ]) {
+      expect(() => sanitizeToolSchema(schema), JSON.stringify(schema)).not.toThrow();
+      expect(sanitizeToolSchema(schema), JSON.stringify(schema)).toBe(schema);
+    }
+    expect(sanitizeToolSchema(null)).toBeNull();
+  });
+
+  it('does not mutate the schema it was given', () => {
+    const schema = {
+      type: 'object',
+      properties: { field: { type: 'string', pattern: ARTIFACT_FIELD_PATTERN } },
+      patternProperties: { [String.raw`^\p{L}+$`]: { type: 'string' } },
+    };
+    const before = structuredClone(schema);
+    const sanitized = sanitizeToolSchema(deepFreeze(schema)) as any;
+    expect(schema).toEqual(before);
+    expect(sanitized).not.toBe(schema);
+    expect(sanitized.properties.field).toEqual({ type: 'string' });
+  });
 });
+
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === 'object') {
+    for (const entry of Object.values(value)) deepFreeze(entry);
+    Object.freeze(value);
+  }
+  return value;
+}


### PR DESCRIPTION
A tool can describe one of its inputs with a text pattern, and some of those patterns are spelled in
a way OpenAI refuses to accept. When that happens the whole session fails from the very first
message — the failure fixed in #194 for Claude Code's Artifact tool. Two more spellings were still
getting through, and this fixes both, so a tool that uses either keeps working instead of taking the
session down with it. It also stops the cleanup from quietly rewriting parts of a tool's description
that were never the problem, which in one case could make a tool reject input it used to accept.

Fixes #197, fixes #198.

## The failure

`src/tool-schema-sanitize.ts` (added in #195) strips JSON Schema regexes that OpenAI's validator
rejects, because it rejects the same constructs python-jsonschema does — the 400 reads
`Invalid schema for function 'X': '<regex>' is not a 'regex'`, that library's format-checker wording.
Artifact ships on every request, so one bad regex ended the session from `hello`.

Two regex-valued positions exist and the far side compiles both, but only one was checked:

| | before | after |
| --- | --- | --- |
| `pattern` keyword | checked | checked |
| every **key** of `patternProperties` | **not checked → 400** | checked |
| `\u{...}` escape | **not recognized → 400** | recognized |

`patternProperties` keys are regexes: the 2020-12 applicator vocabulary gives
`patternProperties.propertyNames` `format: "regex"`, and I reproduced the identical
`is not a 'regex'` message locally from that metaschema before touching any code.

## Reachability

Neither is reachable from a Claude Code 2.1.266 built-in. A census of the extracted bundle found all
28 `patternProperties` occurrences inside vendored schema libraries (Ajv, the Zod converters, the
draft metaschemas) and none in a tool schema; zero `\x{}` regex literals anywhere; and of the 27
literals using `\u{}`, none reaches a tool schema. Exactly **14 distinct `pattern` values** reach a
built-in tool schema, and Artifact's `field` is the only Python-incompatible one. Both are reachable from
an **MCP or plugin tool**, whose schema Claude Code forwards verbatim: the bundle takes
`inputJSONSchema` straight from the MCP `tools/list` result and emits it as `input_schema`. No
credential or host compromise required. So: live on a supported route, triggered by a third-party
tool the user installed.

## The change

**Walk only declared schema positions.** The old walk visited every nested object hunting for a
`pattern` key, so it also edited keywords that hold instance *data*: a `pattern` member inside a
`const` or an `enum` is a value the schema requires, and deleting it changed which inputs the tool
accepts. Those, plus `default` and `examples`, are now opaque. This also removes the
`typeof value === 'string'` guess about whether a `pattern` key is the keyword or a tool parameter
named `pattern` (Grep has one) — a parameter always lives under `properties`, whose keys an
allowlist walker never inspects.

**Check `patternProperties` keys**, dropping the entry with its key, since the key *is* the
constraint.

**Recognize `\u{}`/`\x{}`.** `\u{}` is the same u-flag family as the `\p{}` that caused #194.
`\x{}` is *not* — it throws under `u`, and in a legacy regex it reads as "x, 41 times". It is
stripped anyway because an author can still write the string and Python rejects it; I did not
observe a live 400 for it, and the comment says so.

**Character-class awareness**, so `^[(?<]+$` — a class merely listing `(`, `?` and `<` — is no
longer misread as a JS named group and stripped.

**`Object.fromEntries` for the copies**, so a schema property named `__proto__` is defined rather
than assigned and no longer vanishes.

## Two defects the review panel found, both fixed here

**The allowlist narrowed too far.** It omitted `dependencies` (draft-07) and `contentSchema`
(2019-09+), so a regex there reached OpenAI — a regression the old walk-everything code did not
have. The walked set must be the union across *every* draft, not one of them: in a single session
OpenAI compiled regexes under `$defs` (2019+), `prefixItems` (2020) and array-form `items` (≤2019).

**Dropping a `patternProperties` entry could make the schema stricter.** With a sibling
`additionalProperties` or `unevaluatedProperties`, the dropped entry was the only thing *admitting*
its keys — remove it alone and those keys go from permitted to forbidden, so the tool silently stops
accepting input it used to. Verified with Ajv, not reasoned about:

```
before accepts {"abc":"ok"}: true
after  accepts {"abc":"ok"}: false   <<< NARROWED
```

The sibling closure keyword is now dropped with the entry (`true` is already the permissive default
and is left alone). **Sanitizing only ever loosens** is now the module's stated invariant.

## Evidence

**Live A/B against the real Codex backend**, three builds, two clodex endpoint servers on isolated
ports (`--no-discovery`, so the shared dev server was untouched). MID is the pre-review commit,
included to show the regression was real and not theoretical:

| probe | `main` | pre-review | this PR |
| --- | --- | --- | --- |
| ordinary `^[a-z]+$` | 200 | 200 | 200 |
| bad regex **only** in a `patternProperties` key | **400** | 200 | 200 |
| valid `patternProperties` key | 200 | 200 | 200 |
| `^\u{41}+$` in `pattern` | **400** | 200 | 200 |
| `\p{L}` under `dependencies` | 200 | **400** | 200 |
| `\p{L}` under `contentSchema` | 200 | **400** | 200 |
| `dependencies` array form | 200 | 200 | 200 |
| `const` holding a `pattern` member | 200 | 200 | 200 |

**Mutation discipline.** 21 feature-deletion mutants, full-file runs, every one red — each escape
family separately, character-class enter and exit separately, each keyword's set membership deleted
one at a time, all three `Object.fromEntries` sites, the closure-widening guard, and an in-place-
mutation mutant against the deep-freeze test. Six behaviors that were observable but unpinned got
tests, including the over-scope negative that a property or `$defs` entry merely *named* like a
regex is never treated as one.

An Ajv semantic oracle ("for every instance accepted before, still accepted after") was run over a
9-schema corpus as a one-off and reddens without the closure fix. It is not in the suite — it needs
a pnpm-internal import path and a new direct dependency, and the hand-written tests already pin all
five closure mutants on their own.

**Gate.** `pnpm typecheck` clean, `pnpm test` 2513/2513 (114 files), `pnpm build` clean; hostile
`CLODEX_HOME="$(mktemp -d)"` run clean. Node v24.14.1, no proxy vars set. Product smoke test on the
default proxy path, both legs: Anthropic passthrough `--model haiku` → `HAIKU-OK`, translated
`--model luna` → `MODEL-OK`.

## Claims I corrected rather than inherited

The file asserted that dropping a constraint "loses a hint, not a guard: Claude Code validates tool
input against its own schema before executing." **That is false**, and I verified it in the 2.1.266
bundle rather than trusting the comment:

- registered tools get `c({}).passthrough()` as `inputSchema`, with the real schema parked in
  `inputJSONSchema` — `safeParse` enforces nothing
- the MCP path checks only that `required` keys are *present* (`E4n`), never compiling `pattern`
- the Ajv-shaped validator nearby is StructuredOutput ("Output does not match required schema") —
  output, not tool input

Only a built-in whose Zod schema carries the constraint is still guarded (Artifact's
`field: s().regex(...)`). For an MCP or plugin tool the dropped regex is a genuinely lost guard.
Still the better trade — the alternative is a 400 that kills the session — but it is a real cost,
and it is now the documented reason nothing is dropped that does not have to be.

Also corrected: "OpenAI validates with Python's `re`" (behavioural observation, not knowledge of
their backend); "at any depth" and "every regex Python cannot compile" (it is a targeted scanner
over an allowlist, and neither is exhaustive); the `default`/`examples` rationale (annotations, not
acceptance-changing); "clodex never meets the strict path *because* of `strict: false`"
(`@ai-sdk/openai-compatible` also goes to Chat Completions, non-strict by default); and the
lookaround claim, which is wrong on variable-width lookbehind — legal in ECMAScript, rejected by
Python.

## What I deliberately left out

The panel found a family of **pre-existing** scanner false accepts that also 400 live, none of them
introduced or touched by this PR and none covered by #197/#198:

- `[\w-.]` — a shorthand escape as a character-range endpoint (the common email/slug slip)
- the JS `[^]` idiom, and `[]`
- bare `\pL`/`\P`/`\k` without the brace or angle bracket, `\c` control escapes
- backreferences to a group that does not exist
- variable-width lookbehind, alternated or quantified — needs a real regex parser to detect

None appears among the 14 `pattern` values that reach a built-in tool schema; all need a
hand-written MCP or plugin schema. They are now documented as known limits in the module header and
`.claude/docs/translation.md` rather than silently absent. Widening the scanner is a separate
decision with its own over-rejection cost, so it belongs in its own change.

## Not verified

- No live probe of `\x{}` — it is stripped on the strength of Python rejecting it, and the code says
  so. The bundle census found zero `\x{}` regex literals in Claude Code at all, so it is defensive
  against a hand-written schema rather than an observed failure.
- OpenCode Go (`@ai-sdk/openai-compatible`) gets sanitized like any OpenAI-format route; I have no
  credentials for it, so whether it *needs* Python-oriented stripping is unverified. Pre-existing
  behavior, unchanged here.
- The strict-path lookaround rejection rests on the two linked issue reports; the vercel maintainers
  could not reproduce it synthetically. It is attributed as a report, not stated as fact.
