### PR TITLE
fix(oauth): keep more cached conversations alive when many subagents run at once

### DIFF
--- a/.claude/docs/oauth-continuation.md
+++ b/.claude/docs/oauth-continuation.md
@@ -67,8 +67,8 @@ not divide. **Count each response once**: 254 request ids here carry more than o
 (retries), so joining usage per decision double-counts the successful attempt and inflated these very
 numbers by ~2.3M tokens.
 
-**Connection pools are process-wide, not per-partition:** `maxConnections` (established, default 32)
-and `maxNurseryConnections` (default 8). A head starts in the nursery and is promoted when selected
+**Connection pools are process-wide, not per-partition:** `maxConnections` (established, default 64)
+and `maxNurseryConnections` (default 48). A head starts in the nursery and is promoted when selected
 for its first continuation, before that continuation is known to succeed — so a workload whose
 concurrent subagents inherit the parent's Claude session id, and therefore share one partition, can
 lose heads before their next turn and with them the continuation.
@@ -84,14 +84,16 @@ classified from this snapshot.
 
 An isolated socket is never registered, so it never evicts anything, while a retained one runs
 `evictOldestIdleGeneration` first, **so a newly retained sibling can displace an older idle head that
-its own conversation was going to come back for.** That is reachable at the default nursery cap of 8:
+its own conversation was going to come back for.** That was reachable at a nursery cap of 8, the
+default when this was written:
 seven idle heads from finished turns, an eighth conversation streaming its first response, and one
 divergent sibling in that partition — the sibling is retained, the oldest idle head is evicted, and
 resuming that conversation costs a fresh upgrade and a full-context resend. Constructed and observed
 through the transport (nine sockets before this change, ten after), so the mechanism is established;
 its frequency in ordinary traffic is not, and the cap replay below finds no eviction-caused loss
-across the ledger's 27.6 hours — while also showing that at the default nursery cap the evicted head
-had often been idle for only seconds.
+across the ledger's 27.6 hours: the ten real cap evictions displaced heads that had been idle 217-284
+seconds, already at the nursery TTL. The caps were nonetheless raised, on headroom over observed
+concurrency rather than on any observed loss — see the sizing discussion below.
 
 **On a fresh pool, and for a fan-out whose members have distinguishable opening turns, it opened
 fewer sockets** — it reuses instead of dialing. That is not a general result: a warmed pool whose
@@ -104,7 +106,7 @@ itself), 16 conversations x 4 turns started simultaneously against a real ChatGP
 
 | leg | uncached input | client-visible failures | sockets opened | paced: admitted / refused | gauge peak nursery/established | `*_lru_cap` evictions | `parallel_isolated` |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| baseline, caps 32/8 | 74.8% | 1 (pacer 429) | 50 | 38 / 36 | 1/6 | 0 | 42 of 61 |
+| baseline, caps 32/8 (the defaults at the time) | 74.8% | 1 (pacer 429) | 50 | 38 / 36 | 1/6 | 0 | 42 of 61 |
 | this change, caps 32/8 | 47.6% | 0 | 17 | 6 / 1 | 11/16 | 0 | **0 of 65** |
 | baseline, caps 64/24 | 82.0% | 0 | 52 | 42 / 35 | 1/6 | 0 | 44 of 64 |
 | this change, caps 64/24 | 32.8% | 0 | 16 | 6 / 1 | 11/16 | 0 | **0 of 64** |
@@ -158,29 +160,38 @@ neither is an unconditional eviction. The entry displaced is the oldest idle one
 which could be a large long-lived conversation that then resends full context. Watch
 `established_lru_cap` alongside `nursery_lru_cap`.
 
-**No cap setting changed head reuse in this ledger, but the margin at the default is thin.**
-Replaying the ledger's decisions through a pool model — one head per *content key* (partition plus
-first-input-item hash, which is a transport-and-content heuristic, NOT a conversation id), promoted
-on first reuse — gives **92.9% key recurrence (12,307 of 13,245) at every cap pair tested**, from
-8/32 to unlimited. Misses are 938: 935 keys seen for the first time, which have no head by
-definition, plus 3 returning after a TTL expiry. **No miss at any tested cap was caused by an
-eviction.** Collapse the 285 duplicate decisions that retried request ids contribute before counting
-any of this — the undeduplicated figures are 91.8% and 1,111, and this document warns about exactly
-that trap two sections above.
+**Pool caps are sized from peak OCCUPANCY, and a replay that reasons from eviction victim ages will
+mislead you.** The two shipped caps rest on very different evidence and should be changed separately.
 
-What the model does show is how little headroom the default leaves. The LRU victim is the oldest
-IDLE entry, and at nursery 8 it had been idle a median of 26 seconds and as little as **8 seconds**,
-against an inter-turn gap distribution of p50 5s / p90 20s / p99 63s. 85 of the 268 nursery
-evictions displaced a head idle for less than the p90 gap. None of them was in fact reused, so this
-ledger records no loss — but "was not reused" at 8 seconds idle is luck, not margin. Raising the
-nursery cap moves the victim out of that distribution: at 16 no victim is below the p90 gap, and at
-48 none is below the p99 gap.
+The established cap went 32 -> 64 on demand: this ledger's established gauge peaked at 28 against the
+old cap of 32, in ORGANIC traffic, and replaying it with the turns it used to isolate keeping heads of
+their own puts the peak at 46. The nursery cap went 8 -> 48 as a safety valve, not a measured
+requirement: organic nursery occupancy was 1-4 for 22 of 24 hours, a 16-conversation lab fan-out
+reached 11, and the only readings near 24 came from one hour of upstream auth failures and its
+aftermath. 48 is generous on purpose, because an empty slot is free.
 
-Counts and reasons at 8/32 are 268 nursery plus 53 established evictions; at 24/64, 231 nursery and
-none established; at unlimited, none. Only cap pairs were simulated, not measured, and the model
-cuts both ways rather than being uniformly conservative: it lets in-flight heads be evicted, which
-the real pool forbids, but it also assumes every attempt yields an immediately reusable head and
-collapses a conversation's branches into one key.
+**Three modelling traps, all of which this document previously fell into.** A replay of this ledger
+produced a confident story — "at a nursery cap of 8 the evicted head had been idle a median of 26s and
+as little as 8s" — and every part of it was an artifact:
+
+1. It fed EVERY head decision into the pool, including ~3,880 `parallel_isolated` ones. Isolated
+   sockets are never registered, so most modelled victims could not exist.
+2. It never tore down heads whose request FAILED, though `failContext` ends in `deleteEntry`. **84% of
+   its eviction victims were heads that had already failed and been deleted.**
+3. It measured idle time as request-start to request-start, which includes generation time. From
+   completion, the real horizon is p50 0.1s / p90 0.8s / p99 22.2s — far shorter.
+
+**The calibration check that catches all three: that model predicted 231 nursery cap evictions at the
+cap this ledger actually ran under, which recorded 10.** Run that check before trusting any replay
+here. Reasoning from victim age is also degenerate on its own terms — victim age rises monotonically
+with the cap and saturates at the nursery TTL, so the criterion reduces to arrival-rate times window
+and mostly encodes whatever retry storm dominates the sample.
+
+**What the ledger does establish, from its own gauges rather than a model:** 10 real `nursery_lru_cap`
+evictions and zero `established_lru_cap` ones; the nursery victims had been idle 217-284s, already at
+the 5-minute nursery TTL, so no recorded cap eviction cost a reusable conversation. Head reuse was
+cap-invariant across every setting replayed, including unlimited. The case for raising a cap is
+headroom over concurrency, never an observed loss.
 
 **What that ledger's own gauges looked like, pre-change, on caps of 64/24:** pooled connections p50
 16, p90 23, p99 27, max 31 (unweighted per decision); nursery peaked at 24, its cap, with 10
@@ -210,7 +221,35 @@ property of the current connection's reuse history, not of the conversation's ag
 that just took a replacement head after a mismatch or an expiry is in the nursery too (this ledger
 holds 58 new nursery heads whose input already carried several user messages, the largest 529 items).
 Note also that eviction only considers IDLE entries, so while every nursery head is busy the cap
-cannot be enforced immediately. Override via `CLODEX_WS_MAX_CONNECTIONS` /
+cannot be enforced immediately. **Every cap eviction is logged** — `evicting the oldest idle
+<generation> connection to stay within its cap`, with the displaced connection id, the cap, and
+`idle_ms` — and `idleMs` appears on the matching entry in the `evictions` array. Read it as a MARGIN
+indicator, not a cost: a two-second-old victim that never returns cost nothing, and a twenty-minute-old
+one that does return costs a full resend. What it tells you is how close the cap is running to the
+reuse window. Before that, a cap eviction logged nothing that NAMED it as
+one: the socket close left its usual line, but nothing said a cap had displaced a reusable head, so
+identifying the cause needed `--ws-diagnostics` and a JSONL trawl. Watch `idle_ms`, not the eviction
+count: an eviction whose victim had been idle for minutes cost nothing, and one at a few seconds is
+the signal that a cap is too small.
+
+**An empty slot is free, so treat the caps as safety valves rather than tuning knobs.** They are read
+only by the `>=` comparison in `evictOldestIdleGeneration` and echoed into diagnostics; nothing is
+preallocated and the registry is a `Map` of `Set`s sized by live entries, so unused capacity costs
+zero bytes and zero cycles, and eviction's sort is over actual entries. The caps also do not govern
+dial rate — the pacer does. A cap should therefore sit above plausible concurrent demand, because
+hitting one is the expensive event: a reusable conversation is discarded and its next turn pays a full
+uncached prompt plus a fresh upgrade. The pool size a workload actually needs is a property of how
+many agents are running, and churning connections underneath that number costs more than holding them.
+
+What a larger cap does raise is the ceiling on sockets HELD at once — 40 idle heads to 112 — each
+holding its conversation plus the canonical copy memoized for prefix comparison (roughly twice the
+context; 16 in-flight heads measured 11.7MB), bounded in practice by the 5- and 30-minute idle TTLs.
+**File descriptors are the real ceiling and the reason not to go much higher.** 112 is under half the
+256-descriptor soft limit a stock macOS shell commonly carries, and there is no `EMFILE` handling on
+this path, so exceeding a user's limit is an unhandled failure rather than a degraded mode. Check that
+before raising these again. The edge's own per-account connection limit is separate and not known; the
+44 upgrade rejections in this ledger are the only evidence about it.
+Override via `CLODEX_WS_MAX_CONNECTIONS` /
 `CLODEX_WS_MAX_NURSERY_CONNECTIONS` (integer 1–1024; malformed values are logged and ignored). An
 explicit programmatic option outranks the environment so tests are never perturbed. Eviction reasons
 (`nursery_lru_cap`, `established_lru_cap`, `idle_ttl`, `nursery_idle_ttl`, `hard_ttl`) appear in the

--- a/src/oauth/responses-websocket.ts
+++ b/src/oauth/responses-websocket.ts
@@ -35,8 +35,49 @@ const FAILURE_EVENT_TYPES = new Set(['error', 'response.failed', 'response.incom
 export const RESPONSES_WS_HARD_TTL_MS = 55 * 60_000;
 export const RESPONSES_WS_IDLE_TTL_MS = 30 * 60_000;
 export const RESPONSES_WS_NURSERY_IDLE_TTL_MS = 5 * 60_000;
-export const RESPONSES_WS_MAX_CONNECTIONS = 32;
-export const RESPONSES_WS_MAX_NURSERY_CONNECTIONS = 8;
+/**
+ * Pool caps. An unused slot costs nothing — the caps are read only by the `>=`
+ * comparison in `evictOldestIdleGeneration`, nothing is preallocated, and the
+ * registry is sized by live entries — while hitting a cap discards a reusable
+ * conversation whose next turn then pays a full uncached prompt plus a fresh
+ * upgrade. The asymmetry is the whole argument: size these above demand, because
+ * unused capacity is free and a cap that binds is not.
+ *
+ * The two numbers rest on different strengths of evidence. Say so before changing
+ * either.
+ *
+ * `maxConnections` (established) 32 -> 64 is demand-driven. In a 27.6-hour local
+ * ledger the established gauge peaked at 28 against the old cap of 32 — 88% of it —
+ * in ORGANIC traffic, and replaying that ledger with the turns it used to isolate
+ * keeping heads of their own puts the peak at 46. 32 was genuinely tight.
+ *
+ * `maxNurseryConnections` 8 -> 48 is a deliberately generous safety valve, NOT a
+ * measured requirement. Organic nursery occupancy in that ledger was 1-4 for 22 of
+ * 24 hours; a 16-conversation lab fan-out reached 11; the only readings near 24 came
+ * from a single hour of upstream auth failures and its aftermath. 48 covers a
+ * fan-out several times larger than anything observed, and is chosen because
+ * overshoot is free rather than because demand was seen at that level.
+ *
+ * DO NOT re-derive these from eviction victim ages, and distrust any replay that
+ * says you should. An earlier attempt did and was wrong three ways: it fed every
+ * head decision into the pool including ~3,880 `parallel_isolated` ones that are
+ * never registered in a pool at all; it never tore down heads whose request FAILED,
+ * though `failContext` ends in `deleteEntry`, so 84% of its eviction "victims" could
+ * not exist; and it compared idle time against request-start-to-request-start gaps,
+ * which include generation time. The check that catches all of it: that model
+ * predicted 231 nursery cap evictions at the cap this ledger actually ran, which
+ * recorded 10. Measured from completion, the real idle horizon is p50 0.1s / p90
+ * 0.8s / p99 22.2s, and the 10 real cap evictions displaced heads idle 217-284s —
+ * at the 5-minute nursery TTL, costing nothing.
+ *
+ * Neither cap is a hard ceiling: only IDLE entries are evictable, so a generation
+ * can exceed its cap while every head is busy, and isolated sockets are never
+ * registered and never counted. The cost that scales with these numbers is memory —
+ * each retained head holds its conversation plus a canonical copy for prefix
+ * comparison — plus held descriptors, and there is no EMFILE handling on this path.
+ */
+export const RESPONSES_WS_MAX_CONNECTIONS = 64;
+export const RESPONSES_WS_MAX_NURSERY_CONNECTIONS = 48;
 
 export interface ResponsesWebSocketFetchOptions {
   providerId?: string;
@@ -162,7 +203,7 @@ interface ConnectionEntry {
 // conversation prefix instead of letting the newest branch replace the rest.
 // New heads live in a separately capped nursery LRU until their first reuse;
 // established heads therefore never consume nursery capacity, and one-shot
-// nursery traffic never consumes the established LRU's 32 reserved slots.
+// nursery traffic never consumes the established LRU's reserved slots.
 const connections = new Map<string, Set<ConnectionEntry>>();
 let nextConnectionDebugId = 1;
 
@@ -1497,11 +1538,21 @@ function evictOldestIdleGeneration(
   while (connectionCountByGeneration(generation) >= maxConnections && idle.length) {
     const oldest = idle.shift();
     if (oldest) {
+      // Idle age is a MARGIN indicator, not a cost: a victim idle for seconds was
+      // plausibly about to be reused, one idle for minutes was not, and neither
+      // says what the eviction actually cost. Log it as well as recording it,
+      // because the diagnostic ledger needs `--ws-diagnostics` and this does not.
+      const idleMs = Math.max(0, oldest.options.now() - oldest.lastUsedAt);
+      oldest.debug(
+        `evicting the oldest idle ${generation} connection to stay within its cap: `
+        + `connection=${oldest.debugId} idle_ms=${idleMs} cap=${maxConnections} reason=${reason}`,
+      );
       evictions.push({
         connectionId: oldest.debugId,
         partitionKey: oldest.key,
         generation: oldest.generation,
         reason,
+        idleMs,
       });
       deleteEntry(oldest);
     }

--- a/tests/responses-websocket.test.ts
+++ b/tests/responses-websocket.test.ts
@@ -4382,6 +4382,130 @@ describe('createResponsesWebSocketFetch', () => {
     (diagnostics.filter(event => event.event === 'ws_head_decision').at(-1)!.evictions ?? []) as
       Record<string, unknown>[];
 
+  it('reports the shipped pool caps when nothing overrides them', async () => {
+    // The defaults are the deliverable of the sizing change, and they reach behaviour
+    // only through option resolution — so read them back off a decision made by a
+    // fetch constructed the way production constructs one, not off the constants.
+    // The env overrides must be cleared: a developer who exports them for their own
+    // server would otherwise have this test confirm THEIR caps as the shipped ones.
+    const saved = [
+      process.env.CLODEX_WS_MAX_CONNECTIONS,
+      process.env.CLODEX_WS_MAX_NURSERY_CONNECTIONS,
+    ];
+    delete process.env.CLODEX_WS_MAX_CONNECTIONS;
+    delete process.env.CLODEX_WS_MAX_NURSERY_CONNECTIONS;
+    try {
+      const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+      const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
+        accountId: 'acct-default-caps',
+        onDiagnostic: event => diagnostics.push(event),
+      });
+      const response = await wsFetch('https://x', {
+        method: 'POST', headers: {},
+        body: JSON.stringify(sessionPayload([
+          { role: 'user', content: [{ type: 'input_text', text: 'default caps' }] },
+        ])),
+      });
+      lastSocket().emit('open');
+      emitTextResponse(lastSocket(), 'resp_default_caps', 'ok');
+      await readAll(response);
+      expect(diagnostics.filter(event => event.event === 'ws_head_decision').at(-1))
+        .toMatchObject({ maxConnections: 64, maxNurseryConnections: 48 });
+    } finally {
+      if (saved[0] !== undefined) process.env.CLODEX_WS_MAX_CONNECTIONS = saved[0];
+      if (saved[1] !== undefined) process.env.CLODEX_WS_MAX_NURSERY_CONNECTIONS = saved[1];
+    }
+  });
+
+  it('says how long an evicted head had been idle, in the log and the ledger', async () => {
+    // Whether a cap is costing anything turns entirely on the victim's idle age. A cap
+    // eviction used to log nothing that NAMED it as one — the socket close left a line,
+    // but nothing said a cap had displaced a reusable head, unlike the TTL path beside
+    // it — so the only record of the cause needed --ws-diagnostics and a JSONL trawl.
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    const debug: string[] = [];
+    let clock = 1_000;
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, message => debug.push(message), {
+      accountId: 'acct-eviction-idle-age',
+      maxNurseryConnections: 1,
+      now: () => clock,
+      onDiagnostic: event => diagnostics.push(event),
+    });
+    const send = (text: string): Promise<Response> => wsFetch('https://x', {
+      method: 'POST', headers: {},
+      body: JSON.stringify(sessionPayload([{ role: 'user', content: [{ type: 'input_text', text }] }])),
+    });
+
+    const first = await send('first conversation');
+    const firstSocket = lastSocket();
+    firstSocket.emit('open');
+    // Spend time BEFORE the head goes idle, so that an idle age computed from
+    // `createdAt` instead of `lastUsedAt` would read 9,000ms rather than 7,000.
+    clock += 2_000;
+    emitTextResponse(firstSocket, 'resp_evicted', 'ok');
+    await readAll(first);
+
+    // The head goes idle here, and sits idle for a measurable stretch.
+    clock += 7_000;
+    const second = await send('second conversation');
+    expect(firstSocket.close).toHaveBeenCalled();
+
+    expect(diagnostics.filter(event => event.event === 'ws_head_decision').at(-1))
+      .toMatchObject({ evictions: [{ reason: 'nursery_lru_cap', idleMs: 7_000 }] });
+    expect(debug).toContain(
+      'ws: evicting the oldest idle nursery connection to stay within its cap: '
+      + 'connection=1 idle_ms=7000 cap=1 reason=nursery_lru_cap',
+    );
+
+    lastSocket().emit('open');
+    emitTextResponse(lastSocket(), 'resp_second', 'ok');
+    await readAll(second);
+  });
+
+  it('evicts the least recently used idle head, not merely any idle one', async () => {
+    // The whole sizing argument rests on the victim being the LEAST recently used: that
+    // is what makes an evicted head one whose conversation has plausibly finished. With
+    // a cap of 1 and a single idle head, order cannot be observed, so nothing pinned it
+    // and reversing the sort passed the entire file.
+    const diagnostics: ResponsesWebSocketDiagnosticEvent[] = [];
+    let clock = 1_000;
+    const wsFetch = createResponsesWebSocketFetch(WS_URL, undefined, {
+      accountId: 'acct-lru-order',
+      maxNurseryConnections: 2,
+      now: () => clock,
+      onDiagnostic: event => diagnostics.push(event),
+    });
+    const turn = (text: string): Promise<Response> => wsFetch('https://x', {
+      method: 'POST', headers: {},
+      body: JSON.stringify(sessionPayload([{ role: 'user', content: [{ type: 'input_text', text }] }])),
+    });
+
+    // Two heads go idle at known, different times: connection 1 first, then 2.
+    for (const [index, text] of ['older conversation', 'newer conversation'].entries()) {
+      const response = await turn(text);
+      const socket = lastSocket();
+      socket.emit('open');
+      clock += 1_000 * (index + 1);
+      emitTextResponse(socket, `resp_lru_${index}`, 'ok');
+      await readAll(response);
+    }
+    const [olderSocket, newerSocket] = fakeSockets;
+
+    clock += 5_000;
+    const third = await turn('third conversation');
+
+    // Connection 1 went idle at 2,000 and connection 2 at 4,000; it is now 9,000, so
+    // connection 1 has been idle 7,000ms against connection 2's 5,000ms and must go.
+    expect(diagnostics.filter(event => event.event === 'ws_head_decision').at(-1))
+      .toMatchObject({ evictions: [{ connectionId: 1, reason: 'nursery_lru_cap', idleMs: 7_000 }] });
+    expect(olderSocket!.close).toHaveBeenCalled();
+    expect(newerSocket!.close).not.toHaveBeenCalled();
+
+    lastSocket().emit('open');
+    emitTextResponse(lastSocket(), 'resp_lru_third', 'ok');
+    await readAll(third);
+  });
+
   it('honors CLODEX_WS_MAX_NURSERY_CONNECTIONS', async () => {
     process.env.CLODEX_WS_MAX_NURSERY_CONNECTIONS = '1';
     try {
@@ -4395,7 +4519,7 @@ describe('createResponsesWebSocketFetch', () => {
   it('ignores a malformed connection cap rather than reinterpreting it', async () => {
     process.env.CLODEX_WS_MAX_NURSERY_CONNECTIONS = 'lots';
     try {
-      // Falls back to the default of 8, so two heads coexist without eviction.
+      // Falls back to the shipped nursery default, so two heads coexist without eviction.
       expect(lastEvictions(await fillTwoNurseryHeads('acct-env-nursery-bad'))).toEqual([]);
     } finally {
       delete process.env.CLODEX_WS_MAX_NURSERY_CONNECTIONS;


### PR DESCRIPTION
## What this changes

clodex keeps a reusable connection per conversation, so a later turn sends only the new message
instead of the whole history. Those connections live in two fixed-size pools, and when a pool is full
the least-recently-used idle one is dropped — costing that conversation its cache. Both caps are
raised, and every cap eviction now says so in the log.

- `CLODEX_WS_MAX_CONNECTIONS` (established): **32 → 64**
- `CLODEX_WS_MAX_NURSERY_CONNECTIONS` (nursery): **8 → 48**

An unused slot in either pool costs nothing — the caps are read only by the `>=` comparison that
decides whether to evict, nothing is preallocated, and the registry is sized by live entries. A cap
that binds costs a full uncached prompt plus a fresh connection. That asymmetry is the case for
sizing both above demand.

## The two numbers rest on different evidence

This matters to whoever revisits them, so it is stated plainly in the code comment too.

**Established 32 → 64 is demand-driven.** In a 27.6-hour local diagnostics ledger the established
gauge peaked at **28 against the old cap of 32** — 88% of it — in ordinary traffic, in an hour
unrelated to any incident. Replaying that ledger with the turns it used to isolate keeping
connections of their own (as they now do, after #219) puts the peak at **46**. 32 was genuinely
tight.

**Nursery 8 → 48 is a deliberately generous safety valve, not a measured requirement.** Ordinary
nursery occupancy in that ledger was **1–4 for 22 of its 24 hours**; a 16-conversation lab fan-out
reached **11**; the only readings near 24 came from a single hour of upstream authentication failures
and its aftermath. 48 covers a fan-out several times larger than anything observed, and is chosen
because overshooting is free — not because demand was seen at that level.

**No observed eviction ever cost anyone a cached conversation.** The ten real cap evictions in that
ledger displaced connections idle **217–284 seconds**, already at the five-minute nursery timeout.
The case for raising a cap is headroom over concurrency, not a loss.

## Three modelling traps, documented so they are not repeated

An earlier version of this PR justified the raise from eviction victim ages and was wrong. The
reasoning is recorded in the code comment and the subsystem doc because the replay is tempting and
its output is confidently misleading. It:

1. fed every head decision into the pool model, including ~3,880 `parallel_isolated` ones —
   isolated sockets are never registered, so most modelled victims could not exist;
2. never tore down heads whose request **failed**, though `failContext` ends in `deleteEntry`, so
   **84% of its eviction victims were heads already deleted**;
3. measured idle time as request-start to request-start, which includes generation time. From
   completion, where idle actually begins, the horizon is p50 0.1s / p90 0.8s / p99 22.2s.

**The check that catches all three:** that model predicted **231** nursery cap evictions at the cap
the ledger actually ran under, which recorded **10**. Run that calibration before trusting any replay
of this data. Reasoning from victim age is degenerate anyway — victim age rises monotonically with
the cap and saturates at the TTL, so the criterion collapses into arrival-rate × window and mostly
encodes whatever retry storm dominates the sample.

## Observability

`evictOldestIdleGeneration` previously logged **nothing that identified a cap eviction**. The socket
close left its usual line, but nothing said a cap had displaced a reusable conversation, so the only
record required `--ws-diagnostics` and a JSONL trawl. Now:

```
ws: evicting the oldest idle nursery connection to stay within its cap: connection=7 idle_ms=2431 cap=48 reason=nursery_lru_cap
```

and `idleMs` is recorded on the matching entry in the diagnostic `evictions` array. Read it as a
**margin** indicator, not a cost — a two-second-old victim that never returns cost nothing, a
twenty-minute-old one that returns costs a full resend. What it tells you is how close a cap is
running to the window in which conversations come back.

## Neither cap is a hard ceiling

Only **idle** entries are evictable, so a generation can exceed its cap while every head is busy
(a lab fan-out reached 11 against a cap of 8), and isolated sockets are never registered or counted.
What scales with these numbers is memory — each retained head holds its conversation plus a canonical
copy for prefix comparison — and held descriptors. There is no `EMFILE` handling on this path, which
is filed separately; that is the prerequisite for removing these caps entirely and letting the pools
grow to whatever the machine can actually support.

## Tests

Three new, and mutation results:

| mutation | verdict |
| --- | --- |
| revert both defaults to 32/8 | RED |
| revert nursery alone, 48 → 8, and 48 → 47 | RED |
| delete the eviction log line | RED |
| drop `idleMs` from the diagnostic | RED |
| idle age from `createdAt` instead of `lastUsedAt` | RED |
| reverse the LRU sort (evict the newest idle head) | RED |
| drop the `Math.max(0, …)` floor | **SURVIVED** |

The survivor is disclosed: nothing drives the clock backwards, and it matches the identical
unpinned floors already beside it on the TTL path.

Two of those tests exist because of review findings. Reversing the eviction sort previously passed
the entire file — the sizing argument rests on the victim being *least* recently used, and nothing
pinned it, because the first version of the test used a cap of 1 where order cannot be observed.
The defaults test clears `CLODEX_WS_MAX_*` from the environment and restores them in a `finally`:
without that, a developer who exports those variables for their own server has the test confirm
*their* caps as the shipped ones, which is exactly what happened during development.

`pnpm typecheck && pnpm test && pnpm build` green — 2564 tests, node v24.14.1, isolated `CLODEX_HOME`.

## Review

Two reviewers on separate models, plus an adversarial refuter that re-derived every figure from the
frozen ledger independently. It blocked the original justification, and the numbers above are the
result of that adjudication rather than my first pass. The caps themselves were not contested.
