### PR TITLE
fix(patch): refuse to restore Claude Code from a backup that belongs to a different install

### DIFF
--- a/.claude/docs/patcher.md
+++ b/.claude/docs/patcher.md
@@ -614,7 +614,47 @@ tweakcc's own repack reads back as an ordinary module name.
   the version probed from the binary being patched, its hash must match its own name, and a legacy
   `claude-<ver>.orig` (no hash in the name, possibly mislabeled by an older clodex) must
   additionally report that version when executed (`verifyPristineSource`). Conflicting or
-  unverifiable backups produce a loud error, never a copy. This gate covers both consumers —
+  unverifiable backups produce a loud error, never a copy. **A matching version tag is not install
+  provenance**: the npm platform package and the native installer ship different files under the same
+  Claude Code version, and both are supported, so one machine can hold two same-version installs whose
+  bytes differ. The manifest is the only record of which install a backup was made for, and it holds
+  **one** install — so it can confirm a backup but can never rule one in by elimination. Two states
+  therefore refuse outright rather than fall through to version-tag selection (issue #199, reproduced
+  on real 2.1.266 binaries in issue #199, and again on real 2.1.263 bytes with a byte-differing
+  second copy standing in for the second install; the published 2.1.263 npm and native artifacts are
+  independently known to differ in both size and hash):
+  - the manifest records a **different** `binaryPath` than the resolved target — it vouches for
+    nothing in the backup directory, and the error names the install it does belong to;
+  - the manifest records **this** target but the pristine bytes it named are gone or corrupt — its own
+    testimony says the same-version backups still on disk were made for some other install.
+
+  A manifest speaks only for the `claudeVersion` it was written for. After an upgrade it records a
+  backup of the OLD version, which is not among the new version's candidates at all — so neither
+  refusal fires across a version change, and a restore that was never in danger is not rejected.
+
+  Disqualifying only the backup the manifest names is NOT sufficient and was rejected during review:
+  the manifest holds one install, so every earlier install's backup is an unrecorded orphan carrying
+  the same version tag, and "restore the one it did not name" hands a third install's bytes to the
+  target — turning a `conflicting pristine backups` refusal into a destructive copy. **What remains
+  unprotected is the no-manifest case**, and it is reachable by an ordinary sequence: a successful
+  `--restore` DELETES the manifest, so patch A → restore A → have the target resolve to install B →
+  restore again publishes A's pristine bytes over B, with only a warning. (`~/.clodex` wiped or a
+  different `CLODEX_HOME` get there too.) Selection there still rests on the version tag alone.
+  Worse, a user who answers the `conflicting pristine backups` refusal by deleting one file can
+  launder the wrong bytes into a manifest that the rules above then trust on sight — which is why
+  that message no longer says "remove the wrong one". Closing this needs provenance recorded per
+  backup rather than a single-slot manifest, or requiring `--restore` to see a `/*ccpatch:` marker in
+  the live binary before it copies anything (`clodex patch`'s implicit restore already inspects the
+  source; `--restore` never does). Tracked separately — do not read the rules above as a full
+  guarantee.
+
+  Path identity is plain string equality, so a manifest written under a different spelling of the
+  same path reads as another install and refuses — safe, but a false refusal, and it blocks
+  `clodex patch` as well as `--restore`. **This is not Windows-only**: APFS is case-insensitive and
+  the `fs.realpathSync` clodex uses preserves caller-supplied case (only `.native` corrects it), so a
+  hand-typed `TWEAKCC_CC_INSTALLATION_PATH` reaches it on macOS. `evaluatePatchState` compares the
+  same way. The message names the recorded path, so following its own
+  `TWEAKCC_CC_INSTALLATION_PATH=` advice recovers. This gate covers both consumers —
   `applyPatch` seeds its candidate from those bytes, and **`clodex patch --restore` copies straight
   over the live binary** (nothing to publish atomically), so an unverified backup would be a silent
   downgrade either way. An already-patched binary is never snapshotted as pristine. Legacy backups
@@ -625,15 +665,21 @@ tweakcc's own repack reads back as an ordinary module name.
   interrupted ~250 MB `copyFileSync` would leave a truncated file under a name asserting its content
   hash — the one corruption content-addressing cannot notice without re-hashing.
   `~/.tweakcc/native-binary.backup` is still mirrored from the pristine bytes for `tweakcc
-  --restore`.
+  --restore`. That mirror is a SINGLE slot holding whichever install clodex patched last, so on a
+  machine with two same-version installs `tweakcc --restore` performs exactly the copy the rules
+  above refuse. clodex writes the file but does not control that command.
 - **`clodex patch --restore` must work on a binary that no longer runs** — that is what a pristine
   backup is *for*. It resolves the version from `claude --version` when it can, and otherwise falls
   back to the manifest's `claudeVersion` when `manifest.binaryPath` matches the resolved install and
-  the live bytes could still be what clodex last wrote. An npm placeholder is the exception: it
-  proves a package manager replaced the target, so the old manifest is no longer authoritative for
-  that path even though the wrapper's `package.json` still reveals its version. The placeholder
-  refusal preserves both manifest and backups. Generic broken binaries retain manifest recovery;
-  the patch path keeps the hard `version-unknown` failure and names `--restore` as the recovery.
+  the live bytes could still be what clodex last wrote, establishing provenance without executing
+  anything. An npm placeholder is the exception: it proves a package manager replaced the target, so
+  the old manifest is no longer authoritative for that path even though the wrapper's `package.json`
+  still reveals its version. The placeholder refusal preserves both manifest and backups. Generic
+  broken binaries retain manifest recovery. A successful restore drops the manifest, which is sound
+  only because a manifest recorded against a different install can no longer reach the copy — it is
+  refused during selection, so the other install's rescue record is never deleted with it. The patch
+  path keeps the hard `version-unknown` failure (patching is elective; restoring is the way out), and
+  its error message names `--restore` as the recovery.
 - **Binary resolution bypasses PATH shims** (cmux installs a shim copy):
   `TWEAKCC_CC_INSTALLATION_PATH` → `~/.local/bin/claude` → `findClaudeBinary()`.
   **`~/.local/bin/claude.exe`, which the Windows native installer writes, is deliberately NOT
@@ -641,9 +687,10 @@ tweakcc's own repack reads back as an ordinary module name.
   `findClaudeBinary()` returns the same null for "`CLODEX_CLAUDE_PATH` names a file that is gone" as
   for "nothing found", so a stale explicit override silently became a DIFFERENT install, and
   `--restore` copied the missing install's pristine bytes over it and deleted the manifest —
-  reproduced on real 2.1.266 binaries, with the fallback deletion as the control. It stays out until
-  issue #199 (restore selects a backup by version without proving it belongs to the install being
-  restored) is fixed. **The version is
+  reproduced on real 2.1.266 binaries, with the fallback deletion as the control. The manifest half of that
+  weakness is fixed (see the provenance rule above), so the fallback can land — as its own change
+  carrying its own Windows evidence, not folded into the fix that unblocked it, and only once the
+  no-manifest case above is covered too. **The version is
   probed from that resolved binary** (`getClaudeVersionForBinary`), never from
   `getInstalledClaudeVersion()`, whose PATH lookup can land on a different install and whose
   `'2.1.183'` fallback is only safe for request metadata. The version names the backup that gets

--- a/src/patch-backup.ts
+++ b/src/patch-backup.ts
@@ -22,6 +22,16 @@
 //     no backup existed, and the version-resolution bug generated exactly that
 //     state. Patching poisoned bytes would double-patch the install AND launder
 //     the result into a content-addressed name that rule 1 then trusts on sight.
+//  4. A version tag is not install provenance. The npm platform package and the
+//     native installer ship DIFFERENT files under the same Claude Code version,
+//     and both are supported, so a user can hold two same-version installs whose
+//     bytes differ. The manifest is the only record of which install a backup was
+//     made for, and it holds ONE install, so it can confirm a backup but never
+//     rule one in by elimination: when it records a different install, or names
+//     pristine bytes for this one that are no longer on disk, restoring is
+//     refused rather than guessed (issue #199). What remains is the case of no
+//     manifest at all, where selection still rests on the version tag; the plan
+//     carries a note saying so.
 //
 // Everything here is deterministic given its inputs so the decisions can be
 // tested directly; the caller performs the file copies.
@@ -188,6 +198,14 @@ export function looksLikeLegacyClodexPatch(source: string): boolean {
 
 export interface PatchManifestFacts {
   binaryPath: string;
+  /**
+   * The claude version the manifest was written for. A manifest that recorded a
+   * DIFFERENT version says nothing about the backups tagged with the version now
+   * being restored — its own backup is not even among them — so its testimony is
+   * scoped to its version rather than applied across an upgrade. Absent in
+   * hand-edited or truncated manifests, which are treated as same-version.
+   */
+  claudeVersion?: string;
   backupPath?: string;
   patchedSha256?: string;
   pristineSha256?: string;
@@ -231,13 +249,71 @@ function noBackupMessage(facts: PristineFacts): string {
 }
 
 /**
+ * True when `manifest` recorded WHICH backup holds its install's pristine bytes.
+ * `pristineSha256` is absent from manifests written before content addressing,
+ * so the recorded path counts too; a manifest carrying neither identifies
+ * nothing and can neither confirm nor disqualify a backup.
+ */
+function identifiesABackup(manifest: PatchManifestFacts): boolean {
+  return manifest.pristineSha256 !== undefined || manifest.backupPath !== undefined;
+}
+
+/** The manifest named this install's pristine bytes, and they are no longer usable. */
+function recordedBackupGoneMessage(facts: PristineFacts, manifest: PatchManifestFacts): string {
+  const named = manifest.backupPath ?? `the backup holding sha256 ${manifest.pristineSha256}`;
+  const corrupt = facts.corruptBackups?.length
+    ? ` (${facts.corruptBackups.length} backup file(s) for this version failed integrity checks and were ignored)`
+    : '';
+  const others = facts.backups.length
+    ? `The ${facts.backups.length} other pristine backup(s) tagged claude ${facts.version} there were made `
+      + 'for some other install — two installs of one Claude Code version are different files, so '
+      + 'restoring one of them would overwrite this install with bytes that were never its own. '
+    : '';
+  return `The patch manifest records ${named} as the pristine content of ${facts.binaryPath}, and clodex `
+    + `cannot use it: it is missing from ${backupDir()}, failed its integrity check, or holds a `
+    + `different claude version${corrupt}. ${others}`
+    + 'Reinstall Claude Code to get a pristine binary, then run `clodex patch`.';
+}
+
+/** A manifest for a DIFFERENT install cannot vouch for anything in the backup directory. */
+function otherInstallMessage(facts: PristineFacts, otherBinaryPath: string): string {
+  return `The patch manifest records a different Claude Code install (${otherBinaryPath}), so nothing `
+    + `establishes that a pristine backup tagged claude ${facts.version} in ${backupDir()} belongs to `
+    + `${facts.binaryPath}. Two installs of one Claude Code version are different files, so restoring `
+    + 'by version tag alone would overwrite this install with another one\'s bytes. Set '
+    + `TWEAKCC_CC_INSTALLATION_PATH=${otherBinaryPath} to restore that install instead, or reinstall `
+    + 'Claude Code to make this one pristine.';
+}
+
+/**
  * Pick the pristine bytes to restore over an already-patched binary.
  * Every branch requires bytes whose provenance is established; when none are,
  * the result is an error rather than a guess.
  */
 function selectRestoreSource(facts: PristineFacts): RestorePlan {
   const notes: string[] = [];
-  const manifest = facts.manifest && facts.manifest.binaryPath === facts.binaryPath ? facts.manifest : null;
+  const recorded = facts.manifest;
+  // A manifest speaks only for the version it was written for. After an upgrade
+  // it records a backup of the OLD version, which is not among this version's
+  // candidates — treating that as "the recorded backup is gone" refused a restore
+  // that was never in danger, and treating it as evidence about another install
+  // refused one for a version it had never seen.
+  const speaksForThisVersion = !recorded?.claudeVersion || recorded.claudeVersion === facts.version;
+  const manifest = recorded && recorded.binaryPath === facts.binaryPath && speaksForThisVersion
+    ? recorded
+    : null;
+  // A manifest recorded against a DIFFERENT install is not the same thing as no
+  // manifest: it is positive evidence about the backup directory. The bytes it
+  // names are that other install's pristine bytes, and two supported installs of
+  // ONE Claude Code version are genuinely different files (the npm platform
+  // package and the native installer ship different binaries under the same
+  // version). Discarding the manifest and falling through to version-tag
+  // selection published one install's bytes over the other and then deleted the
+  // manifest, leaving no backup of what it clobbered — issue #199. Same version
+  // is not the same install.
+  const other = recorded && recorded.binaryPath !== facts.binaryPath && speaksForThisVersion
+    ? recorded
+    : null;
 
   // 1. The manifest's recorded pristine content, wherever it now lives. Matching
   //    on content (not path) also survives the legacy → content-addressed rename.
@@ -251,15 +327,31 @@ function selectRestoreSource(facts: PristineFacts): RestorePlan {
   //    match here instead of being copied over a newer binary.
   if (!chosen && manifest?.backupPath) {
     chosen = facts.backups.find(backup => backup.path === manifest.backupPath);
-    if (!chosen) {
-      notes.push(`Recorded pristine backup ${manifest.backupPath} is missing, corrupt, or belongs to another claude version — ignoring it.`);
-    }
+  }
+
+  // 2b. The manifest speaks FOR this install: it recorded which bytes are its
+  //     pristine content. When neither the recorded hash nor the recorded path is
+  //     on disk any more, every remaining same-version backup was made for some
+  //     other install, and the manifest's own testimony says so. Falling through
+  //     to version-tag selection here published another install's bytes.
+  if (!chosen && manifest && identifiesABackup(manifest)) {
+    return { action: 'error', message: recordedBackupGoneMessage(facts, manifest) };
   }
 
   // 3. No manifest help: fall back to the version's backups, but only when they
   //    agree on the content. Two different "pristine" snapshots of one version
   //    mean at least one is wrong; guessing is exactly the destructive move.
   if (!chosen) {
+    // A manifest recorded against a DIFFERENT install vouches for nothing here.
+    // Disqualifying only the backup IT names is not enough: the manifest holds one
+    // install, so every earlier install's backup is an unrecorded orphan carrying
+    // the same version tag, and picking "the one it did not name" hands a third
+    // install's bytes to this one. There is no evidence to select on — refuse.
+    if (other) {
+      return facts.backups.length
+        ? { action: 'error', message: otherInstallMessage(facts, other.binaryPath) }
+        : { action: 'error', message: noBackupMessage(facts) };
+    }
     const distinct = [...new Set(facts.backups.map(backup => backup.sha256))];
     if (distinct.length > 1) {
       return {
@@ -267,11 +359,25 @@ function selectRestoreSource(facts: PristineFacts): RestorePlan {
         message: `Found conflicting pristine backups for claude ${facts.version}: `
           + `${facts.backups.map(backup => backup.path).join(', ')}. `
           + 'They do not hold the same bytes, so clodex cannot tell which one is pristine. '
-          + 'Remove the wrong one (or reinstall Claude Code), then run `clodex patch`.',
+          + 'If this machine has more than one Claude Code install, both are probably genuine — one '
+          + `per install — and deleting either one is a guess. Reinstall the Claude Code at `
+          + `${facts.binaryPath} instead: a pristine install needs no backup, and \`clodex patch\` `
+          + 'will record its own.',
       };
     }
     // Prefer a self-validating name when both spellings hold the same bytes.
     chosen = facts.backups.find(backup => backup.kind === 'content-addressed') ?? facts.backups[0];
+    if (chosen) {
+      // Say so out loud: no manifest records this install, so the ONLY thing tying
+      // these bytes to it is the version tag in the file name. That is the last
+      // place a same-version backup from another install can still be selected.
+      notes.push(
+        `No patch manifest records ${facts.binaryPath}, so ${chosen.path} is being used as its `
+        + `pristine content on the strength of its claude ${facts.version} version tag alone. On a `
+        + 'machine with more than one Claude Code install those bytes may belong to the other one — '
+        + 'a clodex that had recorded this install would have refused rather than guess.',
+      );
+    }
   }
 
   if (!chosen) return { action: 'error', message: noBackupMessage(facts) };

--- a/src/patcher.ts
+++ b/src/patcher.ts
@@ -510,14 +510,15 @@ export type ClaudePatchTarget =
  * symlink) → findClaudeBinary() PATH lookup.
  *
  * `%USERPROFILE%\.local\bin\claude.exe`, which the Windows native installer
- * writes, is deliberately NOT probed here. Adding it as a fallback made an
- * existing restore weakness reachable: `findClaudeBinary()` returns the same
- * null for "CLODEX_CLAUDE_PATH names a file that is gone" as for "nothing was
- * found", so a stale explicit override silently became that other install, and
- * `--restore` copied the missing install's pristine bytes over it and dropped
- * the manifest. Reproduced on real 2.1.266 binaries. It stays out until issue
- * #199 (restore picks a backup by version without proving it belongs to the
- * install being restored) is fixed.
+ * writes, is still NOT probed here. Adding it as a fallback made a restore
+ * weakness reachable: `findClaudeBinary()` returns the same null for
+ * "CLODEX_CLAUDE_PATH names a file that is gone" as for "nothing was found", so
+ * a stale explicit override silently became that other install, and `--restore`
+ * copied the missing install's pristine bytes over it and dropped the manifest.
+ * Reproduced on real 2.1.266 binaries. `--restore` now refuses when the manifest
+ * records another install rather than selecting a backup by version tag (issue
+ * #199), so this fallback can land — but as its own change with its own Windows
+ * evidence, and only once the no-manifest case is covered too.
  *
  * Whatever that finds is then followed through any npm launcher script to the
  * program it starts (see `npm-shim.ts`). `findBinaryOnPath` prefers
@@ -1170,6 +1171,12 @@ function runRestoreCommand(target: ClaudePatchTarget): number {
     return 1;
   }
   copyFileSync(plan.backupPath, binaryPath);
+  // Reaching here means the plan established these bytes as THIS install's
+  // pristine content, so the manifest being cleared is this install's own record
+  // that it was patched. A manifest recorded against a different install cannot
+  // get here: `selectRestoreSource` refuses that case outright rather than
+  // selecting a backup by version tag, which is what used to delete another
+  // install's only rescue record along with clobbering it (issue #199).
   try {
     unlinkSync(getPatchManifestPath());
   } catch {

--- a/tests/patch-backup.test.ts
+++ b/tests/patch-backup.test.ts
@@ -151,6 +151,8 @@ describe('isPatchedClaudeSource', () => {
 const PRISTINE = sha('pristine 2.1.220');
 const PATCHED = sha('patched 2.1.220');
 const OTHER_VERSION = sha('pristine 2.1.215');
+/** Same claude version, different artifact — an npm-platform binary next to a native one. */
+const OTHER_INSTALL_PRISTINE = sha('pristine 2.1.220 npm build');
 
 function candidate(overrides: Partial<BackupCandidate> = {}): BackupCandidate {
   return {
@@ -216,7 +218,7 @@ describe('planPristineSource', () => {
       },
     }));
     expect(plan.action).toBe('error');
-    expect((plan as { message: string }).message).toMatch(/no trustworthy pristine backup/);
+    expect((plan as { message: string }).message).toMatch(/as the pristine content of .*, and clodex cannot use it/);
   });
 
   it('asks for source inspection when the live bytes are unrecognized', () => {
@@ -294,5 +296,171 @@ describe('planRestoreOnly', () => {
 
   it('errors rather than restoring when nothing for this version is trustworthy', () => {
     expect(planRestoreOnly(facts()).action).toBe('error');
+  });
+
+  // Issue #199: a version tag is not install provenance. The npm platform package
+  // and the native installer ship different bytes under the SAME version, so a
+  // backup belonging to the install the manifest records must never be published
+  // over a different install just because the version tags agree.
+  describe('a manifest recorded against another install', () => {
+    const otherInstall = {
+      binaryPath: '/other-install/claude',
+      backupPath: candidate().path,
+      patchedSha256: sha('patched other install'),
+      pristineSha256: PRISTINE,
+    };
+
+    it('refuses instead of publishing that install\'s backup over this one', () => {
+      const plan = planRestoreOnly(facts({ backups: [candidate()], manifest: otherInstall }));
+      expect(plan.action).toBe('error');
+      expect((plan as { message: string }).message).toMatch(/records a different Claude Code install/);
+      expect((plan as { message: string }).message).toContain('/other-install/claude');
+    });
+
+    it('refuses on the patch path too, where the same selection seeds the candidate', () => {
+      const plan = planInspectedPristineSource(
+        facts({ backups: [candidate()], manifest: otherInstall }),
+        { patched: true },
+      );
+      expect(plan.action).toBe('error');
+      expect((plan as { message: string }).message).toMatch(/records a different Claude Code install/);
+    });
+
+    it('disqualifies the recorded backup by path when the manifest predates content addressing', () => {
+      const legacyRecord = { binaryPath: '/other-install/claude', backupPath: candidate().path };
+      const plan = planRestoreOnly(facts({ backups: [candidate()], manifest: legacyRecord }));
+      expect(plan.action).toBe('error');
+      expect((plan as { message: string }).message).toMatch(/records a different Claude Code install/);
+    });
+
+    it('refuses outright when the manifest identifies no backup to disqualify', () => {
+      const plan = planRestoreOnly(facts({
+        backups: [candidate()],
+        manifest: { binaryPath: '/other-install/claude' },
+      }));
+      expect(plan.action).toBe('error');
+      expect((plan as { message: string }).message).toMatch(/records a different Claude Code install/);
+    });
+
+    it('refuses even when a backup that install did NOT record is available', () => {
+      // Tempting to restore "the one it did not name" — and wrong. The manifest
+      // holds ONE install, so an unrecorded backup is just an install the manifest
+      // is silent about: this one, or a third one whose backup was never recorded.
+      // Nothing in the facts tells them apart, so selection here is a guess.
+      const unrecorded = candidate({
+        path: contentAddressedBackupPath('2.1.220', OTHER_INSTALL_PRISTINE, '/backups'),
+        sha256: OTHER_INSTALL_PRISTINE,
+      });
+      const plan = planRestoreOnly(facts({ backups: [candidate(), unrecorded], manifest: otherInstall }));
+      expect(plan.action).toBe('error');
+      expect((plan as { message: string }).message).toMatch(/records a different Claude Code install/);
+    });
+
+    it('refuses when a THIRD install is the target and the orphan is install A\'s', () => {
+      // Patch A (backup X, manifest→A), patch B (backup Y, manifest→B), then
+      // restore against C. Disqualifying only Y would leave X — install A's bytes
+      // — looking unanimous, and publish them over C.
+      const orphanOfA = candidate();
+      const recordedForB = candidate({
+        path: contentAddressedBackupPath('2.1.220', OTHER_INSTALL_PRISTINE, '/backups'),
+        sha256: OTHER_INSTALL_PRISTINE,
+      });
+      const plan = planRestoreOnly(facts({
+        binaryPath: '/third-install/claude',
+        backups: [orphanOfA, recordedForB],
+        manifest: { binaryPath: '/other-install/claude', backupPath: recordedForB.path, pristineSha256: OTHER_INSTALL_PRISTINE },
+      }));
+      expect(plan.action).toBe('error');
+    });
+
+    it('is not evidence about a version it was never written for', () => {
+      // Patch install A at 2.1.220, patch install B at 2.1.221, then restore A.
+      // B's manifest records a 2.1.221 backup, which is not even among 2.1.220's
+      // candidates — refusing here rejected a restore that was never in danger.
+      const plan = planRestoreOnly(facts({
+        backups: [candidate()],
+        manifest: { ...otherInstall, claudeVersion: '2.1.221' },
+      }));
+      expect(plan).toMatchObject({ action: 'restore', backupPath: candidate().path });
+      expect((plan as { notes: string[] }).notes.join(' ')).toMatch(/version tag alone/);
+    });
+
+    it('still refuses when it was written for the version being restored', () => {
+      const plan = planRestoreOnly(facts({
+        backups: [candidate()],
+        manifest: { ...otherInstall, claudeVersion: '2.1.220' },
+      }));
+      expect(plan.action).toBe('error');
+    });
+
+    it('reports the ordinary no-backup error when the version has no backups at all', () => {
+      const plan = planRestoreOnly(facts({ backups: [], manifest: otherInstall }));
+      expect(plan.action).toBe('error');
+      expect((plan as { message: string }).message).toMatch(/no trustworthy pristine backup/);
+    });
+  });
+
+  // The manifest records THIS install and names bytes that are gone. Its own
+  // testimony then says the same-version backups still on disk are some other
+  // install's — so falling back to them was never safe.
+  describe('a manifest whose recorded backup has been deleted', () => {
+    it('refuses instead of restoring a different backup with the same version tag', () => {
+      const orphan = candidate({
+        path: contentAddressedBackupPath('2.1.220', OTHER_INSTALL_PRISTINE, '/backups'),
+        sha256: OTHER_INSTALL_PRISTINE,
+      });
+      const plan = planRestoreOnly(facts({
+        backups: [orphan],
+        manifest: { binaryPath: '/install/claude', backupPath: candidate().path, pristineSha256: PRISTINE },
+      }));
+      expect(plan.action).toBe('error');
+      expect((plan as { message: string }).message).toMatch(/as the pristine content of .*, and clodex cannot use it/);
+    });
+
+    it('does not refuse when the manifest simply predates an upgrade', () => {
+      // The recorded backup is intact; it just belongs to the version this binary
+      // used to be. That is not a missing backup, and this version's own backup is
+      // still the only candidate.
+      const plan = planRestoreOnly(facts({
+        backups: [candidate()],
+        manifest: {
+          binaryPath: '/install/claude',
+          claudeVersion: '2.1.215',
+          backupPath: legacyBackupPath('2.1.215', '/backups'),
+          pristineSha256: OTHER_VERSION,
+        },
+      }));
+      expect(plan).toMatchObject({ action: 'restore', backupPath: candidate().path });
+    });
+
+    it('refuses a legacy orphan too, where only a version probe stood in the way', () => {
+      const legacyOrphan = candidate({
+        path: legacyBackupPath('2.1.220', '/backups'),
+        kind: 'legacy',
+        sha256: OTHER_INSTALL_PRISTINE,
+      });
+      const plan = planRestoreOnly(facts({
+        backups: [legacyOrphan],
+        manifest: { binaryPath: '/install/claude', backupPath: candidate().path },
+      }));
+      expect(plan.action).toBe('error');
+    });
+  });
+
+  describe('no manifest at all', () => {
+    it('still restores, and says the version tag is the only thing tying the backup to the install', () => {
+      const plan = planRestoreOnly(facts({ backups: [candidate()], manifest: null }));
+      expect(plan).toMatchObject({ action: 'restore', backupPath: candidate().path });
+      expect((plan as { notes: string[] }).notes.join(' ')).toMatch(/version tag alone/);
+    });
+
+    it('adds no such note when the manifest records THIS install', () => {
+      const plan = planRestoreOnly(facts({
+        backups: [candidate()],
+        manifest: { binaryPath: '/install/claude', backupPath: candidate().path, pristineSha256: PRISTINE },
+      }));
+      expect(plan).toMatchObject({ action: 'restore', backupPath: candidate().path });
+      expect((plan as { notes: string[] }).notes).toEqual([]);
+    });
   });
 });

--- a/tests/patcher-command.test.ts
+++ b/tests/patcher-command.test.ts
@@ -137,6 +137,16 @@ function installClaude(version: string, bundle = PRISTINE_BUNDLE): string {
   return realpathSync(real);
 }
 
+/**
+ * A SECOND same-version install with different bytes — the npm platform package
+ * beside a native install, which is the shape issue #199 turns destructive.
+ */
+function installOtherClaude(version: string, bundle = `${PRISTINE_BUNDLE}\n// npm platform build\n`): string {
+  const real = join(home, 'npm', 'lib', 'node_modules', '@anthropic-ai', 'claude-code', 'cli');
+  writeFakeClaude(real, version, bundle);
+  return realpathSync(real);
+}
+
 function saveFavorites(): void {
   mkdirSync(clodexHome, { recursive: true });
   writeFileSync(join(clodexHome, 'config.json'), JSON.stringify({
@@ -976,7 +986,7 @@ describe('runPatchCommand pristine backup safety', () => {
 
     expect(await runPatchCommand({})).toBe(1);
     expect(readFileSync(real)).toEqual(patchedBytes);
-    expect(logs.join('\n')).toMatch(/no trustworthy pristine backup/);
+    expect(logs.join('\n')).toMatch(/failed its integrity check/);
   });
 
   it('never stores an already-patched binary as the pristine backup', async () => {
@@ -1091,6 +1101,96 @@ describe('runPatchCommand --restore', () => {
     expect(await runPatchCommand({ restore: true })).toBe(0);
     expect(readFileSync(real)).toEqual(pristineBytes);
     expect(readPatchManifest()).toBeNull();
+  });
+
+  // Issue #199. Two supported installs of ONE Claude Code version are different
+  // files (npm platform package vs native installer), so "same version tag" was
+  // never proof that a backup belongs to the install being restored.
+  it('refuses to restore another install\'s backup over a same-version install', async () => {
+    const patched = installClaude('2.1.220');
+    expect(await runPatchCommand({})).toBe(0);
+    expect(readPatchManifest()?.binaryPath).toBe(patched);
+
+    // A second, pristine 2.1.220 install becomes the target — a stale
+    // CLODEX_CLAUDE_PATH, a PATH change, or a corrected launcher all do this.
+    const other = installOtherClaude('2.1.220');
+    const otherBytes = readFileSync(other);
+    process.env.TWEAKCC_CC_INSTALLATION_PATH = other;
+
+    expect(await runPatchCommand({ restore: true })).toBe(1);
+
+    // The install it had no backup for is untouched, and the manifest that can
+    // still rescue the FIRST install survives.
+    expect(readFileSync(other)).toEqual(otherBytes);
+    expect(readPatchManifest()?.binaryPath).toBe(patched);
+    expect(logs.join('\n')).toMatch(/records a different Claude Code install/);
+
+    // And the rescue the manifest exists for still works.
+    delete process.env.TWEAKCC_CC_INSTALLATION_PATH;
+    expect(await runPatchCommand({ restore: true })).toBe(0);
+    expect(readPatchManifest()).toBeNull();
+  });
+
+  it('refuses even when both installs were patched and both backups are on disk', async () => {
+    // Tempting to restore "the backup the manifest did NOT name" — and unsound.
+    // The manifest holds one install, so an unnamed backup is only an install the
+    // manifest is silent about: this one, or a third whose backup was never
+    // recorded. Nothing on disk tells them apart, so this refuses.
+    const other = installOtherClaude('2.1.220');
+    process.env.TWEAKCC_CC_INSTALLATION_PATH = other;
+    expect(await runPatchCommand({})).toBe(0);
+    const otherPatched = readFileSync(other);
+
+    delete process.env.TWEAKCC_CC_INSTALLATION_PATH;
+    const native = installClaude('2.1.220');
+    expect(await runPatchCommand({})).toBe(0);
+    expect(readPatchManifest()?.binaryPath).toBe(native);
+    expect(backupFiles().filter(name => name.endsWith('.orig'))).toHaveLength(2);
+
+    process.env.TWEAKCC_CC_INSTALLATION_PATH = other;
+    expect(await runPatchCommand({ restore: true })).toBe(1);
+    expect(readFileSync(other)).toEqual(otherPatched);
+    expect(readPatchManifest()?.binaryPath).toBe(native);
+    expect(logs.join('\n')).toMatch(/records a different Claude Code install/);
+  });
+
+  it('still restores an install the manifest passed over at a DIFFERENT version', async () => {
+    // Patch 2.1.220 here, patch a second install at 2.1.221, then come back. The
+    // manifest names a 2.1.221 backup, which is not a candidate for 2.1.220 at
+    // all, so it is no reason to refuse — this used to be a working restore.
+    const real = installClaude('2.1.220');
+    const pristineBytes = readFileSync(real);
+    expect(await runPatchCommand({})).toBe(0);
+
+    const other = installOtherClaude('2.1.221');
+    process.env.TWEAKCC_CC_INSTALLATION_PATH = other;
+    expect(await runPatchCommand({})).toBe(0);
+    expect(readPatchManifest()?.claudeVersion).toBe('2.1.221');
+
+    delete process.env.TWEAKCC_CC_INSTALLATION_PATH;
+    expect(await runPatchCommand({ restore: true })).toBe(0);
+    expect(readFileSync(real)).toEqual(pristineBytes);
+    expect(logs.join('\n')).toMatch(/version tag alone/);
+  });
+
+  it('refuses when the manifest records this install but its backup was deleted', async () => {
+    // The user is told to remove a bad backup by clodex's own error text, so this
+    // state is reachable. The remaining same-version backup belongs to the OTHER
+    // install, and the manifest says so.
+    const other = installOtherClaude('2.1.220');
+    process.env.TWEAKCC_CC_INSTALLATION_PATH = other;
+    expect(await runPatchCommand({})).toBe(0);
+
+    delete process.env.TWEAKCC_CC_INSTALLATION_PATH;
+    const native = installClaude('2.1.220');
+    expect(await runPatchCommand({})).toBe(0);
+    const nativeBackup = readPatchManifest()!.backupPath;
+    const nativePatched = readFileSync(native);
+    rmSync(nativeBackup);
+
+    expect(await runPatchCommand({ restore: true })).toBe(1);
+    expect(readFileSync(native)).toEqual(nativePatched);
+    expect(logs.join('\n')).toMatch(/as the pristine content of/);
   });
 
   it('reports an error instead of restoring when no trustworthy backup exists', async () => {


### PR DESCRIPTION
If you have two Claude Code installs of the same version — an npm install beside a native one —
`clodex patch --restore` could copy the first install's pristine bytes over the second, tell you it
succeeded, and delete the record that was the first install's only way back. You ended up with two
damaged installs and a backup of neither. It now refuses instead, and tells you which install the
backup it found actually belongs to.

## The failure

`clodex patch --restore` (and the implicit restore inside `clodex patch`) selected a pristine backup
by matching **version tag**, and treated that as proof of which install the bytes came from. It
isn't. The npm platform package and the native installer ship genuinely different files under the
same version — for 2.1.263, 199,257,984 bytes versus 205,905,136 — and both are supported.

Reachable sequence, no contrived state: patch install A, have the resolved target become install B
(a stale `CLODEX_CLAUDE_PATH`/`TWEAKCC_CC_INSTALLATION_PATH`, a PATH change, a corrected launcher, or
A simply being uninstalled), run `--restore`. The manifest recorded A, so it was discarded for
naming a different path, and selection fell through to "the backup tagged with this version" — which
was A's. Issue #199, reported against real 2.1.266 binaries; the npm-beside-native shape is what
issue #193's reporter already runs.

## The change

The patch manifest is the only record of which install a backup was made for, and it holds **one**
install — so it can confirm a backup but can never rule one in by elimination. `selectRestoreSource`
now refuses, naming what to do instead, in the two states where that record contradicts the target:

- it records a **different** `binaryPath` — it vouches for nothing in the backup directory;
- it records **this** target but the pristine bytes it named are gone or corrupt — its own testimony
  says the same-version backups still on disk were made for some other install.

A manifest speaks only for the `claudeVersion` it was written for. After an upgrade it names a
backup of the old version, which is not among the new version's candidates at all, so neither
refusal fires across a version change.

`src/patcher.ts` only loses a stale comment and gains one explaining why deleting the manifest after
a restore is now sound. I first added a guard there to keep another install's manifest; the redesign
makes that unreachable, so it was removed rather than left in as dead code.

### What I deliberately left out

**Disqualifying only the backup the manifest names, and restoring the survivor.** That was my first
implementation and it is unsound: the manifest holds one install, so every earlier install's backup
is an unrecorded orphan with the same version tag, and "restore the one it did not name" hands a
third install's bytes to the target. It converted a safe `conflicting pristine backups` refusal on
`main` into a destructive copy. Both review passes found it independently. A regression test pins the
three-install shape specifically.

**The no-manifest case — `--restore` can still pick a backup by version tag when no manifest exists
at all, and that is reachable: a successful `--restore` deletes the manifest.** Tracked in #204 with
two candidate fixes and the laundering variant. Do not read this PR as closing #199 entirely; it
closes the manifest leg, which is what #199's Fix section asks for, and the note the plan now
carries says out loud when selection is resting on a version tag.

**`realpathSync.native` for path identity.** One install spelled two ways (case differences reach
this on APFS, not just Windows) reads as two installs and now refuses — safe, but a false refusal,
and it blocks `clodex patch` as well. Fixing it invalidates the `binaryPath` in every existing
manifest, so it needs a migration. Recorded in #204; `evaluatePatchState` compares the same way.

Two adjacent corrections came out of review: the `conflicting pristine backups` message no longer
says "remove the wrong one" (on a two-install machine both files are genuine, and deleting one
launders the wrong bytes into a manifest the new rules then trust), and the new version-tag warning
no longer suggests checking that the restored binary runs — both artifacts are working Claude Code.

## Tests

Nine new cases across the planner and the end-to-end command, including the three-install shape, the
deleted-recorded-backup shape, and both directions of version scoping.

Feature-deletion mutations, full-file runs, `tests/patch-backup.test.ts` + `tests/patcher-command.test.ts`:

| Mutation | Red |
| --- | --- |
| drop the different-install refusal | 8 |
| drop the recorded-backup-gone refusal | 5 (incl. a pre-existing corrupt-backup test) |
| drop version scoping | 3 |
| restore the rejected "disqualify and keep the survivor" design | 8, incl. the three-install test |

The three-install test is green on `main` (it refuses there for a different reason); it exists to
stop the unsound design coming back, and the table says which mutation isolates it.

## Runtime evidence

Real Claude Code 2.1.263 Mach-O binaries, isolated `CLODEX_HOME` and `TWEAKCC_CONFIG_DIR`, install B
a byte-differing copy of the same pristine bytes. Node 24.14.1, macOS 15, `CLAUDE_CODE_ENTRYPOINT=cli`.

| | `main` (d6a901b) | this branch |
| --- | --- | --- |
| `--restore` targeting install B | exit 0, "Restored pristine claude 2.1.263" | exit 1, names install A |
| B's bytes | **replaced with A's pristine bytes** | unchanged |
| manifest | **deleted** | kept |
| `--restore` targeting A afterwards | impossible, no manifest | exit 0, A pristine and runs |

`pnpm typecheck && pnpm test && pnpm build` green: 2513 tests, 114 files.

## Boundaries I could not verify

- **macOS only.** The planner is pure and platform-independent, and nothing here touches the
  read/repack/restore path, so `scripts/probe-patch-mechanism.mjs` was not run; if a reviewer wants
  ELF/PE coverage for the end-to-end command that is a reasonable ask.
- The second install in the real-binary run is a byte-modified copy of a genuine 2.1.263 binary, not
  a separately published npm artifact — the two published artifacts are independently known to
  differ in size and hash, but I did not install both.
- No provider legs were smoke-tested: this change is confined to backup selection and cannot reach
  the launch, gateway, or translation paths.

## Failure behavior

Every new path is a refusal before any write — exit 1, the binary untouched, the manifest left in
place. The rescue path is unaffected in the states that matter: a manifest recording this install
still restores it, including when the binary is too broken to report its version, and the
stale-launcher rescue from #193 still works.

Refs #199
