### PR TITLE
fix(oauth): restore prompt caching for parallel subagents on ChatGPT models

### DIFF
--- a/.claude/docs/oauth-continuation.md
+++ b/.claude/docs/oauth-continuation.md
@@ -23,11 +23,79 @@ but omitted from comparison, matching the existing expected-assistant snapshot. 
 accepts legacy histories that omitted earlier summaries when the encrypted content matches; this
 compatibility rule is not permission to rewrite summaries in new upstream requests.
 
+### Only a possible parent may force a request onto an isolated socket
+
+An in-process Claude Code subagent forks the session and keeps the root session identity, so it sends
+its parent's id in `X-Claude-Code-Session-Id` (verified in the 2.1.267 bundle; a separately launched
+process has its own). One partition therefore holds many unrelated conversations at once. A request that matches no idle head is pushed to `parallel_isolated` — full
+context, no head retained — only when some **in-flight** head could still turn out to be its parent:
+`couldPrecedeThisRequest`, which is `continuationMatch` against the busy head plus a conservative
+`true` for a head that has committed nothing yet (its first response is still streaming, so there is
+no history to diverge from). Both the arrival gate and the post-pacing re-check use it, and the
+`ws_head_decision` records `isolatedByConnectionId` naming the head that decided it.
+
+Gating instead on "any head in this partition is busy" is expensive *cumulatively*: an isolated socket
+retains no head, so the next turn of that same subagent isolated again for as long as anything in the
+partition was in flight. In one frozen local ledger — 13,530 head decisions spanning
+2026-09-10T03:17Z to 2026-09-11T06:53Z across 20 recorded Claude session ids — 3,995 decisions
+(29.5%) were `parallel_isolated`. Their 3,775 recorded responses reported 202.7M uncached input
+tokens, 96.9% of their input, against 4.2% for responses on continuation decisions. In **3,611 of
+those decisions (90.4%) every recorded busy candidate diverged from the request in a `user`-to-`user`
+comparison** — all 4,983 such comparisons — and those responses account for 196.0M of the uncached tokens. Multiple
+heads per partition were already routine, and an idle head is already continued while a sibling
+streams, so an unrelated busy head was never a reason to give up a chain.
+
+That is observed traffic on one account, not a counterfactual: it does not say 3,611 isolations would
+be *prevented*, nor that their tokens would be saved. A retained head cannot help the turn that
+opened it, only a later turn of the same conversation.
+
+Two measurement traps this section has already fallen into. **Freeze the file before counting** — it
+is appended to live, and an earlier revision mixed figures read minutes apart into a ratio that did
+not divide. **Count each response once**: 254 request ids here carry more than one head decision
+(retries), so joining usage per decision double-counts the successful attempt and inflated these very
+numbers by ~2.3M tokens.
+
 **Connection pools are process-wide, not per-partition:** `maxConnections` (established, default 32)
-and `maxNurseryConnections` (default 8). A head starts in the nursery and is promoted only when
-successfully continued — so a workload fanning out into many concurrent subagent conversations (all
-inheriting the parent's Claude session id, therefore sharing one partition) can evict heads before
-their next turn and lose the continuation. Override via `CLODEX_WS_MAX_CONNECTIONS` /
+and `maxNurseryConnections` (default 8). A head starts in the nursery and is promoted when selected
+for its first continuation, before that continuation is known to succeed — so a workload whose
+concurrent subagents inherit the parent's Claude session id, and therefore share one partition, can
+lose heads before their next turn and with them the continuation.
+
+**Keeping a fan-out's chains alive trades throwaway sockets for retained heads, and that trade can go
+either way.** The mismatching turn still opens its own socket; only a LATER turn of that conversation
+can reuse it. Of the 4,934 primary connection-creation decisions in the ledger above, 3,611 had final
+diagnostics in which every recorded busy candidate showed a `user`-to-`user` divergence. Those are
+candidates for a different decision under this gate, not proof that 3,611 live isolations are replaced
+— the diagnostic reflects mutable entry state at emission time. Of the remaining 384, 319 recorded at
+least one busy strict-prefix candidate and still isolate by design; 65 had no busy candidate left in
+the final diagnostic and cannot be classified from this snapshot. But an isolated socket is never registered, so it
+never evicts anything, while a retained one runs `evictOldestIdleGeneration` first.
+**Eviction pressure is retained arrivals measured against free capacity — both terms matter, neither
+alone.** Seven free nursery slots absorb a width-1 fan-out with no eviction and lose one head to a
+width-8 one; at the cap, width decides whether one head or eight are evicted. A worked sequence goes
+the wrong way: eight idle nursery heads, one
+long-running established head in the target partition, and eight staggered siblings that each diverge
+from it. Retaining all eight evicts all eight older heads, so resuming those conversations inside the
+5-minute nursery TTL needs eight fresh upgrades — 16 rather than 8.
+
+**Cap enforcement touches BOTH pools, at two different moments.** Creating a retained head calls
+`evictOldestIdleGeneration('nursery', maxNurseryConnections, 'nursery_lru_cap')` first; when that head
+is later selected for its first continuation, `continueOnHead` calls
+`evictOldestIdleGeneration('established', maxConnections, 'established_lru_cap')` before promoting it.
+Either call removes an entry only when that generation is at or above its cap AND has an idle entry —
+neither is an unconditional eviction. So this change can raise established-pool pressure as newly
+retained heads are later selected, and the entry displaced is the oldest idle established one, which
+may be a large long-lived conversation that then resends full context. The ledger does not establish
+that established eviction actually becomes more common. Watch `established_lru_cap` alongside
+`nursery_lru_cap`.
+
+An idle nursery head is exposed until its connection is **selected** for its first continuation, which
+is when promotion happens — before that continuation is known to succeed. Nursery membership is a
+property of the current connection's reuse history, not of the conversation's age: a long conversation
+that just took a replacement head after a mismatch or an expiry is in the nursery too (this ledger
+holds 58 new nursery heads whose input already carried several user messages, the largest 529 items).
+Note also that eviction only considers IDLE entries, so while every nursery head is busy the cap
+cannot be enforced immediately. Override via `CLODEX_WS_MAX_CONNECTIONS` /
 `CLODEX_WS_MAX_NURSERY_CONNECTIONS` (integer 1–1024; malformed values are logged and ignored). An
 explicit programmatic option outranks the environment so tests are never perturbed. Eviction reasons
 (`nursery_lru_cap`, `established_lru_cap`, `idle_ttl`, `nursery_idle_ttl`, `hard_ttl`) appear in the
@@ -196,13 +264,16 @@ through the shipped bucket predicts 1,686 waits and 1,590 refusals in one of tho
 **Boundary, deliberate:** the second scan cannot undo an ARRIVAL-time `parallel_isolated` demotion
 when the partition simply goes quiet during the wait. Such a request already has `persistent` false
 and, absent a re-match, keeps it, so it opens an isolated socket that retains no head at all.
-Isolated sockets are 35-38% of decisions in busy diagnostics files — a larger share of the same
-harm than the case this closes.
+Isolated sockets were 30-38% of decisions in busy diagnostics files before the lineage gate above
+narrowed which of them qualify — a larger share of the same harm than the case this closes.
 
 Failing a re-match, an admitted request still demotes itself to `parallel_isolated` if a
-same-partition request went in flight meanwhile — otherwise two requests would each register a
-persistent nursery head for one key and a fan-out would evict other conversations' heads. That check
-is unconditional; only the re-match is gated on having been queued.
+same-partition request that could be its parent went in flight meanwhile — otherwise two requests
+would each register a persistent nursery head for one key and a fan-out would evict other
+conversations' heads. The duplicate this guards against is a second head for ONE conversation, which
+is what `couldPrecedeThisRequest` describes; a head busy on a different conversation is not a
+duplicate of anything, and a brand-new sibling head has committed nothing and so still blocks. That
+check is unconditional; only the re-match is gated on having been queued.
 
 Diagnostics: a `ws_new_connection_paced` event (`outcome` of `admitted`, `refused`, or `aborted`,
 with `waitedMs` / `requiredWaitMs` / `retryAfterSeconds`) and `pacingWaitedMs` on the same request's
@@ -309,6 +380,14 @@ genuine rewind or branch regenerates the call under a new one. These record
   filler the shared rule removes: if either side strips *more* than the rule does — a snapshot or a
   client over-stripping — the two remain unequal after it runs and land in the silent `false` bucket. The `parallel_isolated` arm does not
   warn. **Treat a quiet terminal as weak evidence, not proof.**
+- **A turn that reaches the mismatch branch rather than `parallel_isolated` passes every abandoned head
+  through the canary** — including other conversations' heads once a fan-out keeps them. The identity
+  gates still apply: a tool warning needs both items to be `function_call` with the same non-empty
+  `call_id`, the same string-valued `name`, and `equalAfterStrip === true`; a reasoning warning needs two
+  reasoning items with the same non-empty `encrypted_content` plus a remaining normalized difference.
+  Where independently generated items carry distinct identities these gates exclude them, which reduces
+  unrelated-head noise — but that is **not** proof against a false warning, because a shared or copied
+  history can carry one item identity into more than one request. No such occurrence has been observed.
 - `false` means the difference is one the rule cannot explain — a scalar/array/malformed `arguments`
   that `sanitizedCallArguments` deliberately passes through, a divergence in another field, or a
   genuinely different value — indistinguishable from legitimate divergence, so counted and never

--- a/src/oauth/responses-websocket.ts
+++ b/src/oauth/responses-websocket.ts
@@ -2102,6 +2102,12 @@ export function createResponsesWebSocketFetch(
     let now = resolvedOptions.now();
     const evictions = cleanupExpiredConnections(now);
 
+    // Canonicalize the incoming conversation at most ONCE per request. Both head
+    // scans and the in-flight lineage test below need it, and none of them needs
+    // it when the partition holds nothing to compare against.
+    let canonicalClientItems: string[] | undefined;
+    const clientItems = (): string[] => (canonicalClientItems ??= canonicalItemStrings(inputArray(payload)));
+
     // Hoisted verbatim so the SAME scan can run a second time after a pacing
     // wait: same expressions, same ordering, same tie-breaks. Nothing here is
     // re-tuned — a difference between the two scans could only come from the
@@ -2113,19 +2119,37 @@ export function createResponsesWebSocketFetch(
     } => {
       const scanned = partitionKey ? connectionEntries(partitionKey) : [];
       const idle = scanned.filter(entry => !entry.inFlight);
-      // Canonicalize the incoming conversation ONCE, not once per candidate head.
-      const clientItems = idle.length ? canonicalItemStrings(inputArray(payload)) : [];
+      const canonical = idle.length ? clientItems() : [];
       return {
         candidates: scanned,
         idleCandidates: idle,
         matches: idle
-          .map(entry => ({ entry, match: continuationMatch(entry, payload, clientItems) }))
+          .map(entry => ({ entry, match: continuationMatch(entry, payload, canonical) }))
           .filter((candidate): candidate is { entry: ConnectionEntry; match: ContinuationMatch } => candidate.match !== undefined)
           // Prefer the longest matching history, which produces the smallest delta.
           .sort((left, right) => left.match.delta.length - right.match.delta.length
             || (left.match.mode === right.match.mode ? 0 : left.match.mode === 'exact' ? -1 : 1)),
       };
     };
+    /**
+     * Could this request still turn out to be a later turn of what `entry` is
+     * generating right now? Only a head that could is allowed to push the request
+     * onto an isolated socket. Every Claude Code subagent inherits its parent's
+     * session id, so one partition holds many unrelated conversations at once —
+     * and a head busy on one of them says nothing about where another belongs.
+     *
+     * Conservative wherever it cannot tell. A head that has committed nothing yet
+     * (its very first response is still streaming) has no history to diverge
+     * from, so it keeps blocking — which is the case the auxiliary-request
+     * isolation depends on.
+     */
+    const couldPrecedeThisRequest = (entry: ConnectionEntry): boolean =>
+      !entry.responseId || !entry.requestInput || !entry.expectedAssistant
+      || continuationMatch(entry, payload, clientItems()) !== undefined;
+    /** The in-flight head that forced isolation, for the diagnostic. */
+    const blockingHead = (entries: ConnectionEntry[]): ConnectionEntry | undefined =>
+      entries.find(entry => entry.inFlight && couldPrecedeThisRequest(entry));
+
     let { candidates, idleCandidates, matches } = scanForHeads();
     let selected: ConnectionEntry | undefined = matches[0]?.entry;
     let selectedMatch = matches[0]?.match;
@@ -2182,11 +2206,23 @@ export function createResponsesWebSocketFetch(
       return 'continuation';
     };
 
+    let arrivalBlockingHead = selected ? undefined : blockingHead(candidates);
     if (selected && selectedDelta) {
       decision = continueOnHead(selected, selectedMatch);
-    } else if (candidates.some(entry => entry.inFlight)) {
+    } else if (arrivalBlockingHead) {
       // Claude auxiliary requests can share a session id. Never multiplex or
       // queue a request whose lineage cannot yet include the active response.
+      //
+      // Only a head that could still BE this request's parent counts. Gating on
+      // "any head in the partition is busy" instead cost most of the caching on
+      // every parallel fan-out: subagents share their parent's session id, so one
+      // busy subagent sent every other subagent's turn down this branch, and
+      // `persistent = false` meant none of them left a head behind — so the next
+      // turn resent the whole conversation too, for as long as anything was in
+      // flight. Multiple heads per partition are already routine (see the
+      // mismatch branch below) and an idle one is already continued while a
+      // sibling streams, so an unrelated busy head is no reason to give up a
+      // chain.
       selected = undefined;
       persistent = false;
       decision = 'parallel_isolated';
@@ -2336,17 +2372,25 @@ export function createResponsesWebSocketFetch(
       // forcing the full-context resends that open still more connections. An
       // overlap like this takes an isolated socket today; keep that.
       //
+      // Same lineage test as on arrival, and for the same reason: the duplicate
+      // this guards against is a second head for ONE conversation, which is what
+      // a head that could still be this request's parent describes. A head busy
+      // on a different conversation is not a duplicate of anything.
+      //
       // Unconditional, NOT gated on having waited: `admit` is async, so even an
       // immediate admission resumes a microtask later, and two same-partition
       // requests arriving in one tick both resume having waited zero. The head
       // scan above ran before that yield either way. It yields to a head this
       // request can continue, exactly as the arrival-time chain does.
-      if (!selected && persistent && partitionKey
-        && connectionEntries(partitionKey).some(entry => entry.inFlight)) {
-        persistent = false;
-        decision = 'parallel_isolated';
-        debug('parallel request using an isolated socket after pacing');
-        if (pacingRescanOutcome === 'no_change') pacingRescanOutcome = 'parallel_isolated';
+      if (!selected && persistent && partitionKey) {
+        const blocked = blockingHead(connectionEntries(partitionKey));
+        if (blocked) {
+          arrivalBlockingHead = blocked;
+          persistent = false;
+          decision = 'parallel_isolated';
+          debug('parallel request using an isolated socket after pacing');
+          if (pacingRescanOutcome === 'no_change') pacingRescanOutcome = 'parallel_isolated';
+        }
       }
     }
 
@@ -2414,6 +2458,12 @@ export function createResponsesWebSocketFetch(
       createdConnectionId: selected ? undefined : nextConnectionDebugId,
       ...(pacingWaitedMs !== undefined ? { pacingWaitedMs } : {}),
       ...(pacingRescanOutcome !== undefined ? { pacingRescanOutcome } : {}),
+      // Which busy head this request could not be told apart from. Without it an
+      // isolated turn reads as unexplained, and isolation is the single largest
+      // source of uncached prompt tokens on this transport.
+      ...(decision === 'parallel_isolated' && arrivalBlockingHead
+        ? { isolatedByConnectionId: arrivalBlockingHead.debugId }
+        : {}),
       ...(suppressedMismatchWarnings !== undefined ? { suppressedMismatchWarnings } : {}),
       createdGeneration: selected ? undefined : persistent ? 'nursery' : 'isolated',
       incrementalInputItems: selectedDelta?.length,

--- a/tests/responses-websocket.test.ts
+++ b/tests/responses-websocket.test.ts
@@ -3339,6 +3339,358 @@ describe('createResponsesWebSocketFetch', () => {
     await readAll(next);
   });
 
+  it('keeps a parallel conversation on its own chain while an unrelated head streams', async () => {
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
+      accountId: 'acct-subagent-fanout',
+      onDiagnostic: event => diagnostics.push(event),
+    });
+    const send = (input: unknown[]): Promise<Response> => wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(input)),
+    });
+    const decisions = (): ResponsesWebSocketDiagnosticEvent[] =>
+      diagnostics.filter(event => event.event === 'ws_head_decision');
+
+    // Conversation A earns a committed head by completing a turn, so its stored
+    // history is something a later request can be compared against.
+    const aFirstUser = { role: 'user', content: [{ type: 'input_text', text: 'conversation A' }] };
+    const aTurnOne = await send([aFirstUser]);
+    const aSocket = lastSocket();
+    aSocket.emit('open');
+    emitTextResponse(aSocket, 'resp_a1', 'A answer');
+    await readAll(aTurnOne);
+
+    // ...and is mid-response on its NEXT turn when the sibling arrives, which is
+    // what a real tool loop looks like. The head is in flight with a committed
+    // prefix — the shape no other test covers.
+    const aTurnTwo = await send([
+      aFirstUser,
+      { role: 'assistant', content: [{ type: 'output_text', text: 'A answer' }] },
+      { role: 'user', content: [{ type: 'input_text', text: 'A again' }] },
+    ]);
+    expect(lastSocket()).toBe(aSocket);
+    expect(decisions().at(-1)).toMatchObject({ decision: 'continuation' });
+
+    // Conversation B is a different Claude Code subagent. It inherits the parent's
+    // session id, so it lands in A's partition, but its history diverges from A's
+    // at the very first item: A can never become B's parent.
+    const bFirstUser = { role: 'user', content: [{ type: 'input_text', text: 'conversation B' }] };
+    const bTurnOne = await send([bFirstUser]);
+    const bSocket = lastSocket();
+    expect(bSocket).not.toBe(aSocket);
+    expect(decisions().at(-1)).toMatchObject({ decision: 'history_mismatch_new_head' });
+    bSocket.emit('open');
+    emitTextResponse(bSocket, 'resp_b1', 'B answer');
+    await readAll(bTurnOne);
+
+    emitTextResponse(aSocket, 'resp_a2', 'A answer again');
+    await readAll(aTurnTwo);
+
+    // The payoff: B's second turn continues B's chain instead of resending the
+    // whole conversation on yet another throwaway socket.
+    const bNextUser = { role: 'user', content: [{ type: 'input_text', text: 'B again' }] };
+    const bTurnTwo = await send([
+      bFirstUser,
+      { role: 'assistant', content: [{ type: 'output_text', text: 'B answer' }] },
+      bNextUser,
+    ]);
+    expect(lastSocket()).toBe(bSocket);
+    const sent = JSON.parse(bSocket.send.mock.calls[1]![0] as string);
+    expect(sent.previous_response_id).toBe('resp_b1');
+    expect(sent.input).toEqual([bNextUser]);
+    emitTextResponse(bSocket, 'resp_b2', 'B answer again');
+    await readAll(bTurnTwo);
+
+    // A's own chain is untouched by any of it.
+    expect(aSocket.close).not.toHaveBeenCalled();
+    expect(decisions().map(event => event.decision)).toEqual([
+      'new_partition_head', 'continuation', 'history_mismatch_new_head', 'continuation',
+    ]);
+  });
+
+  it('still isolates a parallel request when the busy head could still be its parent', async () => {
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
+      accountId: 'acct-ambiguous-parent',
+      onDiagnostic: event => diagnostics.push(event),
+    });
+    const send = (input: unknown[]): Promise<Response> => wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(input)),
+    });
+    const lastDecision = (): ResponsesWebSocketDiagnosticEvent | undefined =>
+      diagnostics.filter(event => event.event === 'ws_head_decision').at(-1);
+
+    const firstUser = { role: 'user', content: [{ type: 'input_text', text: 'shared root' }] };
+    const turnOne = await send([firstUser]);
+    const socket = lastSocket();
+    socket.emit('open');
+    emitTextResponse(socket, 'resp_1', 'answer');
+    await readAll(turnOne);
+
+    const turnTwo = await send([
+      firstUser,
+      { role: 'assistant', content: [{ type: 'output_text', text: 'answer' }] },
+      { role: 'user', content: [{ type: 'input_text', text: 'second' }] },
+    ]);
+    expect(lastSocket()).toBe(socket);
+
+    // A request that EXTENDS the busy head's committed history could still be a
+    // later turn of the response it is generating, so it must not fork a head.
+    const overlapping = await send([
+      firstUser,
+      { role: 'assistant', content: [{ type: 'output_text', text: 'answer' }] },
+      { role: 'user', content: [{ type: 'input_text', text: 'a different second' }] },
+    ]);
+    const isolatedSocket = lastSocket();
+    expect(isolatedSocket).not.toBe(socket);
+    expect(lastDecision()).toMatchObject({
+      decision: 'parallel_isolated',
+      createdGeneration: 'isolated',
+      isolatedByConnectionId: 1,
+    });
+    isolatedSocket.emit('open');
+    emitTextResponse(isolatedSocket, 'resp_isolated', 'isolated answer');
+    await readAll(overlapping);
+    expect(isolatedSocket.close).toHaveBeenCalled();
+
+    emitTextResponse(socket, 'resp_2', 'second answer');
+    await readAll(turnTwo);
+  });
+
+  it('does not continue a head whose history differs only at the root item', async () => {
+    // The length guard returns early whenever the client history is SHORTER than
+    // the stored prefix, so a divergence test that relies on a short history never
+    // compares item 0 at all. This one is long enough to reach the comparison: B
+    // matches A's stored prefix everywhere EXCEPT the root. Continuing A here
+    // would hand B someone else's `previous_response_id` and drop B's own root
+    // from the delta entirely.
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, { accountId: 'acct-root-only-divergence' });
+    const send = (input: unknown[]): Promise<Response> => wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(input)),
+    });
+    const sharedReply = { role: 'assistant', content: [{ type: 'output_text', text: 'same answer' }] };
+
+    const aTurnOne = await send([{ role: 'user', content: [{ type: 'input_text', text: 'root A' }] }]);
+    const aSocket = lastSocket();
+    aSocket.emit('open');
+    emitTextResponse(aSocket, 'resp_a1', 'same answer');
+    await readAll(aTurnOne);
+
+    // Stored prefix is [root A, assistant]; this is [root B, assistant, user] —
+    // longer, and identical from item 1 onward.
+    const bTurnOne = await send([
+      { role: 'user', content: [{ type: 'input_text', text: 'root B' }] },
+      sharedReply,
+      { role: 'user', content: [{ type: 'input_text', text: 'B continues' }] },
+    ]);
+    expect(fakeSockets).toHaveLength(2);
+    const bSocket = lastSocket();
+    expect(bSocket).not.toBe(aSocket);
+    // A's head was not touched: no second send, so no chain was hijacked.
+    expect(aSocket.send).toHaveBeenCalledTimes(1);
+    bSocket.emit('open');
+    const sent = JSON.parse(bSocket.send.mock.calls[0]![0] as string);
+    expect(sent.previous_response_id).toBeUndefined();
+    expect(sent.input).toHaveLength(3);
+    emitTextResponse(bSocket, 'resp_b1', 'B answer');
+    await readAll(bTurnOne);
+  });
+
+  it('keeps a chain that shares a parent preamble but diverges inside assistant history', async () => {
+    // Subagents fanned out from one Claude session open with the SAME inherited
+    // preamble, so a lineage test that only compares the first item — or that
+    // compares only the head's own request input and ignores the output it
+    // produced — cannot tell these two conversations apart.
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
+      accountId: 'acct-shared-preamble',
+      onDiagnostic: event => diagnostics.push(event),
+    });
+    const send = (input: unknown[]): Promise<Response> => wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(input)),
+    });
+    const preamble = { role: 'user', content: [{ type: 'input_text', text: 'shared parent preamble' }] };
+
+    const aTurnOne = await send([preamble]);
+    const aSocket = lastSocket();
+    aSocket.emit('open');
+    emitTextResponse(aSocket, 'resp_a1', 'A answer');
+    await readAll(aTurnOne);
+
+    // A is mid-response on its next turn, holding a committed prefix of
+    // [preamble] + [assistant "A answer"].
+    const aTurnTwo = await send([
+      preamble,
+      { role: 'assistant', content: [{ type: 'output_text', text: 'A answer' }] },
+      { role: 'user', content: [{ type: 'input_text', text: 'A again' }] },
+    ]);
+    expect(lastSocket()).toBe(aSocket);
+
+    // B shares item 0 with A and first differs at the ASSISTANT item, which sits
+    // in the region A produced rather than the region A was sent.
+    const bPrefix = [
+      preamble,
+      { role: 'assistant', content: [{ type: 'output_text', text: 'B answer' }] },
+    ];
+    const bTurnOne = await send([...bPrefix, { role: 'user', content: [{ type: 'input_text', text: 'B follows' }] }]);
+    const bSocket = lastSocket();
+    expect(bSocket).not.toBe(aSocket);
+    bSocket.emit('open');
+    emitTextResponse(bSocket, 'resp_b1', 'B second answer');
+    await readAll(bTurnOne);
+    emitTextResponse(aSocket, 'resp_a2', 'A answer again');
+    await readAll(aTurnTwo);
+
+    // B kept a head, so its next turn continues instead of resending.
+    const bNextUser = { role: 'user', content: [{ type: 'input_text', text: 'B again' }] };
+    const bTurnTwo = await send([
+      ...bPrefix,
+      { role: 'user', content: [{ type: 'input_text', text: 'B follows' }] },
+      { role: 'assistant', content: [{ type: 'output_text', text: 'B second answer' }] },
+      bNextUser,
+    ]);
+    expect(fakeSockets).toHaveLength(2); // no third socket was constructed
+    const sent = JSON.parse(bSocket.send.mock.calls[1]![0] as string);
+    expect(sent.previous_response_id).toBe('resp_b1');
+    expect(sent.input).toEqual([bNextUser]);
+    expect(bSocket.close).not.toHaveBeenCalled();
+    emitTextResponse(bSocket, 'resp_b2', 'B third answer');
+    await readAll(bTurnTwo);
+  });
+
+  it('isolates a parallel request whose only possible parent matches by omitted reasoning', async () => {
+    // Claude does not always echo a stored reasoning item back. Such a request is
+    // still a descendant of the busy head, so the lineage test has to accept
+    // `continuationMatch`'s omitted-reasoning mode, not exact prefixes only.
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
+      accountId: 'acct-omitted-reasoning-parent',
+      onDiagnostic: event => diagnostics.push(event),
+    });
+    const send = (input: unknown[]): Promise<Response> => wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(input)),
+    });
+    const lastDecision = (): ResponsesWebSocketDiagnosticEvent | undefined =>
+      diagnostics.filter(event => event.event === 'ws_head_decision').at(-1);
+    const firstUser = { role: 'user', content: [{ type: 'input_text', text: 'inspect the file' }] };
+
+    const turnOne = await send([firstUser]);
+    const socket = lastSocket();
+    socket.emit('open');
+    socket.emit('message', Buffer.from(JSON.stringify({ type: 'response.created', response: { id: 'resp_1' } })));
+    socket.emit('message', Buffer.from(JSON.stringify({
+      type: 'response.output_item.added', output_index: 0,
+      item: { type: 'reasoning', id: 'rs_1' },
+    })));
+    socket.emit('message', Buffer.from(JSON.stringify({
+      type: 'response.output_item.done', output_index: 0,
+      item: { type: 'reasoning', id: 'rs_1', encrypted_content: 'enc_1', summary: [] },
+    })));
+    socket.emit('message', Buffer.from(JSON.stringify({
+      type: 'response.output_item.done', output_index: 1,
+      item: { type: 'function_call', id: 'fc_1', call_id: 'call_1', name: 'Read', arguments: '{}', status: 'completed' },
+    })));
+    socket.emit('message', Buffer.from(JSON.stringify({ type: 'response.completed', response: { id: 'resp_1' } })));
+    await readAll(turnOne);
+
+    // The tool result comes back WITHOUT the reasoning item, so this continues
+    // through the omitted-reasoning mode and leaves the head in flight.
+    const echoed = [
+      firstUser,
+      { type: 'function_call', call_id: 'call_1', name: 'Read', arguments: '{}' },
+      { type: 'function_call_output', call_id: 'call_1', output: 'contents' },
+    ];
+    const turnTwo = await send(echoed);
+    expect(lastSocket()).toBe(socket);
+    expect(lastDecision()).toMatchObject({ continuationMatchMode: 'omitted_reasoning' });
+
+    // Another request extending that same reasoning-omitting history could be a
+    // later turn of the response still streaming, so it must not fork a head.
+    const overlapping = await send([...echoed, { role: 'user', content: [{ type: 'input_text', text: 'and again' }] }]);
+    const isolatedSocket = lastSocket();
+    expect(isolatedSocket).not.toBe(socket);
+    expect(lastDecision()).toMatchObject({
+      decision: 'parallel_isolated',
+      createdGeneration: 'isolated',
+      isolatedByConnectionId: 1,
+    });
+    isolatedSocket.emit('open');
+    emitTextResponse(isolatedSocket, 'resp_isolated', 'isolated answer');
+    await readAll(overlapping);
+    expect(isolatedSocket.close).toHaveBeenCalled();
+
+    emitTextResponse(socket, 'resp_2', 'second answer');
+    await readAll(turnTwo);
+  });
+
+  it('finds the possible parent among several busy heads and names it', async () => {
+    // The partition holds an unrelated busy head FIRST and the possible parent
+    // second, so stopping at the first busy candidate reaches the wrong verdict
+    // and the reported connection id is the only thing that proves which head
+    // actually decided the isolation.
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
+      accountId: 'acct-two-busy-heads',
+      onDiagnostic: event => diagnostics.push(event),
+    });
+    const send = (input: unknown[]): Promise<Response> => wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(input)),
+    });
+    const lastDecision = (): ResponsesWebSocketDiagnosticEvent | undefined =>
+      diagnostics.filter(event => event.event === 'ws_head_decision').at(-1);
+    const turn = (text: string) => ({ role: 'user', content: [{ type: 'input_text', text }] });
+    const reply = (text: string) => ({ role: 'assistant', content: [{ type: 'output_text', text }] });
+
+    // Head 1: unrelated conversation, committed.
+    const aRoot = turn('conversation A root');
+    const aOne = await send([aRoot]);
+    const aSocket = lastSocket();
+    aSocket.emit('open');
+    emitTextResponse(aSocket, 'resp_a1', 'A answer');
+    await readAll(aOne);
+
+    // Head 2: a different conversation, committed. Registered after head 1, so it
+    // is the second candidate the scan walks.
+    const bRoot = turn('conversation B root');
+    const bOne = await send([bRoot]);
+    const bSocket = lastSocket();
+    expect(bSocket).not.toBe(aSocket);
+    bSocket.emit('open');
+    emitTextResponse(bSocket, 'resp_b1', 'B answer');
+    await readAll(bOne);
+
+    // Both heads go in flight, A first. Each continues on its own socket, so no
+    // new socket is constructed for either.
+    const aTwo = await send([aRoot, reply('A answer'), turn('A again')]);
+    expect(fakeSockets).toHaveLength(2);
+    expect(aSocket.send).toHaveBeenCalledTimes(2);
+    const bPrefix = [bRoot, reply('B answer')];
+    const bTwo = await send([...bPrefix, turn('B again')]);
+    expect(fakeSockets).toHaveLength(2);
+    expect(bSocket.send).toHaveBeenCalledTimes(2);
+
+    // A request that extends B — and nothing about A — must isolate, and must say
+    // it was B that blocked it.
+    const overlapping = await send([...bPrefix, turn('B a different way')]);
+    const isolatedSocket = lastSocket();
+    expect(isolatedSocket).not.toBe(aSocket);
+    expect(isolatedSocket).not.toBe(bSocket);
+    expect(lastDecision()).toMatchObject({
+      decision: 'parallel_isolated',
+      createdGeneration: 'isolated',
+      isolatedByConnectionId: 2,
+    });
+    isolatedSocket.emit('open');
+    emitTextResponse(isolatedSocket, 'resp_isolated', 'isolated answer');
+    await readAll(overlapping);
+    expect(isolatedSocket.close).toHaveBeenCalled();
+
+    emitTextResponse(aSocket, 'resp_a2', 'A answer again');
+    emitTextResponse(bSocket, 'resp_b2', 'B answer again');
+    await readAll(aTwo);
+    await readAll(bTwo);
+  });
+
   it('retains the main head when a completed auxiliary request starts another branch', async () => {
     const input = [{ role: 'user', content: [{ type: 'input_text', text: 'main' }] }];
     const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, { accountId: 'acct-hidden-branch' });
@@ -4111,6 +4463,9 @@ describe('new-connection pacing', () => {
       // It waited, so it re-scanned; the sibling head it found was in flight,
       // so the demotion is still what decided this.
       pacingRescanOutcome: 'parallel_isolated',
+      // The post-pacing demotion must attribute itself to the head it found,
+      // not leave the field to the arrival scan that saw an empty partition.
+      isolatedByConnectionId: 1,
     });
 
     for (const socket of fakeSockets) socket.emit('open');
@@ -4611,6 +4966,10 @@ describe('new-connection pacing', () => {
     // back rather than delaying whoever asks next.
     expect(releaseToken).toHaveBeenCalledTimes(1);
     expect((decision as { createdConnectionId?: number }).createdConnectionId).toBeUndefined();
+    // This request WAS blocked by a possible parent on arrival, then continued it
+    // after the wait. A turn that ends up perfectly cached must not be labelled
+    // with the head that briefly blocked it, or the ledger reads as an isolation.
+    expect(decision).not.toHaveProperty('isolatedByConnectionId');
     expect(debug).toContain('ws: continuing a chain head that freed up during the pacing wait');
 
     emitTextResponse(siblingSocket, 'resp_rematch_2', 'done');


### PR DESCRIPTION
Parallel Claude Code subagents on a ChatGPT OAuth model were resending their entire conversation on
almost every turn instead of continuing it, which burned prompt tokens and slowed every fan-out. If
you run several subagents at once on `openai-oauth` models, they now keep their place in the
conversation the way a single agent already did.

Fixes #209 — though the cause is not the one the issue proposes, and two of the issue's supporting
claims do not hold. Details below.

## The user-visible failure

Reported in #209 and reproduced independently on a second machine. Grouping translated requests by how
many other translated requests from the same Claude session were in flight when each one started
(local request log, Sep 8–11, 30,992 requests, gpt-5.6-luna/sol):

| in flight | requests | uncached input |
|---|---|---|
| 0 | 9,703 | 7.5% |
| 1–2 | 13,074 | 33.3% |
| 3+ | 8,215 | 49.4% |

Anthropic passthrough over the same window and sessions: 4.9%.

**A note for anyone re-deriving this from the request log:** a full-context resend is booked under
`cacheCreationInputTokens`, not `inputTokens`. Computing uncached input as
`inputTokens / (inputTokens + cacheReadInputTokens)` understates the effect severely — it turns the
table above into a 3.6% → 7.0% non-event. I made exactly that mistake on the first pass.

## Root cause and reachability

`src/oauth/responses-websocket.ts` isolated a request — full context, and `persistent = false` so no
head is retained — whenever ANY connection in its partition was in flight:

```js
} else if (candidates.some(entry => entry.inFlight)) {
```

Every Claude Code subagent sends its parent's session id, and the partition key includes the
session-derived `prompt_cache_key`, so one partition holds many unrelated conversations. One busy
subagent therefore pushed every other subagent's turn onto a throwaway socket — and because nothing
was retained, that subagent's NEXT turn resent everything too, for as long as anything in the
partition was in flight. That compounding is what the table above shows.

**Reachability:** any user running more than one subagent concurrently on any `openai-oauth` model, in
the default proxy mode, with no special configuration. This is the common case, not an edge.

### What the diagnostics actually say

From one WebSocket diagnostics ledger, **frozen before counting** because the file is appended to live
(13,530 head decisions, 2026-09-10T03:03Z to 2026-09-11T06:53Z, 20 recorded Claude session ids; usage
counted once per request id, because 254 request ids carry more than one head decision):

- 3,995 decisions (29.5%) were `parallel_isolated`. Their 3,775 recorded responses reported 202.7M
  uncached input, **96.9%** of their input, against **4.2%** for responses on continuation decisions.
- `matchingCandidateCount` was 0 for **all** 3,995 — isolation only ever fired when no idle head
  matched.
- In **3,611 of them (90.4%)** every recorded busy candidate diverged from the request at a `user`
  item — all 4,983 such comparisons. Those responses carry 196.0M of the uncached tokens.
- 3,995 of the 4,934 primary connection-creation decisions were isolated throwaways.

This is observed traffic on one account, not a counterfactual.

**#209's proposed mechanism is not what the data shows.** The issue describes isolation as firing for
"any request that arrives while another is in flight". It only ever fired when nothing matched, and
90.4% of the time against a head that could not possibly be the request's parent.

Two further corrections, both verified rather than assumed:

- **`prompt_cache_key` is not dropped for `openai-oauth`.** `supportsExplicitOpenAiCaching` being
  false suppresses only `promptCacheOptions` and explicit breakpoints; the key is still serialized into
  the upstream `response.create` frame. Isolation costs the *continuation*, not upstream caching —
  which is why an isolated request still shows partial cache hits.
- **`x-claude-code-agent-id` is not new in 2.1.268.** It is present in every cached Claude Code bundle
  from 2.1.208 through 2.1.266 across all platform variants, and in the installed 2.1.267 binary,
  alongside `x-claude-code-parent-agent-id`, gated on `agentType === "main"` exactly as #209 says.
  2.1.268 itself was not available to inspect. Note also that auxiliary requests (token counting,
  quota checks, model-config lookups) deliberately use a *main* agent context and so send no agent id,
  which is precisely the "Claude auxiliary requests can share a session id" case the original code
  comment was written about — so the header would not fully disambiguate on its own.

## The change

A busy head may force isolation only when it could still turn out to be this request's parent:

```js
const couldPrecedeThisRequest = (entry) =>
  !entry.responseId || !entry.requestInput || !entry.expectedAssistant
  || continuationMatch(entry, payload, clientItems()) !== undefined;
```

- `continuationMatch` is the *same* function normal continuation uses — strict prefix over the head's
  committed history, including the omitted-reasoning tolerance. No new matching logic is introduced.
- The conservative `true` is load-bearing: a head whose first response is still streaming has
  committed nothing, so divergence cannot be proven and it keeps blocking. Deleting that clause
  reddens 8 pre-existing tests.
- Applied at **both** the arrival gate and the post-pacing re-check.
- Otherwise the request falls through to the pre-existing `history_mismatch_new_head` branch, which
  retains a nursery head — so the next turn continues instead of resending.

The original safeguard is intact: "never multiplex or queue a request whose lineage cannot yet include
the active response." Nothing is multiplexed and nothing is queued — a new socket is opened, exactly
as the isolated path already did. Multiple heads per partition were already routine, and an idle
matching head is already continued while a sibling streams (that branch is tested first), so an
unrelated busy head was never a reason to give up a chain.

`ws_head_decision` gains `isolatedByConnectionId`, naming the head that decided an isolation, emitted
only when the final decision is `parallel_isolated`.

### Deliberately out of scope

- **No per-subagent cache key.** See the header note above; the lineage gate fixes the cause without a
  client-version dependency, and splitting partitions would shrink the abandoned-head canary's
  candidate set.
- **The remaining 384 isolations stay.** Those are blocked by a head that has committed nothing yet.
  A follow-up should address them: correlating each blocking head back to the request that put it in
  flight shows **313 of 319** in a sampled class were serving *provably different* content, diverging
  at item 0 — the information needed is `entry.current.originalPayload`, already in memory. That is a
  separate change because the right form of it is deleting the isolation branch, not flipping a flag
  inside a caching fix.
- **Connection caps unchanged.** See the pool-pressure disclosure below.

## Tests and mutations

Five tests added to `tests/responses-websocket.test.ts`, all staging the head's expected-assistant
history through the production producer (`response.output_item.added` / `.done`), never by planting
items in request input:

1. `does not continue a head whose history differs only at the root item` — the client history is
   *longer* than the stored prefix, so the comparison actually reaches item 0. My first version of
   these tests used a shorter history and so never compared it at all.
2. `keeps a parallel conversation on its own chain while an unrelated head streams` — a head in flight
   **with a committed prefix** while an unrelated conversation arrives. Asserts the payoff
   behaviourally: the sibling's second turn carries `previous_response_id` and only the new item.
3. `keeps a chain that shares a parent preamble but diverges inside assistant history` — subagents that
   share an inherited preamble and first differ in the region the head *produced*.
4. `isolates a parallel request whose only possible parent matches by omitted reasoning` — pins the
   omitted-reasoning branch of the lineage test.
5. `finds the possible parent among several busy heads and names it` — two busy committed heads, only
   the second a possible parent. Candidate order is guaranteed (Set insertion order; no
   re-registration on continuation or promotion).

Plus an `isolatedByConnectionId` assertion on the existing post-pacing test, and a
`not.toHaveProperty('isolatedByConnectionId')` assertion on the pacing-rematch test.

Nine mutations, each run against the full file (never `-t` isolation), each red:

| mutation | fails |
|---|---|
| arrival gate back to `candidates.some(e => e.inFlight)` | test 2 |
| pacing-site gate back to the broad predicate | test 2 |
| conservative uncommitted-head clause removed | 8 pre-existing tests |
| compare only the first canonical item | test 3 |
| compare only `requestInput`, ignoring produced output | test 3 |
| accept only `continuationMatch(...)?.mode === 'exact'` | test 4 |
| inspect only the first busy head | test 5 |
| `isolatedByConnectionId` → constant `1` | test 5 |
| drop the post-pacing attribution assignment | pacing test |
| skip item 0 in `isStrictPrefix` | test 1 |
| drop the `decision === 'parallel_isolated'` guard on the diagnostic | pacing-rematch test |

**One mutation still survives, disclosed rather than papered over:** changing `isStrictPrefix`'s
`client.length <= head.length` to `<` accepts an equal-length history as a continuation with an empty
delta. That is pre-existing code outside this diff; I could not establish that a real Claude Code turn
ever sends a completed history with nothing appended, and if it did, this gate's response would be to
isolate — the safe direction. Left unpinned deliberately.

## Runtime evidence

Environment: macOS 25.6.0, Node v24.14.1, pnpm 10.34.5, real ChatGPT OAuth account. Two
`clodex server --endpoint --quick --no-discovery --ws-diagnostics` instances on separate ports — one
built from `origin/main`, one from this branch — driven by an out-of-tree script. Model gpt-5.6-luna.
**Caps were 64/24, not the shipped 32/8 defaults.**

Five alternating-order pairs, staggered 5-conversation fan-out, distinct session id and content salt
per run, pooled over all 10 runs' `ws_head_decision` records (all decisions, not only those with
usage):

| | baseline | this branch |
|---|---|---|
| `continuation` | 21.5% of decisions | **60.8%** |
| `parallel_isolated` | 70.0% | **19.2%** |
| uncached prompt tokens (pooled) | 56.8% | **44.8%** |
| sockets opened | 102 | **49** |

Isolations fell in **all five pairs**; pooled uncached input improved in **four of five** (per-trial
baseline 65.5 / 52.0 / 46.2 / 57.8 / 61.6 against 34.8 / 42.6 / 50.2 / 38.6 / 57.9). One baseline run
completed 20 of 25 planned requests after three `WebSocket closed (1006)` failures and is included as
measured; excluding it slightly *increases* the measured advantage. Treat the decision-mix rows as the
load-bearing result — they follow directly from the change and are far less noisy than the token row.

**The 44.8% is not a prediction for real traffic, and reading it as one is a mistake.** The uncached
tail per continuation is roughly constant at ~2,929 tokens (new user message, tool results, cache-block
boundary). Real continuations average a 69,319-token prompt, so that tail is 4.2%; this synthetic
workload averaged ~13,700 tokens, where the same tail is 21.4%. The A/B measures the mechanism well
and the token percentage misleadingly.

Projecting the decision-mix change onto the frozen ledger's real traffic (819.4M input, 241.0M
uncached, 29.4% overall today):

| scenario | overall uncached |
|---|---|
| today | 29.4% |
| half of freed turns continue | 18.1% |
| at the A/B's observed conversion rate | **13.0%** |
| every freed turn continues | **6.9%** |

That is a projection, not a measurement. Anthropic passthrough over the same window is 4.9%; the
residual gap is the first turn of every conversation, which can never be cached.

**Earlier negative result, disclosed:** the first A/B driver launched all conversations in one burst
and showed no improvement (77.6% → 79.2% uncached). A synchronized burst keeps an uncommitted head in
flight almost always, which this change deliberately still isolates. Real fan-outs stagger. Two later
runs at **default 32/8 caps** gave 70.0% → 66.0% and 71.2% → 66.4% — same direction, smaller margin,
and not pooled with the five-trial experiment because their error counts differ materially.

Also run: `pnpm typecheck`, `pnpm test` (2,556 tests, 115 files), `pnpm build`, and the ws file under a
throwaway `CLODEX_HOME`. Both smoke legs through real Claude Code on the default proxy mode:
`--model haiku -p` → `HAIKU-OK` (Anthropic passthrough) and `--model luna -p` → `LUNA-OK` (the changed
transport).

## What I could not verify

- **The nursery LRU under a genuinely wide fan-out.** This is the main resource risk. Newly retained
  heads are nursery generation (default cap 8), and a reviewer proved a sequence where total upgrades
  *double* (8 → 16): with the nursery at its cap, eight retained siblings evict eight older idle heads,
  which then need fresh upgrades inside the 5-minute TTL. I could not construct a workload that
  reached the cap — peak nursery was 4 and **no `nursery_lru_cap` eviction fired in any run** — so the
  risk is unmeasured rather than cleared. The failure mode is a partial loss of the improvement, not a
  correctness fault, and `evictions[]` on every `ws_head_decision` makes it visible.
- **Established-pool pressure is also increased**, at a second moment: on a retained head's first
  continuation, `continueOnHead` promotes it and evicts from the established pool first. Formerly
  isolated sibling turns now leave heads that later get promoted, so `established_lru_cap` evictions
  become more common, and the displaced head may be a large long-lived conversation. Worth watching
  both counters after this lands.
- **Mid-stream error rate correlates with held connections, and this change holds more.** Peak
  `activeConnectionCount` in the A/B rose from 13 to 31. Bucketing the frozen ledger's 13,530 requests
  by the concurrency in force at each one, mid-stream `ws_response_error` rates were 2.91% (0-9
  connections), 3.30% (10-19), 6.13% (20-29) and 9/12 at 30+ — the last bucket far too small to read.
  This is correlational and confounded: high concurrency also means heavier fan-out and longer
  requests, which could raise error rates independently. Against it, the five patched A/B runs had
  **zero** request failures while one baseline run lost three to `WebSocket closed (1006)`. So there is
  no direct evidence the change increases errors, but the correlation is real and worth watching, and
  it is a caution against raising the connection caps to buy back the eviction pressure above without
  measuring this first.
- **A false negative from the lineage test** — a request that really is a later turn but whose history
  was renormalized so `continuationMatch` misses it — converts an isolated socket into a
  possibly-duplicate head for one conversation. Cost is one pool slot;
  `history_mismatch_new_head` already creates duplicate heads by design on any mismatch. Not observed.
- **Claude Code 2.1.268**, referenced by #209, was not available to inspect.
- Only `openai-oauth` was exercised end to end. The change cannot reach the Anthropic passthrough
  path, which the smoke leg confirms still works.

## Rollback

Reverting restores the previous gate exactly. No persisted state, no config, no wire-format change;
the new diagnostic field is additive.
