### PR TITLE
fix(patch): stop --restore from leaving claude unable to start on macOS

### DIFF
--- a/src/patcher.ts
+++ b/src/patcher.ts
@@ -20,6 +20,7 @@
 
 import { createHash } from 'node:crypto';
 import {
+  chmodSync,
   copyFileSync,
   existsSync,
   mkdtempSync,
@@ -697,10 +698,20 @@ function verifyPristineSource(
  * `rename` within one directory is atomic, so a backup file is either absent or
  * complete — never half-written.
  */
-function publishBackupFile(from: string, to: string): void {
+/**
+ * Copy `from` over `to` by writing a temp file beside it and renaming, so `to` is
+ * replaced as a whole new inode rather than rewritten underneath anything holding
+ * it. Used for backup files, and for the live binary on `--restore`.
+ *
+ * `mode` is applied to the temp file before the rename. `copyFileSync` takes the
+ * SOURCE's mode, not the destination's, so a rename without this would publish a
+ * binary carrying whatever permissions the backup file happened to have.
+ */
+function publishFileByRename(from: string, to: string, mode?: number): void {
   const temp = `${to}.tmp-${process.pid}-${Date.now().toString(36)}`;
   try {
     copyFileSync(from, temp);
+    if (mode !== undefined) chmodSync(temp, mode);
     renameSync(temp, to);
   } catch (err) {
     try {
@@ -941,7 +952,7 @@ export async function applyPatch(
           + `to publish it as ${plan.backupPath}`,
         );
       }
-      publishBackupFile(candidatePath, plan.backupPath);
+      publishFileByRename(candidatePath, plan.backupPath);
     }
 
     // Adopt a legacy `claude-<ver>.orig` under its content address so later runs
@@ -957,13 +968,13 @@ export async function applyPatch(
       const alreadyStored = facts.backups.some(
         candidate => candidate.path === canonical && candidate.sha256 === pristineSha256,
       );
-      if (!alreadyStored) publishBackupFile(backup, canonical);
+      if (!alreadyStored) publishFileByRename(backup, canonical);
       backup = canonical;
     }
 
     // Mirror the pristine copy to tweakcc's restore location (always from the
     // backup, never the live binary — so it stays pristine after patching).
-    publishBackupFile(backup, tweakccMirrorBackupPath());
+    publishFileByRename(backup, tweakccMirrorBackupPath());
 
     const builtIn = applyClodexPatches(loaded.source, desired.config);
     results = builtIn.results;
@@ -1157,8 +1168,15 @@ function runRestoreCommand(target: ClaudePatchTarget): number {
     return 1;
   }
 
-  // Unlike the patch path, this copies straight over the live binary — there is
-  // nothing to publish atomically — so it carries the full provenance check.
+  // Publish the same way the patch path does. Rewriting a binary IN PLACE leaves
+  // it on the same inode, and macOS caches a code signature per vnode for a
+  // binary that has been executed — an in-place overwrite invalidates the pages
+  // under that cache and has been reported to leave every later launch killed
+  // with `Code Signature Invalid` (issue #216) until the file was replaced
+  // through a new inode. The earlier reasoning here was that a restore has
+  // "nothing to publish atomically", which is true and beside the point: what
+  // matters is inode identity, not atomicity. This path still carries the full
+  // provenance check.
   const plan = planRestoreOnly(collectPristineFacts({ version, binaryPath, manifest }));
   if (plan.action === 'error') {
     p.log.error(plan.message);
@@ -1170,7 +1188,31 @@ function runRestoreCommand(target: ClaudePatchTarget): number {
     p.log.error(verified.message);
     return 1;
   }
-  copyFileSync(plan.backupPath, binaryPath);
+  // Keep the live binary's own permissions: `copyFileSync` would hand it the
+  // backup file's instead, and a non-executable claude is a worse outcome than
+  // the one being fixed.
+  let publishedMode: number | undefined;
+  try {
+    publishedMode = statSync(binaryPath).mode;
+  } catch {
+    // The target is gone between the plan and the write; let the rename create it
+    // with the backup's mode rather than refuse a rescue this late.
+  }
+  try {
+    publishFileByRename(plan.backupPath, binaryPath, publishedMode);
+  } catch (err) {
+    // A rename can fail where the old in-place copy would have worked — Windows
+    // refuses to replace a file another process holds open, and a temp file beside
+    // the binary needs a writable directory. This is a rescue command, so fall back
+    // to the in-place write rather than leave a broken install unrestored; the user
+    // is told, because on macOS that write is the fault this path exists to avoid.
+    p.log.warn(
+      `Could not replace ${binaryPath} through a new file (${err instanceof Error ? err.message : String(err)}); `
+      + 'writing the pristine bytes in place instead. If claude then fails to start with a code-signing '
+      + 'error, copy the backup to a new file and move it over the binary by hand.',
+    );
+    copyFileSync(plan.backupPath, binaryPath);
+  }
   // Reaching here means the plan established these bytes as THIS install's
   // pristine content, so the manifest being cleared is this install's own record
   // that it was patched. A manifest recorded against a different install cannot

--- a/tests/patcher-command.test.ts
+++ b/tests/patcher-command.test.ts
@@ -1092,6 +1092,35 @@ describe('runPatchCommand legacy backup compatibility', () => {
 });
 
 describe('runPatchCommand --restore', () => {
+  // Issue #216. Rewriting the binary IN PLACE leaves it on the same inode, and
+  // macOS caches a code signature per vnode once a binary has run — an in-place
+  // overwrite was reported to leave every later launch killed with `Code Signature
+  // Invalid` until the file was replaced through a new inode. The patch path has
+  // always published by rename; this asserts the restore path does too.
+  it('publishes the restored binary as a new inode, not over the old one', async () => {
+    const real = installClaude('2.1.220');
+    const pristineBytes = readFileSync(real);
+    const pristineMode = statSync(real).mode;
+    expect(await runPatchCommand({})).toBe(0);
+    const patchedInode = statSync(real).ino;
+
+    // Take the executable bit off the BACKUP file. Publishing by rename hands the
+    // destination whatever mode the temp copy carries, so without an explicit
+    // chmod this is how a restore produces a claude that cannot be executed —
+    // a worse outcome than the code-signature fault being fixed.
+    const backupPath = readPatchManifest()?.backupPath;
+    expect(backupPath).toBeTruthy();
+    chmodSync(backupPath!, 0o600);
+
+    expect(await runPatchCommand({ restore: true })).toBe(0);
+
+    expect(readFileSync(real)).toEqual(pristineBytes);
+    expect(statSync(real).ino).not.toBe(patchedInode);
+    expect(statSync(real).mode).toBe(pristineMode);
+    // No temp file is left beside it for the backup scanner to trip over.
+    expect(readdirSync(dirname(real)).filter(name => name.includes('.tmp-'))).toEqual([]);
+  });
+
   it('restores the pristine binary and drops the manifest', async () => {
     const real = installClaude('2.1.220');
     const pristineBytes = readFileSync(real);
@@ -1102,6 +1131,34 @@ describe('runPatchCommand --restore', () => {
     expect(readFileSync(real)).toEqual(pristineBytes);
     expect(readPatchManifest()).toBeNull();
   });
+
+  // The rescue path the rename introduces. Creating the temp file needs write
+  // permission on the DIRECTORY; overwriting the existing binary needs it only on
+  // the FILE — so a read-only directory fails the rename publish while leaving the
+  // in-place write available, which is the shape Windows hits when another process
+  // holds the binary open. A restore is a rescue command, so it must still finish.
+  it.skipIf(process.platform === 'win32' || process.getuid?.() === 0)(
+    'falls back to writing in place when it cannot publish a new file',
+    async () => {
+      const real = installClaude('2.1.220');
+      const pristineBytes = readFileSync(real);
+      expect(await runPatchCommand({})).toBe(0);
+      expect(readFileSync(real)).not.toEqual(pristineBytes);
+
+      const dir = dirname(real);
+      const dirMode = statSync(dir).mode;
+      chmodSync(dir, 0o555);
+      try {
+        expect(await runPatchCommand({ restore: true })).toBe(0);
+      } finally {
+        chmodSync(dir, dirMode);
+      }
+
+      expect(readFileSync(real)).toEqual(pristineBytes);
+      expect(readPatchManifest()).toBeNull();
+      expect(logs.join('\n')).toMatch(/writing the pristine bytes in place instead/);
+    },
+  );
 
   // Issue #199. Two supported installs of ONE Claude Code version are different
   // files (npm platform package vs native installer), so "same version tag" was


### PR DESCRIPTION
Closes #216.

## What users hit

`clodex patch --restore` restored the right bytes but wrote them the wrong way, and on macOS that could leave `claude` unable to start at all — every launch killed with `Code Signature Invalid` until the file was replaced by hand.

## Cause

`--restore` did `copyFileSync(backup, binaryPath)`, which rewrites the file **in place**: same inode. macOS caches a code signature per vnode once a binary has been executed, and an in-place overwrite invalidates the pages underneath it. The patch path has always published by writing a temp file beside the target and renaming it (`renameSync(candidatePath, binaryPath)`), so it replaces the inode and never had this problem.

The comment defending the old write said a restore has "nothing to publish atomically". True, and beside the point: what matters is inode identity, not atomicity.

## The change

- `publishBackupFile` is generalised to `publishFileByRename(from, to, mode?)` — same temp-then-rename it already did, plus an explicit mode. Its three existing call sites are unchanged in behaviour.
- `--restore` publishes through it.
- **The live binary's own permissions are applied to the temp file before the rename.** This is load-bearing: `copyFileSync` takes the *source's* mode, so a naive rename would hand `claude` whatever permissions the backup file happened to carry. A non-executable claude would be a worse outcome than the fault being fixed. (This also means the old code was relying on backups happening to be `0755`.)
- **If the rename cannot be done, the in-place write still runs, with a warning.** Windows refuses to replace a file another process holds open, and the temp file needs a writable directory. `--restore` is a rescue command, so finishing matters more than the mechanism — and where the rename fails, the in-place write is no worse than today.

## What I could and could not reproduce

**Confirmed** — the mechanism, by inode, reproducing the reporter's full sequence on a throwaway copy (`TWEAKCC_CC_INSTALLATION_PATH` pointed at the copy, throwaway `CLODEX_HOME` and `TWEAKCC_CONFIG_DIR`):

```
pristine copy    inode=327896995  sha=a681f3008f00
after patch      inode=327897017  sha=d21a68aac02b   ← rename: new inode
after restore    inode=327897017  sha=a681f3008f00   ← copy: SAME inode
```

**Not reproduced** — the `Code Signature Invalid` kill itself, in four configurations on the same macOS/Darwin version as the reporter: identical bytes overwritten in place, different validly-signed bytes in place, in place with a process from that binary alive, and the full patch → exec → restore cycle above. All restored and ran cleanly.

The reporter had ~40 live `claude` processes and said himself he could not tell whether they were necessary. My best theory is that live processes keep the vnode referenced so the invalidated signature state persists to later execs, while without them the vnode is released and re-validated — I did not test that faithfully, since it would have meant driving 40 real sessions on a live account.

I'd land it anyway: it only makes restore do what the patch path already does, it removes a known macOS hazard class, and it cannot be worse than the current write.

## Verification

- Three new-behaviour assertions in one test: the restored binary is on a **new inode**, it keeps its **own permissions** (the test strips the executable bit off the *backup* first, so this can fail), and no temp file is left beside it.
- A second test drives the **fallback**: a read-only parent directory fails the temp-file creation while leaving the in-place write available — POSIX separates write-on-directory from write-on-file — so the rescue path is exercised rather than assumed. Skipped on Windows and as root, where those permissions don't behave that way.
- Mutations, all red: revert to in-place `copyFileSync`; drop the `chmod`; take the mode from the backup instead of the binary; remove the fallback.
- `pnpm typecheck && pnpm test && pnpm build` — 2572 tests, node v24.14.1, isolated `CLODEX_HOME`.
- **Per-format probe** (required by CLAUDE.md for anything in the read/repack/restore path), `scripts/probe-patch-mechanism.mjs` against 2.1.268 builds downloaded for each format: **darwin-arm64 PASS** (19 checks), **linux-x64 PASS** (18), **win32-x64 PASS** (17). All three report `mode-preserved — mode 755`.

#204 covers which backup `--restore` selects and #217 covers which binary it targets; both are separate.
