### PR TITLE
fix(patch): say which install clodex will patch when CLODEX_CLAUDE_PATH points elsewhere

### DIFF
--- a/.claude/docs/patcher.md
+++ b/.claude/docs/patcher.md
@@ -680,6 +680,19 @@ tweakcc's own repack reads back as an ordinary module name.
   refused during selection, so the other install's rescue record is never deleted with it. The patch
   path keeps the hard `version-unknown` failure (patching is elective; restoring is the way out), and
   its error message names `--restore` as the recovery.
+- **`CLODEX_CLAUDE_PATH` does not choose the patch target, and that is deliberate.** It selects the
+  claude that gets LAUNCHED; the patch target override is `TWEAKCC_CC_INSTALLATION_PATH`. Honouring
+  the launch override here would hand the patcher a wrapper shim whenever a user points it at one
+  for launching — `resolveThroughNpmShims` follows npm launchers, not arbitrary wrappers — which is
+  issue #193's "Unable to detect installation type", with the shim's older version then selecting
+  the wrong pristine backup. A committed end-to-end test pins that (`patches the resolved install
+  and never downgrades it to a PATH shim's version`), so an attempt to "fix" the precedence turns
+  red rather than shipping. Issue #217 asked for the precedence to change; what it was right about is
+  that the behaviour was undocumented and that the refusal advice named the variable that cannot
+  work. `clodex patch` now warns when a `CLODEX_CLAUDE_PATH` is set and something else decided the
+  target, and a `TWEAKCC_CC_INSTALLATION_PATH` naming a file that is gone is refused by name rather
+  than falling through to another install.
+
 - **Binary resolution bypasses PATH shims** (cmux installs a shim copy):
   `TWEAKCC_CC_INSTALLATION_PATH` → `~/.local/bin/claude` → `findClaudeBinary()`.
   **`~/.local/bin/claude.exe`, which the Windows native installer writes, is deliberately NOT
@@ -747,7 +760,7 @@ tweakcc's own repack reads back as an ordinary module name.
   is the refusal, not a wrong guess, and closing it properly would mean parsing three shells.
   Resolution failure (a launcher whose program is gone, a `.cmd`/`.ps1` whose program cannot be
   read, two programs named) is a refusal *before* any candidate, backup or manifest write, naming
-  `CLODEX_CLAUDE_PATH` as the way out — never a fallback to patching the launcher, which is what
+  `TWEAKCC_CC_INSTALLATION_PATH` as the way out — never a fallback to patching the launcher, which is what
   produced issue #193's
   "Unable to detect installation type from path ...\\.clodex-patch-XXXX\\claude.cmd". When the
   program's path could be read but the file is gone, that path is what the failure carries, so a

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Patch the installed Claude Code binary so clodex favorites and aliases are first
 | `--disable-local-patches` | Disable local patches and rebuild from pristine bytes without them |
 | `--help` | Help |
 
-On Windows, when Claude Code was installed with `npm install -g`, the `claude` on your PATH is a small launcher script (`claude.cmd`, `claude.ps1`, and an extensionless one) rather than the program itself; `clodex patch` follows it to the program and patches that. (On macOS and Linux npm makes a symlink instead, which always worked.) If the launcher cannot be followed — its program moved or removed, or it names two different programs — `clodex patch` stops without touching anything and tells you to set `CLODEX_CLAUDE_PATH` to the program directly.
+On Windows, when Claude Code was installed with `npm install -g`, the `claude` on your PATH is a small launcher script (`claude.cmd`, `claude.ps1`, and an extensionless one) rather than the program itself; `clodex patch` follows it to the program and patches that. (On macOS and Linux npm makes a symlink instead, which always worked.) If the launcher cannot be followed — its program moved or removed, or it names two different programs — `clodex patch` stops without touching anything and tells you to set `TWEAKCC_CC_INSTALLATION_PATH` to the program directly.
 
 The patch map is built from your favorites and aliases; context windows come from provider metadata. A pristine per-version backup is kept, and a manifest (`~/.clodex/patch-state.json`) makes re-runs no-ops until your config or Claude Code version changes — then the binary is restored first and re-patched fresh. `clodex claude` checks patch freshness at launch and offers to re-patch (a non-blocking notice when not interactive). Re-run `clodex patch` after every `claude` update.
 
@@ -337,7 +337,10 @@ clodex --version    # version
   `CLODEX_CREDENTIAL_HELPER` to an absolute executable path to use an external
   secure store instead; see [credential helpers](docs/credential-helpers.md).
 - Proxied routes forward configured provider headers for API-key and OAuth authentication. Anonymous routes preserve non-credential headers while removing authorization, API-key, cookie, token, secret, and credential-bearing header names before dispatch.
-- `CLODEX_CLAUDE_PATH` overrides Claude Code binary discovery.
+- `CLODEX_CLAUDE_PATH` overrides which Claude Code gets **launched**. It does not choose what
+  `clodex patch` writes to — set `TWEAKCC_CC_INSTALLATION_PATH` for that, and `clodex patch`
+  says so when `CLODEX_CLAUDE_PATH` points somewhere else. The two are separate because a
+  `CLODEX_CLAUDE_PATH` aimed at a wrapper script is right for launching and wrong for patching.
 - **Codex service tier:** `CLODEX_SERVICE_TIER` accepts `fast` (normalized to
   `priority`), `priority`, `flex`, `auto`, or `default`. Clodex requests the
   resolved value only after selecting a ChatGPT/Codex OAuth route; OpenAI

--- a/src/patcher.ts
+++ b/src/patcher.ts
@@ -480,6 +480,16 @@ export function tryAcquirePatchLock(
 export type ClaudePatchTarget =
   | { ok: true; binaryPath: string; version: string }
   | { ok: false; reason: 'binary-not-found' }
+  | {
+      ok: false;
+      /**
+       * TWEAKCC_CC_INSTALLATION_PATH names a file that is not there. Distinct from
+       * `binary-not-found` so the message can say which variable to fix rather
+       * than report that no Claude Code was found while one is installed.
+       */
+      reason: 'patch-target-missing';
+      declaredPath: string;
+    }
   | { ok: false; reason: 'version-unknown'; binaryPath: string }
   | {
       ok: false;
@@ -509,6 +519,19 @@ export type ClaudePatchTarget =
  * TWEAKCC_CC_INSTALLATION_PATH → ~/.local/bin/claude (stable native-install
  * symlink) → findClaudeBinary() PATH lookup.
  *
+ * **The patch target override is TWEAKCC_CC_INSTALLATION_PATH, not
+ * CLODEX_CLAUDE_PATH.** The latter governs which claude gets LAUNCHED and is only
+ * reached here through `findClaudeBinary()`, i.e. last — deliberately. A user
+ * whose CLODEX_CLAUDE_PATH points at a wrapper shim needs that for launching, and
+ * honouring it here patches the wrapper instead of Claude Code: `resolveThroughNpmShims`
+ * follows npm launchers, not arbitrary wrappers, so the wrapper is what would be
+ * handed to tweakcc — issue #193's "Unable to detect installation type", with a
+ * shim's older version selecting the wrong pristine backup on top (the version
+ * note below). Issue #217 asked for it to be honoured; that is why it is not.
+ * What #217 was right about is that the behaviour was undocumented and that the
+ * remedy printed for an unfollowable launcher named the wrong variable — both
+ * fixed, and `clodex patch` now says when it is ignoring a CLODEX_CLAUDE_PATH.
+ *
  * `%USERPROFILE%\.local\bin\claude.exe`, which the Windows native installer
  * writes, is still NOT probed here. Adding it as a fallback made a restore
  * weakness reachable: `findClaudeBinary()` returns the same null for
@@ -535,10 +558,27 @@ export type ClaudePatchTarget =
  * another install publishes those other bytes over the user's Claude Code. There
  * is no fallback version for the same reason: an unprobeable binary is an error.
  */
+/**
+ * Set by the last `resolveClaudeBinaryForPatch` when CLODEX_CLAUDE_PATH was set and
+ * something else decided the patch target. Reported by the command, so the warning
+ * lands next to the target it chose rather than from inside a pure resolver.
+ */
+let ignoredLaunchOverride: { used: string; ignored: string } | null = null;
+
+/** The ignored CLODEX_CLAUDE_PATH the last resolve saw, if any. Clears on read. */
+export function takeIgnoredLaunchOverride(): { used: string; ignored: string } | null {
+  const ignored = ignoredLaunchOverride;
+  ignoredLaunchOverride = null;
+  return ignored;
+}
+
 export function resolveClaudeBinaryForPatch(): ClaudePatchTarget {
-  const envOverride = process.env['TWEAKCC_CC_INSTALLATION_PATH'];
+  const envOverride = process.env['TWEAKCC_CC_INSTALLATION_PATH']?.trim() || null;
   const nativeSymlink = join(homedir(), '.local', 'bin', 'claude');
-  const source = envOverride?.trim()
+  if (envOverride && !existsSync(envOverride)) {
+    return { ok: false, reason: 'patch-target-missing', declaredPath: envOverride };
+  }
+  const source = envOverride
     || (existsSync(nativeSymlink) ? nativeSymlink : null)
     || findClaudeBinary();
   if (!source) return { ok: false, reason: 'binary-not-found' };
@@ -564,6 +604,23 @@ export function resolveClaudeBinaryForPatch(): ClaudePatchTarget {
     };
   }
   resolved = followed.path;
+  // A CLODEX_CLAUDE_PATH that is set but did not decide this is worth one line: it
+  // is documented as overriding discovery, and for the patch target it does not.
+  // Compare the fully resolved program, so naming the install by its symlink or by
+  // the launcher in front of it counts as naming it and says nothing.
+  const launchOverride = process.env['CLODEX_CLAUDE_PATH']?.trim() || null;
+  let launchOverrideResolved: string | null = null;
+  if (launchOverride) {
+    try {
+      const followedOverride = resolveThroughNpmShims(realpathSync(launchOverride));
+      launchOverrideResolved = followedOverride.ok ? followedOverride.path : realpathSync(launchOverride);
+    } catch {
+      launchOverrideResolved = launchOverride;
+    }
+  }
+  ignoredLaunchOverride = launchOverrideResolved && launchOverrideResolved !== resolved
+    ? { used: resolved, ignored: launchOverride as string }
+    : null;
   try {
     if (!statSync(resolved).isFile()) return { ok: false, reason: 'binary-not-found' };
   } catch {
@@ -600,8 +657,8 @@ export function describePatchTargetFailure(
   if (target.reason === 'launcher-unresolved') {
     return `${target.shimPath} starts Claude Code but is not Claude Code itself, and clodex could `
       + `not follow it: ${target.detail}. clodex will not patch a launcher script — that fails with `
-      + '"Unable to detect installation type". Set CLODEX_CLAUDE_PATH to the Claude Code program '
-      + 'itself (for an npm install on Windows that is '
+      + '"Unable to detect installation type". Set TWEAKCC_CC_INSTALLATION_PATH to the Claude Code '
+      + 'program itself (for an npm install on Windows that is '
       + 'node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe under the directory holding the '
       + 'launcher), then run the command again.';
   }
@@ -627,6 +684,12 @@ export function describePatchTargetFailure(
       + `npm install is incomplete. ${remedy} ${retry}${restore} If this is a custom wrapper `
       + 'rather than the npm placeholder, set TWEAKCC_CC_INSTALLATION_PATH to the native Claude '
       + 'Code binary.';
+  }
+  if (target.reason === 'patch-target-missing') {
+    return `TWEAKCC_CC_INSTALLATION_PATH is set to ${target.declaredPath}, which does not exist. `
+      + 'clodex will not look for another Claude Code instead — patching or restoring a different '
+      + 'install than the one you named is how one install\'s pristine bytes end up over another\'s. '
+      + 'Point it at the Claude Code program, or unset it to let clodex find your install.';
   }
   return target.reason === 'binary-not-found'
     ? 'claude binary not found. Install Claude Code or set TWEAKCC_CC_INSTALLATION_PATH.'
@@ -1122,6 +1185,9 @@ export async function applyPatch(
 function runRestoreCommand(target: ClaudePatchTarget): number {
   if (!target.ok && (
     target.reason === 'binary-not-found'
+    // A named path that is not there names no program to restore over, and looking
+    // for another install is exactly what must not happen here.
+    || target.reason === 'patch-target-missing'
     || target.reason === 'native-binary-missing'
   )) {
     p.log.error(describePatchTargetFailure(target, 'restore'));
@@ -1192,6 +1258,14 @@ export async function runPatchCommand(opts: {
   localPatches?: boolean;
 } = {}): Promise<number> {
   const target = resolveClaudeBinaryForPatch();
+  const ignoredOverride = takeIgnoredLaunchOverride();
+  if (ignoredOverride) {
+    p.log.warn(
+      `CLODEX_CLAUDE_PATH is set to ${ignoredOverride.ignored}, but it does not choose what gets `
+      + `patched — ${ignoredOverride.used} does. CLODEX_CLAUDE_PATH selects the claude that gets `
+      + 'LAUNCHED; set TWEAKCC_CC_INSTALLATION_PATH to patch a specific install.',
+    );
+  }
 
   // Handled BEFORE the patch path's version check, because `--restore` has its
   // own rules: it must still work on a binary that no longer runs.

--- a/tests/patcher-command.test.ts
+++ b/tests/patcher-command.test.ts
@@ -183,6 +183,61 @@ afterEach(() => {
   rmSync(home, { recursive: true, force: true });
 });
 
+describe('runPatchCommand patch-target overrides', () => {
+  // Issue #217. CLODEX_CLAUDE_PATH is documented as overriding binary discovery and
+  // does so for LAUNCH, but the patch target is TWEAKCC_CC_INSTALLATION_PATH — on
+  // purpose, because a CLODEX_CLAUDE_PATH aimed at a wrapper shim would have the
+  // patcher rewrite the wrapper. Undocumented, it reads as the override silently
+  // patching a different Claude Code than the one named, so say it out loud.
+  it('says so when CLODEX_CLAUDE_PATH is set but does not choose the patch target', async () => {
+    const real = installClaude('2.1.220');
+    const shim = join(home, 'shim', 'claude');
+    writeFakeClaude(shim, '2.1.215');
+    process.env.CLODEX_CLAUDE_PATH = shim;
+
+    expect(await runPatchCommand({})).toBe(0);
+
+    expect(readPatchManifest()?.binaryPath).toBe(real);
+    const output = logs.join('\n');
+    expect(output).toMatch(/CLODEX_CLAUDE_PATH is set to/);
+    expect(output).toContain(shim);
+    expect(output).toMatch(/set TWEAKCC_CC_INSTALLATION_PATH to patch a specific install/);
+  });
+
+  it('stays quiet when CLODEX_CLAUDE_PATH names the install being patched', async () => {
+    const real = installClaude('2.1.220');
+    // Through a SYMLINK, which is how a native install is normally named
+    // (`~/.local/bin/claude` is one). Comparing the raw value instead of the
+    // resolved program would warn here, on the common case, about nothing.
+    const link = join(home, 'link-to-claude');
+    symlinkSync(real, link);
+    process.env.CLODEX_CLAUDE_PATH = link;
+
+    expect(await runPatchCommand({})).toBe(0);
+
+    expect(readPatchManifest()?.binaryPath).toBe(real);
+    expect(logs.join('\n')).not.toMatch(/does not choose what gets patched/);
+  });
+
+  // A stale explicit target used to report that no Claude Code was found, while one
+  // was installed — and must never fall back to a different install, which is how
+  // #199's restore published one install's pristine bytes over another's.
+  it('refuses a TWEAKCC_CC_INSTALLATION_PATH that is gone instead of finding another install', async () => {
+    const real = installClaude('2.1.220');
+    const pristineBytes = readFileSync(real);
+    process.env.TWEAKCC_CC_INSTALLATION_PATH = join(home, 'gone', 'claude');
+
+    expect(await runPatchCommand({})).toBe(1);
+    expect(await runPatchCommand({ restore: true })).toBe(1);
+
+    expect(readFileSync(real)).toEqual(pristineBytes);
+    expect(readPatchManifest()).toBeNull();
+    const output = logs.join('\n');
+    expect(output).toMatch(/TWEAKCC_CC_INSTALLATION_PATH is set to/);
+    expect(output).toMatch(/will not look for another Claude Code instead/);
+  });
+});
+
 describe('runPatchCommand version resolution', () => {
   it('patches the resolved install and never downgrades it to a PATH shim\'s version', async () => {
     // The reproduced failure: `claude` on PATH is a wrapper shim reporting an
@@ -599,7 +654,7 @@ describe('runPatchCommand npm launcher resolution', () => {
     expect(await runPatchCommand({})).toBe(1);
 
     expect(logs.join('\n')).toMatch(/does not exist/);
-    expect(logs.join('\n')).toMatch(/CLODEX_CLAUDE_PATH/);
+    expect(logs.join('\n')).toMatch(/TWEAKCC_CC_INSTALLATION_PATH/);
     expect(readFileSync(launchers.cmd)).toEqual(launcherBytes);
     expect(backupFiles()).toEqual([]);
     expect(readPatchManifest()).toBeNull();
@@ -615,7 +670,7 @@ describe('runPatchCommand npm launcher resolution', () => {
     expect(await runPatchCommand({})).toBe(1);
 
     expect(logs.join('\n')).toMatch(/could not read which file it starts/);
-    expect(logs.join('\n')).toMatch(/CLODEX_CLAUDE_PATH/);
+    expect(logs.join('\n')).toMatch(/TWEAKCC_CC_INSTALLATION_PATH/);
     expect(backupFiles()).toEqual([]);
     expect(readPatchManifest()).toBeNull();
     expect(candidateDirsIn(binDir)).toEqual([]);
@@ -630,7 +685,7 @@ describe('runPatchCommand npm launcher resolution', () => {
 
     await expect(runLaunchPatchCheck({})).resolves.toBeUndefined();
 
-    expect(stderr.mock.calls.flat().join('\n')).toMatch(/CLODEX_CLAUDE_PATH/);
+    expect(stderr.mock.calls.flat().join('\n')).toMatch(/TWEAKCC_CC_INSTALLATION_PATH/);
     expect(readPatchManifest()).toBeNull();
   });
 
@@ -673,7 +728,7 @@ describe('runPatchCommand npm launcher resolution', () => {
     expect(await runPatchCommand({})).toBe(1);
 
     expect(logs.join('\n')).toMatch(/names more than one program/);
-    expect(logs.join('\n')).toMatch(/CLODEX_CLAUDE_PATH/);
+    expect(logs.join('\n')).toMatch(/TWEAKCC_CC_INSTALLATION_PATH/);
     expect(readFileSync(program)).toEqual(programBytes);
     expect(backupFiles()).toEqual([]);
     expect(readPatchManifest()).toBeNull();
@@ -692,7 +747,7 @@ describe('runPatchCommand npm launcher resolution', () => {
     expect(await runPatchCommand({ restore: true })).toBe(1);
 
     expect(logs.join('\n')).toMatch(/could not read which file it starts/);
-    expect(logs.join('\n')).toMatch(/CLODEX_CLAUDE_PATH/);
+    expect(logs.join('\n')).toMatch(/TWEAKCC_CC_INSTALLATION_PATH/);
     expect(logs.join('\n')).not.toMatch(/claude --version` failed/);
     expect(backupFiles()).toEqual([]);
   });


### PR DESCRIPTION
Closes #217.

## What users hit

`README` says `CLODEX_CLAUDE_PATH` overrides Claude Code binary discovery. Set it and run `clodex patch` on a machine with a native install, and a *different* Claude Code gets patched — the one behind `~/.local/bin/claude`. The override isn't broken; it governs **launching**, and the patch target is `TWEAKCC_CC_INSTALLATION_PATH`. Nothing said so.

## The precedence stays, and the issue's preferred fix would have been a regression

The issue suggested reading `CLODEX_CLAUDE_PATH` at explicit-override rank. I implemented that first, and an existing end-to-end test went red:

> `patches the resolved install and never downgrades it to a PATH shim's version`

That test encodes a reproduced failure. A user whose `CLODEX_CLAUDE_PATH` points at a **wrapper shim** needs it there for launching; honouring it in the patcher hands the shim to tweakcc, because `resolveThroughNpmShims` follows npm launchers and not arbitrary wrappers. That is #193's *"Unable to detect installation type"* — and worse, the shim reports an older version, which selects the wrong pristine backup and can publish those bytes over the real install.

So this takes the issue's second option: keep the precedence, stop being silent about it, and fix the advice that was wrong.

## Changes

- **`clodex patch` warns** when `CLODEX_CLAUDE_PATH` is set and something else chose the target, naming both paths and pointing at `TWEAKCC_CC_INSTALLATION_PATH`. The comparison is against the fully **resolved** program, so naming an install through its own symlink — which is how a native install is normally named — says nothing.
- **The launcher-unresolved refusal now names `TWEAKCC_CC_INSTALLATION_PATH`.** It previously told the user to set `CLODEX_CLAUDE_PATH`, which is the one variable that cannot take effect in that situation: an unfollowable launcher at `~/.local/bin/claude` wins the selection before the override is ever consulted. **Four tests had pinned the ineffective wording**, so the suite was holding the bug in place.
- **A `TWEAKCC_CC_INSTALLATION_PATH` naming a file that is gone is refused by name**, instead of reporting that no Claude Code was found while one is installed. It must not fall through to discovery: that is how #199's restore published one install's pristine bytes over another's, and the same argument applies to the patch path.
- README and `.claude/docs/patcher.md` now say which variable governs which and why they are separate — the deep doc entry says explicitly that an attempt to "fix" the precedence turns the shim test red, so the next person doesn't rediscover this the way I did.

## Verification

Three new tests: the warning fires with both paths named; it stays quiet when the override names the install through a symlink; a stale patch-target override is refused by name for both `patch` and `--restore`, with the binary and manifest untouched.

Mutations, all red:

| mutation | result |
| --- | --- |
| drop the warning | 1 test red |
| stale target falls through to discovery | 1 test red |
| advice names `CLODEX_CLAUDE_PATH` again | **5** tests red |
| compare the raw override instead of the resolved program | 1 test red |

That last one survived on my first attempt — the test named the install by its real path, so it never exercised the resolution. Re-pointed through a symlink, it discriminates.

`pnpm typecheck && pnpm test && pnpm build` — 2573 tests, node v24.14.1, isolated `CLODEX_HOME`.

No behaviour change to which binary is selected, so the per-format probe is not implicated; #226 (issue #216) carries that for the restore write path.
