### PR TITLE
fix(oauth): keep prompt caching when many subagents start at the same moment

### DIFF
--- a/.claude/docs/oauth-continuation.md
+++ b/.claude/docs/oauth-continuation.md
@@ -29,10 +29,22 @@ An in-process Claude Code subagent forks the session and keeps the root session 
 its parent's id in `X-Claude-Code-Session-Id` (verified in the 2.1.267 bundle; a separately launched
 process has its own). One partition therefore holds many unrelated conversations at once. A request that matches no idle head is pushed to `parallel_isolated` — full
 context, no head retained — only when some **in-flight** head could still turn out to be its parent:
-`couldPrecedeThisRequest`, which is `continuationMatch` against the busy head plus a conservative
-`true` for a head that has committed nothing yet (its first response is still streaming, so there is
-no history to diverge from). Both the arrival gate and the post-pacing re-check use it, and the
-`ws_head_decision` records `isolatedByConnectionId` naming the head that decided it.
+`couldPrecedeThisRequest`. A head that has committed a response is tested with `continuationMatch`.
+A head still streaming its very first response has no stored history, but it is not unknowable:
+`entry.current.originalPayload` is the conversation it is generating *for*, and this request can only
+be a later turn of that response if it carries those items as a prefix — `isPrefixOrEqual`, the
+non-strict form, because a client that re-sent the identical turn is a duplicate of the response in
+flight rather than a branch off it and must not be stitched onto a turn whose output it has never
+seen. Two shapes therefore still isolate against an uncommitted head: an exact repeat of the turn
+being generated (a client retry), and a request that extends it. Everything else — the sibling
+subagent whose history diverges at the first item, which is what a fan-out produces — is no longer
+blocked by THIS head, though pacing refusal or a transport failure can still cost it one. Note which
+side is the candidate prefix: a request holding FEWER items than the turn in
+flight, a rewind or an abandoned branch, cannot be a later turn of it, so the in-flight items are
+tested as the prefix of the request and never the reverse. `inFlight` and `current` are set together at dispatch, so the `!current` fallback is for the
+type rather than a state this predicate is reachable with; it blocks rather than guesses. Both the
+arrival gate and the post-pacing re-check use the predicate, and the `ws_head_decision` records
+`isolatedByConnectionId` naming the head that decided it.
 
 Gating instead on "any head in this partition is busy" is expensive *cumulatively*: an isolated socket
 retains no head, so the next turn of that same subagent isolated again for as long as anything in the
@@ -61,33 +73,133 @@ for its first continuation, before that continuation is known to succeed — so 
 concurrent subagents inherit the parent's Claude session id, and therefore share one partition, can
 lose heads before their next turn and with them the continuation.
 
-**Keeping a fan-out's chains alive trades throwaway sockets for retained heads, and that trade can go
-either way.** The mismatching turn still opens its own socket; only a LATER turn of that conversation
-can reuse it. Of the 4,934 primary connection-creation decisions in the ledger above, 3,611 had final
-diagnostics in which every recorded busy candidate showed a `user`-to-`user` divergence. Those are
-candidates for a different decision under this gate, not proof that 3,611 live isolations are replaced
-— the diagnostic reflects mutable entry state at emission time. Of the remaining 384, 319 recorded at
-least one busy strict-prefix candidate and still isolate by design; 65 had no busy candidate left in
-the final diagnostic and cannot be classified from this snapshot. But an isolated socket is never registered, so it
-never evicts anything, while a retained one runs `evictOldestIdleGeneration` first.
-**Eviction pressure is retained arrivals measured against free capacity — both terms matter, neither
-alone.** Seven free nursery slots absorb a width-1 fan-out with no eviction and lose one head to a
-width-8 one; at the cap, width decides whether one head or eight are evicted. A worked sequence goes
-the wrong way: eight idle nursery heads, one
-long-running established head in the target partition, and eight staggered siblings that each diverge
-from it. Retaining all eight evicts all eight older heads, so resuming those conversations inside the
-5-minute nursery TTL needs eight fresh upgrades — 16 rather than 8.
+**Keeping a fan-out's chains alive trades throwaway sockets for retained heads.** The mismatching
+turn still opens its own socket; only a LATER turn of that conversation can reuse it. Of the 4,934
+primary connection-creation decisions in the ledger above, 3,611 had final diagnostics in which every
+recorded busy candidate showed a `user`-to-`user` divergence. Those are candidates for a different
+decision, not proof that 3,611 live isolations are replaced — the diagnostic reflects mutable entry
+state at emission time. Of the remaining 384, 319 recorded at least one busy strict-prefix candidate
+and still isolate by design; 65 had no busy candidate left in the final diagnostic and cannot be
+classified from this snapshot.
+
+An isolated socket is never registered, so it never evicts anything, while a retained one runs
+`evictOldestIdleGeneration` first, **so a newly retained sibling can displace an older idle head that
+its own conversation was going to come back for.** That is reachable at the default nursery cap of 8:
+seven idle heads from finished turns, an eighth conversation streaming its first response, and one
+divergent sibling in that partition — the sibling is retained, the oldest idle head is evicted, and
+resuming that conversation costs a fresh upgrade and a full-context resend. Constructed and observed
+through the transport (nine sockets before this change, ten after), so the mechanism is established;
+its frequency in ordinary traffic is not, and the cap replay below finds no eviction-caused loss
+across the ledger's 27.6 hours — while also showing that at the default nursery cap the evicted head
+had often been idle for only seconds.
+
+**On a fresh pool, and for a fan-out whose members have distinguishable opening turns, it opened
+fewer sockets** — it reuses instead of dialing. That is not a general result: a warmed pool whose
+older conversations return is the case that can lose a head, and siblings that share an opening turn
+still isolate by design. Four single-purpose servers built from pinned commits (endpoint mode,
+`--no-discovery`, own port, freshly started, one leg at a time so each leg had the upstream account to
+itself), 16 conversations x 4 turns started simultaneously against a real ChatGPT-OAuth model,
+2026-09-11. `baseline` is 9bd5205, the commit that introduced the gate for *committed* heads;
+`this change` extends it to uncommitted ones:
+
+| leg | uncached input | client-visible failures | sockets opened | paced: admitted / refused | gauge peak nursery/established | `*_lru_cap` evictions | `parallel_isolated` |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| baseline, caps 32/8 | 74.8% | 1 (pacer 429) | 50 | 38 / 36 | 1/6 | 0 | 42 of 61 |
+| this change, caps 32/8 | 47.6% | 0 | 17 | 6 / 1 | 11/16 | 0 | **0 of 65** |
+| baseline, caps 64/24 | 82.0% | 0 | 52 | 42 / 35 | 1/6 | 0 | 44 of 64 |
+| this change, caps 64/24 | 32.8% | 0 | 16 | 6 / 1 | 11/16 | 0 | **0 of 64** |
+
+Sixteen conversations, sixteen sockets, one head each; all 48 later turns continued. Zero
+`*_lru_cap` evictions on any leg. **Read the socket and decision columns, not the token
+percentages** — an earlier run of the same four legs gave 78.5 / 40.2 / 73.0 / 31.1, and the two
+cap settings differ by 9 points on identical workloads, so the token share carries upstream
+cache variance this experiment does not control. The decision counts are a consequence of the
+code AND of the workload's shape: these 16 conversations had distinct opening turns, which is
+what makes them distinguishable; 16 siblings sharing one opening turn would still isolate, by
+design.
+
+Two things the table must not be read as saying. The baseline's single client-visible 429 is one
+observation in one cell — the baseline's other leg had none despite 35 refusals — so it does not
+establish that this change removes 429s, only that this change asked the pacer for an order of
+magnitude less. And the gauge columns are the counts recorded *in* the decision diagnostic, which
+is emitted before the new entry registers; actual nursery occupancy peaked one higher (4, 11, 2, 11).
+Note nursery reaching 11 against a cap of 8 at all: eviction only considers IDLE entries, so a cap
+is not a ceiling while every head in that generation is busy.
+
+Legs were run one at a time on freshly started servers so that no other *diagnostics-enabled*
+clodex process was competing for the account; an external client or a process without diagnostics
+would be invisible to that check.
+
+**A retraction, because this section previously predicted the opposite.** An earlier run of the
+lineage gate recorded 14 `established_lru_cap` evictions, every one on a promoting decision with
+`establishedConnectionCount` at exactly the cap — which reads as the change causing eviction
+pressure. That server had accumulated 30 established heads from four prior runs still inside their
+30-minute idle TTL. On a fresh process at the same caps there are none. Long-lived servers do
+accumulate, but do not read a cap-sized pool at the start of a measurement as a result of it.
+
+**Comparing against an in-flight turn is memoized per response, not per lookup.** Canonicalizing a
+whole conversation is the one cost this check adds, and a wide fan-out would otherwise pay it once per
+arriving sibling per busy head — measured at 13.6ms per arrival across 16 in-flight heads holding
+11.7MB, against 0.4ms memoized. `RequestContext.canonicalInput` caches it; `originalPayload` is
+assigned once at construction and never reassigned (a transport retry resets `sendPayload` back to it
+and reuses the same context), so the memo has no reachable staleness. The cost it trades for is
+retained size: the canonical strings run about as large as the payload, so an in-flight head holds
+roughly twice its context until the response completes. This mirrors `canonicalPrefix` on the
+committed path, which has the same property. A stale memo could only mis-decide isolate versus
+don't-isolate — the committed history that drives `previous_response_id` is recomputed from
+`originalPayload` and never reads it.
 
 **Cap enforcement touches BOTH pools, at two different moments.** Creating a retained head calls
 `evictOldestIdleGeneration('nursery', maxNurseryConnections, 'nursery_lru_cap')` first; when that head
 is later selected for its first continuation, `continueOnHead` calls
 `evictOldestIdleGeneration('established', maxConnections, 'established_lru_cap')` before promoting it.
 Either call removes an entry only when that generation is at or above its cap AND has an idle entry —
-neither is an unconditional eviction. So this change can raise established-pool pressure as newly
-retained heads are later selected, and the entry displaced is the oldest idle established one, which
-may be a large long-lived conversation that then resends full context. The ledger does not establish
-that established eviction actually becomes more common. Watch `established_lru_cap` alongside
-`nursery_lru_cap`.
+neither is an unconditional eviction. The entry displaced is the oldest idle one in that generation,
+which could be a large long-lived conversation that then resends full context. Watch
+`established_lru_cap` alongside `nursery_lru_cap`.
+
+**No cap setting changed head reuse in this ledger, but the margin at the default is thin.**
+Replaying the ledger's decisions through a pool model — one head per *content key* (partition plus
+first-input-item hash, which is a transport-and-content heuristic, NOT a conversation id), promoted
+on first reuse — gives **92.9% key recurrence (12,307 of 13,245) at every cap pair tested**, from
+8/32 to unlimited. Misses are 938: 935 keys seen for the first time, which have no head by
+definition, plus 3 returning after a TTL expiry. **No miss at any tested cap was caused by an
+eviction.** Collapse the 285 duplicate decisions that retried request ids contribute before counting
+any of this — the undeduplicated figures are 91.8% and 1,111, and this document warns about exactly
+that trap two sections above.
+
+What the model does show is how little headroom the default leaves. The LRU victim is the oldest
+IDLE entry, and at nursery 8 it had been idle a median of 26 seconds and as little as **8 seconds**,
+against an inter-turn gap distribution of p50 5s / p90 20s / p99 63s. 85 of the 268 nursery
+evictions displaced a head idle for less than the p90 gap. None of them was in fact reused, so this
+ledger records no loss — but "was not reused" at 8 seconds idle is luck, not margin. Raising the
+nursery cap moves the victim out of that distribution: at 16 no victim is below the p90 gap, and at
+48 none is below the p99 gap.
+
+Counts and reasons at 8/32 are 268 nursery plus 53 established evictions; at 24/64, 231 nursery and
+none established; at unlimited, none. Only cap pairs were simulated, not measured, and the model
+cuts both ways rather than being uniformly conservative: it lets in-flight heads be evicted, which
+the real pool forbids, but it also assumes every attempt yields an immediately reusable head and
+collapses a conversation's branches into one key.
+
+**What that ledger's own gauges looked like, pre-change, on caps of 64/24:** pooled connections p50
+16, p90 23, p99 27, max 31 (unweighted per decision); nursery peaked at 24, its cap, with 10
+`nursery_lru_cap` evictions; established peaked at 28 of 64 with **zero** `established_lru_cap`
+evictions. So in this ledger the pressured pool was the nursery, not the established one.
+`activeConnectionCount` equals nursery plus established on all 13,530 records, so isolated sockets
+are invisible in it and the true socket count was higher whenever one was open.
+
+**Held connections do NOT have an established relationship with upstream errors here, and an earlier
+revision of this section claimed they did.** Bucketing the ledger's 13,524 upstream-attempt outcomes
+by the pooled-connection count at the nearest preceding head decision gives 2.96% / 3.29% / 3.34%
+below 25 connections and 114 of 630 at 25 or more. That last bucket is one incident: all 114 errors
+fall inside a **5.8-minute window**, where the rate was 114/147; across the other 483 outcomes at 25+
+connections the rate was **zero**. The errors also began below 25 connections and preceded the pool
+climb. Treat the gradient as an artifact of that incident, not a cost of holding connections. (The
+join is also a global latest-gauge proxy rather than a per-request measurement.) What does survive:
+41 of the 44 upgrade rejections — HTTP 429 at the upgrade, from 13 request ids, all of which later
+succeeded — occurred at 20-24 pooled connections, so *dialing* under load is throttled, which is
+what the pacer is for and which this change reduces.
 
 An idle nursery head is exposed until its connection is **selected** for its first continuation, which
 is when promotion happens — before that continuation is known to succeed. Nursery membership is a
@@ -265,15 +377,21 @@ through the shipped bucket predicts 1,686 waits and 1,590 refusals in one of tho
 when the partition simply goes quiet during the wait. Such a request already has `persistent` false
 and, absent a re-match, keeps it, so it opens an isolated socket that retains no head at all.
 Isolated sockets were 30-38% of decisions in busy diagnostics files before the lineage gate above
-narrowed which of them qualify — a larger share of the same harm than the case this closes.
+narrowed which of them qualify — a larger share of the same harm than the case this closes. Under
+that gate a simultaneous 16-way fan-out produced none at all, so what remains of this boundary is
+the retry and extension shapes rather than ordinary fan-out traffic.
 
 Failing a re-match, an admitted request still demotes itself to `parallel_isolated` if a
 same-partition request that could be its parent went in flight meanwhile — otherwise two requests
-would each register a persistent nursery head for one key and a fan-out would evict other
-conversations' heads. The duplicate this guards against is a second head for ONE conversation, which
-is what `couldPrecedeThisRequest` describes; a head busy on a different conversation is not a
-duplicate of anything, and a brand-new sibling head has committed nothing and so still blocks. That
-check is unconditional; only the re-match is gated on having been queued.
+would each register two retained heads for one chain — the invariant being kept is one head per
+chain, not one socket per response. The
+duplicate this guards against is a second head for ONE conversation, which is what
+`couldPrecedeThisRequest` describes. A head busy on a different conversation is not a duplicate of
+anything and does not demote — including a brand-new sibling that has committed nothing, whose
+in-flight items are compared instead. What reaches this branch is a request that exactly repeats or
+strictly extends the turn being generated; an exact repeat is what a client retry produces, though
+the shape alone does not establish the cause. That check is unconditional; only the re-match is gated
+on having been queued.
 
 Diagnostics: a `ws_new_connection_paced` event (`outcome` of `admitted`, `refused`, or `aborted`,
 with `waitedMs` / `requiredWaitMs` / `retryAfterSeconds`) and `pacingWaitedMs` on the same request's

--- a/src/oauth/responses-websocket.ts
+++ b/src/oauth/responses-websocket.ts
@@ -90,6 +90,15 @@ interface RequestContext {
   controller: ReadableStreamDefaultController<Uint8Array>;
   encoder: TextEncoder;
   originalPayload: JsonObject;
+  /**
+   * Memoized canonical items of `originalPayload`, for comparing an arriving
+   * request against the turn this response is generating. `originalPayload` is
+   * assigned once at construction and never reassigned — a transport retry resets
+   * `sendPayload` back to it and reuses this same context — so the memo cannot go
+   * stale, and it keeps a wide fan-out from re-serializing every in-flight
+   * conversation once per arriving sibling.
+   */
+  canonicalInput?: string[];
   sendPayload: JsonObject;
   promptFieldHashes: Record<string, string>;
   instructionsSnapshot?: string;
@@ -796,13 +805,21 @@ function canonicalItemStrings(items: unknown[]): string[] {
   return items.map(item => canonicalJson(normalizeToolCallJson([item])));
 }
 
-/** True when `head` is a strict prefix of `client`. Exits at the first difference. */
-function isStrictPrefix(head: string[], client: string[]): boolean {
-  if (client.length <= head.length) return false;
+/**
+ * True when `head` is a prefix of `client`, counting the two being identical.
+ * Exits at the first difference.
+ */
+function isPrefixOrEqual(head: string[], client: string[]): boolean {
+  if (client.length < head.length) return false;
   for (let index = 0; index < head.length; index += 1) {
     if (head[index] !== client[index]) return false;
   }
   return true;
+}
+
+/** True when `head` is a strict prefix of `client` — equal histories do not count. */
+function isStrictPrefix(head: string[], client: string[]): boolean {
+  return client.length > head.length && isPrefixOrEqual(head, client);
 }
 
 function continuationMatch(
@@ -2138,14 +2155,30 @@ export function createResponsesWebSocketFetch(
      * session id, so one partition holds many unrelated conversations at once —
      * and a head busy on one of them says nothing about where another belongs.
      *
-     * Conservative wherever it cannot tell. A head that has committed nothing yet
-     * (its very first response is still streaming) has no history to diverge
-     * from, so it keeps blocking — which is the case the auxiliary-request
-     * isolation depends on.
+     * A head that has committed nothing yet — its very first response is still
+     * streaming — has no stored history to diverge from, but it is not unknowable:
+     * `current` holds the conversation it is generating for right now, and this
+     * request can only be a later turn of that response if it carries those items
+     * as a prefix. Comparing against them is what keeps a fan-out of subagents
+     * that all start at once from isolating every sibling's opening turn.
+     *
+     * Conservative only where there is genuinely nothing to compare.
      */
-    const couldPrecedeThisRequest = (entry: ConnectionEntry): boolean =>
-      !entry.responseId || !entry.requestInput || !entry.expectedAssistant
-      || continuationMatch(entry, payload, clientItems()) !== undefined;
+    const couldPrecedeThisRequest = (entry: ConnectionEntry): boolean => {
+      if (entry.responseId && entry.requestInput && entry.expectedAssistant) {
+        return continuationMatch(entry, payload, clientItems()) !== undefined;
+      }
+      const streaming = entry.current;
+      // `inFlight` and `current` are set together, so a candidate this predicate is
+      // asked about always has one. Block rather than guess if that ever changes.
+      if (!streaming) return true;
+      // Equality counts, hence `isPrefixOrEqual` rather than the strict form the
+      // continuation check uses: a client that re-sent the same turn is a duplicate
+      // of the response in flight, not a branch off it, and must not be stitched
+      // onto a turn whose output it has never seen.
+      streaming.canonicalInput ??= canonicalItemStrings(inputArray(streaming.originalPayload));
+      return isPrefixOrEqual(streaming.canonicalInput, clientItems());
+    };
     /** The in-flight head that forced isolation, for the diagnostic. */
     const blockingHead = (entries: ConnectionEntry[]): ConnectionEntry | undefined =>
       entries.find(entry => entry.inFlight && couldPrecedeThisRequest(entry));

--- a/tests/responses-websocket.test.ts
+++ b/tests/responses-websocket.test.ts
@@ -597,7 +597,7 @@ describe('createResponsesWebSocketFetch', () => {
     await readAll(continued);
   });
 
-  it('keeps a retried parallel auxiliary request isolated from reusable heads', async () => {
+  it('leaves a reusable head behind when a parallel request had to be retried', async () => {
     const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
     const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
       accountId: 'acct-parallel-transport',
@@ -644,17 +644,22 @@ describe('createResponsesWebSocketFetch', () => {
       headers: {},
       body: JSON.stringify(sessionPayload(nextAuxiliaryInput)),
     });
-    expect(fakeSockets).toHaveLength(4);
-    const nextAuxiliarySocket = lastSocket();
-    expect(nextAuxiliarySocket).not.toBe(auxiliaryReplacement);
-    nextAuxiliarySocket.emit('open');
-    emitTextResponse(nextAuxiliarySocket, 'resp_auxiliary_next', 'done');
+    // No fourth socket. The parallel request ran beside a head that was serving a
+    // different conversation, so it kept a head of its own and this turn continues
+    // it — the cost the old blanket isolation imposed was exactly here, on every
+    // later turn of a conversation that once started beside a busy sibling.
+    expect(fakeSockets).toHaveLength(3);
+    expect(lastSocket()).toBe(auxiliaryReplacement);
+    const continued = JSON.parse(auxiliaryReplacement.send.mock.calls[1]![0] as string);
+    expect(continued.previous_response_id).toBe('resp_auxiliary');
+    expect(continued.input).toEqual([nextAuxiliaryInput[2]]);
+    emitTextResponse(auxiliaryReplacement, 'resp_auxiliary_next', 'done');
     await readAll(nextAuxiliary);
 
     expect(diagnostics).toContainEqual(expect.objectContaining({
       event: 'ws_transport_retry',
       outcome: 'recovered',
-      generation: 'isolated',
+      generation: 'nursery',
     }));
   });
 
@@ -3408,6 +3413,238 @@ describe('createResponsesWebSocketFetch', () => {
     ]);
   });
 
+  it('keeps a simultaneous sibling on its own chain while a first-ever response streams', async () => {
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const debug: string[] = [];
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, message => debug.push(message), {
+      accountId: 'acct-simultaneous-fanout',
+      onDiagnostic: event => diagnostics.push(event),
+    });
+    const send = (input: unknown[]): Promise<Response> => wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(input)),
+    });
+    const decisions = (): ResponsesWebSocketDiagnosticEvent[] =>
+      diagnostics.filter(event => event.event === 'ws_head_decision');
+
+    // A swarm of subagents starting at the same moment: conversation A's very
+    // FIRST response is still streaming, so its head has committed nothing — no
+    // response id, no stored history, nothing a prefix check can run against.
+    const aFirstUser = { role: 'user', content: [{ type: 'input_text', text: 'conversation A' }] };
+    const aTurnOne = await send([aFirstUser]);
+    const aSocket = lastSocket();
+    aSocket.emit('open');
+    expect(decisions().at(-1)).toMatchObject({ decision: 'new_partition_head' });
+
+    // There is still something to compare against: the items A is generating FOR.
+    // B diverges from them at the first item, so A can never become B's parent.
+    const bFirstUser = { role: 'user', content: [{ type: 'input_text', text: 'conversation B' }] };
+    const bTurnOne = await send([bFirstUser]);
+    const bSocket = lastSocket();
+    expect(bSocket).not.toBe(aSocket);
+    expect(decisions().at(-1)).toMatchObject({
+      decision: 'history_mismatch_new_head',
+      createdGeneration: 'nursery',
+    });
+    expect(decisions().at(-1)).not.toHaveProperty('isolatedByConnectionId');
+    expect(debug).not.toContain('ws: parallel request using an isolated socket');
+    bSocket.emit('open');
+    emitTextResponse(bSocket, 'resp_b1', 'B answer');
+    await readAll(bTurnOne);
+    emitTextResponse(aSocket, 'resp_a1', 'A answer');
+    await readAll(aTurnOne);
+
+    // The payoff: B's head survived, so B's second turn sends one item instead of
+    // resending its whole history on yet another throwaway socket.
+    const bNextUser = { role: 'user', content: [{ type: 'input_text', text: 'B again' }] };
+    const bTurnTwo = await send([
+      bFirstUser,
+      { role: 'assistant', content: [{ type: 'output_text', text: 'B answer' }] },
+      bNextUser,
+    ]);
+    expect(fakeSockets).toHaveLength(2);
+    expect(lastSocket()).toBe(bSocket);
+    const sent = JSON.parse(bSocket.send.mock.calls[1]![0] as string);
+    expect(sent.previous_response_id).toBe('resp_b1');
+    expect(sent.input).toEqual([bNextUser]);
+    emitTextResponse(bSocket, 'resp_b2', 'B answer again');
+    await readAll(bTurnTwo);
+  });
+
+  it('does not continue a committed head on a request that adds no new turn', async () => {
+    // Equality is not a continuation: the delta would be empty, so the head would
+    // be asked to produce a second response for a turn it has already answered.
+    // `isStrictPrefix` rejects it, and this is the only test that says so.
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
+      accountId: 'acct-no-new-turn',
+      onDiagnostic: event => diagnostics.push(event),
+    });
+    const firstUser = { role: 'user', content: [{ type: 'input_text', text: 'opening turn' }] };
+    const send = (input: unknown[]): Promise<Response> => wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(input)),
+    });
+
+    const first = await send([firstUser]);
+    const headSocket = lastSocket();
+    headSocket.emit('open');
+    emitTextResponse(headSocket, 'resp_committed', 'the answer');
+    await readAll(first);
+
+    // Exactly the stored prefix — the client's own turn plus the answer it got —
+    // and nothing after it.
+    const echoed = await send([
+      firstUser,
+      { role: 'assistant', content: [{ type: 'output_text', text: 'the answer' }] },
+    ]);
+    expect(fakeSockets).toHaveLength(2);
+    const ownSocket = lastSocket();
+    expect(ownSocket).not.toBe(headSocket);
+    expect(diagnostics.filter(event => event.event === 'ws_head_decision').at(-1))
+      .toMatchObject({ decision: 'history_mismatch_new_head', matchingCandidateCount: 0 });
+    ownSocket.emit('open');
+    expect(JSON.parse(ownSocket.send.mock.calls[0]![0] as string).previous_response_id)
+      .toBeUndefined();
+    emitTextResponse(ownSocket, 'resp_no_new_turn', 'again');
+    await readAll(echoed);
+  });
+
+  it('isolates a request that repeats the turn a head is generating right now', async () => {
+    // The retry case. A second copy of the same turn is not a branch off the
+    // response in flight, it IS that response — asking the head to continue it
+    // would ask it to extend a turn it has not finished. The uncommitted head has
+    // no stored history, so equality against what it is generating is the only
+    // signal there is, and it has to count as "could be this request".
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const debug: string[] = [];
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, message => debug.push(message), {
+      accountId: 'acct-duplicate-inflight',
+      onDiagnostic: event => diagnostics.push(event),
+    });
+    const turn = [{ role: 'user', content: [{ type: 'input_text', text: 'one turn' }] }];
+    const send = (): Promise<Response> => wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(turn)),
+    });
+
+    const first = await send();
+    const firstSocket = lastSocket();
+    firstSocket.emit('open');
+
+    const duplicate = await send();
+    expect(fakeSockets).toHaveLength(2);
+    const duplicateSocket = lastSocket();
+    expect(duplicateSocket).not.toBe(firstSocket);
+    expect(diagnostics.filter(event => event.event === 'ws_head_decision').at(-1))
+      .toMatchObject({
+        decision: 'parallel_isolated',
+        createdGeneration: 'isolated',
+        isolatedByConnectionId: 1,
+      });
+    expect(debug).toContain('ws: parallel request using an isolated socket');
+
+    duplicateSocket.emit('open');
+    expect(JSON.parse(duplicateSocket.send.mock.calls[0]![0] as string).previous_response_id)
+      .toBeUndefined();
+    emitTextResponse(duplicateSocket, 'resp_duplicate', 'answer');
+    await readAll(duplicate);
+    emitTextResponse(firstSocket, 'resp_first', 'answer');
+    await readAll(first);
+  });
+
+  it('keeps its own head when its history is shorter than the turn in flight', async () => {
+    // A rewind or an abandoned branch: fewer items than the response being
+    // generated. A LATER turn of that response is necessarily longer, so a shorter
+    // history can never be its child and there is nothing to be confused with —
+    // which is why `isPrefixOrEqual` is asked whether the IN-FLIGHT items are the
+    // prefix, not the other way round.
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const debug: string[] = [];
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, message => debug.push(message), {
+      accountId: 'acct-shorter-than-inflight',
+      onDiagnostic: event => diagnostics.push(event),
+    });
+    const history = Array.from({ length: 5 }, (_, index) => (
+      index % 2 === 0
+        ? { role: 'user', content: [{ type: 'input_text', text: `turn ${index}` }] }
+        : { role: 'assistant', content: [{ type: 'output_text', text: `answer ${index}` }] }
+    ));
+    const send = (input: unknown[]): Promise<Response> => wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(input)),
+    });
+
+    const streaming = await send(history);
+    const streamingSocket = lastSocket();
+    streamingSocket.emit('open');
+
+    const rewound = history.slice(0, 3);
+    const branch = await send(rewound);
+    expect(fakeSockets).toHaveLength(2);
+    const branchSocket = lastSocket();
+    expect(branchSocket).not.toBe(streamingSocket);
+    const decision = diagnostics.filter(event => event.event === 'ws_head_decision').at(-1);
+    // Persistent, so the rewound conversation's NEXT turn can continue this head.
+    expect(decision).toMatchObject({
+      decision: 'history_mismatch_new_head',
+      createdGeneration: 'nursery',
+    });
+    expect(decision).not.toHaveProperty('isolatedByConnectionId');
+    expect(debug).not.toContain('ws: parallel request using an isolated socket');
+
+    branchSocket.emit('open');
+    const sent = JSON.parse(branchSocket.send.mock.calls[0]![0] as string);
+    expect(sent.previous_response_id).toBeUndefined();
+    expect(sent.input).toEqual(rewound);
+    emitTextResponse(branchSocket, 'resp_branch', 'branch answer');
+    await readAll(branch);
+    emitTextResponse(streamingSocket, 'resp_streaming_long', 'long answer');
+    await readAll(streaming);
+  });
+
+  it('isolates a request that extends the turn a head is generating right now', async () => {
+    // Indistinguishable from the next turn of that very response arriving before
+    // it finished: the items in flight are a prefix of this request. Until the
+    // head commits there is no way to tell a branch from a lineage, so this
+    // request gets its own socket rather than risk being stitched onto a turn
+    // whose output it has not seen.
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
+      accountId: 'acct-extends-inflight',
+      onDiagnostic: event => diagnostics.push(event),
+    });
+    const firstUser = { role: 'user', content: [{ type: 'input_text', text: 'opening turn' }] };
+    const send = (input: unknown[]): Promise<Response> => wsFetch('https://x', {
+      method: 'POST', headers: {}, body: JSON.stringify(sessionPayload(input)),
+    });
+
+    const streaming = await send([firstUser]);
+    const streamingSocket = lastSocket();
+    streamingSocket.emit('open');
+
+    const extension = [
+      firstUser,
+      { role: 'assistant', content: [{ type: 'output_text', text: 'guessed answer' }] },
+      { role: 'user', content: [{ type: 'input_text', text: 'follow-up' }] },
+    ];
+    const extended = await send(extension);
+    expect(fakeSockets).toHaveLength(2);
+    const extendedSocket = lastSocket();
+    expect(extendedSocket).not.toBe(streamingSocket);
+    expect(diagnostics.filter(event => event.event === 'ws_head_decision').at(-1))
+      .toMatchObject({
+        decision: 'parallel_isolated',
+        createdGeneration: 'isolated',
+        isolatedByConnectionId: 1,
+      });
+
+    extendedSocket.emit('open');
+    const sent = JSON.parse(extendedSocket.send.mock.calls[0]![0] as string);
+    expect(sent.previous_response_id).toBeUndefined();
+    expect(sent.input).toEqual(extension);
+    emitTextResponse(extendedSocket, 'resp_extended', 'answer');
+    await readAll(extended);
+    emitTextResponse(streamingSocket, 'resp_streaming', 'answer');
+    await readAll(streaming);
+  });
+
   it('still isolates a parallel request when the busy head could still be its parent', async () => {
     const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
     const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
@@ -4415,11 +4652,11 @@ describe('new-connection pacing', () => {
     );
   });
 
-  it('does not open a second persistent head for a partition that filled up during the wait', async () => {
-    // The head scan runs before the wait. A same-partition request that starts
-    // while this one is queued would otherwise leave BOTH registering
-    // persistent nursery heads for one key, filling the nursery with
-    // duplicates and evicting other conversations' reusable heads.
+  it('does not open a second persistent head for a turn already in flight when it was queued', async () => {
+    // The head scan runs before the wait. A request that is overtaken during the
+    // wait by an identical turn — the same conversation arriving twice, which a
+    // client retry produces — would otherwise leave BOTH registering persistent
+    // nursery heads for one chain: two sockets generating the same response.
     const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
     let releaseQueued: (() => void) | undefined;
     const queued = new Promise<void>(resolve => { releaseQueued = resolve; });
@@ -4444,11 +4681,11 @@ describe('new-connection pacing', () => {
     ));
 
     // Classified with an empty partition, then held inside the pacer.
-    const held = wsFetch('https://x', { method: 'POST', headers: {}, body: body('held') });
+    const held = wsFetch('https://x', { method: 'POST', headers: {}, body: body('one turn') });
     await isQueued;
 
-    // A second request for the same partition gets in and goes in flight.
-    const overtaking = await wsFetch('https://x', { method: 'POST', headers: {}, body: body('overtaking') });
+    // The SAME turn gets in and goes in flight while this one is still queued.
+    const overtaking = await wsFetch('https://x', { method: 'POST', headers: {}, body: body('one turn') });
     lastSocket().emit('open');
 
     releaseQueued!();
@@ -4476,9 +4713,10 @@ describe('new-connection pacing', () => {
   });
 
   it('asks the pacer for every shape of primary new connection', async () => {
-    // Four shapes reach the creation path. The parallel one dominates real
-    // traffic (2,844 of 2,987 observed upgrades), so none of them may be left
-    // on prose.
+    // Four shapes reach the creation path, and none of them may be left on prose.
+    // The parallel one is now the rare shape — it fires only where the busy head
+    // cannot be told apart from this request — so it is also the easiest to break
+    // without noticing.
     const pacer = recordingPacer();
     const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
     const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
@@ -4513,8 +4751,10 @@ describe('new-connection pacing', () => {
     expect(lastDecision()).toMatchObject({ decision: 'history_mismatch_new_head' });
     expect(pacer.admit).toHaveBeenCalledTimes(3);
 
-    // 4. parallel_isolated — same partition while that one is still in flight.
-    const parallel = await send(sessionPayload(turn('a third root')));
+    // 4. parallel_isolated — the same turn again while that one is still in
+    // flight, so nothing distinguishes this request from the response being
+    // generated and it may not branch off it.
+    const parallel = await send(sessionPayload(turn('a different root')));
     expect(lastDecision()).toMatchObject({ decision: 'parallel_isolated' });
     expect(pacer.admit).toHaveBeenCalledTimes(4);
 
@@ -4590,7 +4830,7 @@ describe('new-connection pacing', () => {
     await readAll(second);
   });
 
-  it('demotes a concurrent sibling even when neither request waited', async () => {
+  it('demotes a concurrent duplicate even when neither request waited', async () => {
     // `admit` is async, so even an immediate admission resumes a microtask
     // later and BOTH requests classify themselves against an empty partition
     // before either registers. Gating the re-check on having waited would let
@@ -4638,15 +4878,16 @@ describe('new-connection pacing', () => {
     await readAll(warmup);
     barrierArmed = true;
 
-    const [alpha, beta] = await Promise.all([send('alpha'), send('beta')]);
+    // The same turn twice — what a client retry looks like from here.
+    const [alpha, beta] = await Promise.all([send('one turn'), send('one turn')]);
 
     // The warmup produced a decision of its own; the pair is the last two.
     const decisions = diagnostics.filter(event => event.event === 'ws_head_decision').slice(-2);
     expect(decisions).toHaveLength(2);
     // Both were classified against an empty partition — the race is real...
     expect(decisions.map(event => event.candidateCount)).toEqual([0, 0]);
-    // ...but only one of them may end up holding a persistent head for it.
-    // Without the demotion both are 'nursery': two persistent heads, one key.
+    // ...but only one of them may end up holding a persistent head for this chain.
+    // Without the demotion both are 'nursery': two heads generating one response.
     expect(decisions.map(event => event.createdGeneration).sort())
       .toEqual(['isolated', 'nursery']);
     expect(debug).toContain('ws: parallel request using an isolated socket after pacing');
@@ -5020,11 +5261,13 @@ describe('new-connection pacing', () => {
 
     const decision = diagnostics.filter(event => event.event === 'ws_head_decision').at(-1);
     expect(decision).toMatchObject({
-      decision: 'parallel_isolated',
+      decision: 'history_mismatch_new_head',
       pacingWaitedMs: 4_000,
       pacingRescanOutcome: 'no_change',
       createdConnectionId: 2,
-      createdGeneration: 'isolated',
+      // Persistent, not isolated: an unrelated conversation is entitled to a head
+      // of its own even though a sibling happened to be busy when it arrived.
+      createdGeneration: 'nursery',
     });
     expect((decision as { selectedConnectionId?: number }).selectedConnectionId).toBeUndefined();
     expect(debug).not.toContain('ws: continuing a chain head that freed up during the pacing wait');
@@ -5247,7 +5490,7 @@ describe('new-connection pacing', () => {
     expect(sent.previous_response_id).toBeUndefined();
     expect(sent.input).toEqual(divergent);
     expect(diagnostics.filter(event => event.event === 'ws_head_decision').at(-1))
-      .toMatchObject({ pacingRescanOutcome: 'no_change', createdGeneration: 'isolated' });
+      .toMatchObject({ pacingRescanOutcome: 'no_change', createdGeneration: 'nursery' });
     expect(debug).not.toContain('ws: continuing a chain head that freed up during the pacing wait');
     expect(releaseToken).not.toHaveBeenCalled();
 


### PR DESCRIPTION
## What this fixes

When you run a swarm of Claude Code subagents against a ChatGPT/Codex OAuth model, they all start at
the same moment. Until now, only the first of them got to keep a cached conversation: every sibling
that arrived while another was still producing its first answer was pushed onto a throwaway
connection, which meant it resent its entire conversation on that turn *and* had nothing to reuse on
the next one either. This makes each of those subagents keep its own cached conversation, so a
sixteen-agent fan-out sends one prompt each instead of sixteen full histories over and over.

It continues the fix in #211, which solved this for conversations that had already produced at least
one answer. The remaining case — and the common one in a fan-out, where everything starts at once —
was still being given up on.

## Why it was giving up

A completed response leaves behind a reusable "head" storing what it was sent and what it produced,
so the next turn of that conversation can send only the new message. A request that matches no idle
head is put on an isolated, non-persistent connection when an **in-flight** head might still turn out
to be its parent — we must never stitch a turn onto a conversation that isn't its own.

A head that has not finished its first response yet has stored nothing, so it was treated as a
possible parent of anything. That is not actually unknowable: `entry.current.originalPayload` is the
conversation that head is generating for *right now*, and a request can only be a later turn of that
response if it carries those items as a prefix. Comparing against them keeps exactly two shapes
isolated:

- **An exact repeat of the turn in flight** — what a client retry produces. It is not a branch off
  that response, it *is* that response, so it must not be stitched onto a turn whose output it has
  never seen. Hence the non-strict `isPrefixOrEqual` rather than the strict form the continuation
  check uses.
- **A request that extends it** — indistinguishable from the next turn of that very response arriving
  before it finished.

Everything else — the sibling whose history diverges at the first item, which is what a fan-out
produces — now keeps a head of its own.

`isStrictPrefix` is now expressed in terms of the new `isPrefixOrEqual` rather than duplicating its
loop. A reviewer enumerated all 14,641 pairs of sequences up to length 4 over a 3-symbol alphabet and
confirmed the two bodies are behaviourally identical, so both existing call sites are unaffected.

## Measurements

Four freshly started servers built from pinned commits (endpoint mode, own port, not advertised in
server discovery), 16 conversations x 4 turns launched simultaneously against a real ChatGPT-OAuth
model, run one leg at a time so each had the upstream account to itself. Baseline is 9bd5205 (#211).

| leg | uncached input | client-visible failures | sockets opened | paced: admitted / refused | gauge peak nursery/est | evicted heads | `parallel_isolated` |
| --- | --- | --- | --- | --- | --- | --- | --- |
| baseline, caps 32/8 | 74.8% | 1 (pacer 429) | 50 | 38 / 36 | 1/6 | 0 | 42 of 61 |
| this PR, caps 32/8 | 47.6% | 0 | 17 | 6 / 1 | 11/16 | 0 | **0 of 65** |
| baseline, caps 64/24 | 82.0% | 0 | 52 | 42 / 35 | 1/6 | 0 | 44 of 64 |
| this PR, caps 64/24 | 32.8% | 0 | 16 | 6 / 1 | 11/16 | 0 | **0 of 64** |

Sixteen conversations, sixteen sockets, one head each; all 48 later turns continued.

**Read the socket and decision columns, not the token percentages.** An earlier run of the same four
legs gave 78.5 / 40.2 / 73.0 / 31.1, and the two cap settings differ by 9 points on identical
workloads, so the token share carries upstream cache variance this experiment does not control.

Two things this table should not be read as saying:

- **It does not establish that this removes 429s.** The baseline's one client-visible 429 is a single
  observation in a single cell, and the baseline's other leg had none despite 35 refusals. What it
  does show is that this asks the pacer for an order of magnitude less.
- **The decision counts depend on the workload too.** These 16 conversations had distinct opening
  turns, which is what makes them distinguishable. Sixteen siblings sharing one opening turn would
  still isolate, by design.

The gauge columns are the counts recorded *in* the decision diagnostic, which is emitted before the
new entry registers; actual nursery occupancy peaked one higher (4, 11, 2, 11). Nursery reaching 11
against a cap of 8 at all is because eviction only considers idle entries.

Still worth noting, because it runs against the intuition that retaining more heads costs more
connections: this opens **fewer** sockets, because it reuses instead of dialing.

### Connection-pool caps

Retaining heads where we previously discarded them raises pool pressure in principle, so this was
measured rather than assumed:

- **No leg evicted a pooled head at either cap setting**, and raising the caps from the 32/8 defaults
  to 64/24 left the decision mix, socket count and pool maxima identical. Peak established use was 16
  for 16 conversations, half the default cap.
- Replaying a 27.6-hour local diagnostics ledger (13,530 head decisions, 20 Claude sessions) through
  a pool model gives **92.9% key recurrence (12,307 of 13,245) at every cap pair tested**, from 8/32
  to unlimited. Misses are 938 — 935 keys seen for the first time, which have no head by definition,
  plus 3 returning after a TTL expiry — and **no miss at any tested cap was caused by an eviction.**

Two caveats on that replay, both material. The model keys a "conversation" on partition plus
first-input-item hash, which is a content heuristic and not a conversation id. And the 285 duplicate
decisions contributed by retried request ids must be collapsed first: without that the figures come
out as 91.8% and 1,111, which is the double-counting trap this subsystem's own documentation warns
about. The model is not uniformly conservative either — it lets in-flight heads be evicted, which the
real pool forbids, but it also assumes every attempt yields a reusable head.

**The margin at the default nursery cap is thin, though.** The LRU victim is the oldest idle entry,
and at nursery 8 it had been idle a median of 26 seconds and as little as 8, against an inter-turn gap
distribution of p50 5s / p90 20s / p99 63s. 85 of the 268 nursery evictions displaced a head idle for
less than the p90 gap. None was in fact reused, so this ledger records no loss — but "not reused" at
8 seconds idle is luck, not headroom. Sizing the pools is left to a separate change so that this one
stays reviewable on its own.

### The trade this does make

A newly retained sibling head can evict an older idle head that its own conversation was coming back
for. At the default nursery cap of 8: seven idle heads from finished turns, an eighth conversation
streaming its first response, and one divergent sibling in that partition — the sibling is retained,
the oldest idle head is evicted, and resuming that conversation costs a fresh connection and a
full-context resend. A reviewer constructed this through the transport: nine sockets before, ten
after.

The mechanism is established; its frequency in ordinary traffic is not, and the ledger replay above
finds it costing nothing over four real hours. It is documented rather than designed around, because
fixing it means redesigning eviction policy, which does not belong in this change.

### Cost of the comparison

Comparing against an in-flight conversation means canonicalizing it, and a wide fan-out would
otherwise pay that once per arriving sibling per busy head — measured at 13.6ms per arrival across 16
in-flight heads holding 11.7MB, synchronous on the event loop. It is memoized per response on
`RequestContext.canonicalInput`, which brings it to 0.4ms. `originalPayload` is assigned once at
construction and never reassigned (a transport retry resets `sendPayload` back to it and reuses the
same context), so the memo has no reachable staleness; a reviewer tried to refute that and could not.
It costs retained size — the canonical strings run about as large as the payload — which is the same
property the existing memo on the committed path has.

## Tests

Five new tests, and six existing ones updated because they asserted the old blanket behaviour.

New:
- a simultaneous sibling keeps its own head while a first-ever response streams, **and its next turn
  continues that head** — the end-to-end property this PR exists for
- a request repeating the turn in flight is still isolated
- a request extending the turn in flight is still isolated
- a request *shorter* than the turn in flight keeps its own head
- a committed head is not continued by a request that adds no new turn

Four of the updated tests previously relied on two *different* conversations racing to produce
isolation. They now use the identical turn, which is the case that genuinely must not open two heads
for one chain, so the duplicate-demotion path they were written for is still covered. Two more had
expectations flipped from isolated to persistent.

Mutation results, full-file runs:

| mutation | verdict |
| --- | --- |
| feature deletion — uncommitted heads always block | RED (4 tests) |
| `isPrefixOrEqual` length guard `<` -> `<=` | RED (5) |
| `isPrefixOrEqual` comparison inverted | RED (49) |
| strict form at the new call site | RED (5) |
| compare stored input instead of the in-flight turn | RED (4) |
| `isStrictPrefix` loses strictness | RED (1) |
| incoming shorter than in flight -> isolate | RED (1) |
| `!current` -> don't block | **SURVIVED** |
| delete `isPrefixOrEqual` length fast path | **SURVIVED** |

Both survivors are disclosed rather than papered over, and both were independently verified by a
reviewer rather than taken on my word:

- `!current` is unreachable. `inFlight` and `current` are assigned together in `dispatchContext` and
  cleared together, and the predicate is only asked about entries with `inFlight` true. The fallback
  blocks rather than guesses if that ever changes.
- The length guard is a fast path. A short client already fails the loop, because the comparison hits
  `undefined` against a string.

`pnpm typecheck && pnpm test && pnpm build` green — 2561 tests, node v24.14.1, isolated `CLODEX_HOME`.

## Review

Four reviewers ran before this was pushed, on separate models, two of them in their own worktrees:

- **Correctness** enumerated every `ConnectionEntry` state and proved an in-flight entry is only ever
  fully committed or fully uncommitted, since the three commit fields are assigned together in one
  place and never individually cleared. Confirmed this predicate cannot influence what receives a
  `previous_response_id` — continuation still runs only against idle heads — so a wrong decision here
  can only cost a redundant head or a needless isolated socket, never a wrong-lineage continuation.
  It found the canonicalization cost, which is now fixed.
- **Test discrimination** reproduced the mutation table independently, verified both survivor claims
  in the source, traced each rewritten test to the production branch it actually reaches, and found
  the shorter-history case unpinned. That test was added and turns its mutation red.
- **A cold reviewer**, given no briefing, constructed the eviction case above and flagged that the
  measurements had been taken on an unpinned working tree. All four legs were re-run from pinned
  commits as a result; the numbers in this PR are from that run.
- **An evidence audit** recomputed every number in the diff against the underlying ledger and found
  the measurement prose overstating in several places. All of it is fixed: the cap-replay figures were
  double-counting retried request ids (91.8% -> 92.9%), the ledger spans 27.6 hours and had been
  described as four, "pacer waits" was counting waits plus refusals, the pool peaks are decision-time
  gauges rather than registry peaks, and a claimed relationship between held connections and upstream
  errors turned out to be one 5.8-minute incident — outside it, 483 outcomes at the same connection
  count had zero errors. That last one had been offered as a reason not to raise the pool caps, and it
  does not support that.

Refs #209
