### PR TITLE
docs(oauth): record the real upgrade rejection status so pacing is diagnosed correctly

### DIFF
--- a/.claude/docs/oauth-continuation.md
+++ b/.claude/docs/oauth-continuation.md
@@ -197,9 +197,12 @@ fall inside a **5.8-minute window**, where the rate was 114/147; across the othe
 connections the rate was **zero**. The errors also began below 25 connections and preceded the pool
 climb. Treat the gradient as an artifact of that incident, not a cost of holding connections. (The
 join is also a global latest-gauge proxy rather than a per-request measurement.) What does survive:
-41 of the 44 upgrade rejections — HTTP 429 at the upgrade, from 13 request ids, all of which later
-succeeded — occurred at 20-24 pooled connections, so *dialing* under load is throttled, which is
-what the pacer is for and which this change reduces.
+41 of the 44 upgrade rejections — **HTTP 403** from the edge, from 13 request ids, all of which later
+succeeded — occurred at 20-24 pooled connections, so *dialing* under load is throttled, which is what
+the pacer is for and which this change reduces. Read `httpStatusCode` for the status the edge
+actually returned: `mappedStatusCode` is the DOWNSTREAM status clodex reports to the client, and on
+the throttle branch it is the literal 429 that branch always sets, so it says nothing about what the
+edge sent. A 503 at the upgrade appears too.
 
 An idle nursery head is exposed until its connection is **selected** for its first continuation, which
 is when promotion happens — before that continuation is known to succeed. Nursery membership is a


### PR DESCRIPTION
## What this fixes

The WebSocket continuation notes told anyone debugging connection pacing to read the wrong field, so
a rejected connection would look like a rate limit the OpenAI edge never actually reported.

`ws_response_error` carries two status codes for an upgrade that was refused:

- `httpStatusCode` — what the edge returned.
- `mappedStatusCode` — what clodex reports **downstream** to the client. On the throttle branch this
  is a literal `429` that the code sets unconditionally, so it is the same value no matter what the
  edge sent.

The doc cited the second as though it were the first. Reading `httpStatusCode` in the ledger that
section already cites, all 44 upgrade rejections were **HTTP 403**; a later run produced a 503.

Found while auditing the measurement claims added in #219 — I had asserted 429 there and a reviewer
had said 403. The reviewer was right.

## Verification

```
$ jq -r 'select(.event=="ws_response_error" and .source=="unexpected_response")
         | [.httpStatusCode, .mappedStatusCode] | @tsv' ledger.jsonl | sort | uniq -c
  44 403	429
```

and in `src/oauth/responses-websocket.ts`, the throttle branch sets `mappedStatusCode: 429` as a
constant beside `httpStatusCode: statusCode`.

Documentation only — no source or test changes.