### PR TITLE
chore(canary): say what to do about a release the canary could not fully check

### DIFF
--- a/canary/README.md
+++ b/canary/README.md
@@ -22,9 +22,11 @@ each run, plus sandboxes — removed on success, kept on failure for the investi
 
 ## The three legs, and what each one actually proves
 
-Only two of the eight published builds can go through the real `clodex patch`: `clodex patch`
+Only three of the eight published builds can go through the real `clodex patch`: `clodex patch`
 resolves the version by **executing** the binary, so a foreign build needs either this Mac's own
-architecture or a native-architecture container. The other five get the probe,
+architecture or a native-architecture container. That is `darwin-arm64` on this Mac, plus
+`linux-arm64` and `linux-arm64-musl` in a container — the only two rows in `CANARY_PLATFORM_TABLE`
+carrying an image. The other five get the probe,
 `scripts/probe-patch-mechanism.mjs`, which works on any build from any host because it never
 executes anything.
 
@@ -46,7 +48,7 @@ A probe **does not** prove:
 
 - **that the patched binary runs.** Nothing here starts it, so a repack that produces a PE
   Windows refuses to load, or an ELF the kernel rejects, would still pass. Only the `host` and
-  `container` legs answer that, and only for macOS-arm64 and Linux-arm64.
+  `container` legs answer that, and only for `darwin-arm64`, `linux-arm64` and `linux-arm64-musl`.
 - **that an anchor bound to the right code.** A regex that matches a lookalike function still
   emits valid JavaScript and reports `OK`. The probe checks that a site *applied*, never that it
   applied to the thing it was aimed at.
@@ -57,6 +59,29 @@ probe exercised **zero** patch sites, and Claude Code 2.1.238 shipped with the `
 picker options` anchor no longer matching its `linux-arm64`, `linux-arm64-musl` and `win32-arm64`
 builds. The two Linux builds have container images and were reported as failures. `win32-arm64`
 has none, so it was a probe — and it was reported as a clean pass.
+
+## When the alert is not an all-clear
+
+The two container legs need a running Docker daemon. With Docker Desktop quit they fall back to the
+probe, which establishes nothing about whether a patched Linux binary starts, so the run is recorded
+as `partial` rather than `pass` and the notification withholds the green tick. `partial` does not
+close a version off: the canary re-tries it every `CANARY_PARTIAL_RETRY_HOURS` (6 by default) until
+a run achieves full coverage, so the same release is announced again — with the same verdict — for
+as long as the hole persists.
+
+Because that is a one-action fix, a **pass/partial** notification short of full coverage opens with
+what to do about it, before any of the evidence. Every cause that applies is named, not just the
+first: Docker being down, `--no-container`, a `--platforms` debug run, a host leg that did not pass,
+and a platform package that has not published yet each get their own line.
+
+A `--platforms` run is deduplicated before the matrix is built, and completeness compares distinct
+platform names rather than row counts — otherwise naming one build eight times would reach the
+published-platform count and be announced as a clean pass over seven builds nobody looked at.
+
+A **failure** alert has no such line — it leads with which platforms broke and what a background
+investigation session is doing about it. What it does share is the disclosure that a `--platforms`
+run tested only a subset, because otherwise "breaks `clodex patch` on 1 of 1 builds" reads as a
+statement about the release rather than about one hand-picked build.
 
 ## Install
 

--- a/canary/clodex-patch-canary-platforms.sh
+++ b/canary/clodex-patch-canary-platforms.sh
@@ -84,7 +84,10 @@ platform_names() {
     wanted="$wanted$known
 "
   done
-  printf '%s' "$wanted"
+  # Deduplicated, because coverage_is_complete counts matrix rows against published platforms:
+  # `--platforms darwin-arm64,darwin-arm64,...` repeated eight times would otherwise reach the
+  # published-platform count with one build tested, and be announced as "safe to update".
+  printf '%s' "$wanted" | awk 'NF && !seen[$0]++'
 }
 
 # Called from the main flow, NOT from a `$(...)`: `platform_names` is always read through a command
@@ -830,15 +833,62 @@ matrix_coverage_brief() {
 coverage_is_complete() { # coverage_is_complete <host-platform>
   # Not "did the platforms in the matrix pass" but "was every published platform in it". A
   # --platforms subset run passes every other test in here while having tested almost nothing.
-  [ "$(matrix_total)" -eq "$(printf '%s\n' "$CANARY_PLATFORM_TABLE" | awk -F'|' 'NF' | wc -l | tr -d ' ')" ] || return 1
+  # Each jq's STATUS is checked, not just its output. Testing `[ -z "$(jq ...)" ]` reads a failed
+  # jq — no output — as "nothing was downgraded" and returns full coverage: the one direction this
+  # function may never fail in, since its whole job is to withhold a green tick it cannot justify.
+  local distinct downgraded
+  distinct="$(jq -s -r '[.[].platform] | unique | length' "$MATRIX")" || return 1
+  # Distinct names on both sides, never row counts: equal counts and equal coverage are not the
+  # same claim, and the gap between them is a green tick over seven builds nobody looked at.
+  [ "$distinct" \
+      -eq "$(printf '%s\n' "$CANARY_PLATFORM_TABLE" | awk -F'|' 'NF' | wc -l | tr -d ' ')" ] || return 1
   [ "$(matrix_status_of "$1")" = "pass" ] || return 1
   [ "$(matrix_count error)" -eq 0 ] || return 1
-  [ -z "$(jq -s -r 'map(select(.downgraded == true) | .platform) | join(", ")' "$MATRIX")" ] || return 1
+  downgraded="$(jq -s -r 'map(select(.downgraded == true) | .platform) | join(", ")' "$MATRIX")" || return 1
+  [ -z "$downgraded" ] || return 1
   return 0
 }
 
 matrix_mode_of() { # matrix_mode_of <platform>
   jq -r -s --arg p "$1" 'map(select(.platform == $p) | .mode) | last // "none"' "$MATRIX"
+}
+
+# The one thing to DO about a run that fell short of full coverage — printed at the top of the
+# notification, before any of the detail. A message that reports a hole without naming the hole's
+# cause makes the reader re-derive it from the per-platform list every time, and the cause is
+# almost always "Docker Desktop is quit", which is fixable in one action.
+#
+# Mirrors coverage_is_complete's checks in the same order, and names EVERY cause that applies, not
+# just the first: fixing Docker while a host leg is also broken would otherwise leave the next run
+# short for a reason nobody was told about.
+coverage_gap_action() { # coverage_gap_action <host-platform> <retry-hours>
+  local host="$1" retry_h="$2" acts="" downgraded errors
+  downgraded="$(jq -s -r 'map(select(.downgraded == true) | .platform) | join(" and ")' "$MATRIX")"
+  errors="$(jq -s -r 'map(select(.status != "pass" and .status != "fail") | .platform) | join(", ")' "$MATRIX")"
+
+  if [ -n "${opt_platforms:-}" ]; then
+    acts="$acts
+- This was a \`--platforms\` debug run, so most of the matrix was never tested and no verdict was recorded. Run the canary without \`--platforms\` for a real answer."
+  fi
+  if [ -n "$downgraded" ]; then
+    if [ "${opt_container:-1}" -eq 1 ]; then
+      acts="$acts
+- *Start Docker Desktop.* That is the whole fix: $downgraded can only be patched for real inside a container, and with the daemon down they fall back to a bundle-only probe. The canary re-tries a partly covered release every ${retry_h}h, so the next run after Docker is up should clear this by itself — or run \`clodex-patch-canary.sh --force\` to settle it now."
+    else
+      acts="$acts
+- \`--no-container\` was passed, so $downgraded were never patched for real. Re-run without it."
+    fi
+  fi
+  if [ "$(matrix_status_of "$host")" != "pass" ]; then
+    acts="$acts
+- *This Mac's own leg reported $(matrix_status_of "$host"), so nothing was established for your machine.* Read the run log before updating Claude Code."
+  fi
+  if [ -n "$errors" ]; then
+    acts="$acts
+- $errors could not be tested at all (canary infrastructure or a platform package that has not published yet — not the release). Read the run log; if a package is simply not out yet, the next run picks it up."
+  fi
+  printf '%s' "${acts#
+}"
 }
 
 # How many patch sites actually applied, as opposed to how many were reported on: a SKIP is a site

--- a/canary/clodex-patch-canary-selftest.sh
+++ b/canary/clodex-patch-canary-selftest.sh
@@ -778,14 +778,21 @@ STATE_DIR="$TMP"
 state_set() { printf '%s\n' "$1" > "$STATE_FILE"; }
 state_get() { state_read | jq -r "$1"; }
 
+# Every one of these goes through $CANARY_VERDICT_FILTER, the expression the script itself writes
+# verdicts with. Transcribing the clause under test into the case instead is how the real filter got
+# changed with all of these still green.
+record_verdict() { # record_verdict <version> <status> <baseline-platforms-json>
+  state_update "$CANARY_VERDICT_FILTER" \
+    --arg v "$1" --arg st "$2" --argjson base "$3" \
+    --arg t "" --argjson te 0 --arg sha "" --arg l "" --arg fp "" --arg n "" --argjson pstatus '{}'
+}
+
 # A platform that could not run this time must keep the baseline it had. Replacing rather than
 # merging is how one Docker outage used to erase a platform's history.
 state_set '{"versions":{},"baseline":{"version":"1.0.0","platforms":{
   "linux-x64":{"mode":"probe","sites":{"a":"OK"},"version":"1.0.0"},
   "win32-x64":{"mode":"probe","sites":{"b":"OK"},"version":"1.0.0"}}},"pending":{},"deferred":{}}'
-state_update '.baseline = {version: $v, platforms: ((.baseline.platforms // {}) * $base)}' \
-  --arg v "2.0.0" \
-  --argjson base '{"linux-x64":{"mode":"probe","sites":{"a":"OK"},"version":"2.0.0"}}'
+record_verdict "2.0.0" "pass" '{"linux-x64":{"mode":"probe","sites":{"a":"OK"},"version":"2.0.0"}}'
 matrix_check "a platform that ran advances its baseline" "2.0.0" "$(state_get '.baseline.platforms["linux-x64"].version')"
 matrix_check "a platform that did not run keeps its baseline" "1.0.0" "$(state_get '.baseline.platforms["win32-x64"].version')"
 matrix_check "no platform is dropped from the baseline" "linux-x64 win32-x64" \
@@ -793,9 +800,9 @@ matrix_check "no platform is dropped from the baseline" "linux-x64 win32-x64" \
 
 # "Last release clean on every build" may only be claimed by a fully covered run.
 state_set '{"versions":{},"baseline":null,"pending":{},"deferred":{}}'
-state_update '(if $st == "pass" then .lastCompleteVersion = $v else . end)' --arg v "3.0.0" --arg st "partial"
+record_verdict "3.0.0" "partial" '{}'
 matrix_check "a partial run claims no known-good release" "" "$(state_get '.lastCompleteVersion // ""')"
-state_update '(if $st == "pass" then .lastCompleteVersion = $v else . end)' --arg v "3.0.1" --arg st "pass"
+record_verdict "3.0.1" "pass" '{}'
 matrix_check "a complete run does claim one" "3.0.1" "$(state_get '.lastCompleteVersion')"
 
 # --retriage must re-open a version WITHOUT throwing away the evidence pointers, because the run
@@ -930,6 +937,382 @@ if launch_investigation 9.9.9 "r" "$TMP/x.log" >/dev/null 2>&1; then
 else
   case "$LAST_SLACK" in *"NO PROMPT"*) pass=$((pass + 1)); printf 'ok   %s\n' "an idle session is treated as a failed launch" ;;
     *) fail=$((fail + 1)); printf 'FAIL %s — slack said: %s\n' "an idle session is treated as a failed launch" "$LAST_SLACK" ;; esac
+fi
+
+
+# ---------------------------------------------------------------- coverage_gap_action
+#
+# A run short of full coverage must open with what to DO about it. The first version of the
+# notification reported the hole (":warning: not a full all-clear" plus an eight-line platform
+# table) without ever saying that Docker Desktop being quit was the whole cause, so the same
+# fixable problem read as an unexplained wall of text twice in one evening.
+
+MATRIX="$TMP/matrix.jsonl"
+# reasons matters: a leg that could not run always carries one in production, and
+# matrix_error_notes reads the disclosure out of it rather than out of the status.
+leg_row() { # leg_row <platform> <mode> <status> <downgraded> [reasons]
+  jq -n -c --arg p "$1" --arg m "$2" --arg s "$3" --argjson d "$4" --arg r "${5:-}" \
+    '{platform: $p, mode: $m, status: $s, reasons: $r, downgraded: $d, sites: {}, markers: []}' >> "$MATRIX"
+}
+gap_check() { # gap_check <name> <expected-substring-or-EMPTY>
+  local name="$1" want="$2" got
+  got="$(coverage_gap_action darwin-arm64 6)"
+  if [ "$want" = "EMPTY" ]; then
+    if [ -z "$got" ]; then pass=$((pass + 1)); printf 'ok   %s\n' "$name"
+    else fail=$((fail + 1)); printf 'FAIL %s — expected no action, got:\n%s\n' "$name" "$got"; fi
+  else
+    case "$got" in
+      *"$want"*) pass=$((pass + 1)); printf 'ok   %s\n' "$name" ;;
+      *) fail=$((fail + 1)); printf 'FAIL %s — expected to contain %s, got:\n%s\n' "$name" "$want" "$got" ;;
+    esac
+  fi
+}
+
+# Docker quit: the two Linux legs with container images fall back to a probe.
+: > "$MATRIX"; opt_platforms=""; opt_container=1
+leg_row darwin-arm64 host pass false
+leg_row linux-arm64 probe pass true
+leg_row linux-arm64-musl probe pass true
+gap_check "a Docker outage says to start Docker Desktop" "Start Docker Desktop"
+gap_check "a Docker outage names the platforms it cost" "linux-arm64 and linux-arm64-musl"
+gap_check "a Docker outage quotes the retry cadence" "every 6h"
+
+# Full coverage: nothing to do, and nothing must be invented.
+: > "$MATRIX"; opt_platforms=""; opt_container=1
+leg_row darwin-arm64 host pass false
+leg_row linux-arm64 container pass false
+gap_check "a fully covered run has no action" EMPTY
+
+# --no-container is the operator's own doing, not a daemon that needs starting.
+: > "$MATRIX"; opt_platforms=""; opt_container=0
+leg_row darwin-arm64 host pass false
+leg_row linux-arm64 probe pass true
+gap_check "--no-container is reported as the cause it is" "\`--no-container\` was passed"
+case "$(coverage_gap_action darwin-arm64 6)" in
+  *"Start Docker Desktop"*) fail=$((fail + 1)); printf 'FAIL %s\n' "--no-container does not blame Docker" ;;
+  *) pass=$((pass + 1)); printf 'ok   %s\n' "--no-container does not blame Docker" ;;
+esac
+
+# A host leg that did not pass is the one hole that must not be buried under the others.
+: > "$MATRIX"; opt_platforms=""; opt_container=1
+leg_row darwin-arm64 host error false
+leg_row linux-arm64 probe pass true
+gap_check "a broken host leg is called out" "nothing was established for your machine"
+gap_check "a broken host leg does not hide the Docker cause" "Start Docker Desktop"
+
+# A platform package that has not published yet is an untested leg, not a downgrade.
+: > "$MATRIX"; opt_platforms=""; opt_container=1
+leg_row darwin-arm64 host pass false
+leg_row win32-arm64 none error false
+gap_check "an untested leg names the platform" "win32-arm64"
+gap_check "an untested leg is not blamed on the release" "not the release"
+
+# A --platforms run tested almost nothing; saying "not a full all-clear" without saying why is
+# actively misleading, because it reads as a problem with the release.
+: > "$MATRIX"; opt_platforms="darwin-arm64"; opt_container=1
+leg_row darwin-arm64 host pass false
+gap_check "a --platforms debug run says so" "debug run"
+opt_platforms=""
+
+# ---------------------------------------------------------------- the notification itself
+#
+# Through pass_notification_text, the function the script actually posts, rather than through the
+# pieces it is built from. A review found that deleting the action line from the message left all
+# of the component-level cases green, which is exactly the "tests do not discriminate" failure the
+# pr-verification gate puts first.
+
+msg_setup() { # msg_setup <host-status> <linux-legs-downgraded> [extra-soft-note]
+  MATRIX="$TMP/msgmatrix.jsonl"; : > "$MATRIX"
+  opt_platforms=""; opt_container=1
+  # Production shapes only. `downgraded` is not free-form: run_platform_matrix sets it exactly when
+  # a platform that HAS a container image was tested by the probe instead, so the container-capable
+  # Linux rows must move between container/false and probe/true together. Writing probe+false there
+  # staged a "full coverage" matrix the canary can never actually produce, and any assertion about
+  # full coverage made against it was about nothing.
+  local linux_mode=container
+  [ "$2" = true ] && linux_mode=probe
+  leg_row darwin-arm64 host "$1" false
+  leg_row darwin-x64 probe pass false
+  leg_row linux-x64 probe pass false
+  leg_row linux-arm64 "$linux_mode" pass "$2"
+  leg_row linux-x64-musl probe pass false
+  leg_row linux-arm64-musl "$linux_mode" pass "$2"
+  leg_row win32-x64 probe pass false
+  leg_row win32-arm64 probe pass false
+  VERSION=2.1.268; INSTALLED_VERSION=2.1.267; HOST_PLATFORM=darwin-arm64
+  MAIN_SHA=665c9a0b5d4ce3137f42812ea45309293c468dcd; REPO_DIR="$PWD"
+  HOST_STATUS="$(matrix_status_of "$HOST_PLATFORM")"
+  TOTAL_COUNT="$(matrix_total)"; COVERAGE="$(matrix_coverage_line)"
+  COVERAGE_COMPLETE=0; coverage_is_complete "$HOST_PLATFORM" && COVERAGE_COMPLETE=1
+  DOWNGRADE_NOTES="$(matrix_downgrade_notes)"
+  SUBSET_NOTE=""
+  SOFT_NOTES=""
+  [ -z "${3:-}" ] || SOFT_NOTES="$3
+"
+  [ -z "$DOWNGRADE_NOTES" ] || SOFT_NOTES="$SOFT_NOTES$DOWNGRADE_NOTES
+"
+  MSG="$(pass_notification_text)"
+}
+msg_has() { # msg_has <name> <substring>
+  case "$MSG" in *"$2"*) pass=$((pass + 1)); printf 'ok   %s\n' "$1" ;;
+    *) fail=$((fail + 1)); printf 'FAIL %s — message was:\n%s\n' "$1" "$MSG" ;; esac
+}
+msg_lacks() { # msg_lacks <name> <substring>
+  case "$MSG" in *"$2"*) fail=$((fail + 1)); printf 'FAIL %s — message was:\n%s\n' "$1" "$MSG" ;;
+    *) pass=$((pass + 1)); printf 'ok   %s\n' "$1" ;; esac
+}
+
+# Docker quit — the 2.1.268 run that was announced twice with no stated cause.
+msg_setup pass true "- linux-arm64 was tested as a probe leg this time and a container leg on 2.1.267."
+msg_has "the posted message says what to do" "To close this out:"
+msg_has "the posted message names Docker Desktop" "Start Docker Desktop"
+msg_lacks "the posted message does not claim an all-clear" "safe to update"
+# The action line replaces the duplicate, it does not replace the disclosure: both the per-platform
+# table and the unrelated note still have to survive into what is actually sent.
+msg_has "the posted message still shows the per-platform coverage" ":warning: *linux-arm64*"
+msg_has "the posted message keeps notes the action did not cover" "container leg on 2.1.267"
+# Not anchored to where the note would appear: it must not be anywhere in the message, whatever
+# order the notes happen to be in. The action line says "Start Docker Desktop", never this phrase,
+# so any occurrence at all is the duplicate coming back.
+msg_lacks "the posted message does not repeat the Docker note" "Docker was not available"
+
+# Full coverage — the action machinery must stay entirely out of a green message.
+msg_setup pass false ""
+msg_has "a fully covered run is announced as safe" "safe to update"
+msg_lacks "a fully covered run offers no action" "To close this out:"
+
+# A host leg that did not pass may never be dressed up as a release you can take.
+msg_setup error true ""
+msg_has "a broken host leg withholds the update recommendation" "hold off until a run covers it"
+msg_has "a broken host leg says nothing was established" "nothing was established for you"
+
+# A --platforms run tested a subset, so every count in the message is out of that subset. The pass
+# path says so in its action line; the FAILURE path has no action line, and a review found it
+# announcing "breaks `clodex patch` on 1 of 1 builds" with nothing anywhere saying the other seven
+# published builds were never looked at.
+msg_setup pass false ""
+opt_platforms="darwin-arm64"
+SUBSET_NOTE="$(subset_note)"          # computed, not staged: staging it made the case vacuous
+SOFT_NOTES="$SUBSET_NOTE
+"
+MSG="$(pass_notification_text)"
+msg_has "a subset run discloses the subset" "limited to darwin-arm64"
+msg_has "a subset run says the other builds went untested" "not tested at all"
+opt_platforms=""
+matrix_check "a normal full run adds no subset note" "" "$(subset_note)"
+# --platforms naming every published build covers the release, so it is not a subset run.
+opt_platforms="$(printf '%s\n' "$CANARY_PLATFORM_TABLE" | awk -F'|' 'NF{printf "%s,", $1}' | sed 's/,$//')"
+matrix_check "--platforms naming every build adds no subset note" "" "$(subset_note)"
+opt_platforms="darwin-arm64,linux-x64"
+case "$(subset_note)" in *"limited to"*) pass=$((pass + 1)); printf 'ok   %s\n' "a genuine subset still says so" ;;
+  *) fail=$((fail + 1)); printf 'FAIL %s\n' "a genuine subset still says so" ;; esac
+opt_platforms=""
+SUBSET_NOTE=""
+
+# ---------------------------------------------------------------- wiring
+#
+# The seams between the helpers and the run, which is where the previous round of cases stopped. A
+# review proved that disconnecting the subset note from the production note list, or either composer
+# from the posting, left all of the helper-level assertions green.
+
+# collect_soft_notes is the only producer of SOFT_NOTES. A disclosure that does not make it in here
+# is disclosed in neither notification.
+: > "$MATRIX"; opt_platforms=""; opt_container=1
+leg_row darwin-arm64 host pass false
+leg_row linux-arm64 probe pass true
+leg_row win32-arm64 none error false \
+  "- claude-code-win32-arm64 has still not published 2.1.268 130 minutes after the other platforms did, so it was not tested
+"
+SOFT_NOTES=""
+collect_soft_notes
+soft_has() { case "$SOFT_NOTES" in *"$2"*) pass=$((pass + 1)); printf 'ok   %s\n' "$1" ;;
+  *) fail=$((fail + 1)); printf 'FAIL %s — SOFT_NOTES was:\n%s\n' "$1" "$SOFT_NOTES" ;; esac; }
+soft_has "the run's notes disclose a downgraded leg" "Docker was not available"
+soft_has "the run's notes disclose a leg that could not be tested" "win32-arm64"
+
+# ...including the subset note, which is the failure alert's ONLY disclosure that most of the
+# matrix was skipped.
+opt_platforms="darwin-arm64"; SOFT_NOTES=""
+collect_soft_notes
+soft_has "the run's notes disclose a --platforms subset" "limited to darwin-arm64"
+opt_platforms=""; SOFT_NOTES=""
+collect_soft_notes
+case "$SOFT_NOTES" in *"limited to"*) fail=$((fail + 1)); printf 'FAIL %s\n' "a normal run adds no subset note to the run's notes" ;;
+  *) pass=$((pass + 1)); printf 'ok   %s\n' "a normal run adds no subset note to the run's notes" ;; esac
+
+# announce_verdict is the seam between a composed message and Slack. Both branches must post, and
+# must post what their own composer produced.
+POSTED=""
+slack() { POSTED="$1"; }
+msg_setup pass true ""
+REASONS=""
+announce_verdict
+case "$POSTED" in *"To close this out:"*) pass=$((pass + 1)); printf 'ok   %s\n' "a clean run posts the pass notification" ;;
+  *) fail=$((fail + 1)); printf 'FAIL %s — posted:\n%s\n' "a clean run posts the pass notification" "$POSTED" ;; esac
+
+POSTED=""
+FAILED_PLATFORMS="linux-x64"; REASONS="- PATCH 5 failed on linux-x64"; NEXT_STEP=":mag: investigating"
+BASE_VERSION=2.1.267; COMPACT_PROMPT_DRIFT_ONLY=0; MAIN_SUBJECT="subj"; RUN_LOG="$TMP/r.log"; WORK="$TMP/w"
+announce_verdict
+case "$POSTED" in *"breaks"*) pass=$((pass + 1)); printf 'ok   %s\n' "a broken release posts the failure alert" ;;
+  *) fail=$((fail + 1)); printf 'FAIL %s — posted:\n%s\n' "a broken release posts the failure alert" "$POSTED" ;; esac
+case "$POSTED" in *"To close this out:"*) fail=$((fail + 1)); printf 'FAIL %s\n' "the failure alert is not the pass notification" ;;
+  *) pass=$((pass + 1)); printf 'ok   %s\n' "the failure alert is not the pass notification" ;; esac
+
+# The failure alert carries the run's notes, which is where a subset or a downgrade is disclosed on
+# that path — it has no action line to carry them.
+POSTED=""; SOFT_NOTES="- linux-arm64 got the probe instead.
+"
+announce_verdict
+case "$POSTED" in *"linux-arm64 got the probe instead"*) pass=$((pass + 1)); printf 'ok   %s\n' "the failure alert discloses reduced coverage" ;;
+  *) fail=$((fail + 1)); printf 'FAIL %s — posted:\n%s\n' "the failure alert discloses reduced coverage" "$POSTED" ;; esac
+REASONS=""; SOFT_NOTES=""
+
+# Duplicate --platforms names must not reach the published-platform count and buy a green tick.
+: > "$MATRIX"; opt_platforms="darwin-arm64,darwin-arm64"
+matrix_check "duplicate --platforms names select one platform" "darwin-arm64" "$(platform_names | tr '\n' ' ' | sed 's/ *$//')"
+for _i in 1 2 3 4 5 6 7 8; do leg_row darwin-arm64 host pass false; done
+if coverage_is_complete darwin-arm64; then
+  fail=$((fail + 1)); printf 'FAIL %s\n' "eight rows for one platform is not full coverage"
+else
+  pass=$((pass + 1)); printf 'ok   %s\n' "eight rows for one platform is not full coverage"
+fi
+opt_platforms=""
+
+# ---------------------------------------------------------------- failing under a broken jq
+#
+# Both of these are about which way the canary breaks when a tool it depends on fails mid-run. It
+# may refuse to answer; it may never answer "everything is fine" because it could not tell.
+
+# coverage_is_complete decided the downgrade question with `[ -z "$(jq ...)" ]`, which reads a jq
+# that FAILED — no output — as "nothing was downgraded", and returns full coverage. That is a green
+# tick issued because the check broke, which is the one direction this function may never fail in.
+: > "$MATRIX"; opt_platforms=""; opt_container=1
+leg_row darwin-arm64 host pass false
+leg_row darwin-x64 probe pass false
+leg_row linux-x64 probe pass false
+leg_row linux-arm64 probe pass true
+leg_row linux-x64-musl probe pass false
+leg_row linux-arm64-musl probe pass true
+leg_row win32-x64 probe pass false
+leg_row win32-arm64 probe pass false
+if coverage_is_complete darwin-arm64; then
+  fail=$((fail + 1)); printf 'FAIL %s\n' "downgraded legs are not full coverage"
+else pass=$((pass + 1)); printf 'ok   %s\n' "downgraded legs are not full coverage"; fi
+
+jq() { case "$*" in *downgraded*) return 4 ;; *) command jq "$@" ;; esac; }
+if coverage_is_complete darwin-arm64; then
+  fail=$((fail + 1)); printf 'FAIL %s\n' "a jq that fails cannot buy an all-clear"
+else pass=$((pass + 1)); printf 'ok   %s\n' "a jq that fails cannot buy an all-clear"; fi
+unset -f jq
+
+# announce_verdict composes and posts in one expression no longer: the `|| true` that keeps a Slack
+# outage from killing the canary used to swallow a failure in the RENDERER too, and shipped a
+# "safe to update" headline over a body whose counts had come out empty. set -e does not catch it —
+# a failing assignment inside a function running in a command substitution does not trip errexit —
+# so the composers return non-zero explicitly and this refuses to post rather than post rubbish.
+msg_setup pass false ""
+REASONS=""
+POSTED_FILE="$TMP/posted.txt"; : > "$POSTED_FILE"
+(
+  slack() { printf '%s' "$1" > "$POSTED_FILE"; }
+  jq() { case "$*" in *'.mode == "host"'*) return 4 ;; *) command jq "$@" ;; esac; }
+  announce_verdict
+) >/dev/null 2>&1 && RC=0 || RC=$?
+if [ "$RC" -ne 0 ]; then pass=$((pass + 1)); printf 'ok   %s\n' "a broken renderer fails the run"
+else fail=$((fail + 1)); printf 'FAIL %s — announce_verdict returned 0\n' "a broken renderer fails the run"; fi
+if [ ! -s "$POSTED_FILE" ]; then pass=$((pass + 1)); printf 'ok   %s\n' "a broken renderer posts nothing at all"
+else fail=$((fail + 1)); printf 'FAIL %s — it posted:\n%s\n' "a broken renderer posts nothing at all" "$(cat "$POSTED_FILE")"; fi
+
+# ...while a Slack outage on its own must still NOT take the canary down: that is what the `|| true`
+# is for, and tightening the renderer must not have tightened the transport with it.
+: > "$POSTED_FILE"
+(
+  slack() { return 1; }
+  announce_verdict
+) >/dev/null 2>&1 && RC=0 || RC=$?
+if [ "$RC" -eq 0 ]; then pass=$((pass + 1)); printf 'ok   %s\n' "a Slack outage alone does not fail the run"
+else fail=$((fail + 1)); printf 'FAIL %s — announce_verdict returned %s\n' "a Slack outage alone does not fail the run" "$RC"; fi
+
+# ---------------------------------------------------------------- notes_for_display
+#
+# The notification says what to do at the top; the "Worth knowing" list below it must not repeat it.
+
+DOWNGRADE='- Docker was not available, so linux-arm64 got the probe instead.'
+OTHER='- linux-arm64 was tested as a probe leg this time and a container leg on 2.1.267.'
+
+# Both sides through $(...), which strips trailing newlines, so the case is about which notes
+# survive and not about a trailing blank line the caller's own substitution discards anyway.
+notes_check() { # notes_check <name> <all> <covered> <expected>
+  local got want
+  got="$(notes_for_display "$2" "$3")"
+  want="$(printf '%s' "$4")"
+  if [ "$got" = "$want" ]; then pass=$((pass + 1)); printf 'ok   %s\n' "$1"
+  else fail=$((fail + 1)); printf 'FAIL %s\n  want %s\n  got  %s\n' "$1" "$(printf '%s' "$want" | tr '\n' '|')" "$(printf '%s' "$got" | tr '\n' '|')"; fi
+}
+
+notes_check "the note the action line already made is dropped" "$DOWNGRADE
+" "$DOWNGRADE" ""
+
+# The footgun this exists to pin: every note starts with "- ", so an unanchored grep pattern is read
+# as flags. grep then fails and the `|| true` swallows it, taking every unrelated note with it —
+# the reduced-coverage disclosures this canary exists to make.
+notes_check "an unrelated note survives the trim" "$OTHER
+$DOWNGRADE
+" "$DOWNGRADE" "$OTHER
+"
+
+notes_check "nothing is dropped when there is nothing to drop" "$OTHER
+" "" "$OTHER
+"
+
+# Whole-line, not substring: a longer note that quotes the covered one is a different note and has
+# its own thing to say.
+notes_check "a note that merely contains the covered one is kept" "$DOWNGRADE plus a detail
+" "$DOWNGRADE" "$DOWNGRADE plus a detail
+"
+
+# ---------------------------------------------------------------- baseline merge
+#
+# A platform's baseline entry must be exactly what its last passing leg observed. The merge used
+# jq's `*`, which recurses, so a new entry inherited `sites` keys from the entry it replaced. A
+# host/container leg records `probe:PATCH …` names that a probe-only leg never emits, so after one
+# Docker outage the fresh probe entry carried the container run's leftover names, the leg-mode
+# guard saw two matching `probe` modes and compared anyway, and the next run reported all eleven
+# leftover names as checks that had been "not attempted at all this time".
+
+# Driven through $CANARY_VERDICT_FILTER, the script's own expression, rather than a copy of it
+# here: the copy is what let the real filter be edited without any test noticing. The stub installed
+# for the launch_investigation cases above has to go first, or this writes nothing and every
+# assertion below reads back the fixture it started from and passes for free.
+unset -f state_update
+CANARY_STATE_DIR="$TMP/basemerge" CANARY_SOURCE_ONLY=1 . "$CANARY"
+STATE_DIR="$TMP/basemerge"; mkdir -p "$STATE_DIR"; STATE_FILE="$STATE_DIR/state.json"
+jq -n '{versions: {}, inflight: null, deferred: {}, pending: {},
+        baseline: {version: "2.1.267", platforms: {
+          "linux-arm64": {mode: "container",
+                          sites: {"PATCH 1: enum": "OK", "probe:PATCH 1: enum": "OK"}},
+          "win32-x64":   {mode: "probe", sites: {"PATCH 1: enum": "OK"}}}}}' > "$STATE_FILE"
+
+# The next release: linux-arm64 gets the probe (Docker is down), win32-x64 is not in this run.
+record_verdict 2.1.268 partial '{"linux-arm64": {"mode": "probe", "sites": {"PATCH 1: enum": "OK"}}}'
+
+GOT="$(jq -c '.baseline.platforms["linux-arm64"].sites | keys' "$STATE_FILE")"
+if [ "$GOT" = '["PATCH 1: enum"]' ]; then
+  pass=$((pass + 1)); printf 'ok   %s\n' "a probe entry does not inherit the container entry's probe: names"
+else
+  fail=$((fail + 1))
+  printf 'FAIL %s — want ["PATCH 1: enum"], got %s\n' "a probe entry does not inherit the container entry's probe: names" "$GOT"
+fi
+
+# The whole point of merging rather than replacing: a leg that did not run this time keeps its
+# record, so one permanently unavailable platform cannot freeze regression detection for the rest.
+GOT="$(jq -r '.baseline.platforms["win32-x64"].mode // "GONE"' "$STATE_FILE")"
+if [ "$GOT" = "probe" ]; then
+  pass=$((pass + 1)); printf 'ok   %s\n' "a platform absent from this run keeps its previous baseline entry"
+else
+  fail=$((fail + 1))
+  printf 'FAIL %s — win32-x64 mode is %s\n' "a platform absent from this run keeps its previous baseline entry" "$GOT"
 fi
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"

--- a/canary/clodex-patch-canary.sh
+++ b/canary/clodex-patch-canary.sh
@@ -85,6 +85,101 @@ CANARY_PARTIAL_RETRY_HOURS="${CANARY_PARTIAL_RETRY_HOURS:-6}"
 # A background session in one of these states is finished; anything else is still working.
 TERMINAL_AGENT_STATES="done stopped failed error cancelled"
 
+# The "Worth knowing" list, minus whatever the action line at the top of the notification already
+# said. Printing "Docker was not available" three paragraphs below "start Docker Desktop" is what
+# turns a one-line instruction into something that reads as filler and gets skipped. Display only —
+# the note stays in full in the state record either way.
+# One disclosure line, appended to SOFT_NOTES. Both notifications render that list.
+add_soft() { SOFT_NOTES="$SOFT_NOTES- $1
+"; }
+
+# Every disclosure of reduced coverage this run owes the reader, gathered into SOFT_NOTES: legs
+# that errored, legs downgraded to a probe, and a --platforms subset. Both notifications render it,
+# so a note that never makes it in here is disclosed nowhere at all. A function rather than a run of
+# top-level statements because that is the only way the self-test can prove a producer is still
+# wired to it — the subset note was once added to the script and to the tests independently, and
+# deleting the production wiring left every case green.
+#
+# Sets: SOFT_NOTES (appended via add_soft), DOWNGRADE_NOTES and SUBSET_NOTE, which the pass
+# notification reads again to avoid repeating itself.
+collect_soft_notes() {
+  local all line
+  # Separate assignments, not one interpolation: with several substitutions in a single assignment
+  # only the last one's failure is visible to errexit, so a jq fault in an earlier one would
+  # silently drop the very notes that disclose reduced coverage.
+  ERROR_NOTES="$(matrix_error_notes)"
+  DOWNGRADE_NOTES="$(matrix_downgrade_notes)"
+  SUBSET_NOTE="$(subset_note)"
+  all="$ERROR_NOTES
+$DOWNGRADE_NOTES
+$SUBSET_NOTE"
+  while IFS= read -r line; do
+    [ -n "$line" ] && add_soft "${line#- }"
+  done <<EOF
+$all
+EOF
+  return 0
+}
+
+# A --platforms run tested a subset, so every count in either message — "breaks on 1 of 1 builds" —
+# is out of that subset and not out of the release. The pass path also says so in its action line;
+# the failure path has no action line at all, so this note is the only place it is disclosed there.
+# Empty for a normal full run, which is every scheduled one.
+subset_note() {
+  [ -n "${opt_platforms:-}" ] || return 0
+  # A selection is only a subset if it is SMALLER than what is published. `--platforms` naming all
+  # eight covers the release completely, and telling the reader the other builds went untested when
+  # there are no other builds is a false disclosure, which costs the true ones their credibility.
+  local selected published
+  selected="$(platform_names | awk 'NF' | wc -l | tr -d ' ')" || return 1
+  published="$(printf '%s\n' "$CANARY_PLATFORM_TABLE" | awk -F'|' 'NF' | wc -l | tr -d ' ')"
+  [ "$selected" -lt "$published" ] || return 0
+  printf '%s' "- this run was limited to $opt_platforms by \`--platforms\`, so every count here is out of that subset and the other published builds were not tested at all"
+}
+
+notes_for_display() { # notes_for_display <all-notes> [note-already-covered...]
+  local all="$1" kept pats=() note
+  shift
+  for note in "$@"; do
+    # -e for every pattern: each note begins with "- ", and without it grep reads the pattern as
+    # flags, fails, and the `|| true` below swallows that — dropping the entire list and silently
+    # taking every unrelated note, including the reduced-coverage disclosures, with it.
+    [ -z "$note" ] || pats+=(-e "$note")
+  done
+  [ "${#pats[@]}" -gt 0 ] || { printf '%s' "$all"; return 0; }
+  kept="$(printf '%s' "$all" | grep -vxF "${pats[@]}" || true)"
+  [ -z "$kept" ] || kept="$kept
+"
+  printf '%s' "$kept"
+}
+
+# The write that records a release's verdict. Held here rather than inlined at its call site so the
+# self-test can drive the real expression: the test used to carry its own transcription of it, and a
+# transcription is a copy that stops matching the moment one of the two is edited.
+#
+# `.baseline` is what each platform looked like the last time IT came out clean, merged so that a
+# leg which could not run this time keeps its old entry instead of being forgotten while a leg that
+# did run still advances — one permanently unavailable platform cannot freeze regression detection
+# for the other seven.
+#
+# The merge is `+`, NOT `*`. `*` merges recursively, so a platform's new entry would inherit `sites`
+# keys from the entry it replaced. That silently defeats the leg-mode guard in the comparison above:
+# a host/container leg records `probe:PATCH …` names that a probe-only leg never emits, so after one
+# Docker outage the fresh probe entry carried the container run's leftover names, the guard saw two
+# matching `probe` modes and compared anyway, and the next run announced all eleven leftover names
+# as checks that were "not attempted at all this time". A leg's record must be exactly what that leg
+# observed.
+#
+# `.lastCompleteVersion` is the last release that came out clean on EVERY build. It is the only
+# thing entitled to be quoted as "last known good", so it is the only thing gated on `pass`.
+CANARY_VERDICT_FILTER='.versions[$v] = {status: $st, at: $t, atEpoch: $te, clodexSha: $sha, log: $l,
+                                        notes: $n, platforms: $pstatus}
+                       | .baseline = {version: $v, at: $t, clodexSha: $sha, configFingerprint: $fp,
+                                      platforms: ((.baseline.platforms // {}) + $base)}
+                       | (if $st == "pass" then .lastCompleteVersion = $v else . end)
+                       | .deferred = ((.deferred // {}) | del(.[$v]))
+                       | .pending = ((.pending // {}) | del(.[$v]))'
+
 opt_status=0 opt_force=0 opt_launch=1 opt_slack=1 opt_keep=0 opt_version="" opt_retriage=""
 opt_platforms="" opt_container=1
 
@@ -971,6 +1066,156 @@ inflight_status() {
   echo working
 }
 
+# The pass/partial notification, composed rather than posted, so the self-test can read the
+# bytes this actually sends. Assembled inline at the call site, the only things a test could
+# reach were the pieces: deleting the action line from the message left every assertion green.
+#
+# Reads the run's globals: VERSION, INSTALLED_VERSION, HOST_PLATFORM, HOST_STATUS, TOTAL_COUNT,
+# COVERAGE, COVERAGE_COMPLETE, SOFT_NOTES, DOWNGRADE_NOTES, SUBSET_NOTE, MAIN_SHA, REPO_DIR,
+# and $MATRIX.
+pass_notification_text() {
+  # Only the host leg can license an update, so only a host leg that passed may recommend one.
+  # Saying "nothing was established for you" and "the update is yours to take" in one message is
+  # worse than saying neither.
+  if [ "$HOST_STATUS" != "pass" ]; then
+    UPDATE_LINE="Because this Mac's leg did not complete, whether $VERSION patches *here* is unknown — hold off until a run covers it."
+  elif [ "$INSTALLED_VERSION" = "$VERSION" ]; then
+    UPDATE_LINE="You are already on $VERSION — nothing to do."
+  else
+    UPDATE_LINE="You are on $INSTALLED_VERSION, so the update is yours to take whenever you like. Re-run \`clodex patch\` afterwards to re-apply your aliases."
+  fi
+  # What was actually established, in the words of what was actually run. The probe applies every
+  # patch transform to extracted JavaScript but never runs the real `clodex patch` command or starts
+  # its result, so "clodex patch applies cleanly" is still true only of host and container legs.
+  FULL_LEGS="$(jq -s -r 'map(select(.status == "pass" and (.mode == "host" or .mode == "container")) | .platform) | join(", ")' "$MATRIX")" || return 1
+  FULL_COUNT="$(jq -s -r 'map(select(.status == "pass" and (.mode == "host" or .mode == "container"))) | length' "$MATRIX")" || return 1
+  PROBE_COUNT="$(jq -s -r 'map(select(.status == "pass" and .mode == "probe")) | length' "$MATRIX")" || return 1
+  UNTESTED_COUNT="$(jq -s -r 'map(select(.status != "pass" and .status != "fail")) | length' "$MATRIX")" || return 1
+  HOST_APPLIED="$(matrix_applied_sites "$HOST_PLATFORM")" || return 1
+  HOST_TOTAL="$(matrix_total_sites "$HOST_PLATFORM")" || return 1
+  # Only say the binary ran if the leg that runs it actually finished. This sentence asserted it
+  # unconditionally and would state it after a host leg that errored before patching anything.
+  if [ "$HOST_STATUS" = "pass" ]; then
+    HOST_LINE="on this Mac $HOST_APPLIED of $HOST_TOTAL patch sites applied and the patched binary runs and reports $VERSION"
+  else
+    HOST_LINE="*this Mac was not among them* — its leg reported $HOST_STATUS, so nothing was established for you"
+  fi
+  UNTESTED_LINE=""
+  [ "$UNTESTED_COUNT" -eq 0 ] ||
+    UNTESTED_LINE="
+$UNTESTED_COUNT build(s) could not be tested at all this run — they are marked below and are the reason this is not an all-clear."
+
+  # The action comes FIRST, before any of the evidence. A reader who sees ":warning: not a full
+  # all-clear" wants to know what to do about it, and making them infer that from a per-platform
+  # list they have to read to the bottom is how a fixable one-command problem (Docker Desktop is
+  # quit) reads as an unexplained wall of text and gets ignored.
+  ACTION_LINE=""
+  if [ "$COVERAGE_COMPLETE" -eq 1 ]; then
+    PASS_HEAD=":white_check_mark: *Claude Code $VERSION — safe to update.*"
+  else
+    # Deliberately NOT a green tick. Nothing proved this release broken, but the coverage it was
+    # judged on has a hole in it, and a hole reported as a clean pass is the original incident.
+    PASS_HEAD=":warning: *Claude Code $VERSION — nothing broke, but this is not a full all-clear.*"
+    GAP_ACTION="$(coverage_gap_action "$HOST_PLATFORM" "$CANARY_PARTIAL_RETRY_HOURS")" || return 1
+    [ -z "$GAP_ACTION" ] || ACTION_LINE="
+
+:point_right: *To close this out:*
+$GAP_ACTION"
+  fi
+  # Only when there IS an action line: with no action shown, the downgrade note is the only place
+  # the reduced coverage is disclosed at all.
+  DISPLAY_NOTES="$SOFT_NOTES"
+  [ -z "$ACTION_LINE" ] ||
+    DISPLAY_NOTES="$(notes_for_display "$SOFT_NOTES" "$DOWNGRADE_NOTES" "$SUBSET_NOTE")" || return 1
+  # Only mention the bundle-level tier when something is actually in it. "0 got the bundle-level
+  # check only" next to five untested builds reads as a contradiction.
+  PROBE_LINE=""
+  [ "$PROBE_COUNT" -eq 0 ] || PROBE_LINE="
+$PROBE_COUNT got the bundle-level check only: every clodex patch site applied to their own bundle and the repack round-tripped, but no patched binary was started there."
+  printf '%s\n' "$PASS_HEAD$ACTION_LINE
+The real \`clodex patch\` ran on $FULL_COUNT of $TOTAL_COUNT builds ($FULL_LEGS): $HOST_LINE.$PROBE_LINE$UNTESTED_LINE
+Tested against clodex origin/main \`${MAIN_SHA:0:8}\` (not the published $(node -p "require('$REPO_DIR/package.json').version" 2>/dev/null || echo release)), so this is a verdict on main.
+$UPDATE_LINE$( [ -n "$DISPLAY_NOTES" ] && printf '\n\n:information_source: Worth knowing:\n%s' "$DISPLAY_NOTES" )$( [ "$COVERAGE_COMPLETE" -eq 1 ] || printf '\n\n%s' "$COVERAGE" )"
+}
+
+# The failure notification, composed rather than posted, for the same reason as its pass-path
+# twin: a test can then read the bytes that are actually sent instead of the pieces they are
+# built from.
+#
+# Reads: VERSION, INSTALLED_VERSION, HOST_STATUS, TOTAL_COUNT, FAILED_PLATFORMS, REASONS,
+# NEXT_STEP, SOFT_NOTES, BASE_VERSION, COMPACT_PROMPT_DRIFT_ONLY, MAIN_SHA, MAIN_SUBJECT,
+# RUN_LOG, WORK and $MATRIX.
+fail_notification_text() {
+  local HEADLINE="${HEADLINE:-}"
+  # Which platforms broke changes what you should DO, so it leads. A break that spares this Mac is
+  # still a break you ship to everyone else, and a break that includes this Mac is also a "do not
+  # update" for you personally — those are different messages and must not be blurred together.
+  # Note the ordering: "the host passed" is a stronger claim than "the host did not fail", and only
+  # the first justifies telling someone their machine is fine.
+  # Not $BASE_VERSION: the baseline advances per platform, so its version is the last release that
+  # passed SOMETHING. Only .lastCompleteVersion means "clean on every build".
+  LAST_COMPLETE="$(state_read | jq -r '.lastCompleteVersion // empty')" || return 1
+  LAST_GOOD=""
+  [ -z "$LAST_COMPLETE" ] || LAST_GOOD="
+Last release that came out clean on every build: *$LAST_COMPLETE*."
+  if [ "$COMPACT_PROMPT_DRIFT_ONLY" -eq 1 ]; then
+    HEADLINE="$(compact_prompt_drift_headline "$VERSION" "$(matrix_count fail)" "$TOTAL_COUNT")" || return 1
+    IMPACT="$(compact_prompt_drift_impact)$LAST_GOOD"
+  elif [ "$HOST_STATUS" = "fail" ] && [ "$INSTALLED_VERSION" = "$VERSION" ]; then
+    IMPACT="*You are already ON $VERSION and it cannot be patched* — your aliases and effort settings are off until this is fixed. Roll back, or wait for the fix.$LAST_GOOD"
+  elif [ "$HOST_STATUS" = "fail" ]; then
+    IMPACT="*Do not update Claude Code yet* — you are on $INSTALLED_VERSION and patching $VERSION fails on this Mac. Your current patched install keeps working; the risk is only at update time.$LAST_GOOD"
+  elif [ "$HOST_STATUS" != "pass" ]; then
+    IMPACT="*Your Mac was NOT tested this run* (its leg reported $HOST_STATUS), so treat $VERSION as unknown rather than safe for you.$LAST_GOOD"
+  elif [ -n "$FAILED_PLATFORMS" ]; then
+    IMPACT="*Your own Mac is fine* — $VERSION patches cleanly here, so you can update. But clodex is broken on $(printf '%s' "$FAILED_PLATFORMS" | tr ' ' ',' | sed 's/,/, /g'), and Claude Code auto-updates, so users there are being broken as they update.$LAST_GOOD"
+  else
+    HEADLINE=":warning: *Claude Code $VERSION patches, but not the way it used to*"
+    IMPACT="*You can install it — but something clodex used to do no longer applies.* Patching succeeds; a check that passed on $BASE_VERSION now reports differently, which usually means an anchor drifted and a feature is quietly off. Stay on $INSTALLED_VERSION until this is diagnosed if you rely on it."
+  fi
+  [ -n "${HEADLINE:-}" ] ||
+    HEADLINE=":rotating_light: *clodex patch canary: Claude Code $VERSION breaks \`clodex patch\`* on $(matrix_count fail) of $TOTAL_COUNT builds"
+
+  # Reasons and the next step come before the matrix: with eight platforms the matrix alone pushes
+  # everything actionable below the fold on a phone.
+  printf '%s\n' "$HEADLINE
+$IMPACT
+Tested against clodex origin/main \`${MAIN_SHA:0:8}\` — $MAIN_SUBJECT
+
+$REASONS
+$NEXT_STEP
+
+Nothing on your machine was patched or installed. Log: \`$RUN_LOG\` · sandbox: \`$WORK\` · reproduce any leg: \`$WORK/repro.sh <platform>\`
+
+$(matrix_coverage_brief)$( [ -n "$SOFT_NOTES" ] && printf '\n\n:information_source: Also worth knowing:\n%s' "$SOFT_NOTES" )"
+}
+
+# Which notification goes out. One line each way, but it is the seam where a composer is wired to
+# the posting: with the choice inlined in the main flow, a test could prove both composers correct
+# and still not notice that neither was reaching Slack. An empty $REASONS means nothing was proved
+# broken, which is the pass/partial message; anything else is the failure alert.
+announce_verdict() {
+  local text
+  # Composed first, posted second, and NOT in one expression. `slack ... || true` must keep a
+  # Slack outage from taking the canary down, but with the rendering inside that same expression
+  # the `|| true` also swallowed a jq fault in the renderer: the run carried on and posted a
+  # "safe to update" headline over a body whose counts had rendered empty. Composition failing is
+  # a broken canary and has to be fatal; only the transport is allowed to fail quietly.
+  #
+  # The composers signal a render failure by returning non-zero, and each of their own command
+  # substitutions carries `|| return 1` to make that happen, because `set -e` does NOT fire for a
+  # failing assignment inside a function that is itself running in a command substitution — proven
+  # by a fault injected into one of the renderer's jq calls, which shipped a "safe to update"
+  # headline over a body with empty counts.
+  if [ -z "$REASONS" ]; then
+    text="$(pass_notification_text)" || die "could not compose the $VERSION notification — refusing to post a partial one"
+  else
+    text="$(fail_notification_text)" || die "could not compose the $VERSION failure alert — refusing to post a partial one"
+  fi
+  slack "$text" || true
+}
+
+
 # ------------------------------------------------------------------------ main
 
 # Sourcing the script gives you the helpers above and nothing else — that is how the self-test
@@ -1197,8 +1442,6 @@ printf '%s\n' "-----------------------"
 # Without that split, one favourites edit would fail every future release forever, because the
 # baseline only refreshes on a pass.
 SOFT_NOTES=""
-add_soft() { SOFT_NOTES="$SOFT_NOTES- $1
-"; }
 EXTRA_REASONS=""
 
 BASE_CONFIG_FP="$(state_read | jq -r '.baseline.configFingerprint // ""')"
@@ -1269,15 +1512,7 @@ fi
 # Two assignments, not one interpolation: with both substitutions in a single assignment only the
 # last one's failure is visible to errexit, so a jq fault in the first would silently drop the very
 # notes that disclose reduced coverage.
-ERROR_NOTES="$(matrix_error_notes)"
-DOWNGRADE_NOTES="$(matrix_downgrade_notes)"
-ERROR_NOTES="$ERROR_NOTES
-$DOWNGRADE_NOTES"
-while IFS= read -r _line; do
-  [ -n "$_line" ] && add_soft "${_line#- }"
-done <<EOF
-$ERROR_NOTES
-EOF
+collect_soft_notes
 
 if [ "$FINGERPRINT_BEFORE" != "$FINGERPRINT_AFTER" ]; then
   log "WARN: real Claude Code / clodex / tweakcc state changed during the run"
@@ -1327,22 +1562,8 @@ if [ -z "$REASONS" ]; then
   else
     # Only a fully covered run may set the baseline or close the version. Anything less is
     # recorded as `partial`: honest in --status, and re-tried later rather than filed forever.
-    # Two separate ideas, kept separate on purpose:
-    #   .baseline           what each platform looked like the last time IT came out clean. Merged,
-    #                       so a leg that could not run this time keeps its old entry instead of
-    #                       being forgotten, and a leg that did run still advances. A permanently
-    #                       unavailable platform can no longer freeze regression detection for the
-    #                       seven that are fine.
-    #   .lastCompleteVersion the last release that came out clean on EVERY build. That is the only
-    #                       thing entitled to be quoted as "last known good", so it is the only
-    #                       thing gated on complete coverage.
-    state_update '.versions[$v] = {status: $st, at: $t, atEpoch: $te, clodexSha: $sha, log: $l,
-                                   notes: $n, platforms: $pstatus}
-                  | .baseline = {version: $v, at: $t, clodexSha: $sha, configFingerprint: $fp,
-                                 platforms: (((.baseline.platforms // {}) * $base))}
-                  | (if $st == "pass" then .lastCompleteVersion = $v else . end)
-                  | .deferred = ((.deferred // {}) | del(.[$v]))
-                  | .pending = ((.pending // {}) | del(.[$v]))' \
+    # What the filter does, and why each clause is shaped the way it is, is at its definition.
+    state_update "$CANARY_VERDICT_FILTER" \
       --arg v "$VERSION" --arg t "$(now_iso)" --argjson te "$(now_epoch)" --arg sha "$MAIN_SHA" \
       --arg l "$RUN_LOG" --arg fp "$CONFIG_FP" --arg n "$SOFT_NOTES" \
       --arg st "$( [ "$COVERAGE_COMPLETE" -eq 1 ] && echo pass || echo partial )" \
@@ -1350,53 +1571,7 @@ if [ -z "$REASONS" ]; then
   fi
   KEEP_WORK="$opt_keep"
 
-  # Only the host leg can license an update, so only a host leg that passed may recommend one.
-  # Saying "nothing was established for you" and "the update is yours to take" in one message is
-  # worse than saying neither.
-  if [ "$HOST_STATUS" != "pass" ]; then
-    UPDATE_LINE="Because this Mac's leg did not complete, whether $VERSION patches *here* is unknown — hold off until a run covers it."
-  elif [ "$INSTALLED_VERSION" = "$VERSION" ]; then
-    UPDATE_LINE="You are already on $VERSION — nothing to do."
-  else
-    UPDATE_LINE="You are on $INSTALLED_VERSION, so the update is yours to take whenever you like. Re-run \`clodex patch\` afterwards to re-apply your aliases."
-  fi
-  # What was actually established, in the words of what was actually run. The probe applies every
-  # patch transform to extracted JavaScript but never runs the real `clodex patch` command or starts
-  # its result, so "clodex patch applies cleanly" is still true only of host and container legs.
-  FULL_LEGS="$(jq -s -r 'map(select(.status == "pass" and (.mode == "host" or .mode == "container")) | .platform) | join(", ")' "$MATRIX")"
-  FULL_COUNT="$(jq -s -r 'map(select(.status == "pass" and (.mode == "host" or .mode == "container"))) | length' "$MATRIX")"
-  PROBE_COUNT="$(jq -s -r 'map(select(.status == "pass" and .mode == "probe")) | length' "$MATRIX")"
-  UNTESTED_COUNT="$(jq -s -r 'map(select(.status != "pass" and .status != "fail")) | length' "$MATRIX")"
-  HOST_APPLIED="$(matrix_applied_sites "$HOST_PLATFORM")"
-  HOST_TOTAL="$(matrix_total_sites "$HOST_PLATFORM")"
-  # Only say the binary ran if the leg that runs it actually finished. This sentence asserted it
-  # unconditionally and would state it after a host leg that errored before patching anything.
-  if [ "$HOST_STATUS" = "pass" ]; then
-    HOST_LINE="on this Mac $HOST_APPLIED of $HOST_TOTAL patch sites applied and the patched binary runs and reports $VERSION"
-  else
-    HOST_LINE="*this Mac was not among them* — its leg reported $HOST_STATUS, so nothing was established for you"
-  fi
-  UNTESTED_LINE=""
-  [ "$UNTESTED_COUNT" -eq 0 ] ||
-    UNTESTED_LINE="
-$UNTESTED_COUNT build(s) could not be tested at all this run — they are marked below and are the reason this is not an all-clear."
-
-  if [ "$COVERAGE_COMPLETE" -eq 1 ]; then
-    PASS_HEAD=":white_check_mark: *Claude Code $VERSION — safe to update.*"
-  else
-    # Deliberately NOT a green tick. Nothing proved this release broken, but the coverage it was
-    # judged on has a hole in it, and a hole reported as a clean pass is the original incident.
-    PASS_HEAD=":warning: *Claude Code $VERSION — nothing broke, but this is not a full all-clear.*"
-  fi
-  # Only mention the bundle-level tier when something is actually in it. "0 got the bundle-level
-  # check only" next to five untested builds reads as a contradiction.
-  PROBE_LINE=""
-  [ "$PROBE_COUNT" -eq 0 ] || PROBE_LINE="
-$PROBE_COUNT got the bundle-level check only: every clodex patch site applied to their own bundle and the repack round-tripped, but no patched binary was started there."
-  slack "$PASS_HEAD
-The real \`clodex patch\` ran on $FULL_COUNT of $TOTAL_COUNT builds ($FULL_LEGS): $HOST_LINE.$PROBE_LINE$UNTESTED_LINE
-Tested against clodex origin/main \`${MAIN_SHA:0:8}\` (not the published $(node -p "require('$REPO_DIR/package.json').version" 2>/dev/null || echo release)), so this is a verdict on main.
-$UPDATE_LINE$( [ -n "$SOFT_NOTES" ] && printf '\n\n:information_source: Worth knowing:\n%s' "$SOFT_NOTES" )$( [ "$COVERAGE_COMPLETE" -eq 1 ] || printf '\n\n%s' "$COVERAGE" )" || true
+  announce_verdict
 else
   if [ "$COMPACT_PROMPT_DRIFT_ONLY" -eq 1 ]; then
     log "FAIL: Claude Code $VERSION changed the compaction prompt clodex recognizes:"
@@ -1421,14 +1596,19 @@ else
   # the after-the-fact check meaningless.
   # A failure found by a --platforms run IS real and worth alerting on, but it still did not test
   # the rest, so it may not close the version off either.
+  # `notes` as well as `reasons`: a failing run can ALSO have lost coverage (Docker down, a subset,
+  # an unpublished build), and without this the failure record showed a downgraded leg as a plain
+  # "pass" with nothing in `--status` saying its patched binary was never started. Slack disclosed
+  # it; the stored verdict did not, and that is the record anyone reads afterwards.
   state_update '.versions[$v] = {status: $st, at: $t, atEpoch: $te, clodexSha: $sha, log: $l,
-                                 sandbox: $w, reasons: $r, platforms: $pstatus,
+                                 sandbox: $w, reasons: $r, notes: $n, platforms: $pstatus,
                                  investigation: $inv}
                 | .deferred = ((.deferred // {}) | del(.[$v]))
                 | .pending = ((.pending // {}) | del(.[$v]))
                 | (if $inv == "started" then .realStateAtInvestigation = $fp else . end)' \
     --arg v "$VERSION" --arg t "$(now_iso)" --argjson te "$(now_epoch)" --arg sha "$MAIN_SHA" \
     --arg l "$RUN_LOG" --arg w "$WORK" --arg r "$REASONS" --arg fp "$FINGERPRINT_AFTER" \
+    --arg n "$SOFT_NOTES" \
     --arg st "$( [ -n "$opt_platforms" ] && echo partial || echo fail )" \
     --arg inv "$INVESTIGATION_STATUS" --argjson pstatus "$PLATFORM_STATUS_JSON"
 
@@ -1441,47 +1621,7 @@ else
     NEXT_STEP=":bangbang: *The investigation could NOT be started* — see the log. Nobody is working on this; it is yours to pick up."
   fi
 
-  # Which platforms broke changes what you should DO, so it leads. A break that spares this Mac is
-  # still a break you ship to everyone else, and a break that includes this Mac is also a "do not
-  # update" for you personally — those are different messages and must not be blurred together.
-  # Note the ordering: "the host passed" is a stronger claim than "the host did not fail", and only
-  # the first justifies telling someone their machine is fine.
-  # Not $BASE_VERSION: the baseline advances per platform, so its version is the last release that
-  # passed SOMETHING. Only .lastCompleteVersion means "clean on every build".
-  LAST_COMPLETE="$(state_read | jq -r '.lastCompleteVersion // empty')"
-  LAST_GOOD=""
-  [ -z "$LAST_COMPLETE" ] || LAST_GOOD="
-Last release that came out clean on every build: *$LAST_COMPLETE*."
-  if [ "$COMPACT_PROMPT_DRIFT_ONLY" -eq 1 ]; then
-    HEADLINE="$(compact_prompt_drift_headline "$VERSION" "$(matrix_count fail)" "$TOTAL_COUNT")"
-    IMPACT="$(compact_prompt_drift_impact)$LAST_GOOD"
-  elif [ "$HOST_STATUS" = "fail" ] && [ "$INSTALLED_VERSION" = "$VERSION" ]; then
-    IMPACT="*You are already ON $VERSION and it cannot be patched* — your aliases and effort settings are off until this is fixed. Roll back, or wait for the fix.$LAST_GOOD"
-  elif [ "$HOST_STATUS" = "fail" ]; then
-    IMPACT="*Do not update Claude Code yet* — you are on $INSTALLED_VERSION and patching $VERSION fails on this Mac. Your current patched install keeps working; the risk is only at update time.$LAST_GOOD"
-  elif [ "$HOST_STATUS" != "pass" ]; then
-    IMPACT="*Your Mac was NOT tested this run* (its leg reported $HOST_STATUS), so treat $VERSION as unknown rather than safe for you.$LAST_GOOD"
-  elif [ -n "$FAILED_PLATFORMS" ]; then
-    IMPACT="*Your own Mac is fine* — $VERSION patches cleanly here, so you can update. But clodex is broken on $(printf '%s' "$FAILED_PLATFORMS" | tr ' ' ',' | sed 's/,/, /g'), and Claude Code auto-updates, so users there are being broken as they update.$LAST_GOOD"
-  else
-    HEADLINE=":warning: *Claude Code $VERSION patches, but not the way it used to*"
-    IMPACT="*You can install it — but something clodex used to do no longer applies.* Patching succeeds; a check that passed on $BASE_VERSION now reports differently, which usually means an anchor drifted and a feature is quietly off. Stay on $INSTALLED_VERSION until this is diagnosed if you rely on it."
-  fi
-  [ -n "${HEADLINE:-}" ] ||
-    HEADLINE=":rotating_light: *clodex patch canary: Claude Code $VERSION breaks \`clodex patch\`* on $(matrix_count fail) of $TOTAL_COUNT builds"
-
-  # Reasons and the next step come before the matrix: with eight platforms the matrix alone pushes
-  # everything actionable below the fold on a phone.
-  slack "$HEADLINE
-$IMPACT
-Tested against clodex origin/main \`${MAIN_SHA:0:8}\` — $MAIN_SUBJECT
-
-$REASONS
-$NEXT_STEP
-
-Nothing on your machine was patched or installed. Log: \`$RUN_LOG\` · sandbox: \`$WORK\` · reproduce any leg: \`$WORK/repro.sh <platform>\`
-
-$(matrix_coverage_brief)$( [ -n "$SOFT_NOTES" ] && printf '\n\n:information_source: Also worth knowing:\n%s' "$SOFT_NOTES" )" || true
+  announce_verdict
 fi
 
 log "done"


### PR DESCRIPTION
When the release-monitoring canary cannot check a new Claude Code release on every platform, its
Slack alert now opens by telling you what to do about it. The usual cause is simply that Docker
Desktop is not running, which stops two of the Linux builds being tested properly. Until now the
alert mentioned that only in a footnote below a long platform table, so it read as an unexplained
wall of warnings — and because an incompletely-checked release gets retried, the same message
arrived twice in one evening with nothing saying that starting Docker would settle it.

The alert also stops repeating itself: a note the new action line already made is no longer printed
again further down.

## User-visible failure

Two notifications, six hours apart, for Claude Code 2.1.268, identical in substance. Neither said
why coverage was short or what would fix it. Nothing was wrong with the release or with clodex —
Docker was quit, so `linux-arm64` and `linux-arm64-musl` fell back to a bundle-only probe, the run
was recorded `partial` rather than `pass`, and `partial` is deliberately retried every six hours
until a run achieves full coverage.

The second alert additionally listed eleven patch checks as "not attempted at all this time", which
was untrue.

## Root cause and reachability

Both reach every scheduled hourly run; no flags required.

1. **No action in the alert.** The message reported the hole and left the reader to infer the cause
   from the per-platform table.
2. **The eleven phantom dropped checks.** The per-platform baseline merge used jq's `*`, which
   merges recursively, so a platform's new entry inherited `sites` keys from the entry it replaced.
   That defeats the leg-mode guard in the comparison: a host/container leg records `probe:PATCH …`
   names that a probe-only leg never emits, so after one Docker outage the fresh probe entry carried
   the container run's leftover names and the next run reported them as dropped. `+` keeps the
   per-platform merge intact while making a leg's record exactly what that leg observed.

## Also fixed

Found while reviewing the above; each is reachable, and the first three are ways the canary could
fail in the direction it exists to prevent.

- `coverage_is_complete` decided the downgrade question with `[ -z "$(jq …)" ]`, so a jq that
  *failed* — no output — read as "nothing was downgraded" and returned full coverage. A green tick
  issued because the check itself broke.
- Composing the message inside `slack "$(…)" || true` let that `|| true` — which exists so a Slack
  outage cannot take the canary down — also swallow a failure in the renderer. A fault injected into
  one of its jq calls posted a "safe to update" headline over a body whose counts had rendered
  empty, and returned success. `set -e` does not catch this: a failing assignment inside a function
  running in a command substitution does not trip errexit. Composition is now fatal, transport is
  still not, and both directions are pinned by tests.
- A failing run recorded no coverage notes, so `--status` showed a leg whose patched binary was
  never started as a plain `pass`.
- `--platforms` was disclosed on the pass path but not the failure path, which announced "breaks
  `clodex patch` on 1 of 1 builds" with nothing saying the other seven were never looked at.
  Duplicate names are now rejected and completeness compares distinct platform names rather than row
  counts — naming one build eight times used to reach the published-platform count and earn a green
  "safe to update". Naming all eight no longer claims builds went untested when none did.

## Deliberately not changed

The green "safe to update" message for a fully covered run is byte-identical to `main`; the action
machinery stays entirely out of it.

## Tests

The verdict write, both notification bodies, the note collection, the subset note and the choice
between the two alerts move into named units, because the self-test previously carried its own
transcriptions of them — which is how the `*` was edited with every assertion still green. The tests
now drive what the script actually uses.

179 assertions. Verified by mutation, including reverting `*`, deleting the action line from the
posted message, disconnecting either composer from the posting, dropping the subset note from the
note list, reverting the fail-open coverage check, removing the composer guards, and tightening the
transport by mistake — each turns at least one case red.

Extracting the two message bodies was proven behaviour-preserving by rendering old and new and
diffing bytes: the pass body over three branch combinations, the failure body over six.

## Runtime evidence

This branch's canary was run against all eight live 2.1.268 builds, Docker up, isolated state
(`CANARY_STATE_DIR`) and Slack suppressed. All eight legs passed, both Linux ARM legs as real
containers, and it composed the correct green message — "ran on 3 of 8 builds", no action line, no
subset note. The real state directory was untouched.

Environment: macOS arm64, node v24.14.1, self-test green under bash 5.3.9 and bash 3.2.57.
`pnpm typecheck`, 2550 tests and `pnpm build` green.

## What I could not verify

Nothing automated runs the canary's top-level flow, so deleting a main-flow *call* to one of the
extracted units is still invisible to the suite. That is why the end-to-end run above was done.

ShellCheck goes from 51 findings to 65 at default severity, introducing no new codes: SC2016 on the
jq filter constants, which must not expand shell variables, and SC2034/SC1090/SC2329 on globals and
functions shared across the sourced files and the self-test. All classes are already present on
`main` for the same reasons.

## Docs

`canary/README.md`: the real patch runs on three of eight builds, not two, and the `container` leg
covers `linux-arm64-musl` as well as `linux-arm64`.