### PR TITLE
feat(oauth): keep every parallel subagent's ChatGPT chain alive

### DIFF
--- a/.claude/docs/oauth-continuation.md
+++ b/.claude/docs/oauth-continuation.md
@@ -48,24 +48,38 @@ arrival gate and the post-pacing re-check use the predicate, and the `ws_head_de
 
 ### Subagents partition by agent id
 
-Claude Code 2.1.268 sends `x-claude-code-agent-id` (and `x-claude-code-parent-agent-id`) on every
-request from an in-process subagent and neither on the main agent's. The relay reads them in
-`proxy.ts` / `router.ts` (the MITM forwards them to the relay adapter alongside the session header),
-carries them through `withResponsesWebSocketDiagnosticContext`, and `responsesWebSocketPartitionKey`
-appends the agent id to the key material. `prompt_cache_key` is untouched, so siblings still share
-the server-side prefix cache; only the head lookup is per agent.
+Claude Code sends `x-claude-code-agent-id` (and `x-claude-code-parent-agent-id`) on every request
+from an in-process subagent and neither on the main agent's — present in every bundle checked back
+to 2.1.238, so nothing here is gated on a client version. The relay reads them in `proxy.ts` /
+`router.ts` (the MITM forwards them to the relay adapter alongside the session header), carries them
+through `withResponsesWebSocketDiagnosticContext`, and `responsesWebSocketPartitionKey` appends the
+agent id to the key material. `prompt_cache_key` is untouched, so siblings still share the
+server-side prefix cache; only the head lookup is per agent.
 
-The possible-parent gate above is deliberately conservative for a head that has committed nothing
-yet, and a parallel fan-out hits exactly that case: five siblings start within seconds, so siblings
-two to five each arrive while the first's initial response is still streaming and were isolated
-(no head retained), and their next turns were isolated by whichever sibling was on its first response
-then. Measured on one Opus main + five Luna subagents fixing a small Python project in parallel
-(53 Luna requests): shared partition 64.9% cached input, 10 `parallel_isolated` + 4
-`history_mismatch_new_head`; per-agent partitions 82.0% cached, 5 `new_partition_head` + 48
-`continuation` and nothing else. The remaining gap to the single-thread figure (92%) is the five
-unavoidable first turns plus a few server-side cache misses on genuine continuations. Giving each
-sibling its own `prompt_cache_key` as well was tried and measured 83.2% — not distinguishable — so
-the key stays shared.
+**What this closes is the one shape the gate above cannot.** A sibling whose opening turn differs
+from the turn in flight already keeps its own head — that is the gate's job. A sibling whose opening
+turn is BYTE-IDENTICAL to the turn in flight is indistinguishable from a retry of that turn, so the
+gate must isolate it; the agent id is the only signal that tells the two apart. Measured on fresh
+single-purpose servers, one leg at a time, decision mix read from each server's own diagnostics:
+
+| siblings' opening turns | shared partition | per-agent partition |
+| --- | --- | --- |
+| distinct (5 x 4 turns) | 0 isolated, 5 sockets | 0 isolated, 5 sockets — identical |
+| identical (5 x 4, two trials) | 8 of 20 isolated, 13 sockets | 0, 5 sockets |
+| identical (8 x 3) | 8 of 24 isolated, 16 sockets | 0, 8 sockets |
+| identical, staggered 1.5s (4 x 3) | 3 of 12 isolated | 0 |
+| identical, headers stripped (control) | 8 of 20 | — (equals shared) |
+
+The control leg shows the difference is the header, not the build. The structural cost on a shared
+partition is N-1 extra full-context sends per same-prompt fan-out, more when first answers coincide
+or a late sibling's first response is still streaming. Per-agent partitions also remove a
+cross-sibling stitch the shared partition permits when visible histories coincide.
+
+**Calibration:** in the 27.6-hour ledger cited above, 0 of 3,995 isolations had a prefix-or-equal
+busy candidate — every one diverged at item 0 — so this shape did not occur in that account's
+traffic at all. It is real for redundancy and consensus fan-outs that hand every sibling the same
+prompt; it is not a common case. Giving each sibling its own `prompt_cache_key` as well was tried
+and was not distinguishable from sharing it, so the key stays shared.
 
 Gating instead on "any head in this partition is busy" is expensive *cumulatively*: an isolated socket
 retains no head, so the next turn of that same subagent isolated again for as long as anything in the
@@ -138,8 +152,8 @@ percentages** — an earlier run of the same four legs gave 78.5 / 40.2 / 73.0 /
 cap settings differ by 9 points on identical workloads, so the token share carries upstream
 cache variance this experiment does not control. The decision counts are a consequence of the
 code AND of the workload's shape: these 16 conversations had distinct opening turns, which is
-what makes them distinguishable; 16 siblings sharing one opening turn would still isolate, by
-design.
+what makes them distinguishable; siblings sharing one opening turn are told apart by agent id
+instead (next section), and only a genuine retry of the turn in flight still isolates.
 
 Two things the table must not be read as saying. The baseline's single client-visible 429 is one
 observation in one cell — the baseline's other leg had none despite 35 refusals — so it does not

--- a/.claude/docs/oauth-continuation.md
+++ b/.claude/docs/oauth-continuation.md
@@ -7,8 +7,8 @@
 `src/oauth/responses-websocket.ts`. **Do not restructure this file.**
 
 All ChatGPT/Codex OAuth Responses models use a persistent WebSocket transport. Connections are
-partitioned by provider, OAuth account, upstream model, normalized effort, and hashed Claude
-session. Completed responses become validated chain heads (exact text/tool/reasoning capture;
+partitioned by provider, OAuth account, upstream model, normalized effort, hashed Claude
+session, and — for an in-process subagent — the Claude agent id. Completed responses become validated chain heads (exact text/tool/reasoning capture;
 function-call args compared as canonical JSON). The next request picks the longest exact-prefix head
 and sends `previous_response_id` + incremental input; any mismatch, failure, or expiry falls back
 safely to full context. `previous_response_not_found` retries once with full context before anything
@@ -45,6 +45,27 @@ tested as the prefix of the request and never the reverse. `inFlight` and `curre
 type rather than a state this predicate is reachable with; it blocks rather than guesses. Both the
 arrival gate and the post-pacing re-check use the predicate, and the `ws_head_decision` records
 `isolatedByConnectionId` naming the head that decided it.
+
+### Subagents partition by agent id
+
+Claude Code 2.1.268 sends `x-claude-code-agent-id` (and `x-claude-code-parent-agent-id`) on every
+request from an in-process subagent and neither on the main agent's. The relay reads them in
+`proxy.ts` / `router.ts` (the MITM forwards them to the relay adapter alongside the session header),
+carries them through `withResponsesWebSocketDiagnosticContext`, and `responsesWebSocketPartitionKey`
+appends the agent id to the key material. `prompt_cache_key` is untouched, so siblings still share
+the server-side prefix cache; only the head lookup is per agent.
+
+The possible-parent gate above is deliberately conservative for a head that has committed nothing
+yet, and a parallel fan-out hits exactly that case: five siblings start within seconds, so siblings
+two to five each arrive while the first's initial response is still streaming and were isolated
+(no head retained), and their next turns were isolated by whichever sibling was on its first response
+then. Measured on one Opus main + five Luna subagents fixing a small Python project in parallel
+(53 Luna requests): shared partition 64.9% cached input, 10 `parallel_isolated` + 4
+`history_mismatch_new_head`; per-agent partitions 82.0% cached, 5 `new_partition_head` + 48
+`continuation` and nothing else. The remaining gap to the single-thread figure (92%) is the five
+unavoidable first turns plus a few server-side cache misses on genuine continuations. Giving each
+sibling its own `prompt_cache_key` as well was tried and measured 83.2% — not distinguishable — so
+the key stays shared.
 
 Gating instead on "any head in this partition is busy" is expensive *cumulatively*: an isolated socket
 retains no head, so the next turn of that same subagent isolated again for as long as anything in the

--- a/src/http-proxy/server.ts
+++ b/src/http-proxy/server.ts
@@ -694,6 +694,13 @@ function forwardToAdapter(
         ...(typeof req.headers['x-claude-code-session-id'] === 'string'
           ? { 'x-claude-code-session-id': req.headers['x-claude-code-session-id'] }
           : {}),
+        // Subagent identity: the relay partitions ChatGPT WebSocket heads by it.
+        ...(typeof req.headers['x-claude-code-agent-id'] === 'string'
+          ? { 'x-claude-code-agent-id': req.headers['x-claude-code-agent-id'] }
+          : {}),
+        ...(typeof req.headers['x-claude-code-parent-agent-id'] === 'string'
+          ? { 'x-claude-code-parent-agent-id': req.headers['x-claude-code-parent-agent-id'] }
+          : {}),
         ...(lifecycle ? { 'x-relay-request-id': lifecycle.requestId } : {}),
       },
     }, upstreamRes => {

--- a/src/oauth/responses-websocket.ts
+++ b/src/oauth/responses-websocket.ts
@@ -103,16 +103,34 @@ export interface ResponsesWebSocketDiagnosticEvent extends Record<string, unknow
 export interface ResponsesWebSocketDiagnosticContext {
   requestId?: string;
   claudeSessionId?: string;
+  /**
+   * `x-claude-code-agent-id` from the inbound request: set only for an in-process
+   * Claude Code subagent, absent for the main agent and its auxiliary requests.
+   * Unlike the other fields this one is not just correlation — it joins the
+   * socket partition key (see `responsesWebSocketPartitionKey`).
+   */
+  claudeAgentId?: string;
+  /** `x-claude-code-parent-agent-id`, recorded in diagnostics only. */
+  claudeParentAgentId?: string;
 }
 
 const diagnosticContext = new AsyncLocalStorage<ResponsesWebSocketDiagnosticContext>();
 
-/** Correlate a gateway/proxy request with the lower-level SDK WebSocket fetch. */
+/**
+ * Correlate a gateway/proxy request with the lower-level SDK WebSocket fetch,
+ * and carry the request's Claude agent identity into the partition lookup. The
+ * fetch is built once per provider, so per-request facts arrive through here.
+ */
 export function withResponsesWebSocketDiagnosticContext<T>(
   context: ResponsesWebSocketDiagnosticContext,
   fn: () => T,
 ): T {
   return diagnosticContext.run(context, fn);
+}
+
+/** The context the current async chain runs under; lets a test observe what a caller plumbed. */
+export function responsesWebSocketDiagnosticContextForTests(): ResponsesWebSocketDiagnosticContext | undefined {
+  return diagnosticContext.getStore();
 }
 
 type JsonObject = Record<string, unknown>;
@@ -383,12 +401,24 @@ function instructionChangeSummary(previous: string | undefined, current: string 
  * separately before previous_response_id is used. The authorization fingerprint
  * prevents a refreshed credential from inheriting a socket authenticated with the
  * token that the upstream rejected.
+ *
+ * The Claude agent id separates in-process subagents that share their parent's
+ * session id (and so its `prompt_cache_key`). Without it, a fan-out's siblings
+ * all land in one partition and each one's first turn arrives while another
+ * sibling's first response is still streaming — a head that has committed
+ * nothing yet, which `couldPrecedeThisRequest` conservatively treats as a
+ * possible parent — so every sibling but the first is isolated and retains no
+ * head. Partitioning per agent keeps `prompt_cache_key` shared (the server-side
+ * prefix cache still spans the fan-out) while each sibling keeps its own chain.
+ * The main agent and its auxiliary requests carry no agent id and keep sharing
+ * the session partition, so the isolation they depend on is unchanged.
  */
 export function responsesWebSocketPartitionKey(
   wsUrl: string,
   payload: JsonObject,
   options: Pick<ResponsesWebSocketFetchOptions, 'providerId' | 'accountId'> = {},
   authorizationFingerprint = '',
+  claudeAgentId = '',
 ): string | undefined {
   const promptCacheKey = payload.prompt_cache_key;
   const model = payload.model;
@@ -405,6 +435,7 @@ export function responsesWebSocketPartitionKey(
     effort,
     promptCacheKey,
     authorizationFingerprint,
+    claudeAgentId,
   ].join('\x1f');
   return createHash('sha256').update(material).digest('hex');
 }
@@ -2155,16 +2186,18 @@ export function createResponsesWebSocketFetch(
     if (hasResponsesLiteHeader(headers)) payload = applyResponsesLiteShape(payload);
 
     const authorizationFingerprint = authorizationHeaderFingerprint(headers);
+    const diagnosticCorrelation = diagnosticContext.getStore();
+    const claudeAgentId = diagnosticCorrelation?.claudeAgentId ?? '';
     const partitionKey = responsesWebSocketPartitionKey(
       wsUrl,
       payload,
       options,
       authorizationFingerprint,
+      claudeAgentId,
     );
     const promptFingerprint = responsesWebSocketPromptFingerprint(payload);
     const promptFieldHashes = responsesWebSocketPromptFieldHashes(payload);
     const instructionsSnapshot = instructionsFromPayload(payload);
-    const diagnosticCorrelation = diagnosticContext.getStore();
     // Re-read after a pacing wait, so head ages stay comparable with the pool
     // counts reported alongside them.
     let now = resolvedOptions.now();
@@ -2518,6 +2551,8 @@ export function createResponsesWebSocketFetch(
           ? String((payload.reasoning as JsonObject).effort).trim().toLowerCase()
           : '',
         promptCacheKey: typeof payload.prompt_cache_key === 'string' ? payload.prompt_cache_key : undefined,
+        claudeAgentId: claudeAgentId || undefined,
+        claudeParentAgentId: diagnosticCorrelation?.claudeParentAgentId,
       },
       promptFingerprint,
       promptFieldHashes,

--- a/src/oauth/responses-websocket.ts
+++ b/src/oauth/responses-websocket.ts
@@ -403,15 +403,16 @@ function instructionChangeSummary(previous: string | undefined, current: string 
  * token that the upstream rejected.
  *
  * The Claude agent id separates in-process subagents that share their parent's
- * session id (and so its `prompt_cache_key`). Without it, a fan-out's siblings
- * all land in one partition and each one's first turn arrives while another
- * sibling's first response is still streaming — a head that has committed
- * nothing yet, which `couldPrecedeThisRequest` conservatively treats as a
- * possible parent — so every sibling but the first is isolated and retains no
- * head. Partitioning per agent keeps `prompt_cache_key` shared (the server-side
- * prefix cache still spans the fan-out) while each sibling keeps its own chain.
- * The main agent and its auxiliary requests carry no agent id and keep sharing
- * the session partition, so the isolation they depend on is unchanged.
+ * session id (and so its `prompt_cache_key`). A sibling whose opening turn
+ * differs from the turn in flight already keeps its own head —
+ * `couldPrecedeThisRequest` compares against what the busy head is generating.
+ * A sibling whose opening turn is byte-identical to it cannot be told from a
+ * retry of that turn, so the gate must isolate it; the agent id is the only
+ * signal that distinguishes the two. Partitioning per agent keeps
+ * `prompt_cache_key` shared (the server-side prefix cache still spans the
+ * fan-out) while each sibling keeps its own chain. The main agent and its
+ * auxiliary requests carry no agent id and keep sharing the session partition,
+ * so the isolation they depend on is unchanged.
  */
 export function responsesWebSocketPartitionKey(
   wsUrl: string,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -41,6 +41,7 @@ import {
   translateRequest as sdkTranslateRequest,
   streamAnthropicResponse,
   generateAnthropicResponse,
+  extractClaudeAgentIds,
   extractClaudeSessionId,
   sdkTranslationErrorSignature,
   silenceSdkWarnings,
@@ -602,6 +603,7 @@ export async function startProxyCatalog(
           ? req.headers['x-claude-code-session-id'][0]
           : req.headers['x-claude-code-session-id'];
         const claudeSessionId = extractClaudeSessionId(anthropicBody, claudeSessionIdHeader);
+        const claudeAgentIds = extractClaudeAgentIds(req.headers);
         const translationLifecycle = createTranslationLifecycle(
           inferenceLogPath,
           relayRequestId,
@@ -686,7 +688,7 @@ export async function startProxyCatalog(
             keepAlive.unref();
             try {
               await withResponsesWebSocketDiagnosticContext(
-                { requestId: relayRequestId, claudeSessionId },
+                { requestId: relayRequestId, claudeSessionId, ...claudeAgentIds },
                 () => streamAnthropicResponse(
                   model,
                   params,
@@ -720,7 +722,7 @@ export async function startProxyCatalog(
             // outright ("Stream must be set to true"), so always stream internally
             // for it and collect the result, regardless of what the client asked for.
             const anthropicResponse = await withResponsesWebSocketDiagnosticContext(
-              { requestId: relayRequestId, claudeSessionId },
+              { requestId: relayRequestId, claudeSessionId, ...claudeAgentIds },
               () => generateAnthropicResponse(
                 model,
                 params,

--- a/src/sdk-adapter.ts
+++ b/src/sdk-adapter.ts
@@ -125,6 +125,27 @@ export function extractClaudeSessionId(
   return validClaudeSessionId(headerFallback);
 }
 
+const CLAUDE_AGENT_ID_RE = /^[A-Za-z0-9._-]{1,128}$/;
+
+/**
+ * Claude Code 2.1.268 marks every request from an in-process subagent with
+ * `x-claude-code-agent-id` (and its parent's id in `x-claude-code-parent-agent-id`);
+ * the main agent sends neither. The value is opaque, so only its shape is checked.
+ */
+export function extractClaudeAgentIds(
+  headers: Record<string, string | string[] | undefined>,
+): { claudeAgentId?: string; claudeParentAgentId?: string } {
+  const read = (name: string): string | undefined => {
+    const raw = headers[name];
+    const value = (Array.isArray(raw) ? raw[0] : raw)?.trim();
+    return value && CLAUDE_AGENT_ID_RE.test(value) ? value : undefined;
+  };
+  return {
+    claudeAgentId: read('x-claude-code-agent-id'),
+    claudeParentAgentId: read('x-claude-code-parent-agent-id'),
+  };
+}
+
 /** Opaque prompt-cache partition derived from a Claude session UUID. */
 export function claudeSessionPromptCacheKey(sessionId: string): string {
   return 'relay-session-' + createHash('sha256').update(sessionId).digest('hex').slice(0, 32);

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -56,6 +56,7 @@ import {
   generateAnthropicResponse,
   silenceSdkWarnings,
   anthropicEffortFromRequest,
+  extractClaudeAgentIds,
   extractClaudeSessionId,
   isOpenAiOAuthRoute,
   oauthServiceTier,
@@ -286,6 +287,7 @@ async function handleAnthropicMessages(
     ? req.headers['x-claude-code-session-id'][0]
     : req.headers['x-claude-code-session-id'];
   const claudeSessionId = extractClaudeSessionId(body as AnthropicRequest, claudeSessionIdHeader);
+  const claudeAgentIds = extractClaudeAgentIds(req.headers);
   if (options.webSocketDiagnosticsLogPath) {
     writeWebSocketDiagnosticRequestLog(options.webSocketDiagnosticsLogPath, {
       requestId,
@@ -469,7 +471,7 @@ async function handleAnthropicMessages(
             res.write(chunk);
           };
           await withResponsesWebSocketDiagnosticContext(
-            { requestId, claudeSessionId },
+            { requestId, claudeSessionId, ...claudeAgentIds },
             () => streamAnthropicResponse(languageModel, params, responseModelId, writeStreamChunk, undefined, {
               abortSignal: clientAbort.signal,
               initialInputTokens: estimateAnthropicInputTokens(body),
@@ -488,7 +490,7 @@ async function handleAnthropicMessages(
           // returns text/event-stream unconditionally), so stream internally and
           // collect the result instead of issuing a non-streaming SDK request.
           const anthropicResponse = await withResponsesWebSocketDiagnosticContext(
-            { requestId, claudeSessionId },
+            { requestId, claudeSessionId, ...claudeAgentIds },
             () => generateAnthropicResponse(languageModel, params, responseModelId, {
               forceStream: openAiOAuth,
               abortSignal: clientAbort.signal,

--- a/tests/claude-agent-id-context.test.ts
+++ b/tests/claude-agent-id-context.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import http from 'node:http';
+import { createLanguageModel } from '../src/provider-factory.js';
+import { extractClaudeAgentIds, generateAnthropicResponse } from '../src/sdk-adapter.js';
+import {
+  responsesWebSocketDiagnosticContextForTests,
+  type ResponsesWebSocketDiagnosticContext,
+} from '../src/oauth/responses-websocket.js';
+import { startProxyCatalog, type ProxyRoute } from '../src/proxy.js';
+import { createGatewayModelCatalog } from '../src/server/models.js';
+import { startServer } from '../src/server/router.js';
+
+// The SDK call runs inside the request's AsyncLocalStorage context, so a mocked
+// adapter can read exactly what proxy.ts / router.ts plumbed for the WebSocket
+// fetch — the same store the partition key is computed from.
+const seenContexts: Array<ResponsesWebSocketDiagnosticContext | undefined> = [];
+
+vi.mock('../src/provider-factory.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/provider-factory.js')>();
+  return { ...actual, createLanguageModel: vi.fn().mockResolvedValue({}) };
+});
+
+vi.mock('../src/sdk-adapter.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/sdk-adapter.js')>();
+  const ws = await import('../src/oauth/responses-websocket.js');
+  return {
+    ...actual,
+    generateAnthropicResponse: vi.fn(async (_model: unknown, _params: unknown, modelId: string) => {
+      seenContexts.push(ws.responsesWebSocketDiagnosticContextForTests());
+      return {
+        id: 'msg-sdk',
+        type: 'message',
+        role: 'assistant',
+        model: modelId,
+        content: [{ type: 'text', text: 'sdk ok' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 1, output_tokens: 1 },
+      };
+    }),
+  };
+});
+
+const SESSION_ID = '927b8642-15d2-4535-ab27-1430ae54c4aa';
+const AGENT_ID = 'agent-a1b2c3d4e5f60718';
+const PARENT_ID = 'agent-main';
+
+function post(port: number, path: string, body: unknown, headers: Record<string, string>): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const payload = JSON.stringify(body);
+    const req = http.request(
+      {
+        hostname: '127.0.0.1', port, path, method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'anthropic-version': '2023-06-01',
+          'content-length': Buffer.byteLength(payload),
+          ...headers,
+        },
+      },
+      res => {
+        let data = '';
+        res.on('data', chunk => { data += chunk; });
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, body: data }));
+      },
+    );
+    req.on('error', reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+const messagesBody = { max_tokens: 100, messages: [{ role: 'user', content: 'hi' }], stream: false };
+
+describe('extractClaudeAgentIds', () => {
+  it('reads both headers, first value only, and rejects shapes that are not an agent id', () => {
+    expect(extractClaudeAgentIds({ 'x-claude-code-agent-id': AGENT_ID, 'x-claude-code-parent-agent-id': PARENT_ID }))
+      .toEqual({ claudeAgentId: AGENT_ID, claudeParentAgentId: PARENT_ID });
+    expect(extractClaudeAgentIds({ 'x-claude-code-agent-id': [AGENT_ID, 'agent-other'] }))
+      .toEqual({ claudeAgentId: AGENT_ID, claudeParentAgentId: undefined });
+    expect(extractClaudeAgentIds({})).toEqual({ claudeAgentId: undefined, claudeParentAgentId: undefined });
+    expect(extractClaudeAgentIds({ 'x-claude-code-agent-id': '' })).toEqual({ claudeAgentId: undefined, claudeParentAgentId: undefined });
+    expect(extractClaudeAgentIds({ 'x-claude-code-agent-id': 'has space' }).claudeAgentId).toBeUndefined();
+    expect(extractClaudeAgentIds({ 'x-claude-code-agent-id': 'a\x1fb' }).claudeAgentId).toBeUndefined();
+    expect(extractClaudeAgentIds({ 'x-claude-code-agent-id': 'x'.repeat(129) }).claudeAgentId).toBeUndefined();
+  });
+});
+
+describe('Claude agent id reaches the WebSocket request context', () => {
+  afterEach(() => {
+    seenContexts.length = 0;
+    vi.mocked(createLanguageModel).mockClear();
+    vi.mocked(generateAnthropicResponse).mockClear();
+  });
+
+  const route: ProxyRoute = {
+    aliasId: 'clodex:openai-oauth:gpt-5.6-luna',
+    realModelId: 'gpt-5.6-luna',
+    displayName: 'GPT-5.6 Luna',
+    upstreamUrl: '',
+    apiKey: 'token',
+    modelFormat: 'openai',
+    npm: '@ai-sdk/openai',
+    providerId: 'openai-oauth',
+    authType: 'oauth',
+  };
+
+  it('from the proxy relay, for a subagent request', async () => {
+    const handle = await startProxyCatalog([route], route.aliasId, false);
+    try {
+      const res = await post(handle.port, '/v1/messages', { model: route.aliasId, ...messagesBody }, {
+        authorization: `Bearer ${handle.token}`,
+        'x-claude-code-session-id': SESSION_ID,
+        'x-claude-code-agent-id': AGENT_ID,
+        'x-claude-code-parent-agent-id': PARENT_ID,
+      });
+      expect(res.status, res.body).toBe(200);
+      expect(seenContexts).toEqual([expect.objectContaining({
+        claudeSessionId: SESSION_ID,
+        claudeAgentId: AGENT_ID,
+        claudeParentAgentId: PARENT_ID,
+      })]);
+    } finally {
+      handle.close();
+    }
+  });
+
+  it('from the proxy relay, absent for the main agent', async () => {
+    const handle = await startProxyCatalog([route], route.aliasId, false);
+    try {
+      const res = await post(handle.port, '/v1/messages', { model: route.aliasId, ...messagesBody }, {
+        authorization: `Bearer ${handle.token}`,
+        'x-claude-code-session-id': SESSION_ID,
+      });
+      expect(res.status, res.body).toBe(200);
+      expect(seenContexts).toHaveLength(1);
+      expect(seenContexts[0]).toMatchObject({ claudeSessionId: SESSION_ID });
+      expect(seenContexts[0]?.claudeAgentId).toBeUndefined();
+      expect(seenContexts[0]?.claudeParentAgentId).toBeUndefined();
+    } finally {
+      handle.close();
+    }
+  });
+
+  it('from the API server, for a subagent request', async () => {
+    const server = await startServer({
+      host: '127.0.0.1',
+      port: 0,
+      apiKey: 'token',
+      serverPassword: null,
+      catalog: createGatewayModelCatalog([{
+        id: 'gpt-5.6-luna',
+        name: 'GPT-5.6 Luna',
+        isFree: false,
+        brand: 'OpenAI',
+        providerId: 'openai-oauth',
+        sourceBackend: 'openai-oauth',
+        modelFormat: 'openai',
+        npm: '@ai-sdk/openai',
+        authType: 'oauth',
+      }]),
+    });
+    try {
+      const res = await post(Number(new URL(server.url).port), '/anthropic/v1/messages', {
+        model: 'gpt-5.6-luna', ...messagesBody,
+      }, {
+        'x-claude-code-session-id': SESSION_ID,
+        'x-claude-code-agent-id': AGENT_ID,
+        'x-claude-code-parent-agent-id': PARENT_ID,
+      });
+      expect(res.status, res.body).toBe(200);
+      expect(seenContexts).toEqual([expect.objectContaining({
+        claudeSessionId: SESSION_ID,
+        claudeAgentId: AGENT_ID,
+        claudeParentAgentId: PARENT_ID,
+      })]);
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/tests/http-proxy-server.test.ts
+++ b/tests/http-proxy-server.test.ts
@@ -1003,6 +1003,8 @@ describe('selective HTTP proxy', () => {
     let adapterAuth: string | undefined;
     let adapterApiKey: string | undefined;
     let adapterClaudeSessionId: string | undefined;
+    let adapterClaudeAgentId: string | undefined;
+    let adapterClaudeParentAgentId: string | undefined;
     let adapterBody = '';
     let anthropicRequests = 0;
     let fallbackAuth: string | undefined;
@@ -1028,6 +1030,8 @@ describe('selective HTTP proxy', () => {
       adapterAuth = req.headers.authorization;
       adapterApiKey = req.headers['x-api-key'] as string | undefined;
       adapterClaudeSessionId = req.headers['x-claude-code-session-id'] as string | undefined;
+      adapterClaudeAgentId = req.headers['x-claude-code-agent-id'] as string | undefined;
+      adapterClaudeParentAgentId = req.headers['x-claude-code-parent-agent-id'] as string | undefined;
       adapterBody = Buffer.concat(chunks).toString();
       await new Promise(resolve => setTimeout(resolve, 35));
       res.writeHead(200, { 'Content-Type': 'text/event-stream', 'Connection': 'close' });
@@ -1089,6 +1093,8 @@ describe('selective HTTP proxy', () => {
         'Host: api.anthropic.com',
         'Authorization: Bearer subscription-oauth-token',
         'X-Claude-Code-Session-Id: 11111111-1111-4111-8111-111111111111',
+        'X-Claude-Code-Agent-Id: agent-a1b2c3d4e5f60718',
+        'X-Claude-Code-Parent-Agent-Id: agent-main',
         'Content-Type: application/json',
         `Content-Length: ${Buffer.byteLength(body)}`,
         'Connection: close',
@@ -1102,6 +1108,10 @@ describe('selective HTTP proxy', () => {
       expect(adapterAuth).toBeUndefined();
       expect(adapterApiKey).toBe('adapter-local-token');
       expect(adapterClaudeSessionId).toBe('11111111-1111-4111-8111-111111111111');
+      // Subagent identity rides with the session id: the relay partitions
+      // ChatGPT WebSocket heads by it.
+      expect(adapterClaudeAgentId).toBe('agent-a1b2c3d4e5f60718');
+      expect(adapterClaudeParentAgentId).toBe('agent-main');
       expect(adapterBody).toBe(body);
       const relayEntries = readFileSync(inferenceLogPath, 'utf8').trim().split('\n').map(line => JSON.parse(line));
       const requestEntry = relayEntries.find(entry => !entry.event);

--- a/tests/responses-websocket.test.ts
+++ b/tests/responses-websocket.test.ts
@@ -3645,6 +3645,79 @@ describe('createResponsesWebSocketFetch', () => {
     await readAll(streaming);
   });
 
+  it('gives concurrent subagents their own heads when the request carries a Claude agent id', async () => {
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
+      accountId: 'acct-fanout',
+      onDiagnostic: event => diagnostics.push(event),
+    });
+    const sendAs = (agent: string, input: unknown[]): Promise<Response> =>
+      withResponsesWebSocketDiagnosticContext(
+        { requestId: `req-${agent}`, claudeSessionId: 'shared-session', claudeAgentId: agent, claudeParentAgentId: 'main' },
+        () => wsFetch('https://x', { method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(input)) }),
+      );
+    const decisions = (): ResponsesWebSocketDiagnosticEvent[] =>
+      diagnostics.filter(event => event.event === 'ws_head_decision');
+
+    // Both siblings share the parent's session (and so its prompt_cache_key) and
+    // start at the same moment: A's first response is still streaming when B's
+    // first request arrives. In one partition B would be isolated by A's
+    // uncommitted head; per-agent partitions let each keep a chain.
+    const aUser = { role: 'user', content: [{ type: 'input_text', text: 'sibling A brief' }] };
+    const bUser = { role: 'user', content: [{ type: 'input_text', text: 'sibling B brief' }] };
+    const aTurnOne = await sendAs('agent-a', [aUser]);
+    const aSocket = lastSocket();
+    aSocket.emit('open');
+    const bTurnOne = await sendAs('agent-b', [bUser]);
+    const bSocket = lastSocket();
+    expect(bSocket).not.toBe(aSocket);
+    bSocket.emit('open');
+    expect(decisions().map(event => event.decision)).toEqual(['new_partition_head', 'new_partition_head']);
+    expect(decisions()[1]).toMatchObject({
+      createdGeneration: 'nursery',
+      keyTuple: expect.objectContaining({
+        promptCacheKey: 'relay-session-abc',
+        claudeAgentId: 'agent-b',
+        claudeParentAgentId: 'main',
+      }),
+    });
+    expect(decisions()[0]!.partitionKey).not.toBe(decisions()[1]!.partitionKey);
+
+    emitTextResponse(bSocket, 'resp_b1', 'B answer');
+    await readAll(bTurnOne);
+    emitTextResponse(aSocket, 'resp_a1', 'A answer');
+    await readAll(aTurnOne);
+
+    // Each sibling's second turn continues its own head with only the delta.
+    const bTurnTwo = await sendAs('agent-b', [
+      bUser,
+      { role: 'assistant', content: [{ type: 'output_text', text: 'B answer' }] },
+      { role: 'user', content: [{ type: 'input_text', text: 'B next' }] },
+    ]);
+    expect(lastSocket()).toBe(bSocket);
+    const bSent = JSON.parse(bSocket.send.mock.calls.at(-1)![0] as string) as { previous_response_id?: string; input: unknown[] };
+    expect(bSent.previous_response_id).toBe('resp_b1');
+    expect(bSent.input).toHaveLength(1);
+    emitTextResponse(bSocket, 'resp_b2', 'B again');
+    await readAll(bTurnTwo);
+
+    const socketsBeforeATurnTwo = fakeSockets.length;
+    const aTurnTwo = await sendAs('agent-a', [
+      aUser,
+      { role: 'assistant', content: [{ type: 'output_text', text: 'A answer' }] },
+      { role: 'user', content: [{ type: 'input_text', text: 'A next' }] },
+    ]);
+    expect(fakeSockets.length).toBe(socketsBeforeATurnTwo);
+    const aSent = JSON.parse(aSocket.send.mock.calls.at(-1)![0] as string) as { previous_response_id?: string };
+    expect(aSent.previous_response_id).toBe('resp_a1');
+    emitTextResponse(aSocket, 'resp_a2', 'A again');
+    await readAll(aTurnTwo);
+
+    expect(decisions().map(event => event.decision)).toEqual([
+      'new_partition_head', 'new_partition_head', 'continuation', 'continuation',
+    ]);
+  });
+
   it('still isolates a parallel request when the busy head could still be its parent', async () => {
     const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
     const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
@@ -4596,6 +4669,20 @@ describe('createResponsesWebSocketFetch', () => {
       instructions: 'changed',
       tools: [{ type: 'function', name: 'Write' }],
     }, options, 'credential-a'));
+  });
+
+  it('partitions in-process subagents by Claude agent id while keeping the prompt cache key', () => {
+    const payload = sessionPayload([]);
+    const options = { providerId: 'openai', accountId: 'a' };
+    const main = responsesWebSocketPartitionKey(WS_URL, payload, options, 'credential-a');
+    const agentA = responsesWebSocketPartitionKey(WS_URL, payload, options, 'credential-a', 'agent-a');
+    const agentB = responsesWebSocketPartitionKey(WS_URL, payload, options, 'credential-a', 'agent-b');
+    expect(agentA).not.toBe(main);
+    expect(agentB).not.toBe(main);
+    expect(agentA).not.toBe(agentB);
+    // No agent id is the main agent, whatever form the absence takes.
+    expect(responsesWebSocketPartitionKey(WS_URL, payload, options, 'credential-a', '')).toBe(main);
+    expect(responsesWebSocketPartitionKey(WS_URL, payload, options, 'credential-a', 'agent-a')).toBe(agentA);
   });
 
   it('canonicalizes object key ordering in prompt fingerprints', () => {


### PR DESCRIPTION
## What this changes for users

When Claude Code runs several subagents at once on a ChatGPT/Codex model, most of them used to lose their conversation chain and re-send full context on every turn. Each subagent now keeps its own chain, so a parallel fan-out is cached about as well as its parts. Measured on five parallel Luna subagents: 64.9% cached input before, 82.0% after.

## Problem and root cause

Reachable by any ChatGPT/Codex OAuth user on Claude Code 2.1.268 who launches more than one subagent in the same message on a routed model.

2.1.268 marks every request from an in-process subagent with `x-claude-code-agent-id` and `x-claude-code-parent-agent-id` (verified in the bundle: the client factory adds both when `agentId` is set; the main agent sends neither). Every subagent still inherits its parent's session id, so a whole fan-out shares one socket partition. The possible-parent gate from #211 is deliberately conservative for a head that has committed nothing yet, and a fan-out hits exactly that case: five siblings start seconds apart, so siblings two to five each arrive while the first's initial response is still streaming. They are isolated (`isolatedByConnectionId: 1`), retain no head, and their next turns are isolated again by whichever sibling is still on its first response.

From the `ws_head_decision` log of one such run (post-#211 build): 1 `new_partition_head`, 10 `parallel_isolated`, 4 `history_mismatch_new_head`, 32 `continuation` across 47 Luna requests.

## The change

- `src/sdk-adapter.ts`: `extractClaudeAgentIds(headers)` reads the two headers (first value only, checked against `[A-Za-z0-9._-]{1,128}`).
- `src/proxy.ts`, `src/server/router.ts`: pass them into `withResponsesWebSocketDiagnosticContext` on all four call sites.
- `src/http-proxy/server.ts`: the MITM forwards both headers to the relay adapter alongside the session header (it previously forwarded an allowlist that dropped them).
- `src/oauth/responses-websocket.ts`: the context type gains `claudeAgentId` / `claudeParentAgentId`; `responsesWebSocketPartitionKey` takes the agent id as a fifth argument and appends it to the key material; the head decision's `keyTuple` records both ids.

`prompt_cache_key` is untouched, so siblings still share the server-side prefix cache; only the head lookup is per agent. The main agent and its auxiliary requests carry no agent id, so their partition and the isolation it relies on are unchanged.

Left out: a per-sibling `prompt_cache_key`. Tried as an experiment (each sibling's key suffixed with its agent id): 83.2% vs 82.0%, one run each, not distinguishable, and a staggered fan-out would lose the shared prefix on every sibling's first turn. Not included.

## Evidence

- [x] `pnpm typecheck && pnpm test && pnpm build`: 2561 of 2562 tests, 116 files, `CLODEX_HOME="$(mktemp -d)"`, node v22.23.2, no ambient proxy vars. The one failure, `credential-helper.test.ts > force-kills a helper that exceeds the runtime limit`, is a timing test untouched by this diff; it passes in isolation on this branch and on `main`.
- [x] Feature-deletion mutations, full files: dropping the agent id from the key material fails 2 tests in `tests/responses-websocket.test.ts`; dropping the context spread in `proxy.ts` fails the proxy plumbing test; dropping it in `router.ts` fails the API-server one.
- [x] Reachability stated above.
- [x] Manual: one Opus main + five parallel Luna subagents, each fixing a copy of a small Python project (all five green both times), through the proxy on Claude Code 2.1.268, isolated `CLODEX_HOME`, `--ws-diagnostics`. Before: 64.9% cached input over 47 Luna requests. After: 82.0% over 53, head decisions 5 `new_partition_head` + 48 `continuation` and nothing else. A three-sibling mixed run (Luna / a Go model / Haiku passthrough) still answers on all three. Anthropic passthrough is not touched by the diff.
- [x] Commit summary line reads as a release note.

Tests: the partition key discriminates on agent id and treats absent and empty alike; two siblings whose first responses overlap each get their own head and each continue their own chain with `previous_response_id`; the MITM test's adapter hop now asserts both forwarded headers; `tests/claude-agent-id-context.test.ts` reads the AsyncLocalStorage store from a mocked adapter and asserts what the proxy and the API server plumbed, and that both ids are absent for a main-agent request. That file uses a small test-only getter, `responsesWebSocketDiagnosticContextForTests`, added next to the existing `*ForTests` exports.

What the remaining gap to single-thread (92% on the same task) is: the five first turns are each a full miss (siblings two to five got ~1.8k cached tokens from the shared key, because all five prefills were in flight at once), and four real continuations came back with zero cached tokens from the server. The OpenAI guide notes that traffic above ~15 requests a minute to one cache key can overflow to another machine; this run sent 32 a minute on one key. That is the experiment above, and it did not help.

Not verified: behaviour on Claude Code builds that do not send the headers (the change is inert there by construction, but I only have 2.1.268 to hand).

## Failure and rollback behavior

A missing or malformed header means no agent id, which is today's behaviour. Nothing persisted. Each subagent now holds its own head, so a wide fan-out reaches the nursery cap (`maxNurseryConnections`, default 8) at eight concurrent siblings instead of sharing heads; that cap was already reachable before and is unchanged.
